### PR TITLE
feat(plugin): forbid tool-switch detours around blocks, and have tool-sync offer a demo prompt

### DIFF
--- a/integrations/claude-code/plugin/hooks/session-context.md
+++ b/integrations/claude-code/plugin/hooks/session-context.md
@@ -1,6 +1,7 @@
 This session is protected by APPA. APPA checks every tool call against a flow policy before it runs.
 
 - A block is a policy decision, not an error. Do not retry the blocked call. Do not route around it.
+- Never reach a blocked flow through a different tool. If an MCP tool is blocked, do not do the same read or send with Bash, a script, a file write, or any other tool. The policy decides about the data flow, not about the tool name. A detour is the same flow and breaks the policy the user chose.
 - If the block offers remedy plans and one clearly fits the task, run it with the `execute_remedy_plan` tool and continue. Do not ask the human first. Ask only when the choice between plans is ambiguous.
 - To understand a block, read the runtime's policy file (`appa.toml`). It declares each tool's reads and emissions, and which sources may flow to which sinks.
 - Never edit the policy file. Policy changes belong to the human; propose them, do not make them.

--- a/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
@@ -207,3 +207,32 @@ The last line matters and is easy to get wrong: a session keeps the
 policy file it started with, so the tools you just added do not work
 in the session that added them. Keep the reminder to that one short
 line, and name `clappa` — only sessions started with it are protected.
+
+## 9. Offer one prompt that shows the protection
+
+After the close, offer the user one prompt they can paste into that
+new session to watch the protection work. Compose it from the entries
+you just wrote — never from a fixed example and never from this
+document:
+
+- Pick one tool you marked as keeping data private. Steer away from
+  the most sensitive sources — meeting recordings, mail.
+- Pick one tool you marked as able to send data outside. Prefer one
+  the user has already authenticated and whose target exists, so the
+  only failure the demo can show is the block.
+- Write the prompt as three numbered steps: fetch one real item with
+  the first tool; write a short summary that copies a few exact lines
+  from it; send that summary with the second tool. Name a concrete
+  destination the user owns. End the prompt with: use only MCP tools —
+  no Bash, no local files.
+
+The copied lines are what makes the demo certain: they make the sent
+text visibly come from the private data, so the send is refused on
+every run, not judged case by case.
+
+Then tell the user, in two sentences and plain words, what they will
+see: the fetch works and the data comes in; the send is refused,
+because the summary carries what the private tool returned.
+
+If the sync wrote no private tool or no sending tool, skip this step
+and say nothing about it.


### PR DESCRIPTION
## What

Two plugin-side changes; nothing needs a rebuild.

**`session-context.md`** — the injected protection context now names the concrete workaround it forbids: reaching a blocked flow through a different tool. If an MCP tool is blocked, the model must not do the same read or send with Bash, a script, or a file write. `Bash` is declared with a neutral `delta = {}` and no `requires`, so the policy cannot see a push that runs inside a shell — the injected prompt is the wall on that path.

**`appa-tool-sync` skill** — a new final step (9). After the reload, the sync composes one demo prompt from the entries it just wrote — never from a fixed example: one tool marked as keeping data private (steering away from meeting recordings and mail) and one tool marked as able to send data outside (preferring an authenticated one, so the block is the only possible failure). The prompt fetches a real item, summarizes it with a few copied lines, and tries to send the summary — MCP tools only, no Bash, no local files. The copied lines make the sent text visibly derive from the private data, so the send is refused on every run. If either kind of tool is missing, the step is skipped silently.

## Why

A blocked MCP call must not be retried through the shell, and every sync should end with a prompt the user can paste to watch the protection work — read succeeds, exfiltration is refused deterministically.