### PR TITLE
runtime: policy_path on the status read; a zero-rule baseline; the sync skill generates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ claude "set up APPA from this repo for local development"
 ```
 
 Claude starts the dev runtime from source on its own port and prints
-the command that starts a protected session against it. The steps live in
-the [integration guide](integrations/claude-code/README.md).
+the command that starts a protected session against it. For plugin
+work, point the `clappa` shim at the checkout with `--plugin-dir` so
+every prompt file is read live. The steps for both live in the
+[integration guide](integrations/claude-code/README.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
 ## Development
 
 ```sh
-claude "set up APPA from this repo for local development"   # runtime work
-claude "point clappa at this repo's plugin"                 # plugin work
+claude "set up APPA from this repo for local development"
 ```
 
-The first starts the dev runtime from source on its own port and
-prints the command that starts a protected session against it. The
-second makes protected sessions read the plugin's prompt files live
-from the checkout. The steps for both live in the
+Claude starts the dev runtime from source on its own port, points
+`clappa` at the checkout's plugin so protected sessions read the
+prompt files live, and prints the command that starts a protected
+session against the dev runtime. The steps live in the
 [integration guide](integrations/claude-code/README.md).
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
 ## Development
 
 ```sh
-claude "set up APPA from this repo for local development"
+claude "set up APPA from this repo for local development"   # runtime work
+claude "point clappa at this repo's plugin"                 # plugin work
 ```
 
-Claude starts the dev runtime from source on its own port and prints
-the command that starts a protected session against it. For plugin
-work, point the `clappa` shim at the checkout with `--plugin-dir` so
-every prompt file is read live. The steps for both live in the
+The first starts the dev runtime from source on its own port and
+prints the command that starts a protected session against it. The
+second makes protected sessions read the plugin's prompt files live
+from the checkout. The steps for both live in the
 [integration guide](integrations/claude-code/README.md).
 
 ## Documentation

--- a/appa-runtime-v2/runtime/src/main.rs
+++ b/appa-runtime-v2/runtime/src/main.rs
@@ -193,14 +193,31 @@ struct StatusQuery {
     trajectory: String,
 }
 
+/// The status wire answer: the trajectory's projection plus
+/// `policy_path`, the canonical path of the served `--config` file.
+/// The path is a fact of this process, not the log, so it joins the
+/// answer here and never enters `TrajectoryStatus`.
+#[derive(serde::Serialize)]
+struct StatusBody {
+    #[serde(flatten)]
+    status: appa_runtime_v2::api::TrajectoryStatus,
+    policy_path: String,
+}
+
+/// The statusline's read: a projection of the log rendered to strings.
+/// Every refusal is 404 — the statusline fails open to its badge, and
+/// the diagnostic detail stays in this process's tracing.
 async fn status(
     State(state): State<AppState>,
     query: Result<axum::extract::Query<StatusQuery>, axum::extract::rejection::QueryRejection>,
-) -> Result<axum::Json<appa_runtime_v2::api::TrajectoryStatus>, axum::http::StatusCode> {
+) -> Result<axum::Json<StatusBody>, axum::http::StatusCode> {
     let query = query.map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
     let id = appa_runtime_v2::api::TrajectoryId(query.0.trajectory);
     match state.runtime.status(&id) {
-        Some(status) => Ok(axum::Json(status)),
+        Some(status) => Ok(axum::Json(StatusBody {
+            status,
+            policy_path: state.config.display().to_string(),
+        })),
         None => Err(axum::http::StatusCode::NOT_FOUND),
     }
 }
@@ -256,7 +273,9 @@ async fn main() -> ExitCode {
     let state = AppState {
         runtime: Arc::clone(&runtime),
         codec: args.adapter.codec(),
-        config: args.config,
+        // Canonical, so the status read reports a path any consumer can
+        // open regardless of this process's working directory.
+        config: args.config.canonicalize().unwrap_or(args.config),
         adapter: args.adapter,
         instance_id,
     };

--- a/appa-runtime-v2/runtime/tests/claude_code_subagent.rs
+++ b/appa-runtime-v2/runtime/tests/claude_code_subagent.rs
@@ -43,9 +43,36 @@ fn as_root(mut event: serde_json::Value) -> serde_json::Value {
     event
 }
 
+/// The shipped example names its tools without a `delta` on purpose:
+/// results are admitted as fully unknown until a generated rule says
+/// otherwise. These scenarios are about return crossings, not label
+/// generation, so they pin the neutral annotation — `delta = {}` on
+/// every tool the example leaves unannotated — to keep the labels the
+/// crossings reason about definite.
+fn neutralized(example: &str) -> String {
+    let mut parts = example.split("[[policy.tool]]");
+    let mut out = parts.next().expect("the example has a preamble").to_string();
+    for part in parts {
+        out.push_str("[[policy.tool]]");
+        if part.contains("delta =") {
+            out.push_str(part);
+            continue;
+        }
+        let name = part.find("name = ").expect("every tool names itself");
+        let line_end = part[name..].find('\n').expect("the name line ends") + name + 1;
+        out.push_str(&part[..line_end]);
+        out.push_str("delta = {}\n");
+        out.push_str(&part[line_end..]);
+    }
+    out
+}
+
+/// The shipped example deployment, plus whatever policy tables the
+/// scenario adds inside `[policy]` and after `[externals]`.
 fn deployment(policy_extra: &str, externals_extra: &str) -> Runtime {
     let example = std::fs::read_to_string(repo_root().join("integrations/claude-code/examples/claude-code.appa.toml"))
         .expect("the shipped example is readable");
+    let example = neutralized(&example);
     let (policy, externals) = example
         .split_once("[externals]")
         .expect("the example carries an [externals] table");

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -152,6 +152,23 @@ session performing this setup runs the first two and prints the third.
 running session cannot be pointed at a different runtime. To move
 between the installed and the dev runtime, start a new session.
 
+For plugin work — hooks, skills, the setup and session prompts — make
+`clappa` itself load the plugin from the checkout, so every prompt
+file is read live at session start and an edit needs no reinstall or
+cache refresh. Replace the shim's body:
+
+```sh
+#!/bin/sh
+exec env APPA_GATE=1 claude --plugin-dir "/path/to/OpenAPPA/integrations/claude-code/plugin" "$@"
+```
+
+Uninstall the marketplace plugin while the shim carries the flag —
+`claude plugin uninstall appa-runtime` — because a plugin loaded twice
+fires every hook twice. The flag changes where the prompts come from,
+not which runtime serves: the session still gates through the runtime
+its environment selects. When the work merges, reinstall
+`appa-runtime@appa` and drop the flag.
+
 ## Upgrade
 
 The plugin tracks the marketplace. To upgrade the runtime, remove the

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -130,50 +130,42 @@ servers, proposes one policy entry per tool, and marks which tools read data
 that must stay in the session or send data outward. It asks once about servers
 it cannot judge. You review the complete proposal before it writes anything.
 
-For development from a source checkout, run the runtime on its own port
-so an installed runtime on 8787 is untouched, and point a session at it
-with `APPA_RUNTIME_URL` — the hooks, the MCP server, and the statusline
-all follow it:
+For development from a source checkout, one setup covers the runtime
+and the plugin. The dev runtime runs from source on its own port, so
+an installed runtime on 8787 is untouched; `clappa` loads the plugin
+from the checkout, so every prompt file — hooks, skills, the setup and
+session prompts — is read live at session start, and an edit needs no
+reinstall or cache refresh. A Claude session performing this setup
+does all of it and prints the last command instead of running it —
+it is interactive and belongs to the user:
 
 ```sh
 cp integrations/claude-code/examples/claude-code.appa.toml appa.toml
 nohup cargo run --bin appa-runtime-v2 -- --config appa.toml --db appa.db --listen 127.0.0.1:8788 >appa-runtime.log 2>&1 &
+claude plugin uninstall appa-runtime
 APPA_GATE=1 APPA_RUNTIME_URL=http://127.0.0.1:8788 claude --plugin-dir integrations/claude-code/plugin
 ```
 
-The statusline follows the same runtime: its chips and its policy
-statistics both come from the runtime's status read, which names the
-served policy's path.
+and rewrites the `clappa` shim's body:
 
-The last command is interactive and belongs to the user: a Claude
-session performing this setup runs the first two and prints the third.
+```sh
+#!/bin/sh
+exec env APPA_GATE=1 claude --plugin-dir "/path/to/OpenAPPA/integrations/claude-code/plugin" "$@"
+```
+
+The uninstall matters: a plugin loaded twice fires every hook twice.
+The `--plugin-dir` flag changes where the prompts come from, not which
+runtime serves — `clappa` still gates through the installed runtime,
+while the printed command gates through the dev one. The statusline
+follows whichever runtime the session gates through: its chips and its
+policy statistics both come from the runtime's status read, which
+names the served policy's path.
 
 `APPA_RUNTIME_URL` is fixed at session launch, like `APPA_GATE`: a
 running session cannot be pointed at a different runtime. To move
-between the installed and the dev runtime, start a new session.
-
-For plugin work — hooks, skills, the setup and session prompts — make
-`clappa` itself load the plugin from the checkout, so every prompt
-file is read live at session start and an edit needs no reinstall or
-cache refresh. A Claude session asked to point clappa at this repo's
-plugin performs two steps and reports the revert, without explaining
-the mechanics:
-
-1. Replace the `clappa` shim's body:
-
-   ```sh
-   #!/bin/sh
-   exec env APPA_GATE=1 claude --plugin-dir "/path/to/OpenAPPA/integrations/claude-code/plugin" "$@"
-   ```
-
-2. Uninstall the marketplace plugin — `claude plugin uninstall
-   appa-runtime` — because a plugin loaded twice fires every hook
-   twice.
-
-The flag changes where the prompts come from, not which runtime
-serves: the session still gates through the runtime its environment
-selects. The revert, once the work merges: reinstall
-`appa-runtime@appa` and drop the flag.
+between the installed and the dev runtime, start a new session. The
+revert, once the work merges: reinstall `appa-runtime@appa` and drop
+the flag from the shim.
 
 ## Upgrade
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -178,11 +178,12 @@ cannot set it. In a protected session the script shows the APPA pixel
 mascot plus the session's current Trust and Audience, read from the
 process's `GET /status`, and a second row with the policy's tool
 counts: `tools:` is every `[[policy.tool]]` entry in the deployment's
-`appa.toml`, `rules:` the entries carrying more than the neutral
-annotation, and the row names `/appa-tool-sync` as the skill that adds
-rules. In an unprotected session it shows the mascot with a reminder
-that `clappa` starts a protected session, and never queries the
-runtime. Both platform scripts fail open: runtime down, unknown
+`appa.toml`, `rules:` the entries carrying label rules (an argument
+pin such as `parameters` constrains a call and labels nothing, so it
+does not count), and the row names `/appa-tool-sync` as the skill that
+adds rules. In an unprotected session it shows the mascot with a
+reminder that `clappa` starts a protected session, and never queries
+the runtime. Both platform scripts fail open: runtime down, unknown
 trajectory, or malformed input prints the mascot alone, never a blocked
 action. The POSIX script also needs `jq` and `curl`.
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -172,9 +172,12 @@ statusline setting separately if you created them.
 Claude Code reads `statusLine` only from your own settings — a plugin
 cannot set it. In a protected session the script shows the APPA pixel
 mascot plus the session's current Trust and Audience, read from the
-process's `GET /status`. In an unprotected session it shows the mascot
-with a reminder that `clappa` starts a protected session, and never
-queries the
+process's `GET /status`, and a second row with the policy's tool
+counts: `tools:` is every `[[policy.tool]]` entry in the deployment's
+`appa.toml`, `rules:` the entries carrying more than the neutral
+annotation, and the row names `/appa-tool-sync` as the skill that adds
+rules. In an unprotected session it shows the mascot with a reminder
+that `clappa` starts a protected session, and never queries the
 runtime. Both platform scripts fail open: runtime down, unknown
 trajectory, or malformed input prints the mascot alone, never a blocked
 action. The POSIX script also needs `jq` and `curl`.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -138,8 +138,11 @@ all follow it:
 ```sh
 cp integrations/claude-code/examples/claude-code.appa.toml appa.toml
 nohup cargo run --bin appa-runtime-v2 -- --config appa.toml --db appa.db --listen 127.0.0.1:8788 >appa-runtime.log 2>&1 &
-APPA_GATE=1 APPA_RUNTIME_URL=http://127.0.0.1:8788 claude --plugin-dir integrations/claude-code/plugin
+APPA_GATE=1 APPA_RUNTIME_URL=http://127.0.0.1:8788 APPA_CONFIG_DIR="$PWD" claude --plugin-dir integrations/claude-code/plugin
 ```
+
+`APPA_CONFIG_DIR` points the statusline's policy statistics at the dev
+`appa.toml`; without it they read the platform-default policy.
 
 The last command is interactive and belongs to the user: a Claude
 session performing this setup runs the first two and prints the third.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -155,18 +155,24 @@ between the installed and the dev runtime, start a new session.
 For plugin work — hooks, skills, the setup and session prompts — make
 `clappa` itself load the plugin from the checkout, so every prompt
 file is read live at session start and an edit needs no reinstall or
-cache refresh. Replace the shim's body:
+cache refresh. A Claude session asked to point clappa at this repo's
+plugin performs two steps and reports the revert, without explaining
+the mechanics:
 
-```sh
-#!/bin/sh
-exec env APPA_GATE=1 claude --plugin-dir "/path/to/OpenAPPA/integrations/claude-code/plugin" "$@"
-```
+1. Replace the `clappa` shim's body:
 
-Uninstall the marketplace plugin while the shim carries the flag —
-`claude plugin uninstall appa-runtime` — because a plugin loaded twice
-fires every hook twice. The flag changes where the prompts come from,
-not which runtime serves: the session still gates through the runtime
-its environment selects. When the work merges, reinstall
+   ```sh
+   #!/bin/sh
+   exec env APPA_GATE=1 claude --plugin-dir "/path/to/OpenAPPA/integrations/claude-code/plugin" "$@"
+   ```
+
+2. Uninstall the marketplace plugin — `claude plugin uninstall
+   appa-runtime` — because a plugin loaded twice fires every hook
+   twice.
+
+The flag changes where the prompts come from, not which runtime
+serves: the session still gates through the runtime its environment
+selects. The revert, once the work merges: reinstall
 `appa-runtime@appa` and drop the flag.
 
 ## Upgrade

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -138,11 +138,12 @@ all follow it:
 ```sh
 cp integrations/claude-code/examples/claude-code.appa.toml appa.toml
 nohup cargo run --bin appa-runtime-v2 -- --config appa.toml --db appa.db --listen 127.0.0.1:8788 >appa-runtime.log 2>&1 &
-APPA_GATE=1 APPA_RUNTIME_URL=http://127.0.0.1:8788 APPA_CONFIG_DIR="$PWD" claude --plugin-dir integrations/claude-code/plugin
+APPA_GATE=1 APPA_RUNTIME_URL=http://127.0.0.1:8788 claude --plugin-dir integrations/claude-code/plugin
 ```
 
-`APPA_CONFIG_DIR` points the statusline's policy statistics at the dev
-`appa.toml`; without it they read the platform-default policy.
+The statusline follows the same runtime: its chips and its policy
+statistics both come from the runtime's status read, which names the
+served policy's path.
 
 The last command is interactive and belongs to the user: a Claude
 session performing this setup runs the first two and prints the third.

--- a/integrations/claude-code/examples/claude-code-hitl.appa.toml
+++ b/integrations/claude-code/examples/claude-code-hitl.appa.toml
@@ -45,173 +45,131 @@ version = 1
 [[policy.tool]]
 name = "Agent"
 parameters = { type = "object", additionalProperties = true, properties = { run_in_background = { type = "boolean", const = false } } }
-delta = {}
 
 [[policy.tool]]
 name = "AskUserQuestion"
-delta = {}
 
 [[policy.tool]]
 name = "Artifact"
-delta = {}
 
 [[policy.tool]]
 name = "Bash"
-delta = {}
 
 [[policy.tool]]
 name = "BashOutput"
-delta = {}
 
 [[policy.tool]]
 name = "CronCreate"
-delta = {}
 
 [[policy.tool]]
 name = "CronDelete"
-delta = {}
 
 [[policy.tool]]
 name = "CronList"
-delta = {}
 
 [[policy.tool]]
 name = "Edit"
-delta = {}
 
 [[policy.tool]]
 name = "EnterPlanMode"
-delta = {}
 
 [[policy.tool]]
 name = "EnterWorktree"
-delta = {}
 
 [[policy.tool]]
 name = "ExitPlanMode"
-delta = {}
 
 [[policy.tool]]
 name = "ExitWorktree"
-delta = {}
 
 [[policy.tool]]
 name = "Glob"
-delta = {}
 
 [[policy.tool]]
 name = "Grep"
-delta = {}
 
 [[policy.tool]]
 name = "KillShell"
-delta = {}
 
 [[policy.tool]]
 name = "LSP"
-delta = {}
 
 [[policy.tool]]
 name = "ListAgents"
-delta = {}
 
 [[policy.tool]]
 name = "ListMcpResourcesTool"
-delta = {}
 
 [[policy.tool]]
 name = "Monitor"
-delta = {}
 
 [[policy.tool]]
 name = "NotebookEdit"
-delta = {}
 
 [[policy.tool]]
 name = "PushNotification"
-delta = {}
 
 [[policy.tool]]
 name = "Read"
-delta = {}
 
 [[policy.tool]]
 name = "ReadMcpResourceDirTool"
-delta = {}
 
 [[policy.tool]]
 name = "ReadMcpResourceTool"
-delta = {}
 
 [[policy.tool]]
 name = "ReportFindings"
-delta = {}
 
 [[policy.tool]]
 name = "ScheduleWakeup"
-delta = {}
 
 [[policy.tool]]
 name = "SendMessage"
-delta = {}
 
 [[policy.tool]]
 name = "SendUserFile"
-delta = {}
 
 [[policy.tool]]
 name = "Skill"
-delta = {}
 
 [[policy.tool]]
 name = "SlashCommand"
-delta = {}
 
 # `Task` is the earlier name of `Agent`: the same spawn, the same contract.
 [[policy.tool]]
 name = "Task"
 parameters = { type = "object", additionalProperties = true, properties = { run_in_background = { type = "boolean", const = false } } }
-delta = {}
 
 [[policy.tool]]
 name = "TaskCreate"
-delta = {}
 
 [[policy.tool]]
 name = "TaskGet"
-delta = {}
 
 [[policy.tool]]
 name = "TaskList"
-delta = {}
 
 [[policy.tool]]
 name = "TaskOutput"
-delta = {}
 
 [[policy.tool]]
 name = "TaskStop"
-delta = {}
 
 [[policy.tool]]
 name = "TaskUpdate"
-delta = {}
 
 [[policy.tool]]
 name = "TodoWrite"
-delta = {}
 
 [[policy.tool]]
 name = "ToolSearch"
-delta = {}
 
 [[policy.tool]]
 name = "Workflow"
-delta = {}
 
 [[policy.tool]]
 name = "Write"
-delta = {}
 
 # --- tools that bring outside content into the session ---
 
@@ -232,7 +190,6 @@ delta = { trust = "suspicious" }
 
 [[policy.tool]]
 name = "mcp__github__get_me"
-delta = {}
 
 [[policy.tool]]
 name = "mcp__github__search_issues"

--- a/integrations/claude-code/examples/claude-code-hitl.appa.toml
+++ b/integrations/claude-code/examples/claude-code-hitl.appa.toml
@@ -176,11 +176,9 @@ name = "Write"
 # Web pages and search results are authored outside the session.
 [[policy.tool]]
 name = "WebFetch"
-delta = { trust = "suspicious" }
 
 [[policy.tool]]
 name = "WebSearch"
-delta = { trust = "suspicious" }
 
 # --- GitHub, through the GitHub MCP server ---
 #

--- a/integrations/claude-code/examples/claude-code.appa.toml
+++ b/integrations/claude-code/examples/claude-code.appa.toml
@@ -9,11 +9,15 @@
 # exactly the combination of its sources, unchanged; this starting
 # policy makes no such claim for you.
 #
-# Tools that bring outside content into the session — the web tools —
-# carry `delta = { trust = "suspicious" }` instead: their results
-# enter at the low rank of the default trust chain
-# (suspicious < trusted), so a `requires = { trust = "trusted" }` sink
-# never receives them undeclared.
+# The web tools are unannotated like the rest: unknown already fails
+# closed at every declared sink. A generated rule typically gives them
+# `delta = { trust = "suspicious" }` — a definite low rank on the
+# default trust chain (suspicious < trusted) — once reviewed.
+#
+# The only entries carrying more than a name are the `Agent` and `Task`
+# argument pins (`run_in_background = false`): structural, not label
+# rules — the runtime refuses to serve this deployment without them,
+# because a background subagent returns where no hook can check it.
 #
 # The built-in tool set varies by Claude Code version; regenerate the
 # list from a live session when it drifts.
@@ -163,11 +167,9 @@ name = "Write"
 # Web pages and search results are authored outside the session.
 [[policy.tool]]
 name = "WebFetch"
-delta = { trust = "suspicious" }
 
 [[policy.tool]]
 name = "WebSearch"
-delta = { trust = "suspicious" }
 
 # The deployment controls what a subagent starts from: the harness gives
 # every subagent exactly the prompt the parent's spawn call carried, and

--- a/integrations/claude-code/examples/claude-code.appa.toml
+++ b/integrations/claude-code/examples/claude-code.appa.toml
@@ -1,10 +1,13 @@
 # Example deployment for protecting a Claude Code session.
 #
 # Every built-in tool of the harness is named: a tool the policy does
-# not name is blocked, and a named tool without a `delta` key has its
-# results admitted as fully unknown (fail-closed). `delta = {}` is the
-# deliberate neutral annotation: the result's label is the combination
-# of its sources, unchanged.
+# not name is blocked. Almost every tool here is named without a
+# `delta` key on purpose: its results are admitted as fully unknown
+# (fail-closed, `UNK-5`) until a reviewed rule gives the tool a real
+# annotation — run `/appa-tool-sync` to generate those. Write
+# `delta = {}` only as a deliberate decision that a tool's result is
+# exactly the combination of its sources, unchanged; this starting
+# policy makes no such claim for you.
 #
 # Tools that bring outside content into the session — the web tools —
 # carry `delta = { trust = "suspicious" }` instead: their results
@@ -29,173 +32,131 @@ version = 1
 [[policy.tool]]
 name = "Agent"
 parameters = { type = "object", additionalProperties = true, properties = { run_in_background = { type = "boolean", const = false } } }
-delta = {}
 
 [[policy.tool]]
 name = "AskUserQuestion"
-delta = {}
 
 [[policy.tool]]
 name = "Artifact"
-delta = {}
 
 [[policy.tool]]
 name = "Bash"
-delta = {}
 
 [[policy.tool]]
 name = "BashOutput"
-delta = {}
 
 [[policy.tool]]
 name = "CronCreate"
-delta = {}
 
 [[policy.tool]]
 name = "CronDelete"
-delta = {}
 
 [[policy.tool]]
 name = "CronList"
-delta = {}
 
 [[policy.tool]]
 name = "Edit"
-delta = {}
 
 [[policy.tool]]
 name = "EnterPlanMode"
-delta = {}
 
 [[policy.tool]]
 name = "EnterWorktree"
-delta = {}
 
 [[policy.tool]]
 name = "ExitPlanMode"
-delta = {}
 
 [[policy.tool]]
 name = "ExitWorktree"
-delta = {}
 
 [[policy.tool]]
 name = "Glob"
-delta = {}
 
 [[policy.tool]]
 name = "Grep"
-delta = {}
 
 [[policy.tool]]
 name = "KillShell"
-delta = {}
 
 [[policy.tool]]
 name = "LSP"
-delta = {}
 
 [[policy.tool]]
 name = "ListAgents"
-delta = {}
 
 [[policy.tool]]
 name = "ListMcpResourcesTool"
-delta = {}
 
 [[policy.tool]]
 name = "Monitor"
-delta = {}
 
 [[policy.tool]]
 name = "NotebookEdit"
-delta = {}
 
 [[policy.tool]]
 name = "PushNotification"
-delta = {}
 
 [[policy.tool]]
 name = "Read"
-delta = {}
 
 [[policy.tool]]
 name = "ReadMcpResourceDirTool"
-delta = {}
 
 [[policy.tool]]
 name = "ReadMcpResourceTool"
-delta = {}
 
 [[policy.tool]]
 name = "ReportFindings"
-delta = {}
 
 [[policy.tool]]
 name = "ScheduleWakeup"
-delta = {}
 
 [[policy.tool]]
 name = "SendMessage"
-delta = {}
 
 [[policy.tool]]
 name = "SendUserFile"
-delta = {}
 
 [[policy.tool]]
 name = "Skill"
-delta = {}
 
 [[policy.tool]]
 name = "SlashCommand"
-delta = {}
 
 # `Task` is the earlier name of `Agent`: the same spawn, the same contract.
 [[policy.tool]]
 name = "Task"
 parameters = { type = "object", additionalProperties = true, properties = { run_in_background = { type = "boolean", const = false } } }
-delta = {}
 
 [[policy.tool]]
 name = "TaskCreate"
-delta = {}
 
 [[policy.tool]]
 name = "TaskGet"
-delta = {}
 
 [[policy.tool]]
 name = "TaskList"
-delta = {}
 
 [[policy.tool]]
 name = "TaskOutput"
-delta = {}
 
 [[policy.tool]]
 name = "TaskStop"
-delta = {}
 
 [[policy.tool]]
 name = "TaskUpdate"
-delta = {}
 
 [[policy.tool]]
 name = "TodoWrite"
-delta = {}
 
 [[policy.tool]]
 name = "ToolSearch"
-delta = {}
 
 [[policy.tool]]
 name = "Workflow"
-delta = {}
 
 [[policy.tool]]
 name = "Write"
-delta = {}
 
 # --- tools that bring outside content into the session ---
 

--- a/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
@@ -1,209 +1,189 @@
 ---
 name: appa-tool-sync
-description: Probe every MCP server available to this Claude Code installation, collect their tools' wire names, mark what each one reads and sends, and write them into the policy config of the currently running APPA runtime for the user to review. Accepts optional extra instructions as an argument. Use when the user installs a new MCP server, wants the APPA policy to cover their MCP tools, or sees calls blocked as undeclared tools.
+description: Inventory the MCP servers and toolsets available to this Claude Code installation, present one plan for how each tool's data is treated, and on approval generate the policy entries — spawning subagents to write the rules and the dynamic resolvers for tools whose sensitivity depends on their arguments — then write the running APPA runtime's policy and reload it. Accepts optional extra instructions as an argument. Use when the user installs a new MCP server, wants the APPA policy to cover their tools, or sees calls blocked as undeclared tools.
 ---
 
 # appa-tool-sync
 
-Bring the running runtime's policy up to date with the MCP tools
-actually installed. You declare each tool and mark it: what its result
-carries, and whether it sends data out of the session. Mark what the
-tool's own purpose makes plain. Ask the user once about the servers
-you cannot judge.
+Bring the running runtime's policy up to date with the tools actually
+installed. Three phases, in order: **inventory** the toolsets and MCP
+servers, present **one plan**, and on approval **generate** — subagents
+draft the policy entries and the dynamic resolvers, you assemble,
+write, and reload.
 
 Marking is a grant. A tool the policy does not name is blocked, so
-every entry you add releases something. The user sees the full
-overview in step 6 and approves it before anything is written.
+every entry you add releases something. Nothing is written before the
+user approves the plan.
 
-This skill edits one configuration file and calls one endpoint. It
-reads no database and no runtime state. It tells you **where to look**,
-not what you will find: do not assume the policy dialect or which
-servers exist — read them from the machine each time.
+This skill edits one configuration file, may add resolver scripts
+beside it, and calls one endpoint. It tells you **where to look**, not
+what you will find: do not assume the policy dialect or which servers
+exist — read them from the machine each time.
 
 ## Extra instructions
 
 The user can pass extra instructions when invoking the skill
-(`/appa-tool-sync <instructions>`). Read them before step 1. They can
-name servers to skip, marks to force, or the config path. They
-override the defaults in this document. They do not skip the approval
-in step 6 — the user still confirms the overview.
+(`/appa-tool-sync <instructions>`). Read them before phase 1. They can
+name servers to skip, marks to force, or the config path; a single
+blocked flow as the argument scopes the whole run to fixing that flow
+narrowly. They override the defaults in this document. They do not
+skip the approval — the user still confirms the plan.
 
 ## How to speak to the user
 
 Short sentences. Plain words. No jargon.
 
-- Work as a dialogue, not a report: one short message per step, one
-  question at a time, a clear call to action — "approve, or tell me
-  what to change". Never one wall of text.
-- Say what happened, then say what to do. Do not explain the model,
-  the dimensions, or the algebra. Never put a rule id, a TOML key, or
-  a term like *delta*, *audience*, or *label* in a sentence addressed
-  to the user. Write "these tools can send data outside", not "these
-  tools require a public audience".
-- Do not narrate your own mechanics. Sentences like "the written file
-  is byte-identical to the previous sync" mean nothing to the user.
-  Say what changed, or "nothing changed", and stop.
+- One short message per phase. Never a wall of text, and never a
+  question dialog (AskUserQuestion): the plan must be fully visible,
+  and corrections come as a reply, not a menu.
+- Say what happened, then say what to do. Do not explain the model or
+  the algebra. Never put a rule id, a TOML key, or a term like
+  *delta*, *audience*, or *label* in a sentence addressed to the user.
+  Write "these tools can send data outside", not "these tools require
+  a public audience".
 - Report only what is there. A check that found nothing gets no
-  sentence: never write lines like "nothing in the policy points at a
-  tool that is no longer installed" or "no servers needed a question".
-- Ask nothing before the scan. After it, at most two questions: one
-  about the servers you could not judge (step 5), then the overview
-  with its approval (step 6).
+  sentence.
+- Ask nothing before the plan. The plan carries your assumptions;
+  the user's reply corrects them.
 
-## 1. Find the config the runtime is serving
+## Phase 1 — inventory
+
+Find the runtime and its config:
 
 ```sh
 ps ax -o command | grep appa-runtime-v2 | grep -v grep
 ```
 
 Take the `--config` path from the command line. A process started
-without that flag reads `APPA_CONFIG`, or `appa.toml` in its working
-directory; if the path is not on the command line, ask the user for it.
-Ask as well when no process is running.
+without the flag reads `APPA_CONFIG`, or `appa.toml` in its working
+directory; when the path is not on the command line — or no process
+runs — ask the user for it, the one question this skill ever asks
+outside the plan. The runtime's address is
+`${APPA_RUNTIME_URL:-http://127.0.0.1:8787}`.
 
-The runtime's address is `${APPA_RUNTIME_URL:-http://127.0.0.1:8787}`,
-the same variable the plugin's hooks and statusline read.
+Then walk the tool surface:
 
-## 2. Inventory MCP servers and their tools
+- `claude mcp list` names the configured servers. The session's own
+  tool surface carries the wire names: `mcp__<server>__<tool>`, and
+  `mcp__plugin_<plugin>_<server>__<tool>` for plugin-provided servers.
+  The policy must name the exact wire name the harness sends.
+- Keep each tool's description — it is the evidence the plan marks
+  from.
+- A server that is configured but does not connect (refused,
+  unauthenticated) is **skipped**: one line in the plan names it and
+  says to sync again once it connects. Never probe it with questions,
+  never invent its tools.
+- A gateway server (search/run tools that proxy other servers) is
+  unpacked: plan for the downstream servers it fronts, not for the
+  gateway's own generic tools.
+- **Never declare the runtime's own remedy tool**
+  (`mcp__plugin_appa-runtime_appa__execute_remedy_plan`, or whatever
+  reserved name the running plugin serves): the runtime provides it
+  and refuses a policy that names it.
+- Read the config: which tools are already declared, and the entry
+  shape — key names, reader IDs, comments — to preserve.
 
-- `claude mcp list` names the servers configured for this user and
-  project.
-- The session's own tool surface carries the wire names: MCP tools
-  appear as `mcp__<server>__<tool>`, plugin-provided servers as
-  `mcp__plugin_<plugin>_<server>__<tool>`. The policy must name the
-  exact wire name the harness sends — a readable alias will not match.
-- Keep each tool's description. It is the evidence you mark from in
-  step 5; a wire name alone often does not say whether a tool reads or
-  sends.
-- For servers that are configured but not visible in this session
-  (disconnected, unauthenticated), report them as unprobed. Do not
-  invent their tool lists.
+## Phase 2 — one plan, one approval
 
-## 3. Read the current policy
+Decide, from each tool's name and description, how its data is
+treated. Three treatments, in plain words:
 
-Read the config file from step 1. Learn the tool-entry shape from the
-existing entries of the config being edited — the table header, the
-key names, and the reader IDs it already writes — and preserve it.
-List which tools the policy already declares.
+- **stays private** — the result is the user's own content (mail,
+  files, notes, dashboards): the entry narrows the audience.
+- **can send outside** — the tool publishes, posts, shares, or
+  uploads where other people read: the entry requires unrestricted
+  data, and that is the wall — nothing private reaches it.
+- **depends on what it touches** — the same tool reads public and
+  private things depending on an argument (a file path, a URL, a
+  channel): the entry binds a **dynamic resolver** that labels each
+  call by that argument. Name the argument in the plan.
 
-## 4. Mark each tool
+When a description does not decide the treatment, pick the safer one —
+private over public, resolver over a blanket mark — and state the
+assumption as part of that server's plan line. The user flips it in
+their reply if it is wrong. Do not ask beforehand.
 
-Use two audience states only. **Public** is the absence of any
-restriction. **Private** is one restricted reader set: reuse the
-reader ID the config already writes for private data, or write
-`private` when it has none.
+Print the plan as plain text, grouped by server: one line per server —
+name, tool count, treatment — expanding to per-tool lines only where
+one server's tools differ. Name every tool that can send outside; name
+every resolver with the argument it keys on; name the skipped servers.
+Also compare against the config: declared-but-uninstalled tools are
+reported, never deleted unasked.
 
-Decide two things per tool, from its name and its description.
+End the message with one call to action: approve, or say what to
+change. Apply corrections, show the changed lines, repeat until
+approved. Never write without approval.
 
-**What its result carries — the `delta`.** A tool that returns content
-from a private source narrows the audience:
+## Generation reference
+
+Hand this to the drafting subagents; it never reaches the user. Use
+two audience states only: **public** is the absence of restriction;
+**private** is one restricted reader set — reuse the reader ID the
+config already writes, or `private` when it has none.
 
 ```toml
+# stays private — the result narrows the audience:
 delta = { audience = { exactly = ["private"] } }
-```
 
-Every other tool carries nothing:
-
-```toml
-delta = {}
-```
-
-**Whether it sends data out of the session — the `requires`.** A tool
-that publishes, posts, sends, shares, or uploads to a place other
-people read may carry unrestricted values only:
-
-```toml
+# can send outside — the sink takes unrestricted values only:
 requires = { audience = { includes = ["public"] } }
 delta = {}
 ```
 
-Only a Public audience includes `public`, so this is the
-wall: nothing a private tool returned reaches that sink. A tool that
-publishes nowhere gets no `requires`.
+Two rules the loader enforces: an entry carrying `requires` must also
+carry a `delta` key (`UNK-7`), and every audience mention carries its
+operator — `exactly`, `includes`, `cap`, `may_add` — a bare list is a
+load error (`CFG-8`). A tool that both reads private data and sends
+outward carries both lines and is then blocked until a remedy clears
+the gap. This skill marks the audience dimension only: no `trust`, no
+attention marks, no effects.
 
-Two rules the loader enforces:
+## Phase 3 — generate, write, reload
 
-- Write a `delta` key on every entry. A `requires` on an entry with no
-  `delta` is refused at load.
-- Every audience mention carries its operator — `exactly`, `includes`,
-  `cap`, `may_add`. A bare list is a load error.
+On approval, spawn subagents in parallel (the Agent tool), and give
+each one only its own job:
 
-A tool can be both. One that reads private data and sends it outward
-carries the private `delta` and the public `requires` together, and is
-then blocked until a remedy plan clears the gap.
+- **One subagent per server** drafts that server's policy entries, in
+  the exact dialect of the config being edited, from the approved
+  treatments. Tools the plan leaves untreated are named bare — the
+  runtime admits their results as fully unknown, which blocks nothing
+  by itself and keeps them visible as ungenerated.
+- **One subagent per resolver** generates it: a small loopback HTTP
+  service beside the config (`<config dir>/resolvers/<name>`), plus
+  the config wiring that binds the tool's keyed argument to it. The
+  contract is on the machine, not in this file: the subagent reads the
+  config's existing dynamic-resolver entries, and when there are none,
+  the served runtime's own documentation of its externals, before
+  writing either the script or the wiring. The wiring must declare the
+  argument it keys on, or the reload will refuse it.
 
-This skill marks the audience dimension only. It sets no `trust`, no
-attention marks, and no effects. If that limit is worth telling the
-user, one line in the step 8 close is the place — not earlier.
-
-## 5. Ask once, about the servers you could not mark
-
-Some servers state their purpose plainly. A web search returns public
-pages. A local filesystem or a notes server returns private ones. Mark
-those yourself.
-
-For the rest, ask **one** question, about servers and not tools: which
-of these give data that must stay private? Put every
-unclear server in that single question and let the user select. Do not
-ask per tool. Do not ask a second question about the tools that send —
-mark those from their descriptions and show them in step 6.
-
-## 6. Show the marks you came up with, then get approval or corrections
-
-Before writing anything, show how each server ends up configured.
-Compare the inventory against the declarations:
-
-- installed but undeclared → candidate entries;
-- declared but no longer installed → tell the user, never delete
-  unasked.
-
-Group the overview by server. One line per server: its name, how many
-tools, and the mark in plain words — no restriction, keeps data
-private, or can send data outside. Expand to one line per tool only where the
-tools of one server differ. Name the tools that can send data outside
-separately — those decide what gets blocked later.
-
-Print the overview as plain text in the chat, end your turn with the
-call to action on the last line, and wait for the reply. Do not use a
-question dialog (AskUserQuestion): its preview box truncates long
-plans, and the user must see every server. Never ask "write N
-entries?" with only a count.
-
-The call to action is one line: approve, or name anything you want
-treated with extra care — data that must stay private, servers to
-skip, marks to change. Apply each correction, show the changed lines
-again, and repeat until the user approves. Never write the config
-without approval.
-
-## 7. Write the config
-
-Apply the approved entries to the config file, preserving its
-existing entries and comments. The user approved the exact entries in
-step 6, so do not show a diff. Show one only when the write had to
-deviate from what was approved.
-
-## 8. Reload the runtime
+Assemble the drafts yourself: apply them to the config file,
+preserving existing entries and comments. Start each generated
+resolver (background, loopback only) and check it answers before
+reloading. Then:
 
 ```sh
 curl --fail-with-body -sS -X POST "${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/reload"
 ```
 
-The process keeps serving and no session is interrupted. The runtime
-validates the file before it installs it: a refusal answers 422 with
-the reason, changes nothing, and leaves the policy that was already
-serving in place. Give the user the reason in plain words, fix the
-config, and reload again.
+The process keeps serving and no session is interrupted. A refusal
+answers 422 with the reason and changes nothing: give the user the
+reason in plain words, fix, and reload again.
 
-Then close in about four sentences. What happened, and what to do:
+Close in about five sentences. What happened, and what to do:
 
 ```text
 Added 9 tools from 3 servers. The policy is live now.
-Two of them can send data outside: <name>, <name>.
-Notes and files stay private, so those two will block them.
-To use them, start a new clappa session.
+Two can send data outside: <name>, <name>.
+<server>'s reads are labeled per file by a resolver I generated;
+it must be running or those reads are blocked — restart it with
+<command> after a reboot.
+To use the new tools, start a new clappa session.
 ```
 
-The last line matters and is easy to get wrong: a session keeps the
-policy file it started with, so the tools you just added do not work
-in the session that added them. Keep the reminder to that one short
-line, and name `clappa` — only sessions started with it are protected.
+Two closing lines matter and are easy to get wrong. A generated
+resolver is a running process: name the restart command, because after
+a reboot its tools' reads are blocked until it is back. And a session
+keeps the policy it started with, so the tools you just added do not
+work in the session that added them — name `clappa`, since only
+sessions started with it are gated.

--- a/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
@@ -45,13 +45,25 @@ Short sentences. Plain words. No jargon.
   sentence.
 - Ask nothing before the plan. The plan carries your assumptions;
   the user's reply corrects them.
+- Pace: the user should see the plan, not the research. Phases 1 and 2
+  are mechanical — batch the lookups and decide from what is in front
+  of you. A minute of silence before the plan is a failure.
+- Never read memory files, `MEMORY.md`, project docs, or anything
+  beyond this file and the machine state it names. Recalled memory
+  describes past machine states and stale pitfalls; every rule this
+  run needs is written here, and the machine is the source of truth.
 
 ## Phase 1 — inventory
+
+Two tool calls in most sessions: one shell call for the process and
+the server list together, one read of the config. The tool surface —
+the wire names and descriptions — is already in your context; do not
+re-probe it.
 
 Find the runtime and its config:
 
 ```sh
-ps ax -o command | grep appa-runtime-v2 | grep -v grep
+ps ax -o command | grep appa-runtime-v2 | grep -v grep; claude mcp list
 ```
 
 Take the `--config` path from the command line. A process started

--- a/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
@@ -55,15 +55,17 @@ Short sentences. Plain words. No jargon.
 
 ## Phase 1 — inventory
 
-Two tool calls in most sessions: one shell call for the process and
-the server list together, one read of the config. The tool surface —
-the wire names and descriptions — is already in your context; do not
-re-probe it.
+Two tool calls in most sessions: one shell call for the runtime
+process, one read of the config. The tool surface — wire names,
+descriptions, which servers answered, which need auth — is already in
+your context; do not re-probe it. Run `claude mcp list` only when the
+context leaves a server's state genuinely unclear: it health-probes
+every server and waits out the timeouts of the dead ones.
 
 Find the runtime and its config:
 
 ```sh
-ps ax -o command | grep appa-runtime-v2 | grep -v grep; claude mcp list
+ps ax -o command | grep appa-runtime-v2 | grep -v grep
 ```
 
 Take the `--config` path from the command line. A process started

--- a/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
@@ -200,4 +200,4 @@ resolver is a running process: name the restart command, because after
 a reboot its tools' reads are blocked until it is back. And a session
 keeps the policy it started with, so the tools you just added do not
 work in the session that added them — name `clappa`, since only
-sessions started with it are gated.
+sessions started with it are protected.

--- a/integrations/claude-code/plugin/statusline.ps1
+++ b/integrations/claude-code/plugin/statusline.ps1
@@ -3,6 +3,46 @@ $fullBlock = [char]0x2588
 $mascotTop = "$lowerHalf$fullBlock$lowerHalf$lowerHalf$lowerHalf$fullBlock$lowerHalf"
 $mascotBottom = "$fullBlock$fullBlock$lowerHalf$fullBlock$lowerHalf$fullBlock$fullBlock"
 
+# Counts the policy's tools: every [[policy.tool]] entry, and the entries
+# carrying more than the neutral annotation (bare name plus delta = {}).
+# Mirrors statusline.sh; any parse failure returns nothing (fail open).
+function Get-PolicyStats {
+    $configDir = if ($env:APPA_CONFIG_DIR) { $env:APPA_CONFIG_DIR } else { Join-Path $env:APPDATA "appa" }
+    $policy = Join-Path $configDir "appa.toml"
+    if (-not (Test-Path -LiteralPath $policy)) {
+        return $null
+    }
+    try {
+        $total = 0; $rules = 0; $inTool = $false; $tuned = $false
+        foreach ($line in (Get-Content -LiteralPath $policy)) {
+            if ($line -match '^\[\[policy\.tool\]\]') {
+                if ($inTool -and $tuned) { $rules++ }
+                $total++; $inTool = $true; $tuned = $false
+                continue
+            }
+            if ($line -match '^\[policy\.tool\.') {
+                if ($inTool) { $tuned = $true }
+                continue
+            }
+            if ($line -match '^\[') {
+                if ($inTool -and $tuned) { $rules++ }
+                $inTool = $false
+                continue
+            }
+            if ($inTool -and $line -match '^([A-Za-z_]+)[ \t]*=[ \t]*(.*)$') {
+                $key = $Matches[1]
+                if ($key -eq "name") { continue }
+                if ($key -eq "delta" -and $Matches[2] -match '^\{[ \t]*\}[ \t]*$') { continue }
+                $tuned = $true
+            }
+        }
+        if ($inTool -and $tuned) { $rules++ }
+        if ($total -gt 0) { "tools:$total rules:$rules" } else { $null }
+    } catch {
+        $null
+    }
+}
+
 try {
     [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
     if ($env:APPA_GATE -ne "1") {
@@ -28,9 +68,14 @@ try {
     }
 
     Write-Output "$mascotTop  trust:$($status.trust)  audience:$($status.audience)"
-    Write-Output $mascotBottom
 } catch {
     Write-Output $mascotTop
+}
+
+$stats = Get-PolicyStats
+if ($stats) {
+    Write-Output "$mascotBottom  $stats · /appa-tool-sync adds rules"
+} else {
     Write-Output $mascotBottom
 }
 

--- a/integrations/claude-code/plugin/statusline.ps1
+++ b/integrations/claude-code/plugin/statusline.ps1
@@ -5,10 +5,17 @@ $mascotBottom = "$fullBlock$fullBlock$lowerHalf$fullBlock$lowerHalf$fullBlock$fu
 
 # Counts the policy's tools: every [[policy.tool]] entry, and the entries
 # carrying more than the neutral annotation (bare name plus delta = {}).
-# Mirrors statusline.sh; any parse failure returns nothing (fail open).
+# The policy is the file the runtime's status read names in policy_path;
+# when no path arrived, the platform default under APPA_CONFIG_DIR's
+# rules is the fallback. Mirrors statusline.sh; any parse failure
+# returns nothing (fail open).
 function Get-PolicyStats {
-    $configDir = if ($env:APPA_CONFIG_DIR) { $env:APPA_CONFIG_DIR } else { Join-Path $env:APPDATA "appa" }
-    $policy = Join-Path $configDir "appa.toml"
+    param($LivePolicy)
+    $policy = $LivePolicy
+    if (-not $policy -or -not (Test-Path -LiteralPath $policy)) {
+        $configDir = if ($env:APPA_CONFIG_DIR) { $env:APPA_CONFIG_DIR } else { Join-Path $env:APPDATA "appa" }
+        $policy = Join-Path $configDir "appa.toml"
+    }
     if (-not (Test-Path -LiteralPath $policy)) {
         return $null
     }
@@ -68,11 +75,12 @@ try {
     }
 
     Write-Output "$mascotTop  trust:$($status.trust)  audience:$($status.audience)"
+    $livePolicy = $status.policy_path
 } catch {
     Write-Output $mascotTop
 }
 
-$stats = Get-PolicyStats
+$stats = Get-PolicyStats -LivePolicy $livePolicy
 if ($stats) {
     Write-Output "$mascotBottom  $stats · /appa-tool-sync adds rules"
 } else {

--- a/integrations/claude-code/plugin/statusline.ps1
+++ b/integrations/claude-code/plugin/statusline.ps1
@@ -4,7 +4,8 @@ $mascotTop = "$lowerHalf$fullBlock$lowerHalf$lowerHalf$lowerHalf$fullBlock$lower
 $mascotBottom = "$fullBlock$fullBlock$lowerHalf$fullBlock$lowerHalf$fullBlock$fullBlock"
 
 # Counts the policy's tools: every [[policy.tool]] entry, and the entries
-# carrying more than the neutral annotation (bare name plus delta = {}).
+# carrying label rules — more than a bare name, an empty delta = {}, or a
+# parameters argument pin, which constrains arguments and labels nothing.
 # The policy is the file the runtime's status read names in policy_path;
 # when no path arrived, the platform default under APPA_CONFIG_DIR's
 # rules is the fallback. Mirrors statusline.sh; any parse failure
@@ -38,7 +39,7 @@ function Get-PolicyStats {
             }
             if ($inTool -and $line -match '^([A-Za-z_]+)[ \t]*=[ \t]*(.*)$') {
                 $key = $Matches[1]
-                if ($key -eq "name") { continue }
+                if ($key -eq "name" -or $key -eq "parameters") { continue }
                 if ($key -eq "delta" -and $Matches[2] -match '^\{[ \t]*\}[ \t]*$') { continue }
                 $tuned = $true
             }

--- a/integrations/claude-code/plugin/statusline.sh
+++ b/integrations/claude-code/plugin/statusline.sh
@@ -1,15 +1,24 @@
 #!/bin/sh
 # The APPA statusline: the pixel mascot, plus the root trajectory's
-# current Trust and Audience from the runtime's /status read.
+# current Trust and Audience from the runtime's /status read, plus
+# policy statistics from the deployment's appa.toml.
 #
 # The mark is the website mascot as half blocks — solid pixels, eyes
 # as terminal-background gaps, like the SVG. The chips render the
 # statusline's stdin `session_id` mapped to the trajectory the Claude
 # Code adapter names, `cc:<session_id>`.
 #
+# The second row counts the policy's tools: `tools:` is every
+# [[policy.tool]] entry, `rules:` the entries carrying more than the
+# neutral annotation (bare `name` plus `delta = {}`), and the hint
+# names the skill that adds rules. The policy path is the platform
+# default under APPA_CONFIG_DIR's rules; a runtime started with a
+# different --config shows that file's counts or none.
+#
 # A statusline fails open, the opposite of the hooks' `|| exit 2`:
 # every failure — runtime down, unknown trajectory, missing jq or
-# curl, malformed stdin — prints the mascot alone and exits 0.
+# curl, malformed stdin, unreadable policy — prints the mascot alone
+# and exits 0.
 #
 # An unprotected session (no APPA_GATE=1) never queries the runtime; it
 # prints the mascot with a reminder that clappa starts a protected
@@ -30,9 +39,36 @@ if command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
         | "trust:\(.trust)  audience:\(.audience)"' 2>/dev/null) ||
     chips=''
 fi
-if [ -n "$chips" ]; then
-  printf '▄█▄▄▄█▄  %s\n██▄█▄██\n' "$chips"
-else
-  printf '▄█▄▄▄█▄\n██▄█▄██\n'
+
+case "$(uname -s)" in
+  Darwin) config_dir=${APPA_CONFIG_DIR:-"$HOME/Library/Application Support/appa"} ;;
+  *) config_dir=${APPA_CONFIG_DIR:-"${XDG_CONFIG_HOME:-$HOME/.config}/appa"} ;;
+esac
+stats=''
+if [ -f "$config_dir/appa.toml" ] && command -v awk >/dev/null 2>&1; then
+  stats=$(awk '
+    /^\[\[policy\.tool\]\]/ { if (intool && tuned) rules++; total++; intool=1; tuned=0; next }
+    /^\[policy\.tool\./ { if (intool) tuned=1; next }
+    /^\[/ { if (intool && tuned) rules++; intool=0; next }
+    intool && /^[A-Za-z_]+[ \t]*=/ {
+      key=$1
+      if (key == "name") next
+      if (key == "delta") {
+        line=$0; sub(/^[^=]*=[ \t]*/, "", line)
+        if (line ~ /^\{[ \t]*\}[ \t]*$/) next
+      }
+      tuned=1
+    }
+    END {
+      if (intool && tuned) rules++
+      if (total > 0) printf "tools:%d rules:%d", total, rules
+    }
+  ' "$config_dir/appa.toml" 2>/dev/null) || stats=''
 fi
+
+top='▄█▄▄▄█▄'
+bottom='██▄█▄██'
+[ -z "$chips" ] || top="$top  $chips"
+[ -z "$stats" ] || bottom="$bottom  $stats · /appa-tool-sync adds rules"
+printf '%s\n%s\n' "$top" "$bottom"
 exit 0

--- a/integrations/claude-code/plugin/statusline.sh
+++ b/integrations/claude-code/plugin/statusline.sh
@@ -9,9 +9,10 @@
 # Code adapter names, `cc:<session_id>`.
 #
 # The second row counts the policy's tools: `tools:` is every
-# [[policy.tool]] entry, `rules:` the entries carrying more than the
-# neutral annotation (bare `name` plus `delta = {}`), and the hint
-# names the skill that adds rules. The policy is the file the runtime's
+# [[policy.tool]] entry, `rules:` the entries carrying label rules —
+# more than a bare `name`, an empty `delta = {}`, or a `parameters`
+# argument pin, which constrains a call's arguments and labels
+# nothing. The hint names the skill that adds rules. The policy is the file the runtime's
 # status read names in `policy_path` — the served `--config` — so the
 # counts follow the runtime the session gates through; when the read
 # gives no path, the platform default under APPA_CONFIG_DIR's rules is
@@ -63,7 +64,7 @@ if [ -f "$policy" ] && command -v awk >/dev/null 2>&1; then
     /^\[/ { if (intool && tuned) rules++; intool=0; next }
     intool && /^[A-Za-z_]+[ \t]*=/ {
       key=$1
-      if (key == "name") next
+      if (key == "name" || key == "parameters") next
       if (key == "delta") {
         line=$0; sub(/^[^=]*=[ \t]*/, "", line)
         if (line ~ /^\{[ \t]*\}[ \t]*$/) next

--- a/integrations/claude-code/plugin/statusline.sh
+++ b/integrations/claude-code/plugin/statusline.sh
@@ -11,9 +11,11 @@
 # The second row counts the policy's tools: `tools:` is every
 # [[policy.tool]] entry, `rules:` the entries carrying more than the
 # neutral annotation (bare `name` plus `delta = {}`), and the hint
-# names the skill that adds rules. The policy path is the platform
-# default under APPA_CONFIG_DIR's rules; a runtime started with a
-# different --config shows that file's counts or none.
+# names the skill that adds rules. The policy is the file the runtime's
+# status read names in `policy_path` — the served `--config` — so the
+# counts follow the runtime the session gates through; when the read
+# gives no path, the platform default under APPA_CONFIG_DIR's rules is
+# the fallback.
 #
 # A statusline fails open, the opposite of the hooks' `|| exit 2`:
 # every failure — runtime down, unknown trajectory, missing jq or
@@ -29,6 +31,7 @@ if [ "${APPA_GATE:-}" != 1 ]; then
   exit 0
 fi
 chips=''
+live_policy=''
 if command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
   sid=$(printf '%s' "$input" | jq -er '.session_id' 2>/dev/null) &&
     body=$(curl -sf --connect-timeout 0.1 -m 0.3 --get \
@@ -38,14 +41,22 @@ if command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
       jq -er 'select((.trust | type) == "string" and (.audience | type) == "string")
         | "trust:\(.trust)  audience:\(.audience)"' 2>/dev/null) ||
     chips=''
+  live_policy=$(printf '%s' "${body:-}" |
+    jq -er 'select((.policy_path | type) == "string") | .policy_path' 2>/dev/null) ||
+    live_policy=''
 fi
 
-case "$(uname -s)" in
-  Darwin) config_dir=${APPA_CONFIG_DIR:-"$HOME/Library/Application Support/appa"} ;;
-  *) config_dir=${APPA_CONFIG_DIR:-"${XDG_CONFIG_HOME:-$HOME/.config}/appa"} ;;
-esac
+if [ -n "$live_policy" ] && [ -f "$live_policy" ]; then
+  policy=$live_policy
+else
+  case "$(uname -s)" in
+    Darwin) config_dir=${APPA_CONFIG_DIR:-"$HOME/Library/Application Support/appa"} ;;
+    *) config_dir=${APPA_CONFIG_DIR:-"${XDG_CONFIG_HOME:-$HOME/.config}/appa"} ;;
+  esac
+  policy=$config_dir/appa.toml
+fi
 stats=''
-if [ -f "$config_dir/appa.toml" ] && command -v awk >/dev/null 2>&1; then
+if [ -f "$policy" ] && command -v awk >/dev/null 2>&1; then
   stats=$(awk '
     /^\[\[policy\.tool\]\]/ { if (intool && tuned) rules++; total++; intool=1; tuned=0; next }
     /^\[policy\.tool\./ { if (intool) tuned=1; next }
@@ -63,7 +74,7 @@ if [ -f "$config_dir/appa.toml" ] && command -v awk >/dev/null 2>&1; then
       if (intool && tuned) rules++
       if (total > 0) printf "tools:%d rules:%d", total, rules
     }
-  ' "$config_dir/appa.toml" 2>/dev/null) || stats=''
+  ' "$policy" 2>/dev/null) || stats=''
 fi
 
 top='▄█▄▄▄█▄'


### PR DESCRIPTION
Cherry-picks the pending branch work onto this history (12 commits, conflicts resolved against what this main had already absorbed, texts translated to the protected vocabulary):

- **`policy_path` on the status wire**: `GET /status` answers carry the canonical `--config` path, added in the HTTP layer and never entering `TrajectoryStatus`; both statuslines prefer it for locating the policy they count, with the `APPA_CONFIG_DIR`/platform default as fallback — the statistics follow whichever runtime the session is protected by, and the dev launch needs no extra variable.
- **Statusline policy statistics**: the second row's `tools:`/`rules:` counts, where `rules:` counts label rules only — an argument pin (`parameters`) constrains a call and labels nothing.
- **A zero-rule starting policy**: the examples name every built-in tool but pre-fill no `delta` — an unannotated tool's results are admitted as fully unknown until a reviewed rule says otherwise; the web tools' suspicious labels become generated decisions too. The subagent crossing tests pin the neutral annotation themselves (`neutralized()`), since they test return crossings, not label generation. A fresh deployment shows `tools:44 rules:0`.
- **`/appa-tool-sync` becomes inventory → one plan → generation**: no question dialogs and no pre-plan quiz — ambiguity is a stated safer-side assumption the user flips in their reply; unreachable servers are skipped with one plan line; gateways unpack; the runtime's reserved remedy tool is never declared. On approval, subagents generate in parallel: policy entries per server, and a dynamic resolver per argument-dependent tool. The interview reads no memory and probes no server healths — the session context already knows.
- **Development docs**: one prompt sets up the dev runtime and points `clappa` at the checkout's plugin for live prompt files.

Verified: `cargo test -p appa-runtime-v2` green on this base (14 suites); this main's own `plugin_hooks` repair is kept where the histories disagreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)