### PR TITLE
docs: the uninstall removes the statusline entry it wrote

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ claude plugin marketplace remove appa
 pkill -f appa-runtime-v2
 rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
 
+# drop the statusline entry the setup wrote, and keep one of your own:
+jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \
+  ~/.claude/settings.json > ~/.claude/settings.json.new &&
+  mv ~/.claude/settings.json.new ~/.claude/settings.json
+
 # optional — also remove the policy, database, and alias:
 rm -rf ~/.config/appa ~/.local/share/appa      # Linux
 rm -rf ~/Library/"Application Support/appa"    # macOS

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -166,12 +166,22 @@ port keeps serving, and the new binary would never run.
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 pkill -f appa-runtime-v2
-rm ~/.local/bin/appa-runtime-v2
+rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
+
+# drop the statusline entry the setup wrote, and keep one of your own:
+jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \
+  ~/.claude/settings.json > ~/.claude/settings.json.new &&
+  mv ~/.claude/settings.json.new ~/.claude/settings.json
 ```
 
+The setup writes the `statusLine` entry into your own settings, so
+removing the script alone leaves Claude Code running a command that no
+longer exists. The `jq` line removes that entry only while it runs
+`appa-statusline.sh`, so a statusline of your own survives untouched.
+
 The policy and database stay at the locations in the table above; delete
-them only if you want the history gone. Remove a `clappa` alias or a
-statusline setting separately if you created them.
+them only if you want the history gone. Remove a `clappa` shell alias
+separately if you added one instead of the command.
 
 ## Statusline, manually
 

--- a/integrations/claude-code/plugin/hooks/setup-appa.md
+++ b/integrations/claude-code/plugin/hooks/setup-appa.md
@@ -18,7 +18,7 @@ When the user asks for the setup, install the runtime:
 
    Only if that directory is not on the user's `PATH`, fall back to appending `alias clappa='APPA_GATE=1 claude'` to the file matching their shell and tell them to reload it. On Windows, add the matching `clappa` function to the PowerShell profile.
 
-7. Install the statusline, unless `~/.claude/settings.json` already has a `statusLine` entry — never replace one. Copy `statusline.sh` (on Windows, `statusline.ps1`) from the plugin files directory named at the top of this context into the runtime binary's directory as `appa-statusline.sh`, mode 755, and merge into `~/.claude/settings.json`:
+7. Install the statusline, unless `~/.claude/settings.json` already has a `statusLine` entry that runs something other than `appa-statusline.sh` — never replace someone else's. Overwrite an APPA entry that names a different path: an earlier install into another directory leaves one behind. Copy `statusline.sh` (on Windows, `statusline.ps1`) from the plugin files directory named at the top of this context into the runtime binary's directory as `appa-statusline.sh`, mode 755, and merge into `~/.claude/settings.json`:
 
    ```json
    {"statusLine": {"type": "command", "command": "<that path>/appa-statusline.sh"}}

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -35,6 +35,11 @@ claude plugin marketplace remove appa
 pkill -f appa-runtime-v2
 rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
 
+# drop the statusline entry the setup wrote, and keep one of your own:
+jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \
+  ~/.claude/settings.json > ~/.claude/settings.json.new &&
+  mv ~/.claude/settings.json.new ~/.claude/settings.json
+
 # optional — also remove the policy, database, and alias:
 rm -rf ~/.config/appa ~/.local/share/appa      # Linux
 rm -rf ~/Library/"Application Support/appa"    # macOS


### PR DESCRIPTION
Yes — the uninstall forgets the statusline. It removes the *script* and leaves the *setting* that points at it.

## What happens

Setup step 7 does two things: it copies `statusline.sh` to `~/.local/bin/appa-statusline.sh`, and it merges this into the reader's own settings:

```json
{"statusLine": {"type": "command", "command": "~/.local/bin/appa-statusline.sh"}}
```

All three uninstall procedures removed files under `~/.local/bin` and none touched `~/.claude/settings.json`. Two consequences:

1. Claude Code keeps running a status line command that no longer exists.
2. A later setup finds the stale entry and skips the step — step 7 said "never replace one" for *any* existing entry. That is the `Statusline was already configured to that exact path — nothing to merge.` message. When the reinstall uses a different `APPA_INSTALL_DIR`, the entry points at the wrong path and setup refuses to repair it.

## Why it regressed

The removal used to be documented. Commit `cb1d94c` ("uninstall is manual commands only; drop prompts and statusLine edit") deleted it, along with the caveat that it should only apply "if it runs appa-statusline.sh". The command it deleted was:

```sh
jq 'del(.statusLine)' ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
```

That form deletes *any* `statusLine`, including one the reader set for something else — so dropping it was safer than keeping it, and nothing replaced it.

## What changed

The removal is back in all three uninstalls, now conditional:

```sh
jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \
  ~/.claude/settings.json > ~/.claude/settings.json.new &&
  mv ~/.claude/settings.json.new ~/.claude/settings.json
```

The temp file sits beside the target, so the `mv` is atomic rather than crossing filesystems.

The Claude Code guide's uninstall block also removed only `appa-runtime-v2`, leaving `clappa` and `appa-statusline.sh` behind — it now removes what the other two remove.

Step 7 now yields only to a statusline that is not APPA's, so a reinstall can repair its own stale entry.

## Verified

The command was extracted verbatim from the rendered README and run against a sandboxed `HOME`:

| settings.json before | after |
|---|---|
| APPA's entry | removed, other 7 keys intact, no `.new` file left |
| a reader's own `mine.sh` | untouched |
| no `statusLine` key | unchanged |

Also run against a copy of a real `~/.claude/settings.json`: only `statusLine` went, the remaining keys were preserved byte for byte.

`jq` is already assumed by anyone who installed the statusline — `statusline.sh` needs `jq` and `curl` to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)