### PR TITLE
docs: drop the duplicated merge-commit entries from the 0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Bug Fixes
 
-* close at the turn end a call the harness never ran ([ec9130b](https://github.com/archestra-ai/OpenAPPA/commit/ec9130ba599a9bc83f4961e47cad654c01d01bc9))
 * close at the turn end a call the harness never ran ([60e54b6](https://github.com/archestra-ai/OpenAPPA/commit/60e54b64ff3d3fc24a3c268bc927c42c7f342db9))
 * **plugin:** start the runtime at install, and stop a fresh install from failing to start it at all ([#22](https://github.com/archestra-ai/OpenAPPA/issues/22)) ([44845e4](https://github.com/archestra-ai/OpenAPPA/commit/44845e47dcd9043d9a2c8df4fdb0656d143fefe7))
 
@@ -19,21 +18,16 @@
 ### Documentation
 
 * **plugin:** fall back to gh cli when the curl download fails ([e9186e7](https://github.com/archestra-ai/OpenAPPA/commit/e9186e789a076da6be70a1ab3d1443efd1c9c285))
-* **plugin:** install downloads with curl, no GitHub CLI needed ([e0ff316](https://github.com/archestra-ai/OpenAPPA/commit/e0ff316f71ce1c51b608fbecfb7d1c7336b63fd9))
 * **plugin:** install downloads with curl, no GitHub CLI needed (repo is public) ([90267b4](https://github.com/archestra-ai/OpenAPPA/commit/90267b41c5096b54625e4bb71eec3cb5a2d2173b))
-* **plugin:** report install-time runtime state as starts-with-clappa ([7e6075f](https://github.com/archestra-ai/OpenAPPA/commit/7e6075f3032b559a74f587142afcc13ad9ab98d3))
 * **plugin:** report install-time runtime state as starts-with-clappa, not "not started" ([26a05c6](https://github.com/archestra-ai/OpenAPPA/commit/26a05c6c7c0d384bf0648836dec98c1e740f1b37))
 * rewrite README ([#21](https://github.com/archestra-ai/OpenAPPA/issues/21)) ([5c95856](https://github.com/archestra-ai/OpenAPPA/commit/5c95856f748a994119f28af0dbb1f0b408935ca3))
-* show a blocked flow screenshot on the Claude Code page ([1564233](https://github.com/archestra-ai/OpenAPPA/commit/1564233e619763c56d870fca004b191e80abb5b2))
 * show a blocked flow screenshot on the Claude Code page ([7ff55c2](https://github.com/archestra-ai/OpenAPPA/commit/7ff55c2f17fd4a3618783ac28b170b67c183fb41))
 * stop the runtime in the Claude Code uninstall steps ([7d49778](https://github.com/archestra-ai/OpenAPPA/commit/7d49778827d39665feb1a7820e5de5b9a0392b72))
-* stop the runtime in the README uninstall steps too ([19f5a6b](https://github.com/archestra-ai/OpenAPPA/commit/19f5a6b78a786ba8783a515ce08b3d28a5f00542))
 * stop the runtime in the README uninstall steps too ([dd8003c](https://github.com/archestra-ai/OpenAPPA/commit/dd8003c641e7eb9f905b890f21b293b83fb5ddd1))
 
 
 ### Miscellaneous Chores
 
-* add MIT license ([3f130d4](https://github.com/archestra-ai/OpenAPPA/commit/3f130d4c270b1c1bc6a31a9d275457495d9d0f28))
 * add MIT license ([f998d70](https://github.com/archestra-ai/OpenAPPA/commit/f998d709d6f8472b85926567ab029e1a9621f6ac))
 
 ## 0.1.0 (2026-08-18)


### PR DESCRIPTION
The 0.2.0 release notes list six changes twice. This removes the duplicate half of each pair; the root cause is already fixed in the repository settings.

## Why it happened

The repository allowed merge commits with `merge_commit_message: PR_TITLE`, so GitHub wrote the PR title into the merge commit's *body* — and PR titles here are conventional-commit formatted, because the PR Title Linter enforces it. Release Please parses every commit in the release range, so one PR yielded two parseable conventional commits:

```
ec9130b  Merge pull request #15 from archestra-ai/fix/turn-end-closes-abandoned-call
         body: fix: close at the turn end a call the harness never ran
60e54b6  fix: close at the turn end a call the harness never ran
```

Six of the nine merge commits in the 0.2.0 range produced a duplicate this way. Every squash-merged PR (#20, #21, #22) appears exactly once. Release Please has no configuration option to skip merge commits or dedupe entries — its config schema carries neither.

This is not a leak from an earlier release: all 18 commits in the 0.2.0 section post-date the `v0.1.0` tag, and no entry appears in both sections.

## What changed here

Each pair keeps the commit that made the change, and drops the merge commit:

| kept | dropped |
|---|---|
| `60e54b6` | `ec9130b` |
| `90267b4` | `e0ff316` |
| `26a05c6` | `7e6075f` |
| `7ff55c2` | `1564233` |
| `dd8003c` | `19f5a6b` |
| `f998d70` | `3f130d4` |

Two merge commits stay, because in both cases nothing else carries the change: `f2dc0cb` is the only conventional commit for the cast-resolution work (#19's branch commits use `engine:`/`policy:` prefixes), and `7d49778` is the only surviving entry for the Claude Code uninstall change.

## Root cause fix

The repository now allows squash merges only, with the squash title taken from the PR title: `allow_merge_commit=false`, `allow_rebase_merge=false`, `squash_merge_commit_title=PR_TITLE`. One commit per PR, one changelog entry per PR.

## Known related defect, not fixed here

`dbefba5` ("stop the runtime in the Claude Code uninstall steps") is missing from both releases. It was branched before the 0.1.0 release and merged after it, so its committer date (12:31 UTC) sorts before the release commit `37c25c9` (12:37 UTC) and the date-ordered history walk stopped before reaching it. The change reached the notes only through its merge commit `7d49778`, which is why that entry is kept above. Squash-only merging does not prevent this; a PR branched before a release and merged after it can still be skipped.

The 0.1.0 section has three duplicate pairs from the same cause. Left alone — that release is already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)