### PR TITLE
docs(bench): reconcile standard utility totals

### DIFF
--- a/bench/corp/README.md
+++ b/bench/corp/README.md
@@ -261,9 +261,9 @@ Below are the empirical results from 400 evaluated episodes on commit `5b3cc34` 
 agent        utility       ASR  errors  mean s   events  remedies
 -----------------------------------------------------------------
 appa             82%        0%      27   41.2s      545       195
-appa-open        87%       29%       0    9.0s        0         0
+appa-open        84%       29%       0    9.0s        0         0
 fides            30%       29%       0   10.2s      130         0
-fides-open       87%       27%       0    8.8s        0         0
+fides-open       79%       27%       0    8.8s        0         0
 ```
 
 ### Per-Scenario Breakdown (Passes / 5 Reps)

--- a/website/content/docs/evaluation.md
+++ b/website/content/docs/evaluation.md
@@ -33,9 +33,9 @@ The suite contains **20 curated enterprise scenarios** evaluated across **4 poli
 | Agent prompt profile | Policy arm | Task completion (Utility) | Attack success rate (ASR) | Security pass rate |
 |---|---|---:|---:|---:|
 | **Standard** | **OpenAPPA (`appa`)** | **82%** | **0%** | **100%** |
-| | OpenAPPA Open (`appa-open`) | 87% | 29% | 71% |
+| | OpenAPPA Open (`appa-open`) | 84% | 29% | 71% |
 | | FIDES (`fides`) | 30% | 29% | 71% |
-| | FIDES Open (`fides-open`) | 87% | 27% | 73% |
+| | FIDES Open (`fides-open`) | 79% | 27% | 73% |
 | **Red-team Chaos** | **OpenAPPA (`appa`)** | **81%** | **0%** | **100%** |
 | | OpenAPPA Open (`appa-open`) | 87% | 33% | 67% |
 | | FIDES (`fides`) | 27% | 29% | 71% |


### PR DESCRIPTION
## Summary

- correct the standard `appa-open` utility total from 87% to 84%
- correct the standard `fides-open` utility total from 87% to 79%
- keep the website evaluation table aligned with the benchmark README

## Why

The 20-row standard per-scenario matrix sums to 82, 84, 30, and 79 utility passes for `appa`, `appa-open`, `fides`, and `fides-open`, respectively. A later documentation edit changed the two open-arm aggregate values to 87% without changing the scenario rows or adding a corresponding raw run report. This PR restores the aggregate totals supported by the published matrix.

The red-team-chaos values are unchanged because they come from a separate report.

## Validation

- parsed all 20 standard scenario rows and summed each arm: `82, 84, 30, 79`
- `git diff --check`

Documentation only; no benchmark code or run artifacts changed.