### PR TITLE
test: tolerate EPIPE when the ungated hook exits before reading stdin

### DIFF
--- a/appa-runtime-v2/runtime/tests/plugin_hooks.rs
+++ b/appa-runtime-v2/runtime/tests/plugin_hooks.rs
@@ -58,12 +58,20 @@ fn run_gated(command: &str, url: &str, gated: bool) -> (i32, String) {
         .stderr(Stdio::null())
         .spawn()
         .expect("the hook command spawns");
-    child
+    // An ungated hook may exit before reading its stdin, closing the pipe
+    // mid-write; that is a pass condition, so only a non-EPIPE error fails.
+    if let Err(error) = child
         .stdin
         .as_mut()
         .expect("the child has a stdin pipe")
         .write_all(br#"{"hook_event_name":"PreToolUse","session_id":"plugin-test"}"#)
-        .expect("the event writes to the hook's stdin");
+    {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::BrokenPipe,
+            "the event writes to the hook's stdin",
+        );
+    }
     let output = child.wait_with_output().expect("the hook command finishes");
     (
         output.status.code().expect("the hook command exits with a code"),


### PR DESCRIPTION
## Why CI is red

`an_ungated_session_posts_nothing_and_never_blocks` in `appa-runtime-v2/runtime/tests/plugin_hooks.rs` fails on almost every CI run with:

```
panicked at appa-runtime-v2/runtime/tests/plugin_hooks.rs:66:10:
the event writes to the hook's stdin: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```

The shipped hook command starts with `[ "${APPA_GATE:-}" = 1 ] || exit 0; curl ...`. In the ungated case the shell exits 0 immediately and never reads stdin — the exact behavior the test checks. The test then writes the event JSON to the child's stdin, which races the child's exit: if the shell exits first, the pipe's read end is closed and the write fails with EPIPE. On fast local machines the write usually wins; on the slower shared CI runners the shell wins nearly every time, so the job is permanently red.

## Fix

A `BrokenPipe` on that write is a legitimate outcome — the hook is allowed to exit without reading its input — so the test now treats it as success. Any other write error still fails. The meaningful assertions (exit code and stdout) are unchanged, and the other three tests are unaffected because their commands run `curl`, which reads stdin.

Verified locally: `cargo test -p appa-runtime-v2 --test plugin_hooks` — 4 passed.