### PR TITLE
docs: stop the runtime in the README uninstall steps too

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ APPA again; it installs the latest release.
 ```sh
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
+pkill -f appa-runtime-v2
 rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
 
 # optional — also remove the policy, database, and alias:

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -159,6 +159,7 @@ session to set up APPA again; it installs the latest release.
 ```sh
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
+pkill -f appa-runtime-v2
 rm ~/.local/bin/appa-runtime-v2
 ```
 


### PR DESCRIPTION
Follow-up to #9, which covered only the website page: this commit was pushed to that branch after the merge, so it never reached main.

Same fix in both READMEs' Uninstall blocks: add `pkill -f appa-runtime-v2` before the `rm` lines, so a stale runtime cannot keep answering `/health` and be silently reused by a later reinstall.