### PR TITLE
fix(plugin): start the runtime at install, and stop a fresh install from failing to start it at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ claude plugin marketplace add archestra-ai/OpenAPPA &&
 ```
 
 The plugin installs a `clappa` command that runs Claude Code protected by
-OpenAPPA. Plain `claude` sessions stay untouched.
+OpenAPPA. Plain `claude` sessions stay untouched. Setup ends with the runtime
+running and answering, so the first `clappa` session starts at once.
 
 The default policy covers Claude Code's built-in tools only. Start `clappa` and
 run `/appa-tool-sync`: it finds your MCP servers and proposes a policy for them.
@@ -163,9 +164,15 @@ guide](integrations/claude-code/README.md).
 
 ## Upgrade
 
-The plugin tracks the marketplace. To upgrade the runtime, remove
-`~/.local/bin/appa-runtime-v2` and ask a plain `claude` session to set up APPA
-again; it installs the latest release.
+The plugin tracks the marketplace. To upgrade the runtime, stop the running
+one and remove `~/.local/bin/appa-runtime-v2`, then ask a plain `claude` session
+to set up APPA again; it installs the latest release and starts it. Stopping it
+first matters: a runtime already answering on the port keeps serving, and the
+new binary would never run.
+
+```sh
+pkill -f appa-runtime-v2 && rm ~/.local/bin/appa-runtime-v2
+```
 
 ## Uninstall
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -51,7 +51,10 @@ plain `claude` session offers to install it (`hooks/setup-appa.md`) —
 download the release archive for the current system, verify its SHA-256
 against the release `SHA256SUMS` and its version against `version.txt`,
 and place the binary — each step under the session's normal command
-approval. While the repository is private, run
+approval. The last step starts the runtime through the plugin's own
+starter and reports the answer `/health` gave, so the install ends with a
+process that has actually run on this machine, the default policy written,
+and no start left for the first protected session to pay for. While the repository is private, run
 `gh auth login && gh auth setup-git` first.
 
 Linux binaries require glibc 2.34 or newer. Alpine and other musl-only
@@ -107,8 +110,9 @@ start, that the beta is available and `clappa` starts a protected
 session.
 
 A protected session starts the installed runtime at SessionStart when
-nothing healthy answers `/health`, then blocks every action while the
-runtime is unavailable. When the binary is not installed at all, an
+nothing healthy answers `/health` — normally a no-op, because the install
+left it running — then blocks every action while the runtime is
+unavailable. When the binary is not installed at all, an
 unprotected session installs it as a prompted task: its session context
 (`hooks/setup-appa.md`) has the model offer the setup and, on request,
 download the release archive for the current system, verify its
@@ -150,9 +154,11 @@ between the installed and the dev runtime, start a new session.
 
 ## Upgrade
 
-The plugin tracks the marketplace. To upgrade the runtime, remove the
-binary from the location in the table above and ask a plain `claude`
-session to set up APPA again; it installs the latest release.
+The plugin tracks the marketplace. To upgrade the runtime, stop the
+running one, remove the binary from the location in the table above, and
+ask a plain `claude` session to set up APPA again; it installs the latest
+release and starts it. Stop it first: a runtime already answering on the
+port keeps serving, and the new binary would never run.
 
 ## Uninstall
 

--- a/integrations/claude-code/plugin/README.md
+++ b/integrations/claude-code/plugin/README.md
@@ -24,17 +24,24 @@ successful tool-result admission; WSL runs the POSIX hooks as-is.
 without changing Claude's settings automatically; unprotected sessions show
 the mascot with a `clappa` reminder instead of runtime status.
 
-A protected session starts the runtime itself: at session start,
-`hooks/ensure-runtime.sh` (on Windows, `hook.ps1`) launches the
-installed `appa-runtime-v2` when nothing healthy answers `/health`, and
-the session proceeds only once it does. When the binary is not
-installed at all, an unprotected session offers the install as a
-prompted task:
-`hooks/setup-appa.md` tells the model how to download, verify, and
-install the release binary on request, under the session's normal
-command approval — so the plugin alone completes the install. A runtime
-that dies mid-session still blocks the session until the next session
-start brings it back.
+The install and every protected session share one starter,
+`hooks/ensure-runtime.sh` (on Windows, `hook.ps1 -EnsureRuntime`): it
+launches the installed `appa-runtime-v2` when nothing healthy answers
+`/health` and returns only once one does. The last step of the install
+runs it, so a protected session normally finds the runtime already up and
+its SessionStart start is a single health probe. When the binary is not
+installed at all, an unprotected session offers the install as a prompted
+task: `hooks/setup-appa.md` tells the model how to download, verify,
+install, and start the release binary on request, under the session's
+normal command approval — so the plugin alone completes the install. A
+runtime that dies mid-session still blocks the session until the next
+session start brings it back.
+
+Concurrent starts need no lock: the runtime binds the loopback port, so
+the first process to bind serves and every later one exits at once. Each
+hook declares a timeout longer than its own deadline, because Claude Code
+kills a hook that outruns the timeout and then lets the action proceed —
+an undeclared timeout is the one way these hooks fail open.
 
 On session start the hooks also print `hooks/session-context.md` into
 the model's context: short guidance on how to act in a protected session

--- a/integrations/claude-code/plugin/hooks/ensure-runtime.sh
+++ b/integrations/claude-code/plugin/hooks/ensure-runtime.sh
@@ -1,21 +1,30 @@
 #!/bin/sh
 # Starts the installed appa-runtime-v2 when no healthy runtime answers.
-# SessionStart runs this before the hooks post their first event, so a
-# protected session works without a login service. Exit 0 means a healthy
-# runtime answers; any other exit makes the chained protection hook block.
+# Two callers share it: the last step of the install (hooks/setup-appa.md)
+# and every protected SessionStart, which runs it before the hooks post
+# their first event. A protected session therefore needs no login service,
+# and an install that ends here leaves the runtime up, so the first
+# protected session pays nothing for the start. Exit 0 means a healthy
+# runtime answers; any other exit makes the chained protection hook block,
+# and tells the install that it has nothing to report as running.
 # Installing the binary is not this script's job: an unprotected session
 # offers that as a prompted task (hooks/setup-appa.md).
 #
-# The lock only serializes concurrent SessionStarts during the poll window:
-# whichever session creates it spawns the runtime, the others wait on
-# /health. It is removed on every exit path, so it cannot go stale across
-# sessions.
+# Concurrent starts need no lock. The runtime binds the loopback port, so
+# the first process to bind serves and every later one exits at once with
+# "address already in use"; both callers then see the same healthy
+# runtime. The port is a mutex that cannot go stale, while a lock file
+# outlives the hook that Claude Code kills at its timeout and would block
+# every start after it.
 set -u
 
 runtime_url=${APPA_RUNTIME_URL:-http://127.0.0.1:8787}
 
+# One cheap probe. A dead loopback port refuses at once on most systems but
+# hangs under some network stacks (WSL2 mirrored networking), where the
+# deadline is what the probe actually costs.
 healthy() {
-  [ "$(curl -sf -m 2 "$runtime_url/health" 2>/dev/null || true)" = ok ]
+  [ "$(curl -sf -m 1 "$runtime_url/health" 2>/dev/null || true)" = ok ]
 }
 
 if healthy; then
@@ -43,22 +52,26 @@ if [ ! -x "$binary" ]; then
   }
 fi
 
-mkdir -p "$data_dir"
-lock_dir=$data_dir/runtime.hook.lock
-if mkdir "$lock_dir" 2>/dev/null; then
-  trap 'rmdir "$lock_dir" 2>/dev/null || true' 0 1 2 15
-  nohup "$binary" --config "$config_dir/appa.toml" --db "$data_dir/appa.db" \
-    >>"$data_dir/runtime.stdout.log" 2>>"$data_dir/runtime.stderr.log" \
-    </dev/null &
-fi
+# The runtime writes the default policy on its first start and refuses to
+# start when it cannot. Both directories must exist first: they are one
+# path on macOS and two different paths everywhere else.
+mkdir -p "$config_dir" "$data_dir"
 
-attempts=0
-while [ "$attempts" -lt 15 ]; do
+nohup "$binary" --config "$config_dir/appa.toml" --db "$data_dir/appa.db" \
+  >>"$data_dir/runtime.stdout.log" 2>>"$data_dir/runtime.stderr.log" \
+  </dev/null &
+
+# The whole start must finish inside the timeout hooks.json declares for
+# SessionStart, so the wait is a wall-clock budget. A count of probes is
+# not: one probe costs microseconds where the port refuses and the full
+# deadline where it hangs.
+deadline=$(($(date +%s) + 20))
+while [ "$(date +%s)" -lt "$deadline" ]; do
   if healthy; then
     exit 0
   fi
-  attempts=$((attempts + 1))
   sleep 1
 done
-printf 'appa protection: runtime did not become healthy at %s\n' "$runtime_url" >&2
+printf 'appa protection: runtime did not become healthy at %s. Its own error is the last line of %s\n' \
+  "$runtime_url" "$data_dir/runtime.stderr.log" >&2
 exit 1

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -1,5 +1,6 @@
 param(
-    [switch]$SessionContext
+    [switch]$SessionContext,
+    [switch]$EnsureRuntime
 )
 
 # Hooks protect only sessions launched with APPA_GATE=1 (the clappa
@@ -31,10 +32,6 @@ if ($SessionContext) {
     exit 0
 }
 
-if (-not $protected) {
-    exit 0
-}
-
 $runtimeUrl = if ($env:APPA_RUNTIME_URL) {
     $env:APPA_RUNTIME_URL.TrimEnd("/")
 } else {
@@ -43,16 +40,17 @@ $runtimeUrl = if ($env:APPA_RUNTIME_URL) {
 
 function Test-RuntimeHealthy {
     try {
-        (Invoke-RestMethod -Uri "$runtimeUrl/health" -TimeoutSec 2 -UseBasicParsing) -eq "ok"
+        (Invoke-RestMethod -Uri "$runtimeUrl/health" -TimeoutSec 1 -UseBasicParsing) -eq "ok"
     } catch {
         $false
     }
 }
 
 # SessionStart starts the installed runtime when nothing healthy answers,
-# so a protected session works without any service setup. Installing the
-# binary is not this script's job: an unprotected session offers that as a
-# prompted task.
+# so a protected session works without any service setup, and the last step
+# of the install starts it through -EnsureRuntime. Installing the binary is
+# not this script's job: an unprotected session offers that as a prompted
+# task.
 function Start-RuntimeIfDown {
     if (Test-RuntimeHealthy) {
         return
@@ -60,17 +58,48 @@ function Start-RuntimeIfDown {
     if (-not (Test-Path -LiteralPath $binary)) {
         return
     }
+    # The runtime writes the default policy on its first start and refuses
+    # to start when it cannot. The policy and the database live in two
+    # different directories on Windows, so both must exist first.
+    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
     New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
     Start-Process -FilePath $binary -WindowStyle Hidden -ArgumentList @(
         "--config", (Join-Path $configDir "appa.toml"),
         "--db", (Join-Path $dataDir "appa.db")
     ) | Out-Null
-    for ($attempt = 0; $attempt -lt 15; $attempt++) {
+    # A wall-clock budget, not a count of probes: one probe is instant
+    # where the port refuses and costs the full deadline where it hangs.
+    # The whole start must fit inside the timeout hooks.windows.json
+    # declares for SessionStart.
+    $deadline = (Get-Date).AddSeconds(20)
+    while ((Get-Date) -lt $deadline) {
         if (Test-RuntimeHealthy) {
             return
         }
         Start-Sleep -Seconds 1
     }
+}
+
+# The last step of the install starts the runtime through this switch, so
+# the install and every protected session start share one starter. It runs
+# outside the protection guard, because the session that installs is not
+# protected. It exits 0 only while /health answers, which is the proof the
+# install reports.
+if ($EnsureRuntime) {
+    if (-not (Test-Path -LiteralPath $binary)) {
+        [Console]::Error.WriteLine("appa protection: appa-runtime-v2 is not installed; expected at $binary")
+        exit 1
+    }
+    Start-RuntimeIfDown
+    if (Test-RuntimeHealthy) {
+        exit 0
+    }
+    [Console]::Error.WriteLine("appa protection: runtime did not become healthy at $runtimeUrl. Its own error is the last line of $(Join-Path $dataDir 'runtime.stderr.log')")
+    exit 1
+}
+
+if (-not $protected) {
+    exit 0
 }
 
 # The hooks that report a finished turn. They decide nothing, so they

--- a/integrations/claude-code/plugin/hooks/hooks.json
+++ b/integrations/claude-code/plugin/hooks/hooks.json
@@ -1,12 +1,13 @@
 {
-  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and SessionStart prints beta-announcement.md instead of the protection context — a one-line invitation to try clappa — or, when the runtime binary is not installed, setup-appa.md: instructions for the model to offer and perform the install as a prompted task, prefixed with the resolved install target so the instructions and the hooks' binary lookup cannot disagree on the path. In a protected session every hook posts its event to the appa-runtime-v2 process and prints the runtime's answer. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health. curl --fail-with-body exits non-zero on a non-2xx answer and on a connection failure; plain curl exits 0 on server errors and would fail open. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They discard the answer and always exit 0, and take the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
+  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and SessionStart prints beta-announcement.md instead of the protection context — a one-line invitation to try clappa — or, when the runtime binary is not installed, setup-appa.md: instructions for the model to offer and perform the install as a prompted task, prefixed with the resolved install target so the instructions and the hooks' binary lookup cannot disagree on the path. In a protected session every hook posts its event to the appa-runtime-v2 process and prints the runtime's answer. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health; the install runs the same script as its last step, so a protected session normally finds the runtime already up. curl --fail-with-body exits non-zero on a non-2xx answer and on a connection failure; plain curl exits 0 on server errors and would fail open. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. Every hook declares a timeout above its own curl deadline, and SessionStart's also covers the starter's 20-second budget. Claude Code kills a hook that outruns the timeout and then lets the action proceed, because it never reads the killed hook's exit code, so an undeclared timeout is the one way these hooks fail open. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They discard the answer and always exit 0, and take the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "timeout": 150
           },
           {
             "type": "command",
@@ -20,7 +21,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "timeout": 130
           }
         ]
       }
@@ -31,7 +33,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "timeout": 130
           }
         ]
       }
@@ -42,7 +45,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "timeout": 130
           }
         ]
       }
@@ -52,7 +56,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0",
+            "timeout": 40
           }
         ]
       }
@@ -62,7 +67,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0",
+            "timeout": 40
           }
         ]
       }
@@ -72,7 +78,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "timeout": 130
           }
         ]
       }
@@ -82,7 +89,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0",
+            "timeout": 40
           }
         ]
       }
@@ -93,7 +101,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2"
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "timeout": 130
           }
         ]
       }

--- a/integrations/claude-code/plugin/hooks/hooks.windows.json
+++ b/integrations/claude-code/plugin/hooks/hooks.windows.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "powershell.exe",
             "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
-            "timeout": 130
+            "timeout": 150
           },
           {
             "type": "command",

--- a/integrations/claude-code/plugin/hooks/setup-appa.md
+++ b/integrations/claude-code/plugin/hooks/setup-appa.md
@@ -8,7 +8,7 @@ When the user asks for the setup, install the runtime:
 2. Download the archive plus `SHA256SUMS` and `version.txt` into a temporary directory: `curl -fsSL -O https://github.com/archestra-ai/OpenAPPA/releases/latest/download/<asset>` for each of the three assets. No authentication is needed. `gh release download --repo archestra-ai/OpenAPPA --pattern <asset>` works too when `gh` is already installed.
 3. Verify before anything runs: the archive's SHA-256 must equal its line in `SHA256SUMS` (`shasum -a 256` or `sha256sum`). On a mismatch, stop and tell the user; do not install.
 4. Extract the archive and check the binary: `./appa-runtime-v2 --version` must print exactly `appa-runtime-v2 <contents of version.txt>`.
-5. Install the binary to the install target named at the top of this context, mode 755, creating the directory when needed. That exact path is where the plugin's hooks look for it; do not choose a different location. Do not start it: protected sessions start it on demand. When reporting this step, do not say "not started" as if something is missing — say the runtime will be started when `clappa` is called, formatting `clappa` as inline code.
+5. Install the binary to the install target named at the top of this context, mode 755, creating the directory when needed. That exact path is where the plugin's hooks look for it; do not choose a different location. Step 8 starts it.
 6. Create the `clappa` command as an executable, not an alias, so it works in every open terminal with no shell reload: write `clappa` into the same directory as the runtime binary, mode 755, containing:
 
    ```sh
@@ -26,6 +26,13 @@ When the user asks for the setup, install the runtime:
 
    It shows the APPA mascot with the session's trust and audience when protected, and a `clappa` reminder when not.
 
-8. Finish by telling the user to start a protected session with `clappa`. Add a tip on the next line: run the `/appa-tool-sync` skill in the `clappa` session to build the initial security policy. Format both `clappa` and `/appa-tool-sync` as inline code.
+8. Start the runtime and confirm it answers. First ask whether one already runs: `curl -sS -m 2 http://127.0.0.1:8787/health`, or `$APPA_RUNTIME_URL/health` when that variable is set.
+
+   - Nothing answers — the usual case on a first install. Start it with the plugin's own starter, `sh "<plugin files>/hooks/ensure-runtime.sh"`, taking `<plugin files>` from the top of this context. On native Windows, run `powershell.exe -NoProfile -File "<plugin files>\hooks\hook.ps1" -EnsureRuntime`. The starter runs the installed binary and exits 0 only after `/health` answers `ok`; every protected session start runs the same script. Then repeat the `/health` request yourself and report what it printed. The first start also writes the default policy, so step 9's `/appa-tool-sync` tip has a file to work on.
+   - The request prints `ok` — a runtime from an earlier install is still running. Its version is not readable over HTTP, so do not report the binary you just installed as the running one. Tell the user to stop the old process and to ask for this step again: `pkill -f appa-runtime-v2`, on Windows `Stop-Process -Name appa-runtime-v2`. Warn them that stopping it blocks every protected session that is already open, because the hooks fail closed.
+
+   If the starter exits non-zero, the runtime is not running. Report that, quote the last lines of `runtime.stderr.log` in the data directory, and stop. Do not describe the setup as finished.
+
+9. Finish by telling the user that the runtime is running and that `clappa` starts a protected session. Add a tip on the next line: run the `/appa-tool-sync` skill in the `clappa` session to build the initial security policy. Format both `clappa` and `/appa-tool-sync` as inline code.
 
 If the `curl` download fails, ask the user to install the GitHub CLI, then try again with `gh release download`.


### PR DESCRIPTION
The install placed the runtime binary and left the first protected session to start it. On Linux that start could never succeed, and the session paid two minutes to find out.

## What was wrong

`ensure-runtime.sh` created the data directory and then passed `--config` into a directory it never created. Policy and data are the same path on macOS, and two different paths everywhere else, so on Linux every fresh install produced:

```
appa-runtime-v2: cannot create /home/ubuntu/.config/appa/appa.toml: No such file or directory (os error 2)
```

The starter then polled a port that would never answer. Fifteen probes against a loopback port that hangs instead of refusing cost 45 seconds — longer than the hook timeout Claude Code applies — so SessionStart was killed. Two further defects turned that into the reported symptom:

- The POSIX `hooks.json` declared no `timeout`. Claude Code kills a hook that outruns its own default and lets the action proceed, because it never reads the killed hook's exit code, so the trailing `exit 2` never ran and the turn went through **ungated**. `hooks.windows.json` already declared timeouts.
- The start lock was removed on every exit path the script controls, but not when the hook is killed. A lock left behind stopped every later start from spawning anything.

## What changed

- Create both directories before starting the runtime, on POSIX and on Windows.
- Wait on a wall-clock budget instead of a count of probes: one probe costs microseconds where the port refuses and the full deadline where it hangs.
- Drop the lock. The loopback bind is already a mutex — the first runtime to bind serves, later ones exit at once, and a port cannot go stale.
- Declare a `timeout` on every hook, above its own curl deadline; SessionStart also covers the starter's budget.
- The last step of the install now runs the same starter and reports what `/health` answered, so the install ends with a process that has actually run on this machine and the default policy written. A runtime from an earlier install keeps the port and its version is not readable over HTTP, so that case is reported as needing a restart rather than as success.
- Add `hook.ps1 -EnsureRuntime` so Windows has the same standalone starter.

## Measured on Linux (WSL2), cold slate

| | before | after |
|---|---|---|
| protected session, no runtime running | **107s**, runtime never started, turn ran ungated | **9s**, runtime healthy |
| protected session, runtime already up | — | 7s (model latency only) |
| `ensure-runtime.sh` alone, cold | 45s → exit 1 | 2s → exit 0 |

Three concurrent starters converge on one runtime in 2s; the losers log `Address already in use` and exit.

## Checks

- `cargo test -p appa-runtime-v2 --test plugin_hooks` — 6 passed
- `sh -n` and `shellcheck -s sh` on the plugin shell scripts — clean
- `jq` validation of both hook maps and both marketplace manifests — clean
- `claude plugin validate` — passes
- Live: cold and warm protected sessions, and a protected session making a real tool call, all against the changed plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)