### PR TITLE
docs: make uninstall a Claude prompt; align website install with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,18 @@ APPA again; it installs the latest release.
 ## Uninstall
 
 ```sh
-claude plugin uninstall appa-runtime
-claude plugin marketplace remove appa
-rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
+claude "uninstall APPA: uninstall the appa-runtime plugin, remove the appa
+plugin marketplace, delete appa-runtime-v2, clappa, and appa-statusline.sh
+from ~/.local/bin, and in ~/.claude/settings.json delete the statusLine
+entry only if it runs appa-statusline.sh — if it chains other commands,
+remove just the appa part"
+```
 
-# optional — also remove the policy, database, alias, and statusline:
-rm -rf ~/.config/appa ~/.local/share/appa      # Linux
-rm -rf ~/Library/"Application Support/appa"    # macOS
-sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
-jq 'del(.statusLine)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
+Optionally, also remove the policy, database, and alias:
+
+```sh
+claude "finish removing APPA: delete the appa config and data directories,
+and remove the clappa alias from my shell rc if present"
 ```
 
 ## Development

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -10,8 +10,9 @@ This page describes how to run Claude Code with OpenAPPA. OpenAPPA integrates wi
 ## Install
 
 ```sh
-claude plugin marketplace add archestra-ai/OpenAPPA
-claude plugin install appa-runtime@appa
+claude plugin marketplace add archestra-ai/OpenAPPA &&
+  claude plugin install appa-runtime@appa &&
+  claude "set up APPA"
 ```
 
 This installs the OpenAPPA plugin into your Claude Code. While OpenAPPA is in beta, the plugin ships a `clappa` command that runs Claude Code protected by OpenAPPA. If you want to just keep using Claude Code, start it as usual — plain `claude` sessions stay untouched.
@@ -24,13 +25,22 @@ The plugin ships the `/appa-tool-sync` skill to guide you through the policy con
 
 ## Uninstall
 
+To uninstall OpenAPPA from Claude Code, ask Claude to remove the plugin and the [runtime](#technical-details) binaries:
+
 ```sh
-claude plugin uninstall appa-runtime
-claude plugin marketplace remove appa
-rm ~/.local/bin/appa-runtime-v2
+claude "uninstall APPA: uninstall the appa-runtime plugin, remove the appa
+plugin marketplace, delete appa-runtime-v2, clappa, and appa-statusline.sh
+from ~/.local/bin, and in ~/.claude/settings.json delete the statusLine
+entry only if it runs appa-statusline.sh — if it chains other commands,
+remove just the appa part"
 ```
 
-The policy file and the decision history stay on disk; delete them only if you want them gone.
+Optionally, also remove the policy file, the decision database, and the shell alias:
+
+```sh
+claude "finish removing APPA: delete the appa config and data directories,
+and remove the clappa alias from my shell rc if present"
+```
 
 ## Technical details
 


### PR DESCRIPTION
## What

- The install block on the website's Claude Code page now matches the README's `&&`-chained form, including the `claude "set up APPA"` step (the ampersands were missing).
- Uninstall instructions in the README and on the website are now two Claude prompts instead of a command list:
  1. Remove the plugin, the marketplace, and the three binaries; the prompt tells Claude to delete the `statusLine` entry only if it runs `appa-statusline.sh`, and to remove just the appa part of a chained entry — the installer never replaces an existing statusline, so uninstall must not delete one.
  2. Optional cleanup: the policy/config and data directories and the `clappa` shell alias.

The full step-by-step commands stay in the integration guide (`integrations/claude-code/README.md#uninstall`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMGFmQaZz4MN8nQyBRhapA