### PR TITLE
fix: close at the turn end a call the harness never ran

### DIFF
--- a/appa-runtime-v2/adapters/claude-code/src/lib.rs
+++ b/appa-runtime-v2/adapters/claude-code/src/lib.rs
@@ -20,7 +20,7 @@
 //! | `PostToolUse` for `Agent` (`Task`) | `SpawnResult` |
 //! | `PostToolUse`, `PostToolUseFailure` | `ToolResult` (the Q14 outcome mapping) |
 //! | `SubagentStart` | `ChildStart`, naming the family's spawn in flight |
-//! | `SubagentStop` | no event: a lifecycle marker |
+//! | `Stop`, `StopFailure`, `SubagentStop` | `TurnEnd` for the actor that finished |
 //!
 //! Subagents. Claude Code spawns a subagent through its `Agent` tool
 //! (`Task` is its older name), so the codec marks that call as the
@@ -36,7 +36,8 @@
 //! the named child against the fork it bound, and the parent receives
 //! what crosses. `SubagentStop` fires before it and carries the same
 //! text, but a hook there cannot substitute what the parent receives —
-//! it can only keep the subagent running — so it maps to no event.
+//! it can only keep the subagent running — so it crosses as the child's
+//! `TurnEnd` and never as its return.
 //! A subagent started with `run_in_background: true` returns through a
 //! task notification no hook observes; the shipped example policies
 //! refuse that argument at the spawn call.
@@ -51,7 +52,7 @@
 //! | `PostToolUseFailure` | `Failure` — the run failed; no effects commit |
 //! | `PostToolUse` with a `tool_response` | `Success` carrying that response's JSON rendering |
 //! | `PostToolUse` with no `tool_response` (absent or null — the wire spells them alike) | `Indeterminate` — no effects commit, the reservation stands |
-//! | no outcome hook at all | nothing is reported; the dispatch stays open |
+//! | no outcome hook at all | nothing is reported; the dispatch stays open until the actor's `TurnEnd` closes it as not run |
 //!
 //! The mapping is total over those shapes. It reads no error shape out
 //! of a `tool_response` body: no recorded live example of one exists,
@@ -313,7 +314,13 @@ fn parse(body: &[u8]) -> Result<Option<HookEvent>, ParseRefusal> {
             })),
             None => Err(malformed("SubagentStart without an agent id")),
         },
-        "SubagentStop" => Ok(None),
+        "Stop" | "StopFailure" => Ok(Some(HookEvent::TurnEnd { actor: event.actor() })),
+        // Without the agent id this would name the root, whose one open
+        // dispatch at this point is the `Agent` spawn still in flight.
+        "SubagentStop" => match event.agent_id.as_deref() {
+            Some(_) => Ok(Some(HookEvent::TurnEnd { actor: event.actor() })),
+            None => Err(malformed("SubagentStop without an agent id")),
+        },
         other => {
             tracing::debug!(hook = other, "hook event outside the codec's mapping");
             Ok(None)
@@ -574,6 +581,28 @@ mod tests {
     }
 
     #[test]
+    fn every_turn_end_hook_names_the_actor_that_finished() {
+        for (hook, child) in [
+            ("Stop", None),
+            ("StopFailure", None),
+            ("SubagentStop", Some(TrajectoryId("cc:s1:a1".to_string()))),
+        ] {
+            let mut body = serde_json::json!({"hook_event_name": hook, "session_id": "s1"});
+            if child.is_some() {
+                body["agent_id"] = serde_json::Value::String("a1".to_string());
+            }
+            let parsed = parse(body.to_string().as_bytes()).expect("the turn end parses");
+            assert_eq!(
+                parsed,
+                Some(HookEvent::TurnEnd {
+                    actor: Actor { root: root(), child },
+                }),
+                "{hook} did not cross as its actor's turn end",
+            );
+        }
+    }
+
+    #[test]
     fn missing_required_fields_are_named_refusals() {
         for (event, detail) in [
             (
@@ -596,6 +625,10 @@ mod tests {
                 serde_json::json!({"hook_event_name": "SubagentStart", "session_id": "s1"}),
                 "SubagentStart without an agent id",
             ),
+            (
+                serde_json::json!({"hook_event_name": "SubagentStop", "session_id": "s1"}),
+                "SubagentStop without an agent id",
+            ),
         ] {
             assert_eq!(
                 parse_value(&event),
@@ -610,7 +643,7 @@ mod tests {
 
     #[test]
     fn unmapped_hooks_parse_to_no_event() {
-        for name in ["Stop", "SubagentStop", "SomethingNew"] {
+        for name in ["PreCompact", "Notification", "SomethingNew"] {
             let event = serde_json::json!({
                 "hook_event_name": name,
                 "session_id": "s1",

--- a/appa-runtime-v2/api/src/lib.rs
+++ b/appa-runtime-v2/api/src/lib.rs
@@ -80,6 +80,11 @@ pub enum HookEvent {
         actor: Actor,
         text: String,
     },
+    /// The actor finished a turn. Nothing it released is still running,
+    /// so a dispatch still open names a call the harness never ran.
+    TurnEnd {
+        actor: Actor,
+    },
     ToolCall {
         actor: Actor,
         call: ProposedCall,

--- a/appa-runtime-v2/runtime/src/api/session.rs
+++ b/appa-runtime-v2/runtime/src/api/session.rs
@@ -188,6 +188,62 @@ impl Session {
         Ok(())
     }
 
+    /// The actor finished a turn. A call still open here got no outcome
+    /// hook and will never get one: Claude Code reports none for a call
+    /// refused at its permission prompt. Left open it refuses every
+    /// later proposal as a second call in flight, for the life of the
+    /// trajectory.
+    ///
+    /// The close is `Indeterminate`, not a failure. What the runtime
+    /// observed is the absence of a report, which does not say whether
+    /// the call ran: an outcome hook that never reached the runtime
+    /// looks the same as a call the harness refused. Indeterminate is
+    /// the outcome for exactly that — the dispatch closes and the
+    /// effect reservation stands, so a real emission is never dropped
+    /// from the ledger on the strength of a missing hook.
+    ///
+    /// Not an engine event when nothing is carried, which is every
+    /// ordinary turn: the view is read, no fact is appended.
+    pub async fn on_turn_end(&mut self) -> Result<(), EventError> {
+        let Some(open) = self.carried_call()? else {
+            tracing::debug!(trajectory = %self.trajectory.0, "turn ended with no call outstanding");
+            return Ok(());
+        };
+        self.abandon_open(&ToolOutcome::Indeterminate).await?;
+        tracing::debug!(
+            trajectory = %self.trajectory.0,
+            dispatch = ?open.id,
+            tool = %open.tool,
+            "call closed as unreported at the turn end",
+        );
+        Ok(())
+    }
+
+    /// The call a turn end closes. A trajectory that has ended or never
+    /// opened carries nothing, so a turn end that names one is a no-op
+    /// rather than a refusal — a turn ends for reasons the engine does
+    /// not model.
+    ///
+    /// A substituted release is never carried. It stands across turns by
+    /// construction: no proposal released it, so no outcome hook is owed
+    /// for it, and it ends only when the harness runs it or proposes
+    /// past it (`claim_or_abandon`). Closing it here would discard the
+    /// remedy that minted it.
+    fn carried_call(&self) -> Result<Option<OpenDispatch>, EventError> {
+        let log = self.inner.log(&self.root)?;
+        let policy = self.inner.resolve_policy(&self.deployment, &log)?;
+        let view = self
+            .inner
+            .engine
+            .rebuild_view(&policy, &log)
+            .map_err(EventError::from)?;
+        match self.inner.engine.liveness(&view, &self.trajectory) {
+            Liveness::Ended | Liveness::Unopened => Ok(None),
+            Liveness::Live if self.inner.engine.substituted_release(&view, &self.trajectory).is_some() => Ok(None),
+            Liveness::Live => Ok(self.inner.engine.open_dispatches(&view, &self.trajectory).pop()),
+        }
+    }
+
     pub async fn on_tool_call(&mut self, call: ProposedCall, spawn: bool) -> Result<ToolCallDecision, EventError> {
         if is_control_tool(&call.tool) {
             tracing::debug!(trajectory = %self.trajectory.0, "control tool passes unchecked");
@@ -276,7 +332,7 @@ impl Session {
         let outcome = ToolOutcome::Failure {
             message: "the harness did not run the substituted call".to_string(),
         };
-        self.abandon_release(&outcome).await?;
+        self.abandon_open(&outcome).await?;
         tracing::debug!(
             trajectory = %self.trajectory.0,
             dispatch = ?open.id,
@@ -287,14 +343,21 @@ impl Session {
         Err(EventError::SubstitutionAbandoned { tool: open.tool })
     }
 
-    async fn abandon_release(&self, outcome: &ToolOutcome) -> Result<EngineDecision, EventError> {
+    /// Close the call this trajectory has open as one that did not run.
+    /// The dispatch is re-read from the view on every replay, so a
+    /// contended append never closes an occurrence the winning writer
+    /// already closed. Both callers reach here with one dispatch open:
+    /// a substituted release the harness declined to run, and a
+    /// released call whose turn ended without an outcome.
+    async fn abandon_open(&self, outcome: &ToolOutcome) -> Result<EngineDecision, EventError> {
         self.drive_with_evidence(
             |context, evidence| {
-                let Some(open) = context.substituted_release() else {
-                    return Err(EventError::CallOutstanding);
+                let open = context.open_dispatches();
+                let [open] = open.as_slice() else {
+                    return Err(EventError::UnknownDispatch);
                 };
                 Ok(EngineEvent::ToolOutcome {
-                    dispatch: open.id,
+                    dispatch: open.id.clone(),
                     outcome: outcome.clone(),
                     evidence,
                     entropy: fresh_entropy(),
@@ -788,13 +851,6 @@ impl Decided<'_> {
             .inner
             .engine
             .open_dispatches(self.view, &self.session.trajectory)
-    }
-
-    fn substituted_release(&self) -> Option<OpenDispatch> {
-        self.session
-            .inner
-            .engine
-            .substituted_release(self.view, &self.session.trajectory)
     }
 
     fn canonical_bytes(&self, call: &ProposedCall) -> Option<Vec<u8>> {
@@ -2852,6 +2908,38 @@ context_control = true
         }
     }
 
+    /// No proposal released the substituted call, so no outcome hook is
+    /// owed for it and a turn that ends before the harness runs it
+    /// leaves it standing. Closing it would discard the remedy.
+    #[tokio::test]
+    async fn a_turn_end_leaves_a_standing_substituted_call_alone() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = Runtime::open(
+            substituting_config(SUBSTITUTED_SEND, None),
+            dir.path().join("appa.db"),
+            None,
+        )
+        .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let hop = narrowed_and_blocked(&runtime, &mut session).await;
+        session.on_remedy(hop, None).await.expect("the hop executes");
+        assert!(standing_release(&runtime).is_some());
+
+        session.on_turn_end().await.expect("the turn end acks");
+
+        assert!(
+            standing_release(&runtime).is_some(),
+            "the substituted call still stands after the turn ended"
+        );
+        assert_eq!(
+            session
+                .on_tool_call(send(REDACTED_BODY), false)
+                .await
+                .expect("the next turn is still handed the substituted call"),
+            ToolCallDecision::Allow { spawn: None },
+        );
+    }
+
     #[tokio::test]
     async fn another_call_while_a_substituted_call_stands_abandons_it() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
@@ -4144,6 +4232,138 @@ context_control = true
             .await
             .expect("with nothing in flight the same end crosses");
         assert!(matches!(runtime.live(&root(), &child("c1")), Err(SessionError::Ended)));
+    }
+
+    /// The harness refused the released call at its permission prompt,
+    /// so no outcome hook fires for it. Without the turn end that
+    /// dispatch would refuse every later proposal for the life of the
+    /// trajectory.
+    #[tokio::test]
+    async fn a_turn_end_closes_the_call_the_harness_never_ran() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
+            .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        assert_eq!(
+            session
+                .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
+                .await
+                .expect("the call releases"),
+            ToolCallDecision::Allow { spawn: None },
+        );
+        assert!(matches!(
+            session.on_tool_call(fetch(serde_json::json!({"a": 2})), false).await,
+            Err(EventError::CallOutstanding),
+        ));
+
+        session.on_turn_end().await.expect("the turn end closes it");
+
+        assert!(runtime.open_dispatches(&root(), &root()).is_empty());
+        assert!(
+            runtime
+                .audit(&root())
+                .expect("the audit reads")
+                .iter()
+                .any(|entry| matches!(
+                    &entry.event,
+                    crate::engine::AuditEvent::Closed {
+                        outcome: crate::engine::DispatchOutcome::Unknown
+                    }
+                )),
+            "the unreported dispatch closed as unknown, not as a run that failed"
+        );
+        assert_eq!(
+            session
+                .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
+                .await
+                .expect("the next turn proposes freely"),
+            ToolCallDecision::Allow { spawn: None },
+        );
+    }
+
+    /// The outcome the close ruled out cannot be reported afterwards:
+    /// a call the log says did not run admits no value.
+    #[tokio::test]
+    async fn an_outcome_reported_after_its_turn_end_is_refused() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
+            .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        session
+            .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
+            .await
+            .expect("the call releases");
+        session.on_turn_end().await.expect("the turn end closes it");
+
+        let error = session
+            .on_tool_result(
+                fetch(serde_json::json!({"a": 1})),
+                ToolOutcome::Success {
+                    body: OutcomeBody::Available("the run did happen".to_string()),
+                },
+            )
+            .await
+            .expect_err("the closed dispatch takes no outcome");
+        assert!(matches!(error, EventError::UnknownDispatch), "got {error:?}");
+    }
+
+    /// A turn end is not an engine event when nothing is outstanding,
+    /// which is every ordinary turn.
+    #[tokio::test]
+    async fn a_turn_end_over_a_settled_trajectory_appends_nothing() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
+            .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        session
+            .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
+            .await
+            .expect("the call releases");
+        session
+            .on_tool_result(
+                fetch(serde_json::json!({"a": 1})),
+                ToolOutcome::Success {
+                    body: OutcomeBody::Available("body".to_string()),
+                },
+            )
+            .await
+            .expect("the outcome closes the dispatch");
+
+        let settled = runtime.log_facts(&root()).len();
+        session.on_turn_end().await.expect("the turn end acks");
+        session.on_turn_end().await.expect("a repeat acks too");
+        assert_eq!(runtime.log_facts(&root()).len(), settled, "no fact is appended");
+    }
+
+    /// A child carries its own dispatches, and one left open holds the
+    /// child's return at the boundary.
+    #[tokio::test]
+    async fn a_child_turn_end_closes_its_abandoned_call_so_the_child_can_end() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
+            .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let mut child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child("c1")).await;
+        child_session
+            .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
+            .await
+            .expect("the child's call releases");
+
+        let error = child_session
+            .on_child_end(Some("done".to_string()))
+            .await
+            .expect_err("a child with a call still open does not end");
+        assert!(matches!(error, EventError::ChildDispatchOpen), "got {error:?}");
+
+        child_session
+            .on_turn_end()
+            .await
+            .expect("the child's turn end closes it");
+        assert!(runtime.open_dispatches(&root(), &child("c1")).is_empty());
+        child_session
+            .on_child_end(Some("done".to_string()))
+            .await
+            .expect("with nothing in flight the child ends");
     }
 
     #[tokio::test]

--- a/appa-runtime-v2/runtime/src/hooks.rs
+++ b/appa-runtime-v2/runtime/src/hooks.rs
@@ -50,6 +50,23 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
                 Err(error) => fold(error, block),
             }
         }
+        HookEvent::TurnEnd { actor } => {
+            // A turn end gates nothing, so it answers `Ack` whatever
+            // happens. The refusal families both mean "do not end the
+            // turn" on this hook, which would hold the harness in a turn
+            // it has finished; a close that failed leaves the call open
+            // and the next proposal refuses on its own.
+            if let Err(error) = on_actor(
+                runtime,
+                &actor,
+                |mut session| async move { session.on_turn_end().await },
+            )
+            .await
+            {
+                tracing::warn!(root = %actor.root.0, %error, "the turn end closed no abandoned call");
+            }
+            HookDecision::Ack
+        }
         HookEvent::ToolCall { actor, call, spawn } => {
             if is_control_tool(&call.tool) {
                 return control_call(runtime, &actor, &call);
@@ -341,6 +358,70 @@ mod tests {
                 ),
             }
         }
+    }
+
+    /// On this hook every refusal family means "do not end the turn",
+    /// so a turn end answers with no opinion whatever the close did —
+    /// including for a session the runtime never opened.
+    #[tokio::test]
+    async fn a_turn_end_answers_with_no_opinion_even_over_an_unknown_session() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_real_runtime(&dir);
+        for hook in ["Stop", "StopFailure", "SubagentStop"] {
+            let mut body = serde_json::json!({
+                "hook_event_name": hook,
+                "session_id": "never-opened",
+                "last_assistant_message": "the summary",
+            });
+            if hook == "SubagentStop" {
+                body["agent_id"] = serde_json::Value::String("a1".to_string());
+            }
+            let (status, answer) = call_hook(&runtime, &serde_json::to_vec(&body).expect("re-serializes")).await;
+            assert_eq!(
+                (status, answer),
+                (200, serde_json::json!({})),
+                "the {hook} hook blocked"
+            );
+        }
+    }
+
+    /// The wedge this hook exists to clear: a released call the harness
+    /// never ran refuses every later proposal until the turn ends.
+    #[tokio::test]
+    async fn a_turn_end_frees_a_trajectory_the_missing_outcome_wedged() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_real_runtime(&dir);
+        let propose = |command: &str| {
+            serde_json::json!({
+                "hook_event_name": "PreToolUse",
+                "session_id": "s1",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            })
+        };
+        let released = call_hook(&runtime, &serde_json::to_vec(&propose("ls")).expect("re-serializes")).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+
+        // The harness refused it at its permission prompt: no outcome hook fires.
+        let wedged = call_hook(
+            &runtime,
+            &serde_json::to_vec(&propose("echo hi")).expect("re-serializes"),
+        )
+        .await;
+        assert_eq!(wedged.1["hookSpecificOutput"]["permissionDecision"], "deny");
+
+        let stop = serde_json::json!({"hook_event_name": "Stop", "session_id": "s1"});
+        assert_eq!(
+            call_hook(&runtime, &serde_json::to_vec(&stop).expect("re-serializes")).await,
+            (200, serde_json::json!({})),
+        );
+
+        let freed = call_hook(
+            &runtime,
+            &serde_json::to_vec(&propose("echo hi")).expect("re-serializes"),
+        )
+        .await;
+        assert_eq!(freed.1["hookSpecificOutput"]["permissionDecision"], "allow");
     }
 
     #[tokio::test]

--- a/appa-runtime-v2/runtime/tests/api_shape.rs
+++ b/appa-runtime-v2/runtime/tests/api_shape.rs
@@ -52,6 +52,11 @@ fn the_declared_vocabulary(event: HookEvent, decision: HookDecision, refusal: Pa
             let _: Option<TrajectoryId> = child;
             let _: String = text;
         }
+        HookEvent::TurnEnd { actor } => {
+            let Actor { root, child } = actor;
+            let _: TrajectoryId = root;
+            let _: Option<TrajectoryId> = child;
+        }
         HookEvent::ToolCall { actor: _, call, spawn } => {
             let ProposedCall { tool, arguments } = call;
             let _: String = tool;

--- a/appa-runtime-v2/runtime/tests/plugin_hooks.rs
+++ b/appa-runtime-v2/runtime/tests/plugin_hooks.rs
@@ -4,28 +4,78 @@ use std::process::{Command, Stdio};
 use axum::Router;
 use axum::routing::post;
 
+/// The hooks that report a finished turn. Every blocking outcome on one
+/// of these means "do not stop", so none of them may carry one.
+const TURN_ENDS: [&str; 3] = ["Stop", "StopFailure", "SubagentStop"];
+
+fn turn_end_command() -> &'static str {
+    "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" \
+     -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+}
+
+fn shipped(file: &str) -> serde_json::Value {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../integrations/claude-code/plugin/hooks")
+        .join(file);
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap_or_else(|_| panic!("the shipped {file} is readable")))
+        .unwrap_or_else(|_| panic!("the shipped {file} parses"))
+}
+
+/// The two shipped hook maps gate the same events. Nothing else compares
+/// them, so a hook added to one and not the other leaves that platform
+/// on the behaviour the other one fixed.
+#[test]
+fn both_shipped_hook_maps_gate_the_same_events() {
+    let posix = shipped("hooks.json");
+    let windows = shipped("hooks.windows.json");
+    let names = |map: &serde_json::Value| {
+        let mut names: Vec<String> = map["hooks"]
+            .as_object()
+            .expect("the hook map is an object")
+            .keys()
+            .cloned()
+            .collect();
+        names.sort();
+        names
+    };
+    assert_eq!(
+        names(&posix),
+        names(&windows),
+        "the shipped hook maps gate different events"
+    );
+    for event in TURN_ENDS {
+        assert!(
+            windows["hooks"][event][0]["hooks"][0]["command"].is_string(),
+            "the Windows map does not gate {event}",
+        );
+    }
+}
+
 fn shipped_command() -> String {
-    let path =
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../integrations/claude-code/plugin/hooks/hooks.json");
-    let hooks: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(path).expect("the shipped hooks.json is readable"))
-            .expect("the shipped hooks.json parses");
+    let hooks = shipped("hooks.json");
     let command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
         .as_str()
         .expect("the PreToolUse hook carries a command")
         .to_string();
-    for event in [
-        "UserPromptSubmit",
-        "PostToolUse",
-        "SubagentStart",
-        "SubagentStop",
-        "PostToolUseFailure",
-    ] {
+    for event in ["UserPromptSubmit", "PostToolUse", "SubagentStart", "PostToolUseFailure"] {
         let entry = &hooks["hooks"][event][0]["hooks"][0]["command"];
         assert_eq!(
             entry.as_str(),
             Some(command.as_str()),
             "the {event} hook command drifted from the PreToolUse one",
+        );
+    }
+    // A turn end decides nothing, and blocking this hook holds the actor
+    // in a turn it has finished, so these three never carry the blocking
+    // exit and never print an answer.
+    for event in TURN_ENDS {
+        let entry = hooks["hooks"][event][0]["hooks"][0]["command"]
+            .as_str()
+            .unwrap_or_else(|| panic!("the {event} hook carries a command"));
+        assert_eq!(
+            entry,
+            turn_end_command(),
+            "the {event} hook is no longer the non-blocking turn-end command",
         );
     }
     assert_eq!(
@@ -136,6 +186,19 @@ async fn an_ungated_session_posts_nothing_and_never_blocks() {
         .expect("the blocking task joins");
     assert_eq!(code, 0, "an ungated session must not be blocked");
     assert_eq!(stdout, "", "an ungated session posts nothing");
+}
+
+/// Blocking a turn end holds the actor in a turn it has finished, so a
+/// runtime that answers nothing costs a call left open, never a turn
+/// that cannot end.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unreachable_runtime_never_blocks_a_turn_end() {
+    let url = refused_url().await;
+    let (code, stdout) = tokio::task::spawn_blocking(move || run_hook(turn_end_command(), &url))
+        .await
+        .expect("the blocking task joins");
+    assert_eq!(code, 0, "a turn end must never block the harness");
+    assert_eq!(stdout, "", "a turn end prints no decision");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -73,6 +73,11 @@ function Start-RuntimeIfDown {
     }
 }
 
+# The hooks that report a finished turn. They decide nothing, so they
+# never block, and they take the shorter deadline: a turn end waits on
+# no evidence round trip.
+$turnEnds = @("Stop", "StopFailure", "SubagentStop")
+
 try {
     $payload = [Console]::In.ReadToEnd()
     $hookInput = $null
@@ -84,11 +89,20 @@ try {
     if ($null -ne $hookInput -and $hookInput.hook_event_name -eq "SessionStart") {
         Start-RuntimeIfDown
     }
+    $timeout = if ($null -ne $hookInput -and $turnEnds -contains $hookInput.hook_event_name) { 30 } else { 120 }
     $response = Invoke-WebRequest -Uri "$runtimeUrl/hook" -Method Post `
-        -ContentType "application/json" -Body $payload -TimeoutSec 120 -UseBasicParsing
+        -ContentType "application/json" -Body $payload -TimeoutSec $timeout -UseBasicParsing
     [Console]::Out.Write([string]$response.Content)
 } catch {
     $failure = $_.Exception.Message
+    # A turn end decides nothing, and every blocking outcome on these
+    # hooks means "do not stop", which would hold the actor in a turn it
+    # has finished. A runtime that does not answer costs a call left
+    # open, which the next turn end closes.
+    if ($null -ne $hookInput -and $turnEnds -contains $hookInput.hook_event_name) {
+        [Console]::Error.WriteLine("OpenAPPA runtime did not answer the turn end: $failure")
+        exit 0
+    }
     if ($null -ne $hookInput -and $hookInput.hook_event_name -eq "PostToolUse") {
         @{
             decision = "block"

--- a/integrations/claude-code/plugin/hooks/hooks.json
+++ b/integrations/claude-code/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and SessionStart prints beta-announcement.md instead of the protection context — a one-line invitation to try clappa — or, when the runtime binary is not installed, setup-appa.md: instructions for the model to offer and perform the install as a prompted task, prefixed with the resolved install target so the instructions and the hooks' binary lookup cannot disagree on the path. In a protected session every hook posts its event to the appa-runtime-v2 process and prints the runtime's answer. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health. curl --fail-with-body exits non-zero on a non-2xx answer and on a connection failure; plain curl exits 0 on server errors and would fail open. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. The context hook is advice, not enforcement, so its failure does not block.",
+  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and SessionStart prints beta-announcement.md instead of the protection context — a one-line invitation to try clappa — or, when the runtime binary is not installed, setup-appa.md: instructions for the model to offer and perform the install as a prompted task, prefixed with the resolved install target so the instructions and the hooks' binary lookup cannot disagree on the path. In a protected session every hook posts its event to the appa-runtime-v2 process and prints the runtime's answer. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health. curl --fail-with-body exits non-zero on a non-2xx answer and on a connection failure; plain curl exits 0 on server errors and would fail open. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They discard the answer and always exit 0, and take the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
   "hooks": {
     "SessionStart": [
       {
@@ -47,6 +47,26 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [
@@ -62,7 +82,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
           }
         ]
       }

--- a/integrations/claude-code/plugin/hooks/hooks.windows.json
+++ b/integrations/claude-code/plugin/hooks/hooks.windows.json
@@ -1,5 +1,5 @@
 {
-  "description": "Native Windows hooks post every event to appa-runtime-v2 through PowerShell. hook.ps1 protects only sessions launched with APPA_GATE=1 (the clappa function); without the variable it exits 0 and -SessionContext prints beta-announcement.md, a one-line invitation to try clappa — or setup-appa.md when the runtime binary is not installed, which has the model offer the install as a prompted task. In a protected session hook.ps1 blocks prompt and tool authorization failures and returns a structured block when a successful tool result cannot be admitted. SessionStart first starts the installed runtime when nothing healthy answers /health. The hook deadline outlasts the runtime's own 120-second evidence deadline. SessionStart also prints session-context.md as non-enforcing guidance.",
+  "description": "Native Windows hooks post every event to appa-runtime-v2 through PowerShell. hook.ps1 protects only sessions launched with APPA_GATE=1 (the clappa function); without the variable it exits 0 and -SessionContext prints beta-announcement.md, a one-line invitation to try clappa — or setup-appa.md when the runtime binary is not installed, which has the model offer the install as a prompted task. In a protected session hook.ps1 blocks prompt and tool authorization failures and returns a structured block when a successful tool result cannot be admitted. SessionStart first starts the installed runtime when nothing healthy answers /health. The hook deadline outlasts the runtime's own 120-second evidence deadline. SessionStart also prints session-context.md as non-enforcing guidance. Stop, StopFailure and SubagentStop are the exception to the blocking exit: they report a finished turn, which decides nothing, and blocking there holds the actor in a turn it has already finished, so hook.ps1 exits 0 for them and takes the shorter deadline. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
   "hooks": {
     "SessionStart": [
       {
@@ -57,6 +57,30 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
+            "timeout": 40
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
+            "timeout": 40
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [
@@ -76,7 +100,7 @@
             "type": "command",
             "command": "powershell.exe",
             "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
-            "timeout": 130
+            "timeout": 40
           }
         ]
       }


### PR DESCRIPTION
A tool call refused at Claude Code's permission prompt fires no outcome hook. Its dispatch stayed open, and `drive` then refused every later proposal as a second call in flight (`a call is already outstanding`) for the life of the trajectory — surviving `SessionStart`, so `/resume` did not clear it either.

## Changes

- `HookEvent::TurnEnd`, mapped from `Stop`, `StopFailure` and `SubagentStop`. `SubagentStop` previously mapped to no event; without an `agent_id` it now refuses as malformed rather than naming the root, whose one open dispatch at that point is the `Agent` spawn.
- `Session::on_turn_end` closes a carried call as `Indeterminate`. What the runtime observed is the absence of a report, which does not say whether the call ran — an outcome hook that never arrived looks the same as a refused call. `Indeterminate` closes the dispatch and leaves the effect reservation standing, so a real emission is never dropped from the ledger on the strength of a missing hook. Nothing is appended when no call is carried, which is every ordinary turn.
- A standing substituted release is left alone: no proposal released it, so no outcome is owed for it and it stands across turns until the harness runs it or proposes past it.
- `abandon_release` becomes `abandon_open`, keyed on the trajectory's open dispatch rather than on `substituted_release` — the latter matches only dispatches no proposal released, so it could never close this one.
- Turn-end hooks never block. Every blocking outcome on `Stop` means "do not stop", so a runtime that is down would otherwise hold the harness in a turn it has finished. They discard the answer, exit 0, and take a shorter deadline since they wait on no evidence round trip. `hooks.windows.json` gains the same three hooks and `hook.ps1` exits 0 for them.

## Tests

Nine added, covering: the wedge clears at the turn end and the close records `Unknown`; an outcome reported after the close is refused; a settled trajectory appends nothing; a standing substituted call survives; a child's turn end unblocks its return; both shipped hook maps gate the same events; an unreachable runtime never blocks a turn end.

`cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --check` clean; 38/38 test binaries pass. `hook.ps1` is unverified by execution — no PowerShell available on the authoring machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMCex7nFSbnyEJQE4HhAHm
