### PR TITLE
docs: stop the runtime in the Claude Code uninstall steps

### DIFF
--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -25,11 +25,12 @@ The plugin ships the `/appa-tool-sync` skill to guide you through the policy con
 
 ## Uninstall
 
-To uninstall OpenAPPA from Claude Code, remove the plugin and the [runtime](#technical-details) binaries:
+To uninstall OpenAPPA from Claude Code, remove the plugin, stop the [runtime](#technical-details), and remove its binaries:
 
 ```sh
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
+pkill -f appa-runtime-v2
 rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
 
 # optional — also remove the policy, database, and alias:


### PR DESCRIPTION
Deleting the binaries and data does not stop a running runtime. The stale process keeps answering `/health`, so a later reinstall's `ensure-runtime.sh` skips starting the new binary, and the old process keeps serving the old policy from a deleted config and database. (This is exactly what happened on a real machine today: uninstall, reinstall at a later time, then `/appa-tool-sync` found a live runtime with no config file on disk.)

This adds one `pkill -f appa-runtime-v2` line before the `rm` lines, and mentions the stop step in the sentence above the block.

`pkill -f` matches the full command line; plain `pkill` can miss the process on macOS, which truncates process names to 15 characters (`appa-runt`).