### PR TITLE
feat: cast resolution — classify unknown values and hold results until classified

### DIFF
--- a/appa-agent-python/src/lib.rs
+++ b/appa-agent-python/src/lib.rs
@@ -98,6 +98,7 @@ impl SessionInner {
                 max_body_bytes: MAX_BODY_BYTES,
                 authorities: Default::default(),
                 sanitizers: Default::default(),
+                casts: Default::default(),
                 dynamic: None,
                 membership: None,
             },

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -609,8 +609,8 @@ impl Engine {
                     &lineage,
                     expansions,
                 ) {
-                    plan::ReturnStagePlan::Resolve { cast, value } => {
-                        return self.resolving(view, views, return_act(child), facts, cast, value);
+                    plan::ReturnStagePlan::Resolve { value, .. } => {
+                        return self.resolving(view, views, return_act(child), facts, value, expansions);
                     }
                     plan::ReturnStagePlan::Stage(plans) => plans,
                 };
@@ -688,7 +688,7 @@ impl Engine {
                 registered.transition.dimension(),
                 expansions,
             ) {
-                Some((cast, value)) => self.resolving(view, views, return_act(child), facts, cast, value),
+                Some((_, value)) => self.resolving(view, views, return_act(child), facts, value, expansions),
                 None => self.rejecting(
                     view,
                     child,
@@ -842,8 +842,8 @@ impl Engine {
             expansions,
         ) {
             plan::ReturnStagePlan::Stage(plans) => plans,
-            plan::ReturnStagePlan::Resolve { cast, value } => {
-                return self.resolving(view, views, return_act(child), facts, cast, value);
+            plan::ReturnStagePlan::Resolve { value, .. } => {
+                return self.resolving(view, views, return_act(child), facts, value, expansions);
             }
         };
         let (batch, staged) = self.pending_stage(
@@ -899,13 +899,14 @@ impl Engine {
         views: &Views,
         act: crate::basis::DecidedAct,
         facts: Vec<Fact>,
-        cast: crate::names::CastName,
         value: crate::value::ValueId,
+        expansions: &Expansions,
     ) -> Result<EngineDecision, TransitionError> {
-        let body = views
-            .value_body(value)
-            .expect("a resolvable source retains the bytes its resolver reads")
-            .clone();
+        // Required here rather than at each caller: the ask carries every applicable cast, and a
+        // constant is read whole to reach the runtime already resolved.
+        expansions.require(&plan::cast_selection_groups(&self.registry))?;
+        let (casts, body) = plan::castable_sources(&self.registry, views, value, expansions)
+            .expect("a resolvable source retains its bytes and the cast the caller selected");
         let append = match facts.is_empty() {
             true => None,
             false => {
@@ -916,7 +917,7 @@ impl Engine {
         };
         Ok(EngineDecision {
             append,
-            follow_up: FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Cast { cast, value, body })),
+            follow_up: FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Cast { casts, value, body })),
         })
     }
 
@@ -1178,8 +1179,8 @@ impl Engine {
             expansions,
         ) {
             plan::ReturnStagePlan::Stage(plans) => plans,
-            plan::ReturnStagePlan::Resolve { cast, value } => {
-                return self.resolving(view, views, return_act(id.child()), facts, cast, value);
+            plan::ReturnStagePlan::Resolve { value, .. } => {
+                return self.resolving(view, views, return_act(id.child()), facts, value, expansions);
             }
         };
         let (batch, staged) = self.pending_stage(
@@ -2060,8 +2061,8 @@ impl Engine {
         Ok(unestablished
             .into_iter()
             .filter_map(|value| {
-                plan::castable_source(&self.registry, &views, value, expansions)
-                    .map(|(cast, body)| EvidenceRequest::Cast { cast, value, body })
+                plan::castable_sources(&self.registry, &views, value, expansions)
+                    .map(|(casts, body)| EvidenceRequest::Cast { casts, value, body })
             })
             .collect())
     }
@@ -9734,8 +9735,12 @@ mod tests {
         );
         let value = match &asked.follow_up {
             FollowUp::ProposalsResolve(requests) => match requests.as_slice() {
-                [EvidenceRequest::Cast { cast, value, body }] => {
-                    assert_eq!(cast.as_str(), "classifier");
+                [EvidenceRequest::Cast { casts, value, body }] => {
+                    assert_eq!(
+                        casts.iter().map(|cast| cast.name.as_str()).collect::<Vec<_>>(),
+                        ["classifier"],
+                        "the ask carries every applicable cast, in registration order"
+                    );
                     assert_eq!(body.as_str(), "read", "the ask carries the bytes the classifier reads");
                     *value
                 }
@@ -13376,7 +13381,10 @@ mod tests {
         assert_eq!(
             asked.follow_up,
             FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Cast {
-                cast: crate::names::CastName::new("classifier"),
+                casts: vec![crate::transition::ApplicableCast {
+                    name: crate::names::CastName::new("classifier"),
+                    constant: None,
+                }],
                 value: ValueId::new(0),
                 body: ValueBody::new("page"),
             }))
@@ -14007,8 +14015,8 @@ mod tests {
             .expect("the unresolved dimension asks for its capable cast");
         assert!(matches!(
             &asked.follow_up,
-            FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Cast { cast, body, .. }))
-                if cast.as_str() == "classifier" && body.as_str() == "page"
+            FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Cast { casts, body, .. }))
+                if casts.iter().any(|cast| cast.name.as_str() == "classifier") && body.as_str() == "page"
         ));
     }
 

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -903,8 +903,9 @@ impl Engine {
         expansions: &Expansions,
     ) -> Result<EngineDecision, TransitionError> {
         // Required here rather than at each caller: the ask carries every applicable cast, and a
-        // constant is read whole to reach the runtime already resolved.
-        expansions.require(&plan::cast_selection_groups(&self.registry))?;
+        // constant is read whole to reach the runtime already resolved. Only the constants whose
+        // scope reaches this value are read, so an unrelated one raises no consult.
+        expansions.require(&plan::constant_groups_reaching(&self.registry, views, value))?;
         let (casts, body) = plan::castable_sources(&self.registry, views, value, expansions)
             .expect("a resolvable source retains its bytes and the cast the caller selected");
         let append = match facts.is_empty() {
@@ -2057,14 +2058,14 @@ impl Engine {
         if unestablished.is_empty() {
             return Ok(Vec::new());
         }
-        expansions.require(&plan::cast_selection_groups(&self.registry))?;
-        Ok(unestablished
-            .into_iter()
-            .filter_map(|value| {
-                plan::castable_sources(&self.registry, &views, value, expansions)
-                    .map(|(casts, body)| EvidenceRequest::Cast { casts, value, body })
-            })
-            .collect())
+        let mut requests = Vec::new();
+        for value in unestablished {
+            expansions.require(&plan::constant_groups_reaching(&self.registry, &views, value))?;
+            if let Some((casts, body)) = plan::castable_sources(&self.registry, &views, value, expansions) {
+                requests.push(EvidenceRequest::Cast { casts, value, body });
+            }
+        }
+        Ok(requests)
     }
 
     fn seal_admissions(
@@ -14176,6 +14177,66 @@ mod tests {
             let mut json = serde_json::to_value(fact).expect("a fact serializes");
             json["ValueAdmitted"]["provenance"]["ProviderRun"]["resolutions"] = resolutions;
             serde_json::from_value(json)
+        }
+
+        /// Selection routes by scope, and scope needs no directory. A constant scoped away from
+        /// this value is not read, so its group never becomes a question the blocked call has to
+        /// answer before its own cast can be asked for.
+        #[test]
+        fn a_constant_scoped_elsewhere_raises_no_membership_for_the_call_it_cannot_reach() {
+            let mut read = plain_tool("read_web");
+            read.tags = vec![crate::names::TagName::new("web")];
+            read.delta = None;
+            let mut elsewhere_read = plain_tool("read_files");
+            elsewhere_read.tags = vec![crate::names::TagName::new("files")];
+            elsewhere_read.delta = None;
+            let mut send = plain_tool("send");
+            send.requires = Requires {
+                label: LabelRequirements {
+                    trust_floor: Some(TRUSTED),
+                    audience: vec![],
+                },
+                ..Requires::default()
+            };
+            let mut cfg = config(vec![read, elsewhere_read, send], vec![]);
+            cfg.casts = vec![
+                resolver_cast(
+                    "web-classifier",
+                    vec![SUSPICIOUS, TRUSTED],
+                    vec![crate::names::TagName::new("web")],
+                ),
+                crate::authority::Cast {
+                    name: crate::names::CastName::new("elsewhere"),
+                    resolution: crate::authority::CastResolution::Constant(crate::authority::DeclaredLabel {
+                        trust: SUSPICIOUS,
+                        audience: grouped(&[], &["team"]),
+                    }),
+                    scope: crate::authority::Scope {
+                        tags: vec![crate::names::TagName::new("files")],
+                    },
+                },
+            ];
+            let e = grouped_engine(cfg, &[], known(TRUSTED, Audience::Public));
+            let mut log = vec![opened(&e)];
+            reads(&e, &mut log, &traj(), "read_web");
+
+            let asked = e
+                .handle(
+                    &viewing(&e, &log),
+                    batch_with("b-scoped", vec![], vec![raw(&call("send", json!({})))], vec![]),
+                )
+                .expect("no membership stands between the block and the cast that clears it");
+            assert!(
+                matches!(
+                    &asked.follow_up,
+                    FollowUp::ProposalsResolve(requests)
+                        if requests.len() == 1
+                            && matches!(&requests[0], EvidenceRequest::Cast { casts, .. }
+                                if casts.iter().map(|cast| cast.name.as_str()).eq(["web-classifier"]))
+                ),
+                "only the cast whose scope reaches the value is asked: {:?}",
+                asked.follow_up
+            );
         }
 
         #[test]

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1408,6 +1408,35 @@ impl Engine {
             _ => None,
         });
         let Some((cast, resolved)) = resolution else {
+            // Resolve the applicable constants before anything appends: a constant whose audience
+            // names a group needs that membership, and raising it here puts the consult one drive
+            // ahead of the cast consult rather than leaving the runtime holding a label it cannot
+            // build.
+            let applicable: Vec<&crate::authority::Cast> = self
+                .registry
+                .casts()
+                .iter()
+                .filter(|registered| registered.scope.covers(&contract.tags))
+                .collect();
+            expansions.require(
+                applicable
+                    .iter()
+                    .filter_map(|registered| match &registered.resolution {
+                        crate::authority::CastResolution::Constant(constant) => Some(constant.audience.groups()),
+                        crate::authority::CastResolution::Resolver { .. } => None,
+                    })
+                    .flatten(),
+            )?;
+            let casts = applicable
+                .iter()
+                .map(|registered| crate::transition::ApplicableCast {
+                    name: registered.name.clone(),
+                    constant: match &registered.resolution {
+                        crate::authority::CastResolution::Constant(constant) => Some(constant.resolve(expansions)),
+                        crate::authority::CastResolution::Resolver { .. } => None,
+                    },
+                })
+                .collect();
             let append = match checkpointed {
                 true => None,
                 false => {
@@ -1420,13 +1449,6 @@ impl Engine {
                     Some(self.seal(view, batch)?)
                 }
             };
-            let casts = self
-                .registry
-                .casts()
-                .iter()
-                .filter(|registered| registered.scope.covers(&contract.tags))
-                .map(|registered| registered.name.clone())
-                .collect();
             return Ok(EngineDecision {
                 append,
                 follow_up: FollowUp::Outcome(OutcomeFollowUp::Resolve(EvidenceRequest::PendingCast {
@@ -8861,8 +8883,14 @@ mod tests {
             FollowUp::Outcome(OutcomeFollowUp::Resolve(
                 crate::transition::EvidenceRequest::PendingCast {
                     casts: vec![
-                        crate::names::CastName::new("paranoid"),
-                        crate::names::CastName::new("stingy"),
+                        crate::transition::ApplicableCast {
+                            name: crate::names::CastName::new("paranoid"),
+                            constant: None,
+                        },
+                        crate::transition::ApplicableCast {
+                            name: crate::names::CastName::new("stingy"),
+                            constant: None,
+                        },
                     ],
                     source,
                     body: raw.clone(),
@@ -13909,6 +13937,66 @@ mod tests {
             let mut json = serde_json::to_value(fact).expect("a fact serializes");
             json["ValueAdmitted"]["provenance"]["ProviderRun"]["resolutions"] = resolutions;
             serde_json::from_value(json)
+        }
+
+        #[test]
+        fn a_group_writing_constant_reaches_the_pending_ask_already_resolved() {
+            let mut scan = plain_tool("scan");
+            scan.delta = Some(Delta {
+                trust: Some(Dim::Unknown),
+                audience: None,
+            });
+            let mut cfg = config(vec![scan], vec![]);
+            cfg.casts = vec![crate::authority::Cast {
+                name: crate::names::CastName::new("paranoid"),
+                resolution: crate::authority::CastResolution::Constant(crate::authority::DeclaredLabel {
+                    trust: SUSPICIOUS,
+                    audience: grouped(&[], &["team"]),
+                }),
+                scope: crate::authority::Scope::default(),
+            }];
+            let e = grouped_engine(cfg, &[], known(TRUSTED, Audience::Public));
+            let log = vec![opened(&e)];
+            let released = proposed(&e, &log, "b1", nonce(), call("scan", json!({}))).expect("the open call releases");
+            let dispatch = match &released.follow_up {
+                FollowUp::Proposals { released, .. } => released[0].dispatch.clone(),
+                other => panic!("the proposal releases, got {other:?}"),
+            };
+            let log = [log, appended_facts(released)].concat();
+            let raw = ValueBody::new("inbox bytes");
+            let report = |expansions: Vec<GroupExpansion>| {
+                EngineEvent::Outcome(ToolReport {
+                    dispatch: dispatch.clone(),
+                    outcome: ToolOutcome::Success {
+                        body: OutcomeBody::Available(raw.clone()),
+                    },
+                    evidence: vec![],
+                    offer_nonce: nonce(),
+                    expansions,
+                })
+            };
+
+            assert_eq!(
+                e.handle(&viewing(&e, &log), report(vec![])),
+                Err(TransitionError::MembershipNeeded { needed: vec![team()] }),
+                "the constant's group is needed to build the ask, one drive before the cast consult"
+            );
+
+            let asked = e
+                .handle(&viewing(&e, &log), report(vec![expansion("team", &["alice"])]))
+                .expect("the pending result asks for its resolution");
+            assert_eq!(
+                asked.follow_up,
+                FollowUp::Outcome(OutcomeFollowUp::Resolve(EvidenceRequest::PendingCast {
+                    casts: vec![crate::transition::ApplicableCast {
+                        name: crate::names::CastName::new("paranoid"),
+                        constant: Some(established(SUSPICIOUS, readers(&["alice"]))),
+                    }],
+                    source: RawResultDigest::of(raw.as_str().as_bytes()),
+                    body: raw.clone(),
+                })),
+                "a constant arrives resolved to literal readers: the runtime never expands a group"
+            );
         }
 
         #[test]

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1784,7 +1784,11 @@ impl Engine {
             });
         }
 
-        let mut facts: Vec<Fact> = match admitted {
+        // The answers to a previous drive's ask, landed before anything reads a label: the
+        // batch then composes against the resolved picture rather than the unresolved one.
+        let (_, cast_facts) = self.applied_casts(view.projection(), &batch.trajectory, &batch.evidence, expansions)?;
+        let mut facts: Vec<Fact> = cast_facts;
+        facts.extend(match admitted {
             0 => batch
                 .provider_results
                 .iter()
@@ -1808,7 +1812,7 @@ impl Engine {
                 })
                 .collect(),
             _ => Vec::new(),
-        };
+        });
 
         let proposals = match self.resolve_proposals(batch) {
             Ok(proposals) => proposals,
@@ -1854,6 +1858,19 @@ impl Engine {
         }
         if !unanswered.is_empty() {
             return Err(TransitionError::DynamicAnswerNeeded { needed: unanswered });
+        }
+
+        // A call blocked only for want of a fact asks for the fact before anything is composed.
+        // Nothing appends here: a resolution advances the family basis, so releases and offers
+        // stamped ahead of it would carry a basis the answer immediately stales.
+        if !self.registry.casts().is_empty() {
+            let requests = self.cast_requests(view, &batch.trajectory, &facts, &proposals, expansions)?;
+            if !requests.is_empty() {
+                return Ok(EngineDecision {
+                    append: None,
+                    follow_up: FollowUp::ProposalsResolve(requests),
+                });
+            }
         }
 
         let mut working = std::borrow::Cow::Borrowed(view.projection());
@@ -2001,6 +2018,52 @@ impl Engine {
             marked_return_shape(call).map_err(|error| (mark.index(), error))?;
         }
         Ok(proposals)
+    }
+
+    /// Every value this batch's blocked calls consume that no fact has established yet, paired
+    /// with the cast that could establish it. Read-only: the check runs again once the answers
+    /// land and the batch is composed against them.
+    fn cast_requests(
+        &self,
+        view: &EngineView,
+        trajectory: &TrajectoryId,
+        facts: &[Fact],
+        proposals: &[ResolvedCall],
+        expansions: &Expansions,
+    ) -> Result<Vec<EvidenceRequest>, TransitionError> {
+        let mut working = std::borrow::Cow::Borrowed(view.projection());
+        for fact in facts {
+            working.to_mut().fold(fact);
+        }
+        let views = working.view(trajectory);
+        let mut unestablished: Vec<crate::value::ValueId> = Vec::new();
+        for call in proposals {
+            let contract = self
+                .registry
+                .tool(call.tool())
+                .expect("a resolved call names a checkable tool");
+            let check::CheckOutcome::Block(raw) =
+                check::evaluate(contract, &views, call, &CallStage::default(), expansions)
+            else {
+                continue;
+            };
+            for fact in &raw.unestablished {
+                if !unestablished.contains(&fact.value) {
+                    unestablished.push(fact.value);
+                }
+            }
+        }
+        if unestablished.is_empty() {
+            return Ok(Vec::new());
+        }
+        expansions.require(&plan::cast_selection_groups(&self.registry))?;
+        Ok(unestablished
+            .into_iter()
+            .filter_map(|value| {
+                plan::castable_source(&self.registry, &views, value, expansions)
+                    .map(|(cast, body)| EvidenceRequest::Cast { cast, value, body })
+            })
+            .collect())
     }
 
     fn seal_admissions(
@@ -4076,6 +4139,7 @@ mod tests {
                     proposals: vec![raw(&spawn)],
                     spawn: Some(crate::transition::SpawnMark::at(0)),
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -4265,6 +4329,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -4320,6 +4385,7 @@ mod tests {
                 proposals: proposals.iter().map(raw).collect(),
                 spawn: None,
                 offer_nonce: nonce(),
+                evidence: Vec::new(),
                 expansions: vec![],
             })
         };
@@ -4480,6 +4546,7 @@ mod tests {
             proposals: vec![raw(&call)],
             spawn: None,
             offer_nonce: nonce(),
+            evidence: Vec::new(),
             expansions: vec![],
         });
 
@@ -4522,6 +4589,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -4918,6 +4986,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -6424,6 +6493,7 @@ mod tests {
                 proposals: vec![raw(&call)],
                 spawn,
                 offer_nonce: nonce(),
+                evidence: Vec::new(),
                 expansions: vec![],
             })
         };
@@ -6541,6 +6611,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: Some(crate::transition::SpawnMark::at(0)),
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -6600,6 +6671,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: Some(crate::transition::SpawnMark::at(0)),
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -6659,6 +6731,7 @@ mod tests {
                     proposals: vec![raw(&call("spawn", json!({})))],
                     spawn: Some(crate::transition::SpawnMark::at(0)),
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 })
             ),
@@ -6684,6 +6757,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: Some(crate::transition::SpawnMark::at(0)),
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -6828,6 +6902,7 @@ mod tests {
                 proposals: vec![raw(&call)],
                 spawn,
                 offer_nonce: nonce(),
+                evidence: Vec::new(),
                 expansions: vec![],
             })
         };
@@ -6973,6 +7048,7 @@ mod tests {
                 proposals: vec![raw(call)],
                 spawn: None,
                 offer_nonce: nonce(),
+                evidence: Vec::new(),
                 expansions: vec![],
             }),
         )
@@ -7091,6 +7167,7 @@ mod tests {
                 proposals: vec![raw(&proposal)],
                 spawn: None,
                 offer_nonce: nonce,
+                evidence: Vec::new(),
                 expansions: vec![],
             }),
         )
@@ -7505,6 +7582,7 @@ mod tests {
                     ],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -8459,6 +8537,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -8631,6 +8710,7 @@ mod tests {
                     proposals: vec![raw(&call)],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 })
             ),
@@ -9597,6 +9677,154 @@ mod tests {
             }
             other => panic!("expected attention gap, got {other:?}"),
         }
+    }
+
+    fn trusted_sink() -> ToolContract {
+        ToolContract {
+            name: ToolName::new("send"),
+            tags: vec![],
+            delta: Some(Delta::NONE),
+            parameters: crate::params::ToolParameters::open(),
+            emits: EffectSet::default(),
+            requires: Requires {
+                label: LabelRequirements {
+                    trust_floor: Some(TRUSTED),
+                    audience: vec![],
+                },
+                ..Requires::default()
+            },
+        }
+    }
+
+    fn classifying_engine() -> Engine {
+        let mut cfg = test_config(vec![trusted_sink(), unknown_read()]);
+        cfg.casts = vec![resolver_cast("classifier", vec![SUSPICIOUS, TRUSTED], vec![])];
+        open_engine(cfg)
+    }
+
+    fn proposing_send(e: &Engine, log: &[Fact], id: &str, evidence: Vec<Evidence>) -> EngineEvent {
+        let _ = e;
+        EngineEvent::Proposals(ProposalBatch {
+            id: crate::transition::ProposalBatchId::new(id),
+            trajectory: traj(),
+            provider_results: Vec::new(),
+            proposals: vec![raw(&call("send", json!({})))],
+            spawn: None,
+            offer_nonce: nonce(),
+            evidence,
+            expansions: {
+                let _ = log;
+                Vec::new()
+            },
+        })
+    }
+
+    #[test]
+    fn a_call_blocked_only_on_an_unresolved_source_asks_for_its_cast() {
+        let e = classifying_engine();
+        let mut log = vec![opened(&e)];
+        reads(&e, &mut log, &traj(), "read_unknown");
+
+        let asked = e
+            .handle(&viewing(&e, &log), proposing_send(&e, &log, "b-ask", Vec::new()))
+            .expect("a block turning on a fact asks for the fact");
+        assert_eq!(
+            asked.append, None,
+            "nothing is decided or appended: a resolution moves the family basis"
+        );
+        let value = match &asked.follow_up {
+            FollowUp::ProposalsResolve(requests) => match requests.as_slice() {
+                [EvidenceRequest::Cast { cast, value, body }] => {
+                    assert_eq!(cast.as_str(), "classifier");
+                    assert_eq!(body.as_str(), "read", "the ask carries the bytes the classifier reads");
+                    *value
+                }
+                other => panic!("expected one cast request, got {other:?}"),
+            },
+            other => panic!("expected a resolution ask, got {other:?}"),
+        };
+
+        // Repeating the ask changes nothing: the request is not an act.
+        assert_eq!(
+            e.handle(&viewing(&e, &log), proposing_send(&e, &log, "b-ask", Vec::new()))
+                .expect("the ask repeats")
+                .append,
+            None
+        );
+
+        let answered = e
+            .handle(
+                &viewing(&e, &log),
+                proposing_send(
+                    &e,
+                    &log,
+                    "b-ask",
+                    vec![Evidence::Cast {
+                        cast: crate::names::CastName::new("classifier"),
+                        value,
+                        resolved: established(TRUSTED, Audience::Public),
+                    }],
+                ),
+            )
+            .expect("the answered batch decides");
+        let facts = appended_facts(answered.clone());
+        assert!(
+            facts.iter().any(|fact| matches!(fact, Fact::CastApplied { .. })),
+            "the resolution lands as a fact under the proposal act: {facts:?}"
+        );
+        assert!(
+            matches!(&answered.follow_up, FollowUp::Proposals { released, .. } if released.len() == 1),
+            "a trusted source clears the floor and the call releases: {:?}",
+            answered.follow_up
+        );
+        assert_eq!(e.validate_replay(&[log, facts].concat()), Ok(()));
+    }
+
+    #[test]
+    fn a_resolution_below_the_floor_blocks_the_call_it_was_asked_for() {
+        let e = classifying_engine();
+        let mut log = vec![opened(&e)];
+        reads(&e, &mut log, &traj(), "read_unknown");
+        let value = match &e
+            .handle(&viewing(&e, &log), proposing_send(&e, &log, "b-low", Vec::new()))
+            .expect("the block asks")
+            .follow_up
+        {
+            FollowUp::ProposalsResolve(requests) => match requests.as_slice() {
+                [EvidenceRequest::Cast { value, .. }] => *value,
+                other => panic!("expected one cast request, got {other:?}"),
+            },
+            other => panic!("expected a resolution ask, got {other:?}"),
+        };
+
+        let decided = e
+            .handle(
+                &viewing(&e, &log),
+                proposing_send(
+                    &e,
+                    &log,
+                    "b-low",
+                    vec![Evidence::Cast {
+                        cast: crate::names::CastName::new("classifier"),
+                        value,
+                        resolved: established(SUSPICIOUS, Audience::Public),
+                    }],
+                ),
+            )
+            .expect("the answered batch decides");
+        let facts = appended_facts(decided.clone());
+        assert!(facts.iter().any(|fact| matches!(fact, Fact::CastApplied { .. })));
+        match &decided.follow_up {
+            FollowUp::Proposals { released, blocked, .. } => {
+                assert!(
+                    released.is_empty(),
+                    "a suspicious source does not clear a trusted floor"
+                );
+                assert_eq!(blocked.len(), 1);
+            }
+            other => panic!("expected a decided batch, got {other:?}"),
+        }
+        assert_eq!(e.validate_replay(&[log, facts].concat()), Ok(()));
     }
 
     #[test]
@@ -10635,6 +10863,7 @@ mod tests {
                     proposals: vec![raw(&call("spawn", json!({})))],
                     spawn: Some(crate::transition::SpawnMark::at(0)),
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )
@@ -10768,6 +10997,7 @@ mod tests {
             proposals,
             spawn,
             offer_nonce: nonce(),
+            evidence: Vec::new(),
             expansions: vec![],
         })
     }
@@ -13909,6 +14139,7 @@ mod tests {
                 proposals,
                 spawn: None,
                 offer_nonce: nonce(),
+                evidence: Vec::new(),
                 expansions,
             })
         }
@@ -13997,6 +14228,20 @@ mod tests {
                 })),
                 "a constant arrives resolved to literal readers: the runtime never expands a group"
             );
+
+            // The membership refusal above discarded an unappended checkpoint. It lands on the
+            // drive that carries the expansion, and the report stays repeatable after it.
+            let facts = appended_facts(asked);
+            assert!(
+                facts.iter().any(|fact| matches!(fact, Fact::DispatchSucceeded { .. })),
+                "the checkpoint lands once the group is expanded: {facts:?}"
+            );
+            let log = [log, facts].concat();
+            let again = e
+                .handle(&viewing(&e, &log), report(vec![expansion("team", &["alice"])]))
+                .expect("the report repeats");
+            assert_eq!(again.append, None, "a repeated report commits nothing twice");
+            assert_eq!(e.validate_replay(&log), Ok(()));
         }
 
         #[test]

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -688,7 +688,7 @@ impl Engine {
                 registered.transition.dimension(),
                 expansions,
             ) {
-                Some((_, value)) => self.resolving(view, views, return_act(child), facts, value, expansions),
+                Some(value) => self.resolving(view, views, return_act(child), facts, value, expansions),
                 None => self.rejecting(
                     view,
                     child,

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -784,10 +784,7 @@ pub(crate) fn confined_stage(
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ReturnStagePlan {
-    Resolve {
-        cast: crate::names::CastName,
-        value: crate::value::ValueId,
-    },
+    Resolve { value: crate::value::ValueId },
     Stage(Vec<ExecutableRemedyPlan>),
 }
 
@@ -824,8 +821,8 @@ pub(crate) fn return_stage(
                 if sanitizer.derive_output(candidate, &[], expansions).is_none() {
                     continue;
                 }
-                if let Some((cast, value)) = resolvable_source(registry, views, fold, dim, expansions) {
-                    return ReturnStagePlan::Resolve { cast, value };
+                if let Some(value) = resolvable_source(registry, views, fold, dim, expansions) {
+                    return ReturnStagePlan::Resolve { value };
                 }
                 continue;
             }
@@ -889,18 +886,15 @@ pub(crate) fn resolvable_source(
     fold: &PartialLabel,
     dim: crate::label::Dimension,
     expansions: &Expansions,
-) -> Option<(crate::names::CastName, crate::value::ValueId)> {
-    fold.unresolved(dim).find_map(|value| {
-        views.value_body(value)?;
-        let prior = views.value_label(value)?;
-        registry
-            .casts()
-            .iter()
-            .find(|cast| {
-                cast.resolution.can_establish(prior, expansions)
-                    && cast.scope.reaches(registry, views, value).unwrap_or(false)
+) -> Option<crate::value::ValueId> {
+    fold.unresolved(dim).find(|value| {
+        views.value_body(*value).is_some()
+            && views.value_label(*value).is_some_and(|prior| {
+                registry.casts().iter().any(|cast| {
+                    cast.resolution.can_establish(prior, expansions)
+                        && cast.scope.reaches(registry, views, *value).unwrap_or(false)
+                })
             })
-            .map(|cast| (cast.name.clone(), value))
     })
 }
 

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -904,6 +904,27 @@ pub(crate) fn resolvable_source(
     })
 }
 
+/// The first registered cast that could establish `value`, beside the bytes it would read.
+/// `None` where the value kept no body, carries no label, or no registered cast reaches it — each
+/// leaves the value unestablished, which fails closed at whatever consumes it.
+pub(crate) fn castable_source(
+    registry: &Registry,
+    views: &Views,
+    value: crate::value::ValueId,
+    expansions: &Expansions,
+) -> Option<(crate::names::CastName, crate::value::ValueBody)> {
+    let body = views.value_body(value)?.clone();
+    let prior = views.value_label(value)?;
+    registry
+        .casts()
+        .iter()
+        .find(|cast| {
+            cast.resolution.can_establish(prior, expansions)
+                && cast.scope.reaches(registry, views, value).unwrap_or(false)
+        })
+        .map(|cast| (cast.name.clone(), body))
+}
+
 /// The established contribution a bound output sanitizer's first derivation would make, resolved
 /// here at dispatch. `None` where the sanitizer is unregistered or does not apply to
 /// this output at all. Resolved rather than left to a later registry read because a mandate group

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -1083,6 +1083,27 @@ pub(crate) fn return_stage_groups(registry: &Registry, lineage: &SanitizerLineag
     groups
 }
 
+/// The groups selecting a cast for `value` reads: the declared audience of every constant cast
+/// whose scope reaches it. Scope routing needs no directory answer, so narrowing by it first
+/// keeps a constant scoped elsewhere from pulling a membership consult into a decision its
+/// answer cannot affect.
+pub(crate) fn constant_groups_reaching(
+    registry: &Registry,
+    views: &Views,
+    value: crate::value::ValueId,
+) -> Vec<GroupName> {
+    registry
+        .casts()
+        .iter()
+        .filter(|cast| cast.scope.reaches(registry, views, value).unwrap_or(false))
+        .filter_map(|cast| match &cast.resolution {
+            crate::authority::CastResolution::Constant(constant) => Some(constant.audience.groups().cloned()),
+            crate::authority::CastResolution::Resolver { .. } => None,
+        })
+        .flatten()
+        .collect()
+}
+
 pub(crate) fn cast_selection_groups(registry: &Registry) -> Vec<GroupName> {
     registry
         .casts()

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -904,25 +904,36 @@ pub(crate) fn resolvable_source(
     })
 }
 
-/// The first registered cast that could establish `value`, beside the bytes it would read.
+/// Every registered cast that could establish `value`, in registration order, beside the bytes
+/// they would read. The runtime tries them in that order until one answers, so a constant
+/// registered last is the declared fallback here exactly as it is at a held result. A constant
+/// arrives already resolved against the memberships pinned for this act.
 /// `None` where the value kept no body, carries no label, or no registered cast reaches it — each
 /// leaves the value unestablished, which fails closed at whatever consumes it.
-pub(crate) fn castable_source(
+pub(crate) fn castable_sources(
     registry: &Registry,
     views: &Views,
     value: crate::value::ValueId,
     expansions: &Expansions,
-) -> Option<(crate::names::CastName, crate::value::ValueBody)> {
+) -> Option<(Vec<crate::transition::ApplicableCast>, crate::value::ValueBody)> {
     let body = views.value_body(value)?.clone();
     let prior = views.value_label(value)?;
-    registry
+    let casts: Vec<crate::transition::ApplicableCast> = registry
         .casts()
         .iter()
-        .find(|cast| {
+        .filter(|cast| {
             cast.resolution.can_establish(prior, expansions)
                 && cast.scope.reaches(registry, views, value).unwrap_or(false)
         })
-        .map(|cast| (cast.name.clone(), body))
+        .map(|cast| crate::transition::ApplicableCast {
+            name: cast.name.clone(),
+            constant: match &cast.resolution {
+                crate::authority::CastResolution::Constant(constant) => Some(constant.resolve(expansions)),
+                crate::authority::CastResolution::Resolver { .. } => None,
+            },
+        })
+        .collect();
+    (!casts.is_empty()).then_some((casts, body))
 }
 
 /// The established contribution a bound output sanitizer's first derivation would make, resolved

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -316,7 +316,7 @@ pub enum EvidenceRequest {
         body: ValueBody,
     },
     Cast {
-        cast: crate::names::CastName,
+        casts: Vec<ApplicableCast>,
         value: crate::value::ValueId,
         body: ValueBody,
     },

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -58,6 +58,9 @@ pub struct ProposalBatch {
     /// and offer identity it derives here and keeps none of it: entropy is input data, never engine
     /// state. Runtime supplies it per act and allocates no offer identity of its own.
     pub offer_nonce: crate::value::OfferNonce,
+    /// The cast answers the runtime obtained for values this batch's calls consume. A batch
+    /// carrying none is the ordinary case; the engine asks only when a block turns on a fact.
+    pub evidence: Vec<Evidence>,
     /// The membership answers the runtime obtained for the groups this act's declarations write:
     /// every group the engine named in a `MembershipNeeded` refusal of this
     /// same act, and nothing the policy does not write.
@@ -397,6 +400,10 @@ pub enum FollowUp {
         spent: Vec<ResolvedCall>,
         settled: Vec<Settled>,
     },
+    /// A call in this batch is blocked only for want of a fact a registered cast could
+    /// establish. Nothing is decided and nothing is appended: a resolution advances the family
+    /// basis, so every release and offer this batch would open must be stamped after it.
+    ProposalsResolve(Vec<EvidenceRequest>),
     Malformed {
         position: usize,
         error: crate::engine::EngineError,
@@ -3563,7 +3570,7 @@ fn belongs_to(sequence: &Sequence<'_>, act: &crate::basis::DecidedAct, fact: &Fa
                 ..
             },
         ) => id == act,
-        (DecidedAct::ChildReturn(_), Fact::CastApplied { .. }) => true,
+        (DecidedAct::ChildReturn(_) | DecidedAct::Proposals(_), Fact::CastApplied { .. }) => true,
         (
             DecidedAct::Offer(act),
             Fact::ChildReturn { id, .. }
@@ -3696,6 +3703,7 @@ mod tests {
                     }],
                     spawn: None,
                     offer_nonce: nonce(),
+                    evidence: Vec::new(),
                     expansions: vec![],
                 }),
             )

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -318,10 +318,20 @@ pub enum EvidenceRequest {
         body: ValueBody,
     },
     PendingCast {
-        casts: Vec<crate::names::CastName>,
+        casts: Vec<ApplicableCast>,
         source: RawResultDigest,
         body: ValueBody,
     },
+}
+
+/// One cast applicable to a pending result, in registration order. A constant cast arrives
+/// already resolved: the engine reads its declared label against the memberships pinned for this
+/// act, so the runtime never expands a group of its own accord. A resolver cast carries `None`
+/// and the runtime consults its endpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApplicableCast {
+    pub name: crate::names::CastName,
+    pub constant: Option<crate::label::EstablishedLabel>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use appa_engine::authority::{
-    Authority, Cast, CastResolution, DeclaredLabel, DeclaredTransition, Hint, Mandate, Sanitizer, SanitizerPoints,
-    Scope,
+    Authority, Cast, CastCeiling, CastResolution, DeclaredLabel, DeclaredTransition, Hint, Mandate, Sanitizer,
+    SanitizerPoints, Scope,
 };
 use appa_engine::contract::{
     AudienceDelta, AudienceRequirement, Delta, DynamicAudienceBinding, HistoryRequirement, LabelRequirements,
@@ -795,7 +795,7 @@ struct RawIncludes {
 struct RawCast {
     name: String,
     constant: Option<RawConstantLabel>,
-    resolver: Option<toml::Value>,
+    resolver: Option<RawCastResolver>,
     #[serde(default)]
     scope: RawScope,
 }
@@ -803,24 +803,77 @@ struct RawCast {
 impl RawCast {
     fn convert(self, chain: &TrustChain) -> Result<Cast, ConfigError> {
         let ctx = format!("cast {}", self.name);
-        if self.resolver.is_some() {
-            return Err(ConfigError::ForbiddenInlineBinding {
-                kind: "cast",
-                name: self.name,
-            });
-        }
         let scope = Scope {
             tags: self.scope.tags.into_iter().map(TagName::new).collect(),
         };
-        match self.constant {
-            Some(constant) => Ok(Cast {
-                name: CastName::new(self.name),
-                resolution: CastResolution::Constant(constant.convert(chain, &ctx)?),
-                scope,
-            }),
-            None => Err(bad_impl("cast", &self.name, "declares no constant")),
-        }
+        let resolution = match (self.constant, self.resolver) {
+            (Some(_), Some(_)) => {
+                return Err(bad_impl(
+                    "cast",
+                    &self.name,
+                    "declares both a constant and a resolver — a cast resolves one way or the other",
+                ));
+            }
+            (Some(constant), None) => CastResolution::Constant(constant.convert(chain, &ctx)?),
+            (None, Some(resolver)) => CastResolution::Resolver {
+                may_cast: resolver.convert(chain, &self.name)?,
+            },
+            (None, None) => return Err(bad_impl("cast", &self.name, "declares neither a constant nor a resolver")),
+        };
+        Ok(Cast {
+            name: CastName::new(self.name),
+            resolution,
+            scope,
+        })
     }
+}
+
+/// A resolver-backed cast as the policy writes it: the ceiling only. The endpoint binds
+/// at the deployment, so any binding key here is refused like every other inline binding.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawCastResolver {
+    may_cast: RawMayCast,
+    url: Option<toml::Value>,
+    builtin: Option<toml::Value>,
+    token_env: Option<toml::Value>,
+}
+
+impl RawCastResolver {
+    fn convert(self, chain: &TrustChain, name: &str) -> Result<CastCeiling, ConfigError> {
+        if self.url.is_some() || self.builtin.is_some() || self.token_env.is_some() {
+            return Err(ConfigError::ForbiddenInlineBinding {
+                kind: "cast",
+                name: name.to_string(),
+            });
+        }
+        let ctx = format!("cast {name} may_cast");
+        Ok(CastCeiling {
+            trust: self
+                .may_cast
+                .trust
+                .iter()
+                .map(|rank| parse_trust(rank, chain, &ctx))
+                .collect::<Result<_, _>>()?,
+            audience: parse_declared_audience(&self.may_cast.audience.cap, &ctx)?,
+        })
+    }
+}
+
+/// The complete product ceiling: the trust ranks a resolver may grant, and the cap its
+/// resolved audience must stay within. An empty `trust` admits no unresolved trust at all.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawMayCast {
+    #[serde(default)]
+    trust: Vec<String>,
+    audience: RawCap,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawCap {
+    cap: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -1018,7 +1071,7 @@ confined_results = ["lookup"]
             ),
             (
                 "cast",
-                "version = 1\n[[cast]]\nname = \"c\"\nresolver = { url = \"https://cast.invalid\", may_cast = { trust = [\"trusted\"] } }\n",
+                "version = 1\n[[cast]]\nname = \"c\"\nresolver = { url = \"https://cast.invalid\", may_cast = { trust = [\"trusted\"], audience = { cap = [\"public\"] } } }\n",
             ),
             (
                 "membership resolver",
@@ -1032,6 +1085,58 @@ confined_results = ["lookup"]
                     Err(ConfigError::ForbiddenInlineBinding { kind: found, .. }) if found == kind
                 ),
                 "{kind} inline binding was accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn a_resolver_cast_registers_the_ceiling_the_policy_declares() {
+        let policy = "version = 1\n\
+             [[tool]]\nname = \"fetch\"\ntags = [\"web\"]\n\
+             [[cast]]\nname = \"content-classifier\"\n\
+             resolver = { may_cast = { trust = [\"suspicious\"], audience = { cap = [\"public\"] } } }\n\
+             [cast.scope]\ntags = [\"web\"]\n";
+        let config = Config::from_toml_str(policy).expect("a resolver cast loads");
+        let cast = config
+            .registry()
+            .cast(&CastName::new("content-classifier"))
+            .expect("content-classifier registers");
+        match &cast.resolution {
+            CastResolution::Resolver { may_cast } => {
+                assert_eq!(may_cast.trust, vec![Trust::new(0)]);
+                assert_eq!(may_cast.audience, DeclaredAudience::Public);
+            }
+            other => panic!("expected a resolver ceiling, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_may_cast_omitting_trust_admits_no_unresolved_trust() {
+        let policy = "version = 1\n\
+             [[tool]]\nname = \"fetch\"\ndelta = { audience = \"unknown\" }\n\
+             [[cast]]\nname = \"audience-only\"\n\
+             resolver = { may_cast = { audience = { cap = [\"public\"] } } }\n\
+             [deployment]\nconfined_results = [\"fetch\"]\n";
+        let config = Config::from_toml_str(policy).expect("an audience-only ceiling loads");
+        assert!(matches!(
+            &config.registry().cast(&CastName::new("audience-only")).expect("it registers").resolution,
+            CastResolution::Resolver { may_cast } if may_cast.trust.is_empty()
+        ));
+    }
+
+    #[test]
+    fn a_cast_declaring_both_forms_or_neither_is_refused() {
+        let both = "version = 1\n[[cast]]\nname = \"c\"\n\
+             constant = { trust = \"suspicious\", audience = { exactly = [\"public\"] } }\n\
+             resolver = { may_cast = { trust = [\"trusted\"], audience = { cap = [\"public\"] } } }\n";
+        let neither = "version = 1\n[[cast]]\nname = \"c\"\n";
+        for (case, policy) in [("both", both), ("neither", neither)] {
+            assert!(
+                matches!(
+                    Config::from_toml_str(policy),
+                    Err(ConfigError::BadImplementation { kind: "cast", .. })
+                ),
+                "a cast declaring {case} must be refused"
             );
         }
     }

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -818,7 +818,13 @@ impl RawCast {
             (None, Some(resolver)) => CastResolution::Resolver {
                 may_cast: resolver.convert(chain, &self.name)?,
             },
-            (None, None) => return Err(bad_impl("cast", &self.name, "declares neither a constant nor a resolver")),
+            (None, None) => {
+                return Err(bad_impl(
+                    "cast",
+                    &self.name,
+                    "declares neither a constant nor a resolver",
+                ));
+            }
         };
         Ok(Cast {
             name: CastName::new(self.name),

--- a/appa-runtime-v2/runtime/src/api/mod.rs
+++ b/appa-runtime-v2/runtime/src/api/mod.rs
@@ -126,6 +126,10 @@ pub enum OpenError {
     ReservedTool(String),
     #[error("policy names {kind} {name}, which has no [externals] binding")]
     UnboundExternal { kind: &'static str, name: String },
+    #[error(
+        "cast {0} declares a constant, which the engine answers from the policy — remove its [externals.casts] binding"
+    )]
+    BoundConstantCast(String),
     #[error("the database is damaged: {0}")]
     Damaged(String),
     #[error("storage failure: {0}")]
@@ -861,16 +865,23 @@ fn validate_deployment(policy: &appa_policy::Config, config: &Config) -> Result<
         }
     }
     // A resolver-backed cast classifies over the wire, so it needs an endpoint. A
-    // constant is answered from the policy itself and binds nothing.
+    // constant is answered from the policy itself and binds nothing — an endpoint bound
+    // to one would never be called, so the deployment is refused rather than left
+    // believing a classifier runs.
     for cast in &rc.casts {
         let name = cast.name.as_str();
-        if matches!(cast.resolution, appa_engine::authority::CastResolution::Resolver { .. })
-            && !config.externals.casts.contains_key(name)
-        {
-            return Err(OpenError::UnboundExternal {
-                kind: "cast",
-                name: name.to_string(),
-            });
+        let bound = config.externals.casts.contains_key(name);
+        match (&cast.resolution, bound) {
+            (appa_engine::authority::CastResolution::Resolver { .. }, false) => {
+                return Err(OpenError::UnboundExternal {
+                    kind: "cast",
+                    name: name.to_string(),
+                });
+            }
+            (appa_engine::authority::CastResolution::Constant(_), true) => {
+                return Err(OpenError::BoundConstantCast(name.to_string()));
+            }
+            _ => {}
         }
     }
     for authority in &rc.authorities {

--- a/appa-runtime-v2/runtime/src/api/mod.rs
+++ b/appa-runtime-v2/runtime/src/api/mod.rs
@@ -854,23 +854,23 @@ fn validate_deployment(policy: &appa_policy::Config, config: &Config) -> Result<
     }
 
     let rc = policy.registry_config();
-    // Cast resolution is not wired in this runtime: an accepted
-    // declaration would sit inert while unestablished blocks stay
-    // terminal, so the declaration itself is refused.
-    if !rc.casts.is_empty() {
-        return Err(OpenError::UnsupportedPolicy(
-            "[[cast]] declarations — cast resolution is not wired in this runtime".to_string(),
-        ));
-    }
     for tool in &rc.tools {
         let name = tool.name.as_str();
-        if tool.pending_cast_dim().is_some() {
-            return Err(OpenError::UnsupportedPolicy(format!(
-                "tool {name} declares a pending-cast (\"unknown\") delta — cast resolution is not wired in this runtime"
-            )));
-        }
         if is_control_tool(name) {
             return Err(OpenError::ReservedTool(name.to_string()));
+        }
+    }
+    // A resolver-backed cast classifies over the wire, so it needs an endpoint. A
+    // constant is answered from the policy itself and binds nothing.
+    for cast in &rc.casts {
+        let name = cast.name.as_str();
+        if matches!(cast.resolution, appa_engine::authority::CastResolution::Resolver { .. })
+            && !config.externals.casts.contains_key(name)
+        {
+            return Err(OpenError::UnboundExternal {
+                kind: "cast",
+                name: name.to_string(),
+            });
         }
     }
     for authority in &rc.authorities {

--- a/appa-runtime-v2/runtime/src/api/session.rs
+++ b/appa-runtime-v2/runtime/src/api/session.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 
 use crate::elicit::Elicitation;
 use crate::engine::{
-    AuthorityVerdict, EngineDecision, EngineEvent, EngineView, ExternalEvidence, ExternalRequest, Feedback, ForkStatus,
-    Liveness, Next, OfferNonce, OpenDispatch, Presentation, engine_id,
+    AuthorityVerdict, CastLabel, CastVerdict, EngineDecision, EngineEvent, EngineView, ExternalEvidence,
+    ExternalRequest, Feedback, ForkStatus, Liveness, Next, OfferNonce, OpenDispatch, Presentation, engine_id,
 };
-use crate::external::{ConsultKind, ConsultOutcome, ReadersResolution};
+use crate::external::{CastAnswer, ConsultKind, ConsultOutcome, ReadersResolution};
 
 use super::{
     ChildReturnDecision, Deployment, EventError, ExactCall, Inner, OfferId, OutcomeBody, ProposedCall, RemedyDecision,
@@ -755,6 +755,46 @@ impl Session {
                     readers,
                 }
             }
+            // Every applicable cast, in registration order, until one answers. A constant
+            // arrives already resolved and answers without a call; a resolver is
+            // consulted. A cast that gives no answer is skipped so a constant registered
+            // last can still serve as the declared fallback — but the first answer
+            // obtained is the one submitted, and the engine alone judges it.
+            ExternalRequest::PendingCast { casts, source, body } => {
+                let payload = serde_json::json!({ "body": body.as_str() });
+                let mut verdict = None;
+                for cast in casts {
+                    let name = cast.name.as_str().to_string();
+                    if let Some(constant) = &cast.constant {
+                        verdict = Some(CastVerdict {
+                            cast: name,
+                            label: CastLabel::Declared(constant.clone()),
+                        });
+                        break;
+                    }
+                    if let Some(answer) = self.classify(&name, &payload).await {
+                        verdict = Some(CastVerdict {
+                            cast: name,
+                            label: CastLabel::Classified(answer),
+                        });
+                        break;
+                    }
+                }
+                ExternalEvidence::PendingCast {
+                    source: *source,
+                    verdict,
+                }
+            }
+            // One cast the engine already chose: no fallthrough, because no other cast
+            // was offered.
+            ExternalRequest::Cast { cast, value, body } => {
+                let payload = serde_json::json!({ "body": body.as_str() });
+                let verdict = self.classify(cast, &payload).await.map(|answer| CastVerdict {
+                    cast: cast.clone(),
+                    label: CastLabel::Classified(answer),
+                });
+                ExternalEvidence::Cast { value: *value, verdict }
+            }
             // The membership resolver wire is the declared external contract verbatim.
             ExternalRequest::Membership { resolver, group } => {
                 let readers = match self.deployment.externals.resolve_membership(resolver, group).await {
@@ -767,6 +807,20 @@ impl Session {
                     readers,
                 }
             }
+        }
+    }
+
+    /// One classifier consult. Every failure — unbound, unreachable, malformed, over the
+    /// body cap — is the same no-answer: a classifier that cannot speak grants nothing.
+    async fn classify(&self, cast: &str, payload: &serde_json::Value) -> Option<CastAnswer> {
+        match self
+            .deployment
+            .externals
+            .consult(ConsultKind::Cast, cast, payload, None)
+            .await
+        {
+            ConsultOutcome::Answer(answer) => CastAnswer::from_wire(&answer),
+            ConsultOutcome::NoAnswer(_) => None,
         }
     }
 }
@@ -1423,20 +1477,46 @@ attends = ["irreversible"]
     }
 
     #[test]
-    fn a_pending_cast_contract_refuses_open() {
+    fn a_pending_cast_contract_opens_with_a_registered_cast() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let policy = r#"
 version = 1
 [[policy.tool]]
 name = "fetch"
 delta = { trust = "unknown" }
+[[policy.cast]]
+name = "paranoid"
+constant = { trust = "suspicious", audience = { exactly = ["public"] } }
 [policy.deployment]
 confined_results = ["fetch"]
 "#;
-        assert!(matches!(
-            Runtime::open(config_with(policy, None), dir.path().join("appa.db"), None),
-            Err(OpenError::UnsupportedPolicy(_)),
-        ));
+        assert!(
+            Runtime::open(config_with(policy, None), dir.path().join("appa.db"), None).is_ok(),
+            "a pending-cast delta is served, not refused"
+        );
+    }
+
+    #[test]
+    fn a_resolver_cast_must_be_bound_at_the_deployment() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let policy = r#"
+version = 1
+[[policy.tool]]
+name = "fetch"
+delta = { trust = "unknown" }
+[[policy.cast]]
+name = "classifier"
+resolver = { may_cast = { trust = ["suspicious"], audience = { cap = ["public"] } } }
+[policy.deployment]
+confined_results = ["fetch"]
+"#;
+        assert!(
+            matches!(
+                Runtime::open(config_with(policy, None), dir.path().join("appa.db"), None),
+                Err(OpenError::UnboundExternal { kind: "cast", .. }),
+            ),
+            "a classifier with no endpoint cannot answer, so the deployment does not open"
+        );
     }
 
     #[test]
@@ -1474,18 +1554,20 @@ starting_label = { trust = "suspicious" }
     }
 
     #[test]
-    fn a_cast_declaration_refuses_open() {
+    fn a_constant_cast_declaration_binds_nothing_and_opens() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let policy = r#"
 version = 1
+[[policy.tool]]
+name = "fetch"
 [[policy.cast]]
 name = "channel-class"
 constant = { trust = "trusted", audience = { exactly = ["public"] } }
 "#;
-        assert!(matches!(
-            Runtime::open(config_with(policy, None), dir.path().join("appa.db"), None),
-            Err(OpenError::UnsupportedPolicy(_)),
-        ));
+        assert!(
+            Runtime::open(config_with(policy, None), dir.path().join("appa.db"), None).is_ok(),
+            "a constant is answered from the policy, so it needs no [externals] entry"
+        );
     }
 
     #[test]
@@ -3168,6 +3250,7 @@ confined_child_return = true
             max_body_bytes: 65536,
             authorities: std::collections::BTreeMap::new(),
             sanitizers: std::collections::BTreeMap::new(),
+            casts: std::collections::BTreeMap::new(),
             dynamic: None,
             membership: None,
         }

--- a/appa-runtime-v2/runtime/src/api/session.rs
+++ b/appa-runtime-v2/runtime/src/api/session.rs
@@ -9,6 +9,8 @@ use crate::engine::{
     ExternalRequest, Feedback, ForkStatus, Liveness, Next, OfferNonce, OpenDispatch, Presentation, engine_id,
 };
 use crate::external::{CastAnswer, ConsultKind, ConsultOutcome, ReadersResolution};
+use appa_engine::transition::ApplicableCast;
+use appa_engine::value::ValueBody;
 
 use super::{
     ChildReturnDecision, Deployment, EventError, ExactCall, Inner, OfferId, OutcomeBody, ProposedCall, RemedyDecision,
@@ -755,46 +757,14 @@ impl Session {
                     readers,
                 }
             }
-            // Every applicable cast, in registration order, until one answers. A constant
-            // arrives already resolved and answers without a call; a resolver is
-            // consulted. A cast that gives no answer is skipped so a constant registered
-            // last can still serve as the declared fallback — but the first answer
-            // obtained is the one submitted, and the engine alone judges it.
-            ExternalRequest::PendingCast { casts, source, body } => {
-                let payload = serde_json::json!({ "body": body.as_str() });
-                let mut verdict = None;
-                for cast in casts {
-                    let name = cast.name.as_str().to_string();
-                    if let Some(constant) = &cast.constant {
-                        verdict = Some(CastVerdict {
-                            cast: name,
-                            label: CastLabel::Declared(constant.clone()),
-                        });
-                        break;
-                    }
-                    if let Some(answer) = self.classify(&name, &payload).await {
-                        verdict = Some(CastVerdict {
-                            cast: name,
-                            label: CastLabel::Classified(answer),
-                        });
-                        break;
-                    }
-                }
-                ExternalEvidence::PendingCast {
-                    source: *source,
-                    verdict,
-                }
-            }
-            // One cast the engine already chose: no fallthrough, because no other cast
-            // was offered.
-            ExternalRequest::Cast { cast, value, body } => {
-                let payload = serde_json::json!({ "body": body.as_str() });
-                let verdict = self.classify(cast, &payload).await.map(|answer| CastVerdict {
-                    cast: cast.clone(),
-                    label: CastLabel::Classified(answer),
-                });
-                ExternalEvidence::Cast { value: *value, verdict }
-            }
+            ExternalRequest::PendingCast { casts, source, body } => ExternalEvidence::PendingCast {
+                source: *source,
+                verdict: self.cascade(casts, body).await,
+            },
+            ExternalRequest::Cast { casts, value, body } => ExternalEvidence::Cast {
+                value: *value,
+                verdict: self.cascade(casts, body).await,
+            },
             // The membership resolver wire is the declared external contract verbatim.
             ExternalRequest::Membership { resolver, group } => {
                 let readers = match self.deployment.externals.resolve_membership(resolver, group).await {
@@ -808,6 +778,30 @@ impl Session {
                 }
             }
         }
+    }
+
+    /// Every applicable cast, in registration order, until one answers. A constant arrives
+    /// already resolved and answers without a call; a resolver is consulted. A cast that gives
+    /// no answer is skipped so a constant registered last serves as the declared fallback —
+    /// but the first answer obtained is the one submitted, and the engine alone judges it.
+    async fn cascade(&self, casts: &[ApplicableCast], body: &ValueBody) -> Option<CastVerdict> {
+        let payload = serde_json::json!({ "body": body.as_str() });
+        for cast in casts {
+            let name = cast.name.as_str().to_string();
+            if let Some(constant) = &cast.constant {
+                return Some(CastVerdict {
+                    cast: name,
+                    label: CastLabel::Declared(constant.clone()),
+                });
+            }
+            if let Some(answer) = self.classify(&name, &payload).await {
+                return Some(CastVerdict {
+                    cast: name,
+                    label: CastLabel::Classified(answer),
+                });
+            }
+        }
+        None
     }
 
     /// One classifier consult. Every failure — unbound, unreachable, malformed, over the
@@ -1567,6 +1561,35 @@ constant = { trust = "trusted", audience = { exactly = ["public"] } }
         assert!(
             Runtime::open(config_with(policy, None), dir.path().join("appa.db"), None).is_ok(),
             "a constant is answered from the policy, so it needs no [externals] entry"
+        );
+    }
+
+    #[test]
+    fn a_constant_cast_bound_to_an_endpoint_refuses_open() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let text = r#"
+[policy]
+version = 1
+[[policy.tool]]
+name = "fetch"
+[[policy.cast]]
+name = "channel-class"
+constant = { trust = "trusted", audience = { exactly = ["public"] } }
+[externals]
+timeout_ms = 2000
+max_body_bytes = 65536
+[externals.casts.channel-class]
+url = "https://classify.example/label"
+"#;
+        let path = dir.path().join("appa.toml");
+        std::fs::write(&path, text).expect("the fixture writes");
+        let config = Config::load(&path).expect("the fixture validates");
+        assert!(
+            matches!(
+                Runtime::open(config, dir.path().join("appa.db"), None),
+                Err(OpenError::BoundConstantCast(_)),
+            ),
+            "an endpoint the engine would never call leaves the deployment believing a classifier runs"
         );
     }
 

--- a/appa-runtime-v2/runtime/src/config.rs
+++ b/appa-runtime-v2/runtime/src/config.rs
@@ -54,6 +54,9 @@ pub struct Externals {
     pub max_body_bytes: usize,
     pub authorities: BTreeMap<String, Implementation>,
     pub sanitizers: BTreeMap<String, Implementation>,
+    /// The classifiers a resolver-backed `[[cast]]` consults. Endpoint-only: a constant
+    /// cast is answered from the policy and binds nothing here.
+    pub casts: BTreeMap<String, Endpoint>,
     pub dynamic: Option<Endpoint>,
     /// The membership resolver the policy's `[membership]` registers.
     pub membership: Option<Endpoint>,
@@ -171,6 +174,8 @@ struct RawExternals {
     authorities: BTreeMap<String, RawImplementation>,
     #[serde(default)]
     sanitizers: BTreeMap<String, RawImplementation>,
+    #[serde(default)]
+    casts: BTreeMap<String, RawImplementation>,
     dynamic: Option<RawImplementation>,
     membership: Option<RawImplementation>,
 }
@@ -237,6 +242,7 @@ impl Config {
                 max_body_bytes: raw.externals.max_body_bytes,
                 authorities: resolve_implementations("authorities", raw.externals.authorities, &lookup)?,
                 sanitizers: resolve_implementations("sanitizers", raw.externals.sanitizers, &lookup)?,
+                casts: resolve_endpoints("casts", raw.externals.casts, &lookup)?,
                 dynamic: raw
                     .externals
                     .dynamic
@@ -299,6 +305,22 @@ fn resolve_implementations(
                 }
             };
             Ok((name, implementation))
+        })
+        .collect()
+}
+
+/// A section whose every entry is an endpoint. A cast classifies content over the wire or
+/// resolves to a declared constant the engine reads itself, so there is no builtin to name.
+fn resolve_endpoints(
+    section: &'static str,
+    raw: BTreeMap<String, RawImplementation>,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<BTreeMap<String, Endpoint>, ConfigError> {
+    raw.into_iter()
+        .map(|(name, entry)| {
+            let endpoint = endpoint_only(section, &name, entry)?;
+            let resolved = resolve_endpoint(section, name.clone(), endpoint, lookup)?;
+            Ok((name, resolved))
         })
         .collect()
 }

--- a/appa-runtime-v2/runtime/src/engine.rs
+++ b/appa-runtime-v2/runtime/src/engine.rs
@@ -132,9 +132,10 @@ pub enum ExternalRequest {
         source: RawResultDigest,
         body: ValueBody,
     },
-    /// Classify one admitted value the engine already chose a cast for.
+    /// Classify one admitted value a blocked act reads. Same cascade, same order: the two
+    /// asks differ only in what the answer resolves.
     Cast {
-        cast: String,
+        casts: Vec<ApplicableCast>,
         value: ValueId,
         body: ValueBody,
     },
@@ -1038,17 +1039,13 @@ impl RuntimeEngine {
                 let chain = self.engine.registry().trust_chain();
                 let mut consults = Vec::new();
                 for request in requests {
-                    let EvidenceRequest::Cast { cast, value, body } = request else {
+                    let EvidenceRequest::Cast { casts, value, body } = request else {
                         return Err(EngineRefusal::Invariant {
                             detail: "a proposal batch asked for something other than a cast".to_string(),
                         });
                     };
                     match cast_state(chain, evidence, value) {
-                        CastAnswerState::Missing => consults.push(ExternalRequest::Cast {
-                            cast: cast.as_str().to_string(),
-                            value,
-                            body,
-                        }),
+                        CastAnswerState::Missing => consults.push(ExternalRequest::Cast { casts, value, body }),
                         CastAnswerState::NoAnswer | CastAnswerState::Resolved => {
                             return Ok(deny_next(
                                 "[appa] no registered cast could establish what this call reads; the call is blocked"
@@ -2082,9 +2079,9 @@ fn resolve_or_withhold(
                 offers: Vec::new(),
             })),
         },
-        EvidenceRequest::Cast { cast, value, body } => match cast_state(chain, evidence, value) {
+        EvidenceRequest::Cast { casts, value, body } => match cast_state(chain, evidence, value) {
             CastAnswerState::Missing => Ok(Next::ResolveExternal(vec![ExternalRequest::Cast {
-                cast: cast.as_str().to_string(),
+                casts,
                 value,
                 body,
             }])),

--- a/appa-runtime-v2/runtime/src/engine.rs
+++ b/appa-runtime-v2/runtime/src/engine.rs
@@ -966,15 +966,15 @@ impl RuntimeEngine {
         };
         let expansions = self.membership_evidence(evidence);
         let decided = if spawn {
-            match self.decide_proposal(view, trajectory, proposed.clone(), entropy, true, &expansions) {
+            match self.decide_proposal(view, trajectory, proposed.clone(), entropy, true, &expansions, evidence) {
                 Ok(decision) => Ok(decision),
                 Err(TransitionError::SpawnUncontrolled) => {
-                    self.decide_proposal(view, trajectory, proposed, entropy, false, &expansions)
+                    self.decide_proposal(view, trajectory, proposed, entropy, false, &expansions, evidence)
                 }
                 Err(error) => Err(error),
             }
         } else {
-            self.decide_proposal(view, trajectory, proposed, entropy, false, &expansions)
+            self.decide_proposal(view, trajectory, proposed, entropy, false, &expansions, evidence)
         };
         let decision = match decided {
             Ok(decision) => decision,
@@ -986,13 +986,20 @@ impl RuntimeEngine {
                     MembershipConsult::Unresolved(group) => Ok(deny(unresolved_group(&call.tool, &group))),
                 };
             }
+            Err(TransitionError::InadmissibleResolution) => {
+                return Ok(deny(
+                    "[appa] the classifier's answer was not admissible; the call is blocked and may be proposed again"
+                        .to_string(),
+                ));
+            }
             Err(error) => return Err(proposal_refusal(error)),
         };
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
-        let then = self.deliver_proposals(view, trajectory, decision.follow_up)?;
+        let then = self.deliver_proposals(view, trajectory, decision.follow_up, evidence)?;
         Ok(EngineDecision { append, then })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn decide_proposal(
         &self,
         view: &EngineView,
@@ -1001,6 +1008,7 @@ impl RuntimeEngine {
         entropy: &OfferNonce,
         spawn: bool,
         expansions: &MembershipEvidence,
+        external: &[ExternalEvidence],
     ) -> Result<CoreDecision, TransitionError> {
         let batch = ProposalBatch {
             id: batch_id(entropy),
@@ -1009,6 +1017,7 @@ impl RuntimeEngine {
             proposals: vec![proposed],
             spawn: spawn.then(|| SpawnMark::at(0)),
             offer_nonce: engine_nonce(entropy),
+            evidence: cast_evidence(self.engine.registry().trust_chain(), external),
             expansions: expansions.expansions(),
         };
         self.engine.handle(view, CoreEvent::Proposals(batch))
@@ -1019,8 +1028,37 @@ impl RuntimeEngine {
         view: &EngineView,
         trajectory: &TrajectoryId,
         follow_up: FollowUp,
+        evidence: &[ExternalEvidence],
     ) -> Result<Next, EngineRefusal> {
         match follow_up {
+            // The engine wants a value classified before it decides. Every ask goes out in one
+            // round so a batch naming several unresolved sources costs one redrive, not one per
+            // source; a cast already asked and unanswered blocks instead of being asked again.
+            FollowUp::ProposalsResolve(requests) => {
+                let chain = self.engine.registry().trust_chain();
+                let mut consults = Vec::new();
+                for request in requests {
+                    let EvidenceRequest::Cast { cast, value, body } = request else {
+                        return Err(EngineRefusal::Invariant {
+                            detail: "a proposal batch asked for something other than a cast".to_string(),
+                        });
+                    };
+                    match cast_state(chain, evidence, value) {
+                        CastAnswerState::Missing => consults.push(ExternalRequest::Cast {
+                            cast: cast.as_str().to_string(),
+                            value,
+                            body,
+                        }),
+                        CastAnswerState::NoAnswer | CastAnswerState::Resolved => {
+                            return Ok(deny_next(
+                                "[appa] no registered cast could establish what this call reads; the call is blocked"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+                Ok(Next::ResolveExternal(consults))
+            }
             FollowUp::Proposals {
                 released: releases,
                 blocked,

--- a/appa-runtime-v2/runtime/src/engine.rs
+++ b/appa-runtime-v2/runtime/src/engine.rs
@@ -47,7 +47,7 @@ use appa_engine::engine::{Engine, EngineError};
 use appa_engine::execute::{AuthorityEvidence, AuthorityReview};
 use appa_engine::fact::{BoundaryKind, CloseOutcome, EffectSet, Fact, ReturnDerivation};
 use appa_engine::groups::GroupExpansion;
-use appa_engine::label::{Audience, Dim, Dimension, Label, PartialLabel, ReaderId, Trust};
+use appa_engine::label::{Audience, Dim, Dimension, EstablishedLabel, Label, PartialLabel, ReaderId, Trust};
 use appa_engine::names::GroupName;
 use appa_engine::plan::{ExecutableRemedyPlan, PlanId, PlannedBlock, RemedyPlan, RequiredRuling};
 use appa_engine::profile::PolicyFileKey as EnginePolicyFileKey;
@@ -59,11 +59,11 @@ use appa_engine::transition::Blocked as CoreBlocked;
 /// the event or passed with the read.
 pub(crate) use appa_engine::transition::EngineView;
 use appa_engine::transition::{
-    ChildFollowUp, ChildReport, ChildSubmission, Confined, EngineDecision as CoreDecision, EngineEvent as CoreEvent,
-    Evidence, EvidenceRequest, FollowUp, ForkBinding, OfferConsult, OfferExecution, OfferFollowUp, OfferOutcome,
-    OutcomeBody as CoreOutcomeBody, OutcomeFollowUp, PendingReturnStage, ProposalBatch, ProposalBatchId,
-    ProposedCall as CoreProposedCall, Released, SpawnMark, ToolOutcome as CoreToolOutcome, ToolReport, TransitionError,
-    TransitionRefusal, ValidatedFactBatch,
+    ApplicableCast, ChildFollowUp, ChildReport, ChildSubmission, Confined, EngineDecision as CoreDecision,
+    EngineEvent as CoreEvent, Evidence, EvidenceRequest, FollowUp, ForkBinding, OfferConsult, OfferExecution,
+    OfferFollowUp, OfferOutcome, OutcomeBody as CoreOutcomeBody, OutcomeFollowUp, PendingReturnStage, ProposalBatch,
+    ProposalBatchId, ProposedCall as CoreProposedCall, Released, SpawnMark, ToolOutcome as CoreToolOutcome, ToolReport,
+    TransitionError, TransitionRefusal, ValidatedFactBatch,
 };
 use appa_engine::value::{
     DispatchId as EngineDispatchId, ForkId, OfferId as EngineOfferId, OfferNonce as EngineOfferNonce, Provenance,
@@ -73,6 +73,7 @@ use appa_eventlog::Log;
 
 use crate::api::OutcomeBody;
 pub(crate) use crate::api::{DispatchId, OfferId, ProposedCall, SpawnBinding, ToolOutcome, TrajectoryId};
+use crate::external::{CastAnswer, CastAudience};
 
 /// One fresh 256-bit random number per act that can surface offers; the
 /// runtime mixes it into every `OfferId` it mints.
@@ -123,6 +124,36 @@ pub enum ExternalRequest {
         resolver: String,
         group: String,
     },
+    /// Classify a result the model has not seen. The applicable casts travel in
+    /// registration order and a constant among them arrives already resolved, so the
+    /// session answers it without a call.
+    PendingCast {
+        casts: Vec<ApplicableCast>,
+        source: RawResultDigest,
+        body: ValueBody,
+    },
+    /// Classify one admitted value the engine already chose a cast for.
+    Cast {
+        cast: String,
+        value: ValueId,
+        body: ValueBody,
+    },
+}
+
+/// One cast's answer as the session obtained it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CastVerdict {
+    pub cast: String,
+    pub label: CastLabel,
+}
+
+/// Where a cast's label came from. A declared constant is the engine's own read echoed
+/// back; a classified answer is a resolver's wire strings, still to be read against the
+/// policy's trust chain.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CastLabel {
+    Declared(EstablishedLabel),
+    Classified(CastAnswer),
 }
 
 /// A typed external answer. `None`/`Abstain` mean the external gave
@@ -148,6 +179,15 @@ pub enum ExternalEvidence {
         resolver: String,
         group: String,
         readers: Option<Vec<String>>,
+    },
+    /// `None` means every applicable cast was asked and none answered usably.
+    PendingCast {
+        source: RawResultDigest,
+        verdict: Option<CastVerdict>,
+    },
+    Cast {
+        value: ValueId,
+        verdict: Option<CastVerdict>,
     },
 }
 
@@ -1048,12 +1088,28 @@ impl RuntimeEngine {
         let report = ToolReport {
             dispatch: dispatch.clone(),
             outcome: engine_outcome(outcome),
-            evidence: sanitizer_evidence(evidence),
+            evidence: [
+                sanitizer_evidence(evidence),
+                cast_evidence(self.engine.registry().trust_chain(), evidence),
+            ]
+            .concat(),
             offer_nonce: engine_nonce(entropy),
             expansions: expansions.expansions(),
         };
         let decision = match self.engine.handle(view, CoreEvent::Outcome(report)) {
             Ok(decision) => decision,
+            // A classifier's answer the engine will not admit — over its ceiling, out of
+            // scope, or disagreeing with a dimension already established. The classifier
+            // misbehaved; the log is not in question, so the result is withheld and the
+            // report stays repeatable rather than refusing the session.
+            Err(TransitionError::InadmissibleResolution) => {
+                return Ok(EngineDecision::deliver(Next::PresentToModel(Presentation::Blocked {
+                    feedback:
+                        "[appa] the classifier's answer was not admissible; the result is withheld and may be retried"
+                            .to_string(),
+                    offers: Vec::new(),
+                })));
+            }
             Err(TransitionError::MembershipNeeded { needed }) => {
                 return match self.membership_consult(&expansions, needed)? {
                     MembershipConsult::Requests(requests) => {
@@ -1077,9 +1133,10 @@ impl RuntimeEngine {
                 Next::PresentToModel(outcome_presentation(outcome, admitted))
             }
             FollowUp::Outcome(OutcomeFollowUp::Resolve(request)) => resolve_or_withhold(
+                self.engine.registry().trust_chain(),
                 request,
                 evidence,
-                "[appa] the sanitizer gave no answer; the result is withheld and may be retried",
+                "[appa] no registered cast or sanitizer answered; the result is withheld and may be retried",
             )?,
             FollowUp::Outcome(OutcomeFollowUp::Staged(confined)) => {
                 Next::PresentToModel(self.confined_delivery(&confined))
@@ -1357,12 +1414,24 @@ impl RuntimeEngine {
             child: engine_id(child),
             fork,
             submission,
-            evidence: sanitizer_evidence(evidence),
+            evidence: [
+                sanitizer_evidence(evidence),
+                cast_evidence(self.engine.registry().trust_chain(), evidence),
+            ]
+            .concat(),
             offer_nonce: engine_nonce(entropy),
             expansions: expansions.expansions(),
         };
         let decision = match self.engine.handle(view, CoreEvent::ChildReturn(report)) {
             Ok(decision) => decision,
+            Err(TransitionError::InadmissibleResolution) => {
+                return Ok(EngineDecision::deliver(Next::PresentToModel(Presentation::Blocked {
+                    feedback:
+                        "[appa] the classifier's answer was not admissible; the return is withheld and may be retried"
+                            .to_string(),
+                    offers: Vec::new(),
+                })));
+            }
             Err(TransitionError::MembershipNeeded { needed }) => {
                 return match self.membership_consult(&expansions, needed)? {
                     MembershipConsult::Requests(requests) => {
@@ -1392,9 +1461,10 @@ impl RuntimeEngine {
                 offers: Vec::new(),
             }),
             FollowUp::Child(ChildFollowUp::Resolve(request)) => resolve_or_withhold(
+                self.engine.registry().trust_chain(),
                 request,
                 evidence,
-                "[appa] the return sanitizer gave no answer; the return is withheld and may be retried",
+                "[appa] no registered cast or return sanitizer answered; the return is withheld and may be retried",
             )?,
             other => {
                 return Err(EngineRefusal::Invariant {
@@ -1805,6 +1875,89 @@ fn outcome_presentation(outcome: &ToolOutcome, admitted: Option<ValueBody>) -> P
     }
 }
 
+/// Whether the session has an answer for a cast the engine asked about. The three states
+/// are what stops a redrive loop: an answer the policy cannot read is `NoAnswer`, never a
+/// fresh request, so a classifier naming a rank outside the chain withholds once instead
+/// of being asked forever.
+enum CastAnswerState {
+    Missing,
+    NoAnswer,
+    Resolved,
+}
+
+fn cast_label(chain: &TrustChain, verdict: &CastVerdict) -> Option<EstablishedLabel> {
+    match &verdict.label {
+        CastLabel::Declared(label) => Some(label.clone()),
+        CastLabel::Classified(answer) => {
+            let trust = chain.rank_of(&answer.trust)?;
+            let audience = match &answer.audience {
+                CastAudience::Public => Audience::Public,
+                CastAudience::Readers(readers) => Audience::restricted(readers.iter().map(ReaderId::new)),
+            };
+            Some(EstablishedLabel::new(trust, audience))
+        }
+    }
+}
+
+fn cast_evidence(chain: &TrustChain, evidence: &[ExternalEvidence]) -> Vec<Evidence> {
+    evidence
+        .iter()
+        .filter_map(|entry| match entry {
+            ExternalEvidence::PendingCast {
+                source,
+                verdict: Some(verdict),
+            } => Some(Evidence::PendingCast {
+                cast: appa_engine::names::CastName::new(verdict.cast.clone()),
+                source: *source,
+                resolved: cast_label(chain, verdict)?,
+            }),
+            ExternalEvidence::Cast {
+                value,
+                verdict: Some(verdict),
+            } => Some(Evidence::Cast {
+                cast: appa_engine::names::CastName::new(verdict.cast.clone()),
+                value: *value,
+                resolved: cast_label(chain, verdict)?,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn pending_cast_state(chain: &TrustChain, evidence: &[ExternalEvidence], source: &RawResultDigest) -> CastAnswerState {
+    for entry in evidence {
+        if let ExternalEvidence::PendingCast {
+            source: reported,
+            verdict,
+        } = entry
+            && reported == source
+        {
+            return match verdict.as_ref().and_then(|verdict| cast_label(chain, verdict)) {
+                Some(_) => CastAnswerState::Resolved,
+                None => CastAnswerState::NoAnswer,
+            };
+        }
+    }
+    CastAnswerState::Missing
+}
+
+fn cast_state(chain: &TrustChain, evidence: &[ExternalEvidence], value: ValueId) -> CastAnswerState {
+    for entry in evidence {
+        if let ExternalEvidence::Cast {
+            value: reported,
+            verdict,
+        } = entry
+            && *reported == value
+        {
+            return match verdict.as_ref().and_then(|verdict| cast_label(chain, verdict)) {
+                Some(_) => CastAnswerState::Resolved,
+                None => CastAnswerState::NoAnswer,
+            };
+        }
+    }
+    CastAnswerState::Missing
+}
+
 fn sanitizer_evidence(evidence: &[ExternalEvidence]) -> Vec<Evidence> {
     evidence
         .iter()
@@ -1854,6 +2007,7 @@ fn authority_verdict(evidence: &[ExternalEvidence], name: &str) -> Option<(Autho
 }
 
 fn resolve_or_withhold(
+    chain: &TrustChain,
     request: EvidenceRequest,
     evidence: &[ExternalEvidence],
     withheld: &str,
@@ -1879,9 +2033,28 @@ fn resolve_or_withhold(
                 body,
             }]))
         }
-        EvidenceRequest::Cast { .. } | EvidenceRequest::PendingCast { .. } => Err(EngineRefusal::Invariant {
-            detail: "the engine asked for a cast resolution this runtime does not drive".to_string(),
-        }),
+        EvidenceRequest::PendingCast { casts, source, body } => match pending_cast_state(chain, evidence, &source) {
+            CastAnswerState::Missing => Ok(Next::ResolveExternal(vec![ExternalRequest::PendingCast {
+                casts,
+                source,
+                body,
+            }])),
+            CastAnswerState::NoAnswer | CastAnswerState::Resolved => Ok(Next::PresentToModel(Presentation::Blocked {
+                feedback: withheld.to_string(),
+                offers: Vec::new(),
+            })),
+        },
+        EvidenceRequest::Cast { cast, value, body } => match cast_state(chain, evidence, value) {
+            CastAnswerState::Missing => Ok(Next::ResolveExternal(vec![ExternalRequest::Cast {
+                cast: cast.as_str().to_string(),
+                value,
+                body,
+            }])),
+            CastAnswerState::NoAnswer | CastAnswerState::Resolved => Ok(Next::PresentToModel(Presentation::Blocked {
+                feedback: withheld.to_string(),
+                offers: Vec::new(),
+            })),
+        },
     }
 }
 

--- a/appa-runtime-v2/runtime/src/external.rs
+++ b/appa-runtime-v2/runtime/src/external.rs
@@ -20,6 +20,7 @@ const HITL: &str = "hitl";
 pub enum ConsultKind {
     Authority,
     Sanitizer,
+    Cast,
 }
 
 impl ConsultKind {
@@ -27,6 +28,7 @@ impl ConsultKind {
         match self {
             ConsultKind::Authority => "authority",
             ConsultKind::Sanitizer => "sanitizer",
+            ConsultKind::Cast => "cast",
         }
     }
 }
@@ -54,6 +56,54 @@ pub enum NoAnswerReason {
 pub enum ConsultOutcome {
     Answer(serde_json::Value),
     NoAnswer(NoAnswerReason),
+}
+
+/// One classifier's complete answer, as the wire carried it and before the engine judges
+/// it: a trust rank name and an audience. Both dimensions or nothing — a cast establishes
+/// a whole label, so a half-filled answer is malformed rather than partially useful. The
+/// names stay unresolved here: only the engine holds the trust chain and the ceiling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CastAnswer {
+    pub trust: String,
+    pub audience: CastAudience,
+}
+
+/// The audience half of a cast answer. `Public` is legal here — unlike a dynamic
+/// resolver's reader set, a cast may resolve to public where its `may_cast` cap admits
+/// it — but `public` may never appear beside literal readers, and a group name is never a
+/// classifier's to write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CastAudience {
+    Public,
+    Readers(Vec<String>),
+}
+
+impl CastAnswer {
+    /// Read one classifier answer off the wire. Every rejection is a no-answer, never a
+    /// denial: a malformed classifier grants nothing and blocks nothing.
+    pub fn from_wire(answer: &serde_json::Value) -> Option<CastAnswer> {
+        let trust = answer.get("trust")?.as_str()?.to_string();
+        if trust.is_empty() {
+            return None;
+        }
+        let audience = match answer.get("audience")? {
+            serde_json::Value::String(token) if token == "public" => CastAudience::Public,
+            serde_json::Value::Array(readers) => {
+                let readers: Option<Vec<String>> = readers
+                    .iter()
+                    .map(|reader| match reader.as_str() {
+                        Some(reader) if !reader.is_empty() && reader != "public" && !reader.starts_with('@') => {
+                            Some(reader.to_string())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                CastAudience::Readers(readers?)
+            }
+            _ => return None,
+        };
+        Some(CastAnswer { trust, audience })
+    }
 }
 
 /// The outcome of one reader-set resolution — dynamic or membership:
@@ -123,6 +173,7 @@ pub struct ExternalServices {
     max_body_bytes: usize,
     authorities: BTreeMap<String, AuthorityBackend>,
     sanitizers: BTreeMap<String, SanitizerBackend>,
+    casts: BTreeMap<String, Endpoint>,
     dynamic: Option<Endpoint>,
     membership: Option<Endpoint>,
 }
@@ -186,6 +237,7 @@ impl ExternalServices {
             max_body_bytes: config.max_body_bytes,
             authorities,
             sanitizers,
+            casts: config.casts,
             dynamic: config.dynamic,
             membership: config.membership,
         })
@@ -229,6 +281,10 @@ impl ExternalServices {
                     None => ConsultOutcome::NoAnswer(NoAnswerReason::Malformed),
                 },
                 Some(SanitizerBackend::Module(module)) => self.call_module(module, kind, name, payload).await,
+            },
+            ConsultKind::Cast => match self.casts.get(name) {
+                None => unregistered(kind, name),
+                Some(endpoint) => self.post_consult(endpoint, kind, name, payload).await,
             },
         }
     }
@@ -471,6 +527,7 @@ mod tests {
             max_body_bytes: cap,
             authorities: BTreeMap::new(),
             sanitizers: BTreeMap::new(),
+            casts: BTreeMap::new(),
             dynamic: dynamic_url.clone().map(|url| Endpoint { url, token: None }),
             membership: dynamic_url.map(|url| Endpoint { url, token: None }),
         }

--- a/appa-runtime-v2/runtime/tests/cast.rs
+++ b/appa-runtime-v2/runtime/tests/cast.rs
@@ -29,6 +29,12 @@ name = "scan_files"
 tags = ["files"]
 delta = { trust = "unknown" }
 
+# Unannotated and inside the files scope: the lazy path meets the same cast cascade,
+# constant fallback included.
+[[policy.tool]]
+name = "list_files"
+tags = ["files"]
+
 [[policy.tool]]
 name = "notify"
 requires = { trust = "trusted" }
@@ -460,6 +466,32 @@ async fn a_source_the_classifier_calls_suspicious_blocks_the_call_that_asked() {
         HookDecision::DenyCall { .. }
     ));
     assert_eq!(classifier.bodies(), vec![PAGE.to_string()]);
+}
+
+/// The cascade is one rule, not two: a blocked call whose classifier is silent falls
+/// through to the constant behind it exactly as a held result does.
+#[tokio::test]
+async fn a_blocked_call_falls_through_to_the_constant_when_the_classifier_is_silent() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("files-classifier", Answer::Down);
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "list_files").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    assert_eq!(returned(&runtime, "list_files", FILES).await, HookDecision::Ack);
+    assert!(matches!(
+        propose(&runtime, "notify").await,
+        HookDecision::DenyCall { .. }
+    ));
+    assert_eq!(
+        established(&runtime),
+        vec![("files-fallback".to_string(), "suspicious".to_string())],
+        "the constant answered the ask the silent classifier left"
+    );
+    assert_eq!(classifier.consults(), 1);
 }
 
 /// A classifier that cannot speak grants nothing and blocks nothing: the value stays

--- a/appa-runtime-v2/runtime/tests/cast.rs
+++ b/appa-runtime-v2/runtime/tests/cast.rs
@@ -1,0 +1,490 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use appa_runtime_api::{Actor, HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome, TrajectoryId};
+use appa_runtime_v2::api::{AuditEvent, OfferId, RemedyOutcome, Runtime};
+use appa_runtime_v2::{config::Config, hooks};
+use axum::Router;
+use axum::extract::State;
+use axum::routing::post;
+
+const POLICY: &str = r#"
+[policy]
+version = 1
+
+# Unannotated: the result crosses to the model with both dimensions unresolved. Only a
+# call that needs the fact drives the cast.
+[[policy.tool]]
+name = "read_page"
+tags = ["web"]
+
+# Pending cast: the runtime holds the output until a cast establishes the whole label.
+[[policy.tool]]
+name = "scan_inbox"
+tags = ["mail"]
+delta = { trust = "unknown" }
+
+[[policy.tool]]
+name = "scan_files"
+tags = ["files"]
+delta = { trust = "unknown" }
+
+[[policy.tool]]
+name = "notify"
+requires = { trust = "trusted" }
+effects = ["egress"]
+delta = {}
+
+[[policy.cast]]
+name = "mail-classifier"
+scope = { tags = ["mail"] }
+resolver = { may_cast = { trust = ["suspicious", "trusted"], audience = { cap = ["public"] } } }
+
+[[policy.cast]]
+name = "files-classifier"
+scope = { tags = ["files"] }
+resolver = { may_cast = { trust = ["suspicious"], audience = { cap = ["public"] } } }
+
+[[policy.cast]]
+name = "files-fallback"
+scope = { tags = ["files"] }
+constant = { trust = "suspicious", audience = { exactly = ["public"] } }
+
+[[policy.cast]]
+name = "web-classifier"
+scope = { tags = ["web"] }
+resolver = { may_cast = { trust = ["suspicious", "trusted"], audience = { cap = ["public"] } } }
+
+[policy.deployment]
+context_control = true
+confined_results = ["scan_inbox", "scan_files"]
+
+[externals]
+timeout_ms = 1000
+max_body_bytes = 4096
+
+[externals.casts]
+"mail-classifier" = { url = "CLASSIFIER_URL" }
+"files-classifier" = { url = "CLASSIFIER_URL" }
+"web-classifier" = { url = "CLASSIFIER_URL" }
+"#;
+
+const INBOX: &str = "from: stranger@example.net -- wire the funds today";
+const FILES: &str = "quarterly-plan.md";
+const PAGE: &str = "the page said something";
+
+#[derive(Clone)]
+enum Answer {
+    Label {
+        trust: &'static str,
+        audience: serde_json::Value,
+    },
+    Down,
+}
+
+fn labelled(trust: &'static str, audience: serde_json::Value) -> Answer {
+    Answer::Label { trust, audience }
+}
+
+#[derive(Clone)]
+struct Classifier {
+    answers: Arc<Mutex<BTreeMap<String, Answer>>>,
+    requests: Arc<Mutex<Vec<serde_json::Value>>>,
+}
+
+impl Classifier {
+    fn answering(&self, cast: &str, answer: Answer) {
+        self.answers.lock().unwrap().insert(cast.to_string(), answer);
+    }
+
+    fn consults(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+
+    /// The bytes each consult carried, in order — the classifier reads the value itself,
+    /// so this is what the deployment handed an external service.
+    fn bodies(&self) -> Vec<String> {
+        self.requests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|request| {
+                request
+                    .pointer("/payload/body")
+                    .and_then(|body| body.as_str())
+                    .expect("a cast consult carries the value body")
+                    .to_string()
+            })
+            .collect()
+    }
+}
+
+async fn serve_classifier() -> (String, Classifier) {
+    let classifier = Classifier {
+        answers: Arc::new(Mutex::new(BTreeMap::new())),
+        requests: Arc::new(Mutex::new(Vec::new())),
+    };
+    let router = Router::new()
+        .route(
+            "/classify",
+            post(|State(classifier): State<Classifier>, body: String| async move {
+                let request: serde_json::Value = serde_json::from_str(&body).expect("the request is JSON");
+                let name = request
+                    .get("name")
+                    .and_then(|name| name.as_str())
+                    .expect("a consult names its cast")
+                    .to_string();
+                classifier.requests.lock().unwrap().push(request);
+                match classifier.answers.lock().unwrap().get(&name).cloned() {
+                    Some(Answer::Label { trust, audience }) => (
+                        axum::http::StatusCode::OK,
+                        serde_json::json!({
+                            "version": 1,
+                            "answer": { "trust": trust, "audience": audience },
+                        })
+                        .to_string(),
+                    ),
+                    Some(Answer::Down) | None => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom".to_string()),
+                }
+            }),
+        )
+        .with_state(classifier.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("an ephemeral loopback port binds");
+    let addr = listener.local_addr().expect("the bound address is readable");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("the stub serves");
+    });
+    (format!("http://{addr}/classify"), classifier)
+}
+
+fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
+    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
+}
+
+fn root() -> TrajectoryId {
+    TrajectoryId("cast-test".to_string())
+}
+
+fn actor() -> Actor {
+    Actor {
+        root: root(),
+        child: None,
+    }
+}
+
+fn call(tool: &str) -> ProposedCall {
+    ProposedCall {
+        tool: tool.to_string(),
+        arguments: raw(serde_json::json!({})),
+    }
+}
+
+fn reopened(dir: &tempfile::TempDir, url: &str) -> Arc<Runtime> {
+    let path = dir.path().join("appa.toml");
+    std::fs::write(&path, POLICY.replace("CLASSIFIER_URL", url)).expect("the fixture writes");
+    let config = Config::load(&path).expect("the fixture validates");
+    Arc::new(Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens"))
+}
+
+async fn opened(dir: &tempfile::TempDir, url: &str) -> Arc<Runtime> {
+    let runtime = reopened(dir, url);
+    assert_eq!(
+        hooks::handle(&runtime, HookEvent::SessionStart { root: root() }).await,
+        HookDecision::Ack
+    );
+    runtime
+}
+
+async fn propose(runtime: &Arc<Runtime>, tool: &str) -> HookDecision {
+    hooks::handle(
+        runtime,
+        HookEvent::ToolCall {
+            actor: actor(),
+            call: call(tool),
+            spawn: false,
+        },
+    )
+    .await
+}
+
+async fn returned(runtime: &Arc<Runtime>, tool: &str, body: &str) -> HookDecision {
+    hooks::handle(
+        runtime,
+        HookEvent::ToolResult {
+            actor: actor(),
+            call: call(tool),
+            outcome: ToolOutcome::Success {
+                body: OutcomeBody::Available(body.to_string()),
+            },
+        },
+    )
+    .await
+}
+
+fn last_offer(feedback: &str) -> OfferId {
+    feedback
+        .lines()
+        .filter_map(|line| {
+            let after = line.split("offer_id:").nth(1)?;
+            let rest = after.trim_start().strip_prefix('"')?;
+            Some(OfferId(rest[..rest.find('"')?].to_string()))
+        })
+        .next_back()
+        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
+}
+
+/// Every classification the log holds, as the audit reads it back: the cast that answered
+/// and the trust rank it established.
+fn established(runtime: &Runtime) -> Vec<(String, String)> {
+    runtime
+        .audit(&root())
+        .expect("the audit reads")
+        .into_iter()
+        .filter_map(|entry| match entry.event {
+            AuditEvent::Cast { cast, resolved } => Some((cast, resolved.trust)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn withheld(decision: HookDecision, body: &str) -> String {
+    let HookDecision::ReplaceOutput { output } = decision else {
+        panic!("the held result is withheld, got {decision:?}");
+    };
+    assert!(
+        !output.contains(body),
+        "the held bytes must not reach the model: {output}"
+    );
+    output
+}
+
+/// The whole hold-and-inspect release: the model sees the tool's bytes only after a cast
+/// established a label the session already permits.
+#[tokio::test]
+async fn a_held_result_the_classifier_clears_reaches_the_model_whole() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("mail-classifier", labelled("trusted", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "scan_inbox").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    assert_eq!(
+        returned(&runtime, "scan_inbox", INBOX).await,
+        HookDecision::Ack,
+        "a non-restricting classification releases the result unchanged"
+    );
+    assert_eq!(
+        classifier.bodies(),
+        vec![INBOX.to_string()],
+        "the classifier read the held bytes, once"
+    );
+}
+
+/// A classification that narrows the session holds the bytes back until the agent accepts
+/// the narrowing, and then delivers them as the remedy call's own answer.
+#[tokio::test]
+async fn a_narrowing_classification_holds_the_bytes_until_the_agent_accepts() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("mail-classifier", labelled("suspicious", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "scan_inbox").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    let feedback = withheld(returned(&runtime, "scan_inbox", INBOX).await, INBOX);
+    assert_eq!(
+        runtime.execute_remedy(&actor(), last_offer(&feedback)).await,
+        RemedyOutcome::Returned {
+            value: INBOX.to_string()
+        },
+        "acceptance is what releases the held value"
+    );
+}
+
+/// An answer over the cast's declared `may_cast` ceiling grants nothing, and grants
+/// nothing by way of the constant registered behind it either: a classifier that answers
+/// wider than its policy allows is a misbehaving classifier, not a silent one. The report
+/// is not decided by it, so the same result reported again is judged afresh.
+#[tokio::test]
+async fn an_answer_over_the_ceiling_withholds_the_result_and_stays_retryable() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("files-classifier", labelled("trusted", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "scan_files").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    withheld(returned(&runtime, "scan_files", FILES).await, FILES);
+    assert_eq!(classifier.consults(), 1, "the classifier did answer");
+    assert!(
+        established(&runtime).is_empty(),
+        "an answer over the ceiling establishes nothing, and falls through to no constant"
+    );
+
+    classifier.answering("files-classifier", labelled("suspicious", serde_json::json!("public")));
+    let feedback = withheld(returned(&runtime, "scan_files", FILES).await, FILES);
+    assert_eq!(
+        runtime.execute_remedy(&actor(), last_offer(&feedback)).await,
+        RemedyOutcome::Returned {
+            value: FILES.to_string()
+        },
+        "the over-ceiling answer withheld the result without closing the dispatch"
+    );
+    assert_eq!(
+        established(&runtime),
+        vec![("files-classifier".to_string(), "suspicious".to_string())]
+    );
+}
+
+/// A classifier that cannot speak is skipped, so a constant registered behind it is the
+/// declared fallback the deployment gets when its endpoint is down.
+#[tokio::test]
+async fn a_silent_classifier_falls_through_to_the_constant_behind_it() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("files-classifier", Answer::Down);
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "scan_files").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    let feedback = withheld(returned(&runtime, "scan_files", FILES).await, FILES);
+    assert_eq!(
+        runtime.execute_remedy(&actor(), last_offer(&feedback)).await,
+        RemedyOutcome::Returned {
+            value: FILES.to_string()
+        }
+    );
+    assert_eq!(
+        established(&runtime),
+        vec![("files-fallback".to_string(), "suspicious".to_string())]
+    );
+    assert_eq!(classifier.consults(), 1, "the constant answered without a call");
+}
+
+/// A classifier is consulted once. Reopening the deployment rebuilds the same decision
+/// from the log alone — the classification is a recorded fact, not a question re-asked.
+#[tokio::test]
+async fn a_reopened_deployment_replays_the_classification_without_asking_again() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("mail-classifier", labelled("suspicious", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "scan_inbox").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    let feedback = withheld(returned(&runtime, "scan_inbox", INBOX).await, INBOX);
+    assert!(matches!(
+        runtime.execute_remedy(&actor(), last_offer(&feedback)).await,
+        RemedyOutcome::Returned { .. }
+    ));
+    let consulted = classifier.consults();
+    drop(runtime);
+
+    // The stub now refuses every consult: anything the replay still needs to ask would
+    // change the outcome rather than hide.
+    classifier.answering("mail-classifier", Answer::Down);
+    let runtime = reopened(&dir, &url);
+    assert_eq!(
+        established(&runtime),
+        vec![("mail-classifier".to_string(), "suspicious".to_string())],
+        "the classification is in the log, not in the runtime's memory"
+    );
+    assert!(
+        matches!(propose(&runtime, "notify").await, HookDecision::DenyCall { .. }),
+        "the replayed label still blocks the trusted sink"
+    );
+    assert_eq!(
+        classifier.consults(),
+        consulted,
+        "replay reaches no classifier: an established label is a fact, not a question"
+    );
+}
+
+/// An unannotated tool's result crosses whole and unresolved. The cast runs later, driven
+/// by the first call whose only obstacle is that missing fact.
+#[tokio::test]
+async fn a_call_blocked_on_an_unresolved_source_drives_the_cast_that_clears_it() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("web-classifier", labelled("trusted", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "read_page").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    assert_eq!(returned(&runtime, "read_page", PAGE).await, HookDecision::Ack);
+    assert_eq!(
+        classifier.consults(),
+        0,
+        "an unannotated result is not classified on its way in"
+    );
+
+    assert_eq!(
+        propose(&runtime, "notify").await,
+        HookDecision::AllowCall { spawn: None },
+        "the blocked call drove the cast, and the answer cleared the floor"
+    );
+    assert_eq!(classifier.bodies(), vec![PAGE.to_string()]);
+}
+
+/// The same lazy path, refused: the classifier answers below the sink's floor, so the call
+/// that asked for the fact is the call the fact blocks.
+#[tokio::test]
+async fn a_source_the_classifier_calls_suspicious_blocks_the_call_that_asked() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("web-classifier", labelled("suspicious", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "read_page").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    assert_eq!(returned(&runtime, "read_page", PAGE).await, HookDecision::Ack);
+    assert!(matches!(
+        propose(&runtime, "notify").await,
+        HookDecision::DenyCall { .. }
+    ));
+    assert_eq!(classifier.bodies(), vec![PAGE.to_string()]);
+}
+
+/// A classifier that cannot speak grants nothing and blocks nothing: the value stays
+/// unresolved, so the call it would have cleared stays blocked and the ask can be retried.
+#[tokio::test]
+async fn a_silent_classifier_leaves_the_source_unresolved() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    classifier.answering("web-classifier", Answer::Down);
+    let runtime = opened(&dir, &url).await;
+
+    assert_eq!(
+        propose(&runtime, "read_page").await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    assert_eq!(returned(&runtime, "read_page", PAGE).await, HookDecision::Ack);
+    assert!(matches!(
+        propose(&runtime, "notify").await,
+        HookDecision::DenyCall { .. }
+    ));
+
+    classifier.answering("web-classifier", labelled("trusted", serde_json::json!("public")));
+    assert_eq!(
+        propose(&runtime, "notify").await,
+        HookDecision::AllowCall { spawn: None },
+        "the unanswered ask left nothing decided, so the retry resolves it"
+    );
+}

--- a/website-chat-playground/src/world.rs
+++ b/website-chat-playground/src/world.rs
@@ -157,6 +157,9 @@ pub fn externals_for(policy: &appa_policy::Config, base: &str) -> Externals {
                 (name, endpoint(url))
             })
             .collect(),
+        // The playground serves no classifier route, so a resolver-backed cast stays
+        // unbound and refuses the policy at open. Constant casts need no binding.
+        casts: std::collections::BTreeMap::new(),
         dynamic: Some(Endpoint {
             url: format!("{base}{DYNAMIC_RESOLVER_PATH}"),
             token: None,

--- a/website-chat-playground/tests/sessions.rs
+++ b/website-chat-playground/tests/sessions.rs
@@ -73,15 +73,42 @@ trust_chain = ["suspicious", "trusted"]
 [[tool]]
 name = "list_customers"
 delta = { audience = "unknown" }
+
+[[cast]]
+name = "classifier"
+resolver = { may_cast = { trust = ["suspicious"], audience = { cap = ["public"] } } }
 "#;
 
     let Err(error) = sessions
         .create(policy, &[System::Crm].into_iter().collect(), MODEL)
         .await
     else {
-        panic!("a pending-cast delta must be refused, not accepted and left inert");
+        panic!("the playground serves no classifier route, so a resolver-backed cast must be refused");
     };
     assert!(matches!(error, CreateError::Open(_)), "got: {error}");
+}
+
+#[tokio::test]
+async fn a_pending_cast_delta_runs_under_a_constant_cast() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let sessions = sessions(&dir, Duration::from_secs(600));
+    let policy = r#"
+version = 1
+trust_chain = ["suspicious", "trusted"]
+
+[[tool]]
+name = "list_customers"
+delta = { audience = "unknown" }
+
+[[cast]]
+name = "paranoid"
+constant = { trust = "suspicious", audience = { exactly = ["public"] } }
+"#;
+
+    sessions
+        .create(policy, &[System::Crm].into_iter().collect(), MODEL)
+        .await
+        .expect("a constant cast is answered from the policy, so the deployment runs it");
 }
 
 #[tokio::test]

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -256,4 +256,15 @@ constant = { trust = "suspicious",
              audience = { exactly = ["public"] } }  # Complete label; unscoped fallback, registered last
 ```
 
-Applicable casts — matched by scope tags — evaluate in registration order. Register constant casts last: a cast placed after a constant that covers it can never run, and the loader refuses it. The engine validates every resolver response against its declared `may_cast` ceiling before admitting the value. A `public` audience cap is an open gate: it lets a single resolver answer resolve a value to `public` and lift its audience restriction entirely — review it like any covering mandate.
+```toml
+[externals.casts.content-classifier]           # the deployment binds the classifier
+url = "https://classify.corp/label"
+```
+
+A resolver is the only implementation a cast takes: the answer is a label the `may_cast` ceiling has to bound, not a stock transform, so `builtin` is refused. A constant is answered from the policy, so it binds nothing and an `[externals]` entry for it is a load error.
+
+Applicable casts — matched by scope tags — evaluate in registration order until one answers. A resolver that cannot answer — unreachable, timed out, malformed — is skipped, which is what makes a trailing constant the deployment's declared fallback. Register constant casts last: a cast placed after a constant that covers it can never run, and the loader refuses it.
+
+The engine validates every resolver response against its declared `may_cast` ceiling before admitting the value. An answer over the ceiling is refused outright and falls through to nothing: a classifier answering wider than its policy allows is misbehaving, not silent, and the result stays withheld. A `public` audience cap is an open gate: it lets a single resolver answer resolve a value to `public` and lift its audience restriction entirely — review it like any covering mandate.
+
+A tool that declares its own pending dimension — `delta = { trust = "unknown" }` — is held rather than annotated late: the deployment lists it in `confined_results`, the runtime keeps the raw result from the model, and the cast reads it first. A restricting answer reaches the agent as a narrowing offer, and the bytes are delivered only if it accepts.

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -34,7 +34,7 @@ OpenAPPA operates on three runtime concepts:
 
 Policy definitions remain strictly declarative TOML configurations. Instead of writing static allow or block rules for every tool interaction, developers declare tool contracts—specifying what permissions a tool requires (`requires`), how its output restricts security labels (`delta`), and what side effects it causes (`effects`). From these contracts, OpenAPPA automatically derives whether an action is permitted, blocked, or remediable across multi-step agent workflows.
 
-Dynamic judgment—such as regex filters, ML classifiers, or human approval queues—lives in registered components (authorities, sanitizers, casts) running as HTTP endpoints (`resolver`) or in-process modules (`builtin`). Every component is bounded by a strict mandate and may carry an advisory `hint` explaining its purpose to the agent during remedy selection.
+Dynamic judgment—such as regex filters, ML classifiers, or human approval queues—lives in registered components. Authorities and sanitizers run as HTTP endpoints (`resolver`) or in-process modules (`builtin`), are bounded by a strict `mandate`, and may carry an advisory `hint` explaining their purpose to the agent during remedy selection. Casts either declare a fixed label (`constant`) or call a classifier over HTTP (`resolver`) under a `may_cast` ceiling. Every answer is checked against the component's declared limit before it is admitted.
 
 ## Labels only move one way
 
@@ -153,10 +153,12 @@ Unannotated tools return data with an **Unknown** label state, representing unve
 |---|---|
 | **Unannotated Tool Dispatch** | Succeeds and assigns **Unknown** label state to its output. |
 | **Unregistered Tool Dispatch** | Refused directly by the engine before execution. |
-| **Requirement Check (`requires`)** | Fails closed when consuming an **Unknown** label value. |
+| **Requirement Check (`requires`)** | Drives the cast registered for the value, then checks the label it established; fails closed when no cast answers. |
 | **Child Merge Boundary** | Unknown child returns merge like any read: unresolved identities cross while every known restriction holds. Registered casts resolve them where the return policy consumes the dimension. |
 
-An Unknown label state does not halt execution until a tool contract's `requires` clause explicitly checks the value. To resolve an **Unknown** state, deployments register a **cast** component that assigns the value's complete label based on static rules or external evaluation services. This design allows deployments to start with a few high-risk tool annotations and incrementally expand policy coverage over time.
+An Unknown label state does not halt execution until a tool contract's `requires` clause explicitly checks the value. At that point the engine drives the **cast** registered for the value — a component that assigns its complete label from a fixed declaration or an external classifier — and decides on the answer it establishes. A value no registered cast reaches stays Unknown, and the call that needed it is refused. This design allows deployments to start with a few high-risk tool annotations and incrementally expand policy coverage over time.
+
+A deployment that would rather inspect the data before the model sees it declares the pending dimension on the tool itself, with `delta = { trust = "unknown" }`. The tool runs, the runtime holds its raw result back, and the cast reads the bytes the model has not: a non-restricting label releases the result, and a restricting one is offered to the agent as a narrowing to accept.
 
 ## Deploy at the gateway alone, or add components for full coverage
 


### PR DESCRIPTION
Wires cast resolution end to end. The engine already implemented the algebra; the runtime could not drive it and the policy loader could not express a resolver-backed cast.

## What lands

**Policy** — a `[[cast]]` may declare `resolver = { may_cast = { trust = [...], audience = { cap = [...] } } }`. A cast declares a constant or a resolver, never both and never neither. `may_cast` omitting `trust` admits no unresolved trust.

**Deployment** — `[externals.casts.<name>]` binds a classifier endpoint. Resolver-only: `builtin` is refused, because the answer is a label the ceiling has to bound rather than a stock transform. An unbound resolver cast refuses open; so does an endpoint bound to a constant cast, which the engine answers from the policy and would never call.

**Hold and inspect** — a tool declaring `delta = { trust = "unknown" }` under `confined_results` runs, the runtime holds its raw result, and the cast reads the bytes the model has not seen. A non-restricting label releases the result unchanged; a restricting one reaches the agent as a narrowing offer and the bytes are delivered only as the `execute_remedy_plan` response.

**Cast on demand** — a call blocked only on an unresolved source now drives the cast that would clear it, on the tool-call path as well as at a child return. The ask carries no appended facts, because a resolution moves the family basis and a decided batch would collide with it on redrive.

**One cascade** — both asks carry every applicable cast in registration order and the runtime tries them until one answers. A silent resolver falls through, so a trailing constant is the deployment's declared fallback. An answer over the ceiling falls through to nothing: a classifier answering wider than its policy allows is misbehaving, not silent.

## Acceptance

| Property | Where it is pinned |
|---|---|
| No leaks | `a_narrowing_classification_holds_the_bytes_until_the_agent_accepts` — the placeholder never carries the body, and acceptance is what releases it |
| Ceiling check fails closed and stays retryable | `an_answer_over_the_ceiling_withholds_the_result_and_stays_retryable` — nothing established, no fallthrough, and the same report judged afresh |
| Atomic tagging | structural: `EstablishedLabel` cannot represent an unresolved dimension, so a half-tagged answer is unrepresentable |
| Deterministic replay | `a_reopened_deployment_replays_the_classification_without_asking_again` — the stub refuses every consult after the restart and the decision is unchanged |

`runtime/tests/cast.rs` drives nine flows through the real deployment over an HTTP classifier stub.

## Note for review

`drive_with_evidence` awaits external consults sequentially, so N independent cast consults serialize. This is pre-existing and shared by every external kind — byte-identical at the base commit — and this branch only adds a request kind that flows through it. Parallelizing it is a change to shared machinery with a HITL hazard (a human consult must not be raced), so it is left alone here.
