### PR TITLE
feat: add first-visit reader-ping prompt

### DIFF
--- a/website/app/api/reader-ping/route.ts
+++ b/website/app/api/reader-ping/route.ts
@@ -1,0 +1,103 @@
+/* Reader ping — a first-visit address goes to the team's Slack and nowhere else.
+   The modal promises the reader that nothing is stored, so this route must keep
+   that promise literally: no database, no file, no analytics call, and no log
+   line carrying the address in production. The only sink is the webhook. */
+
+const WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+
+/* Deliberately loose — this is a notification, not an identity check. It rejects
+   the shapes that are certainly not addresses and lets everything else through,
+   because a reader who mistypes their own address is not a case worth policing. */
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LENGTH = 254; // RFC 5321 §4.5.3.1
+
+/* The endpoint is public and unauthenticated, so without a cap it is a free
+   relay into the team's Slack. Per-instance and in-memory: serverless spreads
+   requests across instances, so this thins a flood rather than stopping one.
+   It is the cheap half of the defence — the webhook's own rate limit is the
+   other half. */
+const WINDOW_MS = 60_000;
+const MAX_PER_WINDOW = 5;
+const hits = new Map<string, number[]>();
+
+function rateLimited(key: string): boolean {
+  const now = Date.now();
+  const recent = (hits.get(key) ?? []).filter((t) => now - t < WINDOW_MS);
+  recent.push(now);
+  hits.set(key, recent);
+
+  // Unbounded growth would be the real leak; drop keys that have gone quiet.
+  if (hits.size > 5_000) {
+    for (const [k, times] of hits) {
+      if (times.every((t) => now - t >= WINDOW_MS)) hits.delete(k);
+    }
+  }
+  return recent.length > MAX_PER_WINDOW;
+}
+
+/* Slack renders `&`, `<` and `>` as markup. An address is attacker-controlled
+   text, so it is escaped before it reaches a message body. */
+function escapeSlack(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export async function POST(request: Request) {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown";
+
+  if (rateLimited(ip)) {
+    return Response.json({ error: "Too many requests. Try again in a minute." }, { status: 429 });
+  }
+
+  let email: unknown;
+  let path: unknown;
+  try {
+    const body = await request.json();
+    email = body?.email;
+    path = body?.path;
+  } catch {
+    return Response.json({ error: "Malformed request." }, { status: 400 });
+  }
+
+  if (typeof email !== "string" || email.length > MAX_EMAIL_LENGTH || !EMAIL.test(email.trim())) {
+    return Response.json({ error: "That does not look like an email address." }, { status: 400 });
+  }
+
+  const address = email.trim();
+  // Only ever a path from our own site; truncated so it cannot pad the message.
+  const page = typeof path === "string" ? path.slice(0, 120) : "/";
+
+  if (!WEBHOOK_URL) {
+    /* In development the address goes to the developer's own terminal, which is
+       the closest thing to "the team was notified" that a laptop can offer. In
+       production a missing webhook must fail loudly: silently accepting the
+       address would tell the reader their address was delivered when it was
+       dropped, and printing it would store it in the platform's log retention —
+       breaking the promise the modal makes. */
+    if (process.env.NODE_ENV === "development") {
+      console.info(`[reader-ping] ${address} opened ${page}`);
+      return new Response(null, { status: 204 });
+    }
+    return Response.json({ error: "Notifications are not configured." }, { status: 503 });
+  }
+
+  try {
+    const slack = await fetch(WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: `:open_book: *${escapeSlack(address)}* opened \`${escapeSlack(page)}\``,
+      }),
+    });
+    if (!slack.ok) {
+      return Response.json({ error: "Could not reach the team right now." }, { status: 502 });
+    }
+  } catch {
+    return Response.json({ error: "Could not reach the team right now." }, { status: 502 });
+  }
+
+  // 204: there is deliberately nothing to return, because nothing was kept.
+  return new Response(null, { status: 204 });
+}

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -2328,6 +2328,215 @@ samp {
 }
 
 
+/* ————————————————————————————————————————————————
+   Reader ping (first-visit prompt)
+   ———————————————————————————————————————————————— */
+.ping-overlay {
+  position: fixed;
+  inset: 0;
+  /* Above the search overlay (50): the search dialog is reachable from the
+     header, and the two must never stack ambiguously. */
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(3px);
+  animation: ping-overlay-in 180ms ease both;
+}
+
+.ping-overlay.is-closing {
+  animation: ping-overlay-out 160ms ease both;
+}
+
+.ping-dialog {
+  position: relative;
+  width: 100%;
+  max-width: 452px;
+  /* Tighter foot than head: the status line below the form reserves its own
+     row whether or not it has text, and doubles as the dialog's bottom margin. */
+  padding: 28px 28px 16px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.22);
+  overflow: hidden;
+  animation: ping-dialog-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.is-closing .ping-dialog {
+  animation: ping-dialog-out 160ms ease both;
+}
+
+/* A hairline of the site's one interactive hue, so the dialog is anchored to
+   the brand without spending the accent on a large surface. */
+.ping-dialog::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-border));
+}
+
+.ping-eyebrow {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-weak);
+}
+
+.ping-title {
+  margin: 6px 0 0;
+  font-family: var(--font-mono);
+  font-size: 19px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text-strong);
+}
+
+.ping-lede {
+  margin: 8px 0 0;
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--text-weak);
+}
+
+.ping-form {
+  margin-top: 18px;
+}
+
+/* The lede and placeholder already name the field; a control still needs a
+   real label for assistive technology. */
+.ping-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.ping-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ping-input {
+  flex: 1 1 12rem;
+  min-width: 0;
+  padding: 9px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--text-strong);
+}
+
+.ping-input::placeholder {
+  color: var(--text-weak);
+}
+
+.ping-input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+
+.ping-button {
+  flex: 0 0 auto;
+  padding: 9px 18px;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-inverted);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.ping-button:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.ping-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Reserves its line so the dialog does not resize when a result arrives. */
+.ping-status {
+  min-height: 1.4em;
+  margin: 10px 0 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-weak);
+}
+
+.ping-status.ok {
+  color: var(--accent);
+}
+
+.ping-status.error {
+  color: var(--danger);
+}
+
+@keyframes ping-overlay-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes ping-overlay-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes ping-dialog-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.985);
+  }
+}
+
+@keyframes ping-dialog-out {
+  to {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+}
+
+@media (max-width: 480px) {
+  .ping-dialog {
+    padding: 24px 20px 12px;
+  }
+
+  .ping-input,
+  .ping-button {
+    flex: 1 1 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ping-overlay,
+  .ping-overlay.is-closing,
+  .ping-dialog,
+  .is-closing .ping-dialog {
+    animation: none;
+  }
+}
+
 /* Tailwind utility names for the shadcn tokens. Two remaps on purpose:
    `--color-accent` reads the ui hover-surface token (the site's `--accent`
    is the strong green and stays out of component hover backgrounds), and

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 
 import { MobileNavProvider } from "@/components/MobileNav";
+import { ReaderPing } from "@/components/ReaderPing";
 import { SearchProvider } from "@/components/SearchProvider";
 import { THEME_INIT_SCRIPT } from "@/components/ThemeToggle";
 
@@ -37,6 +38,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <MobileNavProvider>
           <SearchProvider>{children}</SearchProvider>
         </MobileNavProvider>
+        {/* Mounted at the root so it greets a reader landing on any page, not
+            only the home page. Shows once per browser, then never again. */}
+        <ReaderPing />
       </body>
     </html>
   );

--- a/website/components/ReaderPing.tsx
+++ b/website/components/ReaderPing.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/* First-visit prompt: the reader may leave an address, and the team gets one
+   notification that they stopped by. Nothing is stored — see
+   `app/api/reader-ping/route.ts`, which has the only sink.
+
+   The prompt is dismissable by design. This is an open-source project whose
+   docs are the product surface; a wall in front of them would cost more
+   readers than the addresses are worth. */
+
+const SEEN_KEY = "openappa-reader-ping";
+
+/* Long enough that the page has painted and the reader has seen what they came
+   for, short enough that the prompt is still part of arriving rather than an
+   interruption partway through a paragraph. */
+const APPEAR_DELAY_MS = 1_400;
+
+type Status =
+  | { state: "idle" }
+  | { state: "sending" }
+  | { state: "sent" }
+  | { state: "error"; message: string };
+
+function alreadySeen(): boolean {
+  try {
+    return localStorage.getItem(SEEN_KEY) !== null;
+  } catch {
+    // Private-mode storage failures must not turn this into a prompt on every
+    // page view; when we cannot remember the reader, we do not ask.
+    return true;
+  }
+}
+
+// Bypasses the "already seen" check for previewing the prompt without
+// clearing localStorage — ?reader-ping=1 on any page.
+function forcedOpen(): boolean {
+  return new URLSearchParams(window.location.search).get("reader-ping") === "1";
+}
+
+function remember(outcome: "sent" | "skipped") {
+  try {
+    localStorage.setItem(SEEN_KEY, outcome);
+  } catch {
+    /* Nothing to do: the prompt simply may appear again next visit. */
+  }
+}
+
+export function ReaderPing() {
+  const [open, setOpen] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<Status>({ state: "idle" });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const restoreFocusTo = useRef<Element | null>(null);
+
+  useEffect(() => {
+    const forced = forcedOpen();
+    if (!forced && alreadySeen()) return;
+    // Forced previews skip the arrival delay: whoever added the param wants
+    // to see the dialog, not wait for it.
+    const timer = setTimeout(() => setOpen(true), forced ? 0 : APPEAR_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    restoreFocusTo.current = document.activeElement;
+    // Waits a frame so the entry transition does not fight the focus scroll.
+    const timer = setTimeout(() => inputRef.current?.focus(), 60);
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  function dismiss(outcome: "sent" | "skipped") {
+    remember(outcome);
+    setClosing(true);
+    setTimeout(() => {
+      setOpen(false);
+      if (restoreFocusTo.current instanceof HTMLElement) restoreFocusTo.current.focus();
+    }, 160);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismiss("skipped");
+        return;
+      }
+      /* A modal must not hand focus back to the page behind it. The dialog has
+         few enough controls to cycle them directly rather than pull in a
+         focus-trap dependency. */
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), input:not(:disabled), [href], [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (status.state === "sending") return;
+    setStatus({ state: "sending" });
+
+    try {
+      const response = await fetch("/api/reader-ping", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, path: window.location.pathname }),
+      });
+
+      if (response.ok) {
+        setStatus({ state: "sent" });
+        setEmail("");
+        // Lets the reader actually see the confirmation before it disappears.
+        setTimeout(() => dismiss("sent"), 1_500);
+        return;
+      }
+
+      const result = await response.json().catch(() => null);
+      setStatus({
+        state: "error",
+        message: result?.error ?? "That didn't go through. Please try again.",
+      });
+    } catch {
+      setStatus({ state: "error", message: "Could not reach the team. Please try again." });
+    }
+  }
+
+  if (!open) return null;
+
+  const sending = status.state === "sending";
+  const sent = status.state === "sent";
+
+  /* The backdrop deliberately does not dismiss: a stray click beside the dialog
+     should not count as an answer. Escape is the only way out. */
+  return (
+    <div className={`ping-overlay${closing ? " is-closing" : ""}`}>
+      <div
+        className="ping-dialog"
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ping-title"
+        aria-describedby="ping-lede"
+      >
+        {/* Matches the badge beside the wordmark in the header, so the prompt
+            reads as part of the project rather than a bolted-on capture form. */}
+        <p className="ping-eyebrow">Preview &amp; RFC</p>
+        <h2 className="ping-title" id="ping-title">
+          Say hello before you read
+        </h2>
+        <p className="ping-lede" id="ping-lede">
+          OpenAPPA is in preview and the model is still open for argument. We would love to know who
+          is checking it out.
+        </p>
+
+        <form className="ping-form" onSubmit={onSubmit}>
+          <label className="ping-label" htmlFor="ping-email">
+            Email address
+          </label>
+          <div className="ping-controls">
+            <input
+              id="ping-email"
+              className="ping-input"
+              ref={inputRef}
+              type="email"
+              name="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@company.com"
+              autoComplete="email"
+              required
+              disabled={sending || sent}
+            />
+            <button
+              className="ping-button"
+              type="submit"
+              disabled={sending || sent || email.trim() === ""}
+            >
+              {sending ? "Sending…" : sent ? "Sent" : "Say hello"}
+            </button>
+          </div>
+        </form>
+
+        {/* Reserves its line so the dialog does not jump when a result lands. */}
+        <p
+          className={`ping-status${sent ? " ok" : status.state === "error" ? " error" : ""}`}
+          role="status"
+          aria-live="polite"
+        >
+          {sent
+            ? "Thank you. The team has been notified — and that is the end of it."
+            : status.state === "error"
+              ? status.message
+              : ""}
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Dismissable modal on first visit asks readers for an email; team gets a one-time Slack notification via a server-only webhook route (`app/api/reader-ping/route.ts`)
- Nothing is stored: no database, no mailing list, sink is Slack only
- `?reader-ping=1` query param forces the prompt open for testing without clearing localStorage

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] Manually verified in Chrome: modal appears once, dismisses via Escape, submits successfully, does not reappear after dismissal, light/dark themes both correct
- [x] `SLACK_WEBHOOK_URL` set in Vercel (Production + Preview) — needs a deploy to take effect