### PR TITLE
docs: uninstall is manual commands only

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ claude "finish removing APPA: delete the appa config and data directories,
 and remove the clappa alias from my shell rc if present"
 ```
 
+To uninstall manually instead:
+
+```sh
+claude plugin uninstall appa-runtime
+claude plugin marketplace remove appa
+rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
+
+# optional — also remove the policy, database, alias, and statusline:
+rm -rf ~/.config/appa ~/.local/share/appa      # Linux
+rm -rf ~/Library/"Application Support/appa"    # macOS
+sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
+jq 'del(.statusLine)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
+```
+
 ## Development
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -25,32 +25,14 @@ APPA again; it installs the latest release.
 ## Uninstall
 
 ```sh
-claude "uninstall APPA: uninstall the appa-runtime plugin, remove the appa
-plugin marketplace, delete appa-runtime-v2, clappa, and appa-statusline.sh
-from ~/.local/bin, and in ~/.claude/settings.json delete the statusLine
-entry only if it runs appa-statusline.sh — if it chains other commands,
-remove just the appa part"
-```
-
-Optionally, also remove the policy, database, and alias:
-
-```sh
-claude "finish removing APPA: delete the appa config and data directories,
-and remove the clappa alias from my shell rc if present"
-```
-
-To uninstall manually instead:
-
-```sh
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
 
-# optional — also remove the policy, database, alias, and statusline:
+# optional — also remove the policy, database, and alias:
 rm -rf ~/.config/appa ~/.local/share/appa      # Linux
 rm -rf ~/Library/"Application Support/appa"    # macOS
 sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
-jq 'del(.statusLine)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
 ```
 
 ## Development

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -42,6 +42,20 @@ claude "finish removing APPA: delete the appa config and data directories,
 and remove the clappa alias from my shell rc if present"
 ```
 
+To uninstall manually instead:
+
+```sh
+claude plugin uninstall appa-runtime
+claude plugin marketplace remove appa
+rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
+
+# optional — also remove the policy, database, alias, and statusline:
+rm -rf ~/.config/appa ~/.local/share/appa      # Linux
+rm -rf ~/Library/"Application Support/appa"    # macOS
+sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
+jq 'del(.statusLine)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
+```
+
 ## Technical details
 
 OpenAPPA runs on your machine as a single binary with a built-in web server. That server is what receives the Claude Code hooks.

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -25,35 +25,17 @@ The plugin ships the `/appa-tool-sync` skill to guide you through the policy con
 
 ## Uninstall
 
-To uninstall OpenAPPA from Claude Code, ask Claude to remove the plugin and the [runtime](#technical-details) binaries:
-
-```sh
-claude "uninstall APPA: uninstall the appa-runtime plugin, remove the appa
-plugin marketplace, delete appa-runtime-v2, clappa, and appa-statusline.sh
-from ~/.local/bin, and in ~/.claude/settings.json delete the statusLine
-entry only if it runs appa-statusline.sh — if it chains other commands,
-remove just the appa part"
-```
-
-Optionally, also remove the policy file, the decision database, and the shell alias:
-
-```sh
-claude "finish removing APPA: delete the appa config and data directories,
-and remove the clappa alias from my shell rc if present"
-```
-
-To uninstall manually instead:
+To uninstall OpenAPPA from Claude Code, remove the plugin and the [runtime](#technical-details) binaries:
 
 ```sh
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
 
-# optional — also remove the policy, database, alias, and statusline:
+# optional — also remove the policy, database, and alias:
 rm -rf ~/.config/appa ~/.local/share/appa      # Linux
 rm -rf ~/Library/"Application Support/appa"    # macOS
 sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
-jq 'del(.statusLine)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
 ```
 
 ## Technical details


### PR DESCRIPTION
Replaces the Claude uninstall prompts from PR #4 with plain manual commands.

- README.md and website/content/docs/claude-code.md now show one manual uninstall block and no Claude prompts.
- Both files show the same block. The plugin ships clappa and the statusline script, so the block removes those binaries too.
- The jq edit of statusLine in ~/.claude/settings.json is dropped.