### PR TITLE
docs: refine OpenAPPA onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![Status: Preview & RFC](https://img.shields.io/badge/status-preview%20%26%20RFC-orange.svg)](https://openappa.com)
-[![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-black.svg)](https://openappa.com/claude-code)
 
 </div>
 
@@ -24,100 +23,17 @@
 OpenAPPA sits between an agent and its tools and answers one question before
 every action: **is this data allowed to go to this destination?**
 
-It is powered by APPA — Agentic Permissions Policy Algebra — a formal system
-that tracks the sensitivity and trust of everything an agent reads, and checks
-every outbound call against it. Checks run *before* dispatch, so sensitive data
-never reaches an unauthorized tool. When a call would violate policy, the agent
-does not get a generic error: it gets remedy plans it can act on.
+It is powered by APPA — Agentic Permissions Policy Algebra — which tracks the
+sensitivity and trust of everything an agent reads and checks every outbound
+call against it. Checks run *before* dispatch, so sensitive data never reaches
+an unauthorized tool. Classifiers and PII detectors are probabilistic; a
+declared flow decision here holds on every run, which is what it takes to trust
+an agent around medical or financial records.
 
-## Why
-
-The more tools and data an agent is connected to, the more it can do — and the
-more it can leak. Exfiltration has hit production assistants repeatedly:
-[ChatGPT](https://simonwillison.net/2023/Apr/14/new-prompt-injection-attack-on-chatgpt-web-version-markdown-imag/),
-[Google Bard](https://simonwillison.net/2023/Nov/4/hacking-google-bard-from-prompt-injection-to-data-exfiltration/),
-[GitHub Copilot Chat](https://simonwillison.net/2024/Jun/16/github-copilot-chat-prompt-injection/),
-[Slack AI](https://simonwillison.net/2024/Aug/20/data-exfiltration-from-slack-ai/),
-[Microsoft 365 Copilot "EchoLeak"](https://www.hackthebox.com/blog/cve-2025-32711-echoleak-copilot-vulnerability),
-[ChatGPT Deep Research "ShadowLeak"](https://thehackernews.com/2025/09/shadowleak-zero-click-flaw-leaks-gmail.html).
-
-PII detectors and prompt-injection classifiers are probabilistic: they hold on
-most runs. OpenAPPA tracks data flows instead of classifying data, so a declared
-flow decision holds on every run — which is what it takes to trust an agent
-around medical or financial records. Where non-deterministic judgment is
-genuinely unavoidable, you plug it in explicitly, as a registered component.
-
-## Quickstart
-
-OpenAPPA ships as a Claude Code plugin:
-
-```sh
-claude plugin marketplace add archestra-ai/OpenAPPA &&
-  claude plugin install appa-runtime@appa &&
-  claude "set up APPA"
-```
-
-The plugin installs a `clappa` command that runs Claude Code protected by
-OpenAPPA. Plain `claude` sessions stay untouched. Setup ends with the runtime
-running and answering, so the first `clappa` session starts at once.
-
-The default policy covers Claude Code's built-in tools only. Start `clappa` and
-run `/appa-tool-sync`: it finds your MCP servers and proposes a policy for them.
-
-![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](website/public/images/claude-code-blocked-flow.png)
-
-Full setup, Windows notes and file locations: [Claude Code
-integration](https://openappa.com/claude-code) ·
-[`integrations/claude-code`](integrations/claude-code/README.md).
-
-## How it works
-
-Three runtime concepts carry the whole model:
-
-| Concept | What it is |
-|---|---|
-| **Label** | Attached to every running trajectory. Tracks *audience* (which readers may receive this data) and *trust* (vetted internal source vs. unvetted web content). |
-| **Tool contract** | Per-tool declaration. Reading data restricts the label (`delta`); an outbound call states what the label must satisfy (`requires`). |
-| **Remedy plan** | What the agent gets back when a call exceeds its permissions — narrow reach, run a sanitizer, ask an authority, or isolate the read in a child branch. |
-
-**Labels only move one way.** A `delta` can intersect the audience, lower trust,
-or change nothing — never widen. So data cannot be laundered by passing it
-through intermediate steps or an LLM call. The current label is a fold over
-everything admitted so far:
-
-```ts
-label = admittedLabels.reduce(narrow, startingLabel)   // narrow only ever restricts
-```
-
-Restriction is not paralysis. An **authority** can approve one specific outbound
-call without raising the label, a **sanitizer** can derive a clean value that
-keeps public reach, and a **child branch** isolates a sensitive read from the
-main workflow.
-
-Policy is declarative TOML — no bespoke `if`s, no guardrail prompts. A tool
-contract is typically four lines:
-
-```toml
-[[tool]]
-name  = "fetch_support_ticket"
-tags  = ["support"]                                    # scope tag for authority routing
-# CRM is trusted infrastructure; the ticket body is customer-written text
-delta = { trust = "suspicious", audience = { exactly = ["support"] } }
-
-[[tool]]
-name    = "apply_db_migration"
-effects = ["migration.applied", "mutation"]
-delta   = {}                                           # status string carries no label
-
-[tool.requires]
-trust     = "trusted"
-effects   = { has = ["backup.completed"], has_no = ["migration.applied"] }
-attention = ["sre-signoff"]                            # fresh sign-off on every call
-```
-
-Read the whole model in one sitting: [How it
-works](https://openappa.com/how-it-works). Every declaration, operator and
-review red flag: [Policy reference](https://openappa.com/contracts).
+Policy is declarative TOML, and the engine is a pure decision core — a function
+of the event log, no IO — so it embeds inside your own agent: in-process from
+Rust or Python, or as a sidecar every step is checked against. Broader coverage
+across those surfaces is the active work.
 
 ## Benchmarks
 
@@ -138,60 +54,27 @@ with GPT-5.6 Luna, 35 episodes per arm:
 Methodology, TAU-bench and AgentThreatBench results:
 [Benchmarks](https://openappa.com/evaluation).
 
-## Repository layout
+## Try it: Claude Code
 
-| Path | What it holds |
-|---|---|
-| [`appa-engine`](appa-engine) | The pure decision core — a function of the event log. No IO. The reference for what every term means. |
-| [`appa-policy`](appa-policy) | The policy-dialect compiler: TOML → the engine's internal form. |
-| [`appa-eventlog`](appa-eventlog) | The trajectory log and its storage. |
-| [`appa-builtin`](appa-builtin) | The author surface for builtin modules (sanitizers, authorities, casts). |
-| [`appa-runtime-v2`](appa-runtime-v2) | The process that sits between an agent and its tools. |
-| [`appa-example-agent`](appa-example-agent) | A protoagent on runtime-v2: owns the loop, transcript and tool catalogue. |
-| [`appa-agent-python`](appa-agent-python) | Synchronous PyO3 bindings for mediating calls from Python. |
-| [`integrations`](integrations) | Harness integrations — Claude Code today. |
-| [`website`](website) | [openappa.com](https://openappa.com) and the docs it serves. |
-
-## Development
+The Claude Code plugin is a playground for the model, not the product. It is the
+fastest way to watch a policy make a decision on real work:
 
 ```sh
-claude "set up APPA from this repo for local development"
+claude plugin marketplace add archestra-ai/OpenAPPA &&
+  claude plugin install appa-runtime@appa &&
+  claude "set up APPA"
 ```
 
-Claude starts the dev runtime from source on its own port and prints the command
-that opens a protected session against it. The steps live in the [integration
-guide](integrations/claude-code/README.md).
+This installs a `clappa` command that runs Claude Code protected by OpenAPPA;
+plain `claude` sessions stay untouched. Run `/appa-tool-sync` in a plain
+`claude` session to bring your MCP servers into the policy, then start `clappa`
+to try the protected flow.
 
-## Upgrade
+![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](website/public/images/claude-code-blocked-flow.png)
 
-The plugin tracks the marketplace. To upgrade the runtime, stop the running
-one and remove `~/.local/bin/appa-runtime-v2`, then ask a plain `claude` session
-to set up APPA again; it installs the latest release and starts it. Stopping it
-first matters: a runtime already answering on the port keeps serving, and the
-new binary would never run.
-
-```sh
-pkill -f appa-runtime-v2 && rm ~/.local/bin/appa-runtime-v2
-```
-
-## Uninstall
-
-```sh
-claude plugin uninstall appa-runtime
-claude plugin marketplace remove appa
-pkill -f appa-runtime-v2
-rm ~/.local/bin/appa-runtime-v2 ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
-
-# drop the statusline entry the setup wrote, and keep one of your own:
-jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \
-  ~/.claude/settings.json > ~/.claude/settings.json.new &&
-  mv ~/.claude/settings.json.new ~/.claude/settings.json
-
-# optional — also remove the policy, database, and alias:
-rm -rf ~/.config/appa ~/.local/share/appa      # Linux
-rm -rf ~/Library/"Application Support/appa"    # macOS
-sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
-```
+Setup, upgrade and uninstall: [Claude Code
+integration](https://openappa.com/claude-code) ·
+[`integrations/claude-code`](integrations/claude-code/README.md).
 
 ## Status
 

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1013,6 +1013,118 @@ samp {
 }
 
 /* ————————————————————————————————————————————————
+   Claude Code guide — policy setup, two commands
+   ———————————————————————————————————————————————— */
+.claude-policy-timing {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr);
+  margin: 1.25rem 0 1.75rem;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--accent-bg);
+  overflow: hidden;
+}
+
+.claude-policy-duration {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 18px;
+  border-right: 1px solid var(--accent-border);
+  font-family: var(--font-mono);
+}
+
+.claude-policy-duration strong {
+  color: var(--accent);
+  font-size: 19px;
+  line-height: 1.2;
+}
+
+.claude-policy-duration span {
+  margin-top: 4px;
+  color: var(--text-weak);
+  font-size: 10px;
+}
+
+.claude-policy-timing-copy {
+  padding: 13px 18px;
+}
+
+.prose .claude-policy-timing-copy p {
+  margin: 0.35rem 0;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.claude-session-choice {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin: 1.25rem 0 2rem;
+}
+
+.claude-session-choice > div {
+  display: flex;
+  flex-direction: column;
+  min-height: 132px;
+  padding: 16px;
+  border: 1px solid var(--border-weak);
+  border-radius: 7px;
+  background: var(--bg-weak);
+}
+
+.claude-session-choice code {
+  align-self: flex-start;
+  margin-bottom: 16px;
+  color: var(--text-weak);
+}
+
+.claude-session-choice strong {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.claude-session-choice span {
+  margin-top: 4px;
+  color: var(--text-weak);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.claude-session-choice .claude-session-protected {
+  border-color: var(--accent-border);
+  background: var(--accent-bg);
+}
+
+.claude-session-protected code,
+.claude-session-protected strong {
+  color: var(--accent);
+}
+
+.prose img[alt*="Claude Code session"] {
+  display: block;
+  width: 100%;
+  margin: 1.25rem 0 2rem;
+  border: 1px solid var(--border-weak);
+  border-radius: 9px;
+}
+
+@media (max-width: 600px) {
+  .claude-policy-timing {
+    grid-template-columns: 1fr;
+  }
+
+  .claude-policy-duration {
+    border-right: none;
+    border-bottom: 1px solid var(--accent-border);
+  }
+
+  .claude-session-choice {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ————————————————————————————————————————————————
    Benchmark highlight panel (home) — emphasis bars, two small multiples
    ———————————————————————————————————————————————— */
 .bench-panel {

--- a/website/components/ClaudeCodeStory.tsx
+++ b/website/components/ClaudeCodeStory.tsx
@@ -1,0 +1,37 @@
+export function ClaudePolicyTiming() {
+  return (
+    <aside className="claude-policy-timing" aria-label="Policy setup timing">
+      <div className="claude-policy-duration">
+        <strong>~10 min</strong>
+        <span>for the demo policy</span>
+      </div>
+      <div className="claude-policy-timing-copy">
+        <p>
+          Claude typically needs about ten minutes to inspect your tools, ask any necessary questions,
+          and generate the initial policy.
+        </p>
+        <p>
+          <strong>In a corporate deployment, this is a one-time governance step.</strong> The policy is
+          generated, reviewed, and approved once, then shared across the protected agent surfaces.
+        </p>
+      </div>
+    </aside>
+  );
+}
+
+export function ClaudeSessionChoice() {
+  return (
+    <div className="claude-session-choice" aria-label="Choose a Claude Code session">
+      <div>
+        <code>$ claude</code>
+        <strong>Standard Claude Code</strong>
+        <span>The plugin leaves this path unchanged.</span>
+      </div>
+      <div className="claude-session-protected">
+        <code>$ clappa</code>
+        <strong>Claude Code + OpenAPPA</strong>
+        <span>Tool flows are checked against your policy.</span>
+      </div>
+    </div>
+  );
+}

--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -9,6 +9,10 @@ import remarkGfm from "remark-gfm";
 import { AdvisorySignup } from "@/components/AdvisorySignup";
 import { BenchmarkHighlight } from "@/components/BenchmarkHighlight";
 import { BrandAssets } from "@/components/BrandKit";
+import {
+  ClaudePolicyTiming,
+  ClaudeSessionChoice,
+} from "@/components/ClaudeCodeStory";
 import { CodeBlock } from "@/components/CodeBlock";
 import { ClaudeCodeHooksFigure } from "@/components/figures/ClaudeCodeHooksFigure";
 import { ConnectedAgentFigure } from "@/components/figures/ConnectedAgentFigure";
@@ -29,6 +33,8 @@ const DIRECTIVES: Record<string, () => ReactNode> = {
   "advisory-signup": () => <AdvisorySignup />,
   "benchmark-highlight": () => <BenchmarkHighlight />,
   "brand-assets": () => <BrandAssets />,
+  "claude-policy-timing": () => <ClaudePolicyTiming />,
+  "claude-session-choice": () => <ClaudeSessionChoice />,
   "fig-claude-code-hooks": () => <ClaudeCodeHooksFigure />,
   "fig-connected-agent": () => <ConnectedAgentFigure />,
   "fig-exfiltration": () => <ExfiltrationFigure />,

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -2,14 +2,12 @@
 title: Claude Code
 category: Integration
 order: 5
-description: Putting OpenAPPA between Claude Code and its tools.
+description: Start with one protected Claude Code session, then carry the same policy boundary across your agents.
 ---
 
-This page describes how to run Claude Code with OpenAPPA. OpenAPPA integrates with Claude Code as a plugin; while it is in beta, the plugin ships a `clappa` command that runs Claude Code protected by OpenAPPA.
+OpenAPPA is designed for multiple agent surfaces. **Claude Code is simply the first demo:** the plugin makes the policy visible in a familiar terminal and gives you a fast way to try it.
 
-![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](/images/claude-code-blocked-flow.png)
-
-## Install
+## Install the Claude Code demo
 
 ```sh
 claude plugin marketplace add archestra-ai/OpenAPPA &&
@@ -17,17 +15,55 @@ claude plugin marketplace add archestra-ai/OpenAPPA &&
   claude "set up APPA"
 ```
 
-This installs the OpenAPPA plugin into your Claude Code. While OpenAPPA is in beta, the plugin ships a `clappa` command that runs Claude Code protected by OpenAPPA. If you want to just keep using Claude Code, start it as usual — plain `claude` sessions stay untouched.
+The setup installs the local runtime and adds `clappa`, a protected way to start Claude Code. It does not replace `claude` or change how your ordinary sessions start.
 
-![A Claude Code session protected by OpenAPPA; the statusline shows the session's current trust and audience](/images/claude-code-protected-session.png)
+## 1. Teach OpenAPPA about your tools
 
-`clappa` makes sure the [OpenAPPA runtime](#technical-details) is live before the session starts.
+:::claude-policy-timing:::
 
-The plugin ships the `/appa-tool-sync` skill to guide you through the policy configuration: it finds your MCP servers and proposes a policy config for them.
+Start a normal, unprotected session, then run the policy setup skill:
+
+```sh
+claude
+```
+
+```text
+/appa-tool-sync
+```
+
+The skill inspects the MCP servers and tools available to Claude Code. It uses their declared purpose to identify what they read and which actions can send data outside the session. When a data boundary is unclear, it asks you one focused question.
+
+Before it writes anything, the skill shows the full proposal for approval. The result is deterministic policy config: exact tool contracts, audience rules, and any resolver definitions the setup needs. The model helps draft the file; the OpenAPPA runtime enforces the file.
+
+## 2. Try a flow that should be blocked
+
+Leave the setup session and start Claude Code with OpenAPPA:
+
+```sh
+clappa
+```
+
+Now ask for an explicit transfer from a private source to a public destination. For example:
+
+```text
+Create a public GitHub issue from the action items in my private meeting recording.
+```
+
+Claude can read the meeting, but that read narrows who may receive the resulting data. When it later proposes the public GitHub write, OpenAPPA checks the accumulated data against the destination and blocks the flow before the tool runs.
+
+The refusal is not a generic warning. It names the policy conflict and can offer a valid path forward, such as using a permitted destination, applying a configured sanitizer, or asking an authorized reviewer.
+
+![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](/images/claude-code-blocked-flow.png)
+
+## Choose protection per session
+
+Installing the plugin does not force every Claude Code session through OpenAPPA. Use `clappa` when you want the policy boundary. Use `claude` when you do not.
+
+:::claude-session-choice:::
 
 ## Uninstall
 
-To uninstall OpenAPPA from Claude Code, remove the plugin, stop the [runtime](#technical-details), and remove its binaries:
+To uninstall OpenAPPA from Claude Code, remove the plugin, stop the local runtime, and remove its binaries:
 
 ```sh
 claude plugin uninstall appa-runtime
@@ -45,11 +81,3 @@ rm -rf ~/.config/appa ~/.local/share/appa      # Linux
 rm -rf ~/Library/"Application Support/appa"    # macOS
 sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
 ```
-
-## Technical details
-
-OpenAPPA runs on your machine as a single binary with a built-in web server. That server is what receives the Claude Code hooks.
-
-The plugin registers Claude Code hooks. Each hook sends its event to the OpenAPPA runtime, and the OpenAPPA runtime answers before the action runs.
-
-:::fig-claude-code-hooks:::


### PR DESCRIPTION
Refines the README and Claude Code guide around the multi-surface product story, one-time policy setup, and the explicit claude-to-clappa demo flow.