### PR TITLE
docs: invite readers to the Discord server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 [How it works](https://openappa.com/how-it-works) ·
 [Policy reference](https://openappa.com/contracts) ·
 [Benchmarks](https://openappa.com/evaluation) ·
-[Paper](https://arxiv.org/abs/2607.24625)
+[Paper](https://arxiv.org/abs/2607.24625) ·
+[Discord](https://discord.gg/B5fmSxHKZ7)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![Status: Preview & RFC](https://img.shields.io/badge/status-preview%20%26%20RFC-orange.svg)](https://openappa.com)
+[![Discord](https://img.shields.io/badge/discord-join%20chat-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/B5fmSxHKZ7)
 
 </div>
 
@@ -81,7 +83,7 @@ integration](https://openappa.com/claude-code) ·
 OpenAPPA is a **preview and an RFC**. The model is settled enough to build
 against and deliberately open to argument — config and wire surfaces may break
 without shims. Read the [paper](https://arxiv.org/abs/2607.24625), then open an
-issue.
+issue — or come argue in the [Discord](https://discord.gg/B5fmSxHKZ7).
 
 ## License
 

--- a/website/app/(site)/layout.tsx
+++ b/website/app/(site)/layout.tsx
@@ -7,9 +7,14 @@ export default function SiteLayout({ children }: { children: React.ReactNode }) 
       {children}
       <footer className="site-footer">
         <span>© {new Date().getFullYear()} OpenAPPA</span>
-        <a href="https://github.com/archestra-ai/OpenAPPA" target="_blank" rel="noreferrer">
-          GitHub
-        </a>
+        <span className="site-footer-links">
+          <a href="https://discord.gg/B5fmSxHKZ7" target="_blank" rel="noreferrer">
+            Discord
+          </a>
+          <a href="https://github.com/archestra-ai/OpenAPPA" target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </span>
       </footer>
     </>
   );

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -340,6 +340,13 @@ samp {
   color: var(--text-strong);
 }
 
+/* Icon-only nav links (the Discord mark) center on the text baseline row and
+   inherit the same rest/hover colors as their text siblings. */
+.site-header nav a.discord-link {
+  display: inline-flex;
+  align-items: center;
+}
+
 /* Below the docked breakpoint the header keeps only the menu button and the
    wordmark. Search, Paper, GitHub and the theme toggle move into the drawer —
    the same place the page navigation already lives, so one tap reaches all of
@@ -1459,6 +1466,11 @@ samp {
 
 .site-footer a:hover {
   color: var(--text-strong);
+}
+
+.site-footer-links {
+  display: inline-flex;
+  gap: 20px;
 }
 
 /* ————————————————————————————————————————————————

--- a/website/components/DiscordIcon.tsx
+++ b/website/components/DiscordIcon.tsx
@@ -1,0 +1,17 @@
+/* The official Discord mark, drawn in currentColor so it takes whatever the
+   surrounding link's color is — the muted icon tone at rest, text-strong on
+   hover — and stays right in both themes without a variant per context. */
+export function DiscordIcon({ size = 17 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size * (96.36 / 127.14)}
+      viewBox="0 0 127.14 96.36"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z" />
+    </svg>
+  );
+}

--- a/website/components/DocsSidebar.tsx
+++ b/website/components/DocsSidebar.tsx
@@ -70,6 +70,9 @@ export function DocsSidebar({
             <a href="https://github.com/archestra-ai/openappa" target="_blank" rel="noreferrer">
               GitHub
             </a>
+            <a href="https://discord.gg/B5fmSxHKZ7" target="_blank" rel="noreferrer">
+              Discord
+            </a>
             <ThemeToggle />
           </div>
         </div>

--- a/website/components/Header.tsx
+++ b/website/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import Link from "next/link";
 
+import { DiscordIcon } from "@/components/DiscordIcon";
 import { Logo } from "@/components/Logo";
 import { MobileNavToggle } from "@/components/MobileNav";
 import { SearchIcon, useSearch } from "@/components/SearchProvider";
@@ -57,6 +58,16 @@ export function Header({ fullBleed = false }: { fullBleed?: boolean }) {
           </a>
           <a href="https://github.com/archestra-ai/openappa" target="_blank" rel="noreferrer">
             GitHub
+          </a>
+          <a
+            href="https://discord.gg/B5fmSxHKZ7"
+            target="_blank"
+            rel="noreferrer"
+            className="discord-link"
+            aria-label="Join the OpenAPPA Discord"
+            title="Join the OpenAPPA Discord"
+          >
+            <DiscordIcon />
           </a>
           <ThemeToggle />
         </nav>

--- a/website/content/docs/index.md
+++ b/website/content/docs/index.md
@@ -35,3 +35,4 @@ And where it is genuinely unavoidable, OpenAPPA also lets you plug in non-determ
 - [How OpenAPPA works](/how-it-works) — the whole model in one sitting.
 - [Reading a policy](/contracts) — what each declaration means, and what a wrong one looks like.
 - [Benchmarks](/evaluation) — empirical paper results and running bench-corp.
+- [Discord](https://discord.gg/B5fmSxHKZ7) — questions, feedback, and RFC discussion with the people building it.


### PR DESCRIPTION
Adds the Discord invite (https://discord.gg/B5fmSxHKZ7) everywhere a reader looks for the community.

## Website

- **Header** — the official Discord mark as an icon-only nav link between GitHub and the theme toggle. Drawn in `currentColor`, so it takes the nav's muted rest tone and text-strong hover in both light and dark themes.
- **Footer** — a Discord text link beside GitHub.
- **Mobile drawer** — a Discord link in the chrome row (Paper · GitHub · Discord), where the header's links live below 1024px.
- **Landing "Where next"** — a bullet: questions, feedback, and RFC discussion.

## README

- Discord badge next to the license/status shields.
- Discord in the top link row.
- The status section's "open an issue" call now offers the Discord as well.

`pnpm typecheck` passes; verified in Chrome in both themes.