### PR TITLE
refactor(engine): collapse the decision-path duplication in appa-engine

### DIFF
--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -13,7 +13,7 @@ use crate::value::ToolName;
 /// A **declared** restrictive label contribution: what a successful call folds into the trajectory.
 /// Every delta only ever narrows — minimum trust, intersect audience — so a permissive delta is
 /// unrepresentable. A dimension may also be declared [`Dim::Unknown`]: **pending-cast** — the
-/// result's actual state is established by a registered cast at admission (RP5), so the raw result
+/// result's actual state is established by a registered cast at admission, so the raw result
 /// is confined until then.
 ///
 /// A contract may carry no delta at all ([`ToolContract::delta`] is `None`): the tool is

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1535,11 +1535,6 @@ impl Engine {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
-    /// The success checkpoint a still-open dispatch owes before any external step runs: its
-    /// declared effects commit now, while value finalization — an output sanitizer derivation, a
-    /// pending-cast resolution — is still in flight. Empty where the log already records the
-    /// observation.
     /// The remedy menu a staged return offers, with the group requirement raised before the menu
     /// reads anything. A `Resolve` answer is the caller's to continue: the three callers that can
     /// see one continue differently, so this never decides for them.
@@ -1586,6 +1581,10 @@ impl Engine {
         ))
     }
 
+    /// The success checkpoint a still-open dispatch owes before any external step runs: its
+    /// declared effects commit now, while value finalization — an output sanitizer derivation, a
+    /// pending-cast resolution — is still in flight. Empty where the log already records the
+    /// observation.
     fn observed_checkpoint(
         &self,
         views: &Views,
@@ -1621,6 +1620,7 @@ impl Engine {
         )?))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn stage_candidate(
         &self,
         view: &EngineView,
@@ -1774,12 +1774,15 @@ impl Engine {
         })
     }
 
-    fn decide_proposals(
+    /// The guards a proposal batch passes before anything is read for a decision, in the order the
+    /// boundary applies them. Returns how many provider results the log already admitted for this
+    /// batch identity.
+    fn admissible_batch(
         &self,
-        view: &EngineView,
+        views: &Views,
         batch: &ProposalBatch,
         expansions: &Expansions,
-    ) -> Result<EngineDecision, TransitionError> {
+    ) -> Result<usize, TransitionError> {
         if let Some(mark) = batch.spawn {
             if mark.index() >= batch.proposals.len() {
                 return Err(TransitionError::SpawnMarkOutOfRange);
@@ -1791,7 +1794,6 @@ impl Engine {
         if batch.proposals.is_empty() && batch.provider_results.is_empty() {
             return Err(TransitionError::EmptyBatch);
         }
-        let views = view.projection().view(&batch.trajectory);
         // An ended branch is closed to new work, releases and admissions included.
         if views.has_ended(&batch.trajectory) {
             return Err(TransitionError::BranchEnded);
@@ -1823,25 +1825,92 @@ impl Engine {
                     .flat_map(ToolContract::groups),
             )?;
         }
+        Ok(admitted)
+    }
 
-        if let Some(decided) = views.decided_batch(&batch.id) {
-            if decided.trajectory != batch.trajectory {
-                return Err(TransitionError::BatchIdentityConflict);
+    /// A batch identity the log already decided answers from the record and appends nothing. The
+    /// repeat must carry the same trajectory and the same canonical payload, or it is a different
+    /// batch wearing a spent identity.
+    fn replayed_batch(
+        &self,
+        views: &Views,
+        batch: &ProposalBatch,
+        expansions: &Expansions,
+    ) -> Result<Option<EngineDecision>, TransitionError> {
+        let Some(decided) = views.decided_batch(&batch.id) else {
+            return Ok(None);
+        };
+        if decided.trajectory != batch.trajectory {
+            return Err(TransitionError::BatchIdentityConflict);
+        }
+        let recorded = decided.clone();
+        let Ok(proposals) = self.resolve_proposals(batch) else {
+            return Err(TransitionError::BatchIdentityConflict);
+        };
+        if recorded.payload != CanonicalDigest::of_batch(&proposals, batch.spawn) {
+            return Err(TransitionError::BatchIdentityConflict);
+        }
+        let expansions = expansions
+            .clone()
+            .inheriting(&self.recorded_expansions(&recorded.resolutions));
+        Ok(Some(EngineDecision {
+            append: None,
+            follow_up: self.decided_follow_up(views, batch, &proposals, &recorded.released, &expansions)?,
+        }))
+    }
+
+    /// Every proposal carries the memberships and dynamic answers its contract declares. A gap is
+    /// the runtime's to fill before the batch can be composed; a foreign claim is a refusal.
+    fn answered_proposals(&self, proposals: &[ResolvedCall]) -> Result<(), TransitionError> {
+        let mut needed = Vec::new();
+        let mut unanswered = Vec::new();
+        for call in proposals {
+            let contract = self
+                .registry
+                .tool(call.tool())
+                .expect("a resolved call names a checkable tool");
+            match check::validate_memberships(contract, call) {
+                Ok(()) => {}
+                Err(check::MembershipRefusal::Needed(reads)) => needed.extend(reads.into_iter().map(|read| read.group)),
+                Err(check::MembershipRefusal::Foreign(argument)) => {
+                    return Err(TransitionError::ForeignMembership { argument });
+                }
             }
-            let recorded = decided.clone();
-            let Ok(proposals) = self.resolve_proposals(batch) else {
-                return Err(TransitionError::BatchIdentityConflict);
-            };
-            if recorded.payload != CanonicalDigest::of_batch(&proposals, batch.spawn) {
-                return Err(TransitionError::BatchIdentityConflict);
+            match check::validate_dynamic_resolutions(contract, call) {
+                Ok(()) => {}
+                Err(check::DynamicRefusal::Needed(bindings)) => {
+                    for binding in bindings {
+                        if !unanswered.contains(&binding) {
+                            unanswered.push(binding);
+                        }
+                    }
+                }
+                Err(check::DynamicRefusal::Foreign(argument)) => {
+                    return Err(TransitionError::ForeignDynamicAnswer { argument });
+                }
             }
-            let expansions = expansions
-                .clone()
-                .inheriting(&self.recorded_expansions(&recorded.resolutions));
-            return Ok(EngineDecision {
-                append: None,
-                follow_up: self.decided_follow_up(&views, batch, &proposals, &recorded.released, &expansions)?,
-            });
+        }
+        if !needed.is_empty() {
+            needed.sort();
+            needed.dedup();
+            return Err(TransitionError::MembershipNeeded { needed });
+        }
+        if !unanswered.is_empty() {
+            return Err(TransitionError::DynamicAnswerNeeded { needed: unanswered });
+        }
+        Ok(())
+    }
+
+    fn decide_proposals(
+        &self,
+        view: &EngineView,
+        batch: &ProposalBatch,
+        expansions: &Expansions,
+    ) -> Result<EngineDecision, TransitionError> {
+        let views = view.projection().view(&batch.trajectory);
+        let admitted = self.admissible_batch(&views, batch, expansions)?;
+        if let Some(answer) = self.replayed_batch(&views, batch, expansions)? {
+            return Ok(answer);
         }
 
         // The answers to a previous drive's ask, landed before anything reads a label: the
@@ -1883,42 +1952,7 @@ impl Engine {
                 });
             }
         };
-        let mut needed = Vec::new();
-        let mut unanswered = Vec::new();
-        for call in &proposals {
-            let contract = self
-                .registry
-                .tool(call.tool())
-                .expect("a resolved call names a checkable tool");
-            match check::validate_memberships(contract, call) {
-                Ok(()) => {}
-                Err(check::MembershipRefusal::Needed(reads)) => needed.extend(reads.into_iter().map(|read| read.group)),
-                Err(check::MembershipRefusal::Foreign(argument)) => {
-                    return Err(TransitionError::ForeignMembership { argument });
-                }
-            }
-            match check::validate_dynamic_resolutions(contract, call) {
-                Ok(()) => {}
-                Err(check::DynamicRefusal::Needed(bindings)) => {
-                    for binding in bindings {
-                        if !unanswered.contains(&binding) {
-                            unanswered.push(binding);
-                        }
-                    }
-                }
-                Err(check::DynamicRefusal::Foreign(argument)) => {
-                    return Err(TransitionError::ForeignDynamicAnswer { argument });
-                }
-            }
-        }
-        if !needed.is_empty() {
-            needed.sort();
-            needed.dedup();
-            return Err(TransitionError::MembershipNeeded { needed });
-        }
-        if !unanswered.is_empty() {
-            return Err(TransitionError::DynamicAnswerNeeded { needed: unanswered });
-        }
+        self.answered_proposals(&proposals)?;
 
         // A call blocked only for want of a fact asks for the fact before anything is composed.
         // Nothing appends here: a resolution advances the family basis, so releases and offers

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -417,7 +417,7 @@ impl Engine {
         }];
         let batch = self.declaring(
             crate::basis::DecidedAct::Binding(binding.fork.clone()),
-            advance_of(self, view, &batch),
+            Sequence::advance_of(self, view, &batch),
             batch,
         );
         Ok(EngineDecision {
@@ -452,7 +452,7 @@ impl Engine {
         let body = match &report.submission {
             ChildSubmission::Void => {
                 let batch = branch::submit_void_return(&views, child).map_err(branch_refusal)?;
-                let batch = self.declaring(return_act(child), advance_of(self, view, &batch), batch);
+                let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
                 return Ok(EngineDecision {
                     append: Some(self.seal(view, batch)?),
                     follow_up: FollowUp::Child(ChildFollowUp::Ended),
@@ -587,7 +587,7 @@ impl Engine {
             branch::RawCrossing::Merged(crossing) => {
                 facts.extend(crossing);
                 let batch = facts;
-                let batch = self.declaring(return_act(child), advance_of(self, view, &batch), batch);
+                let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
                 Ok(EngineDecision {
                     append: Some(self.seal(view, batch)?),
                     follow_up: FollowUp::Child(ChildFollowUp::Merged { admitted: body }),
@@ -746,7 +746,7 @@ impl Engine {
         });
         let Some(derived) = derived else {
             let batch = facts;
-            let batch = self.declaring(return_act(child), advance_of(self, view, &batch), batch);
+            let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
             return Ok(EngineDecision {
                 append: Some(self.seal(view, batch)?),
                 follow_up: FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Sanitizer {
@@ -823,7 +823,7 @@ impl Engine {
                 self.registry.resolutions(expansions),
             ));
             let batch = facts;
-            let batch = self.declaring(return_act(child), advance_of(self, view, &batch), batch);
+            let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
             return Ok(EngineDecision {
                 append: Some(self.seal(view, batch)?),
                 follow_up: FollowUp::Child(ChildFollowUp::Merged { admitted: derived }),
@@ -886,7 +886,7 @@ impl Engine {
             resolutions: self.registry.resolutions(expansions),
         });
         let batch = facts;
-        let batch = self.declaring(return_act(child), advance_of(self, view, &batch), batch);
+        let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
         Ok(EngineDecision {
             append: Some(self.seal(view, batch)?),
             follow_up: FollowUp::Child(ChildFollowUp::Rejected { reason }),
@@ -912,7 +912,7 @@ impl Engine {
             true => None,
             false => {
                 let batch = facts;
-                let batch = self.declaring(act, advance_of(self, view, &batch), batch);
+                let batch = self.declaring(act, Sequence::advance_of(self, view, &batch), batch);
                 Some(self.seal(view, batch)?)
             }
         };
@@ -1062,7 +1062,8 @@ impl Engine {
                             true => None,
                             false => {
                                 let batch = cast_facts;
-                                let batch = self.declaring(return_act(child), advance_of(self, view, &batch), batch);
+                                let batch =
+                                    self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
                                 Some(self.seal(view, batch)?)
                             }
                         };
@@ -1303,10 +1304,15 @@ impl Engine {
                             let append = match checkpointed {
                                 Some(_) => None,
                                 None => {
-                                    let checkpoint = self
-                                        .observe_success(&views, dispatch, &call, ObservedResult::Available(raw_digest))
-                                        .expect("an open, unreported dispatch checkpoints its observed success");
-                                    let advance = advance_of(self, view, &checkpoint);
+                                    let checkpoint = admit::observe_success(
+                                        &self.registry,
+                                        &views,
+                                        dispatch,
+                                        &call,
+                                        ObservedResult::Available(raw_digest),
+                                    )
+                                    .expect("an open, unreported dispatch checkpoints its observed success");
+                                    let advance = Sequence::advance_of(self, view, &checkpoint);
                                     let batch = self.declaring(
                                         crate::basis::DecidedAct::Outcome(dispatch.clone()),
                                         advance,
@@ -1442,10 +1448,15 @@ impl Engine {
             let append = match checkpointed {
                 true => None,
                 false => {
-                    let checkpoint = self
-                        .observe_success(views, dispatch, call, ObservedResult::Available(raw_digest))
-                        .expect("an open, unreported dispatch checkpoints its observed success");
-                    let advance = advance_of(self, view, &checkpoint);
+                    let checkpoint = admit::observe_success(
+                        &self.registry,
+                        views,
+                        dispatch,
+                        call,
+                        ObservedResult::Available(raw_digest),
+                    )
+                    .expect("an open, unreported dispatch checkpoints its observed success");
+                    let advance = Sequence::advance_of(self, view, &checkpoint);
                     let batch =
                         self.declaring(crate::basis::DecidedAct::Outcome(dispatch.clone()), advance, checkpoint);
                     Some(self.seal(view, batch)?)
@@ -1518,13 +1529,14 @@ impl Engine {
         admission: ResultAdmission,
         expansions: &Expansions,
     ) -> Result<EngineDecision, TransitionError> {
-        let batch = self
-            .admit_result(views, dispatch, call, admission, expansions)
-            .map_err(|error| match error {
-                AdmitError::SanitizerTransitionUnmet | AdmitError::SanitizerBindingMismatch => {
-                    TransitionError::SanitizerUnapplicable
+        let batch =
+            admit::admit_result(&self.registry, views, dispatch, call, admission, expansions).map_err(|error| {
+                match error {
+                    AdmitError::SanitizerTransitionUnmet | AdmitError::SanitizerBindingMismatch => {
+                        TransitionError::SanitizerUnapplicable
+                    }
+                    other => unreachable!("the outcome path admits what the log already proved: {other}"),
                 }
-                other => unreachable!("the outcome path admits what the log already proved: {other}"),
             })?;
         let admitted = batch.iter().find_map(|fact| match fact {
             Fact::ValueAdmitted { value, .. } => Some(value.body.clone()),
@@ -1532,7 +1544,7 @@ impl Engine {
         });
         let batch = self.declaring(
             crate::basis::DecidedAct::Outcome(dispatch.clone()),
-            advance_of(self, view, &batch),
+            Sequence::advance_of(self, view, &batch),
             batch,
         );
         Ok(EngineDecision {
@@ -1563,7 +1575,7 @@ impl Engine {
                 _ => unreachable!("a staged record is a derived candidate"),
             };
             facts.extend(
-                self.observe_success(views, dispatch, call, ObservedResult::Available(source))
+                admit::observe_success(&self.registry, views, dispatch, call, ObservedResult::Available(source))
                     .expect("an open, unreported dispatch checkpoints its observed success"),
             );
         }
@@ -1993,7 +2005,6 @@ impl Engine {
             follow_up: FollowUp::Proposals {
                 released,
                 blocked,
-                forks: Vec::new(),
                 spent: Vec::new(),
                 settled: Vec::new(),
             },
@@ -2204,7 +2215,6 @@ impl Engine {
         )?;
         let mut released = Vec::new();
         let mut blocked = Vec::new();
-        let mut forks = Vec::new();
         let mut spent = Vec::new();
         let mut settled = Vec::new();
         let mut next = recorded.iter().peekable();
@@ -2218,7 +2228,6 @@ impl Engine {
                     fork: prepared_fork(views, dispatch),
                 }),
                 Some(dispatch) => {
-                    forks.extend(prepared_fork(views, dispatch));
                     settled.push(Settled {
                         dispatch: dispatch.clone(),
                         call: call.clone(),
@@ -2280,7 +2289,6 @@ impl Engine {
         Ok(FollowUp::Proposals {
             released,
             blocked,
-            forks,
             spent,
             settled,
         })
@@ -2440,15 +2448,15 @@ impl Engine {
         mut facts: Vec<Fact>,
         expansions: &Expansions,
     ) -> Result<EngineDecision, TransitionError> {
-        let admitted = self
-            .admit_result(
-                views,
-                dispatch,
-                call,
-                ResultAdmission::CandidateAccepted { offer: execution.offer },
-                expansions,
-            )
-            .unwrap_or_else(|error| unreachable!("the confined stage admits what the log already proved: {error}"));
+        let admitted = admit::admit_result(
+            &self.registry,
+            views,
+            dispatch,
+            call,
+            ResultAdmission::CandidateAccepted { offer: execution.offer },
+            expansions,
+        )
+        .unwrap_or_else(|error| unreachable!("the confined stage admits what the log already proved: {error}"));
         facts.extend(admitted);
         let value = crossed(&facts);
         let advance = Sequence::advance_of(self, view, &facts);
@@ -2541,15 +2549,15 @@ impl Engine {
         for fact in &facts {
             after.fold(fact);
         }
-        let admitted = self
-            .admit_result(
-                &after.view(views.trajectory()),
-                dispatch,
-                call,
-                ResultAdmission::CandidateAdmissible,
-                expansions,
-            )
-            .unwrap_or_else(|error| unreachable!("the confined stage admits what this act just derived: {error}"));
+        let admitted = admit::admit_result(
+            &self.registry,
+            &after.view(views.trajectory()),
+            dispatch,
+            call,
+            ResultAdmission::CandidateAdmissible,
+            expansions,
+        )
+        .unwrap_or_else(|error| unreachable!("the confined stage admits what this act just derived: {error}"));
         facts.extend(admitted);
         let value = crossed(&facts);
         let advance = Sequence::advance_of(self, view, &facts);
@@ -3426,33 +3434,6 @@ impl Engine {
         ))
     }
 
-    /// Close a dispatch and admit its result — raw, cast-resolved, or withheld. The label folds only
-    /// from an admitted value, never from the close.
-    pub(crate) fn admit_result(
-        &self,
-        views: &Views,
-        dispatch: &DispatchId,
-        call: &ResolvedCall,
-        admission: ResultAdmission,
-        expansions: &Expansions,
-    ) -> Result<Vec<Fact>, AdmitError> {
-        admit::admit_result(&self.registry, views, dispatch, call, admission, expansions)
-    }
-
-    /// Record observed success for a still-open dispatch: its declared effects commit now, at the
-    /// one append point the spec puts at success, while any value finalization — an
-    /// output sanitizer derivation, a pending-cast resolution — is still in flight. See
-    /// [`crate::admit::observe_success`].
-    pub(crate) fn observe_success(
-        &self,
-        views: &Views,
-        dispatch: &DispatchId,
-        call: &ResolvedCall,
-        observed: crate::fact::ObservedResult,
-    ) -> Result<Vec<Fact>, AdmitError> {
-        admit::observe_success(&self.registry, views, dispatch, call, observed)
-    }
-
     /// Attach the sound remedies to a raw block: executable plans and prose recommendations. An empty
     /// result (no plans, no curative recommendation) is a proof the block is unliftable over the
     /// implemented remedy subset — see [`crate::plan`].
@@ -3501,12 +3482,8 @@ impl Engine {
         contract_for(&self.registry, tool)
     }
 
-    fn contract(&self, call: &ResolvedCall) -> Result<&ToolContract, EngineError> {
-        self.checkable_contract(call.tool())
-    }
-
     fn validated_contract(&self, call: &ResolvedCall) -> Result<&ToolContract, EngineError> {
-        let contract = self.contract(call)?;
+        let contract = self.checkable_contract(call.tool())?;
         contract
             .parameters
             .validate(call.arguments())
@@ -3562,10 +3539,6 @@ fn settled_outcome(views: &Views, dispatch: &DispatchId) -> SettledOutcome {
             admitted: views.admitted_body(dispatch).cloned(),
         },
     }
-}
-
-fn advance_of(engine: &Engine, view: &EngineView, facts: &[Fact]) -> crate::basis::BasisAdvance {
-    Sequence::advance_of(engine, view, facts)
 }
 
 fn approved_release(
@@ -4875,9 +4848,15 @@ mod tests {
         admission: crate::admit::ResultAdmission,
     ) {
         let p = Projection::build(log, log.len() as u64);
-        let batch = e
-            .admit_result(&p.view(&traj()), dispatch, c, admission, &Expansions::default())
-            .unwrap();
+        let batch = admit::admit_result(
+            &e.registry,
+            &p.view(&traj()),
+            dispatch,
+            c,
+            admission,
+            &Expansions::default(),
+        )
+        .unwrap();
         log.extend(batch);
     }
 
@@ -6572,9 +6551,13 @@ mod tests {
             .expect("the repeat answers from the record");
         assert_eq!(repeat.append, None);
         match repeat.follow_up {
-            FollowUp::Proposals { released, forks, .. } => {
+            FollowUp::Proposals { released, .. } => {
                 assert!(released.is_empty(), "an invoked call is not re-released");
-                assert_eq!(forks, vec![fork.clone()], "its fork still awaits a child");
+                assert_eq!(
+                    e.fork_status(&after_run, &fork),
+                    ForkStatus::Prepared,
+                    "its fork still awaits a child"
+                );
             }
             other => panic!("expected a proposal answer, got {other:?}"),
         }
@@ -8746,19 +8729,20 @@ mod tests {
         let mut log = vec![opened(&e)];
         let dispatch = open(&e, &mut log, &call);
         let body = ValueBody::new("the ticket");
-        let checkpoint = e
-            .observe_success(
-                &Projection::build(&log, log.len() as u64).view(&traj()),
-                &dispatch,
-                &call,
-                crate::fact::ObservedResult::Available(crate::value::RawResultDigest::of(body.as_str().as_bytes())),
-            )
-            .expect("an open dispatch checkpoints");
+        let checkpoint = admit::observe_success(
+            &e.registry,
+            &Projection::build(&log, log.len() as u64).view(&traj()),
+            &dispatch,
+            &call,
+            crate::fact::ObservedResult::Available(crate::value::RawResultDigest::of(body.as_str().as_bytes())),
+        )
+        .expect("an open dispatch checkpoints");
         log.extend(checkpoint);
         let views = Projection::build(&log, log.len() as u64);
 
         assert_eq!(
-            e.admit_result(
+            admit::admit_result(
+                &e.registry,
                 &views.view(&traj()),
                 &dispatch,
                 &call,
@@ -8771,7 +8755,8 @@ mod tests {
             crate::admit::AdmitError::ObservationMismatch
         );
         assert!(
-            e.admit_result(
+            admit::admit_result(
+                &e.registry,
                 &views.view(&traj()),
                 &dispatch,
                 &call,
@@ -9645,9 +9630,14 @@ mod tests {
             CheckOutcome::Block(_)
         ));
         let p = Projection::build(&log, log.len() as u64);
-        let batch = e
-            .observe_success(&p.view(&traj()), &dispatch, &scan_call, ObservedResult::Unavailable)
-            .unwrap();
+        let batch = admit::observe_success(
+            &e.registry,
+            &p.view(&traj()),
+            &dispatch,
+            &scan_call,
+            ObservedResult::Unavailable,
+        )
+        .unwrap();
         log.extend(batch);
         let p = Projection::build(&log, log.len() as u64);
         assert!(p.view(&traj()).is_open(&dispatch));
@@ -10276,17 +10266,17 @@ mod tests {
         let t = traj();
         let dispatch = open(&e, &mut log, &proposed);
         let p = Projection::build(&log, log.len() as u64);
-        let batch = e
-            .admit_result(
-                &p.view(&t),
-                &dispatch,
-                &proposed,
-                ResultAdmission::SuccessRaw {
-                    body: ValueBody::new("raw"),
-                },
-                &Expansions::default(),
-            )
-            .unwrap();
+        let batch = admit::admit_result(
+            &e.registry,
+            &p.view(&t),
+            &dispatch,
+            &proposed,
+            ResultAdmission::SuccessRaw {
+                body: ValueBody::new("raw"),
+            },
+            &Expansions::default(),
+        )
+        .unwrap();
         log.extend(batch);
         let p = Projection::build(&log, log.len() as u64);
         let current = p.view(&t).current_label();

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -65,6 +65,36 @@ pub struct Engine {
     child_return: ReturnPolicy,
 }
 
+/// Where a stage is opened: the act that opens it, what that act moves, the nonce its offer ids
+/// derive from, and the subject its offers stand on.
+#[derive(Clone, Copy)]
+struct Opening<'a> {
+    act: &'a crate::basis::DecidedAct,
+    advance: &'a crate::basis::BasisAdvance,
+    nonce: &'a crate::value::OfferNonce,
+    subject: &'a crate::basis::SubjectKey,
+}
+
+/// A refused call and the block the check produced for it — what a remedy menu is planned over.
+#[derive(Clone, Copy)]
+struct BlockedCall<'a> {
+    call: &'a ResolvedCall,
+    raw: &'a crate::check::RawBlock,
+    stage: &'a CallStage,
+    role: plan::CallRole,
+}
+
+/// What a staged return's remedy menu is computed over: the crossing the child owes, at the
+/// label and body the stage stands on, and the sanitizer lineage that reached it.
+struct ReturnStageInput<'a> {
+    child: &'a TrajectoryId,
+    fold: &'a PartialLabel,
+    label: &'a Label,
+    body: &'a ValueBody,
+    residual: &'a Narrowing,
+    lineage: &'a SanitizerLineage,
+}
+
 impl Engine {
     /// The one validated constructor: policy and declaration validate together in one
     /// load — the structural registry lints and provider-run split, the profile-exact planner-cap
@@ -597,18 +627,19 @@ impl Engine {
                 let fold = views.branch_label(child);
                 let candidate = fold.bound().clone().into_label();
                 let lineage = SanitizerLineage::default();
-                expansions.require(&plan::return_stage_groups(&self.registry, &lineage))?;
-                let stage = match plan::return_stage(
-                    &self.registry,
+                let menu = self.return_menu(
                     views,
-                    child,
-                    &fold,
-                    &candidate,
-                    &body,
-                    &narrowing,
-                    &lineage,
+                    ReturnStageInput {
+                        child,
+                        fold: &fold,
+                        label: &candidate,
+                        body: &body,
+                        residual: &narrowing,
+                        lineage: &lineage,
+                    },
                     expansions,
-                ) {
+                )?;
+                let stage = match menu {
                     plan::ReturnStagePlan::Resolve { value, .. } => {
                         return self.resolving(view, views, return_act(child), facts, value, expansions);
                     }
@@ -829,18 +860,19 @@ impl Engine {
                 follow_up: FollowUp::Child(ChildFollowUp::Merged { admitted: derived }),
             });
         };
-        expansions.require(&plan::return_stage_groups(&self.registry, &lineage))?;
-        let stage = match plan::return_stage(
-            &self.registry,
+        let menu = self.return_menu(
             views,
-            child,
-            fold,
-            &label,
-            &derived,
-            &residual,
-            &lineage,
+            ReturnStageInput {
+                child,
+                fold,
+                label: &label,
+                body: &derived,
+                residual: &residual,
+                lineage: &lineage,
+            },
             expansions,
-        ) {
+        )?;
+        let stage = match menu {
             plan::ReturnStagePlan::Stage(plans) => plans,
             plan::ReturnStagePlan::Resolve { value, .. } => {
                 return self.resolving(view, views, return_act(child), facts, value, expansions);
@@ -943,7 +975,18 @@ impl Engine {
             .ok_or(TransitionError::UnknownDispatch)?
             .digest();
         let advance = Sequence::advance_of(self, view, &facts);
-        let (_, offers, opened) = self.open_offers(views, &act, &advance, &nonce, &subject, &call, &stage, expansions);
+        let (_, offers, opened) = self.open_offers(
+            views,
+            Opening {
+                act: &act,
+                advance: &advance,
+                nonce: &nonce,
+                subject: &subject,
+            },
+            &call,
+            &stage,
+            expansions,
+        );
         facts.extend(opened);
         let batch = self.declaring(act, advance, facts);
         Ok((
@@ -1168,18 +1211,19 @@ impl Engine {
         }
         let fold = views.branch_label(id.child());
         let lineage = views.lineage(&subject);
-        expansions.require(&plan::return_stage_groups(&self.registry, &lineage))?;
-        let stage = match plan::return_stage(
-            &self.registry,
+        let menu = self.return_menu(
             views,
-            id.child(),
-            &fold,
-            &label,
-            &body,
-            &residual,
-            &lineage,
+            ReturnStageInput {
+                child: id.child(),
+                fold: &fold,
+                label: &label,
+                body: &body,
+                residual: &residual,
+                lineage: &lineage,
+            },
             expansions,
-        ) {
+        )?;
+        let stage = match menu {
             plan::ReturnStagePlan::Stage(plans) => plans,
             plan::ReturnStagePlan::Resolve { value, .. } => {
                 return self.resolving(view, views, return_act(id.child()), facts, value, expansions);
@@ -1276,16 +1320,7 @@ impl Engine {
                         let contract = self.validated_contract(&call)?;
                         if contract.pending_cast_dim().is_some() {
                             return self.resolving_cast(
-                                view,
-                                &views,
-                                dispatch,
-                                &call,
-                                contract,
-                                raw,
-                                raw_digest,
-                                report,
-                                checkpointed.is_some(),
-                                expansions,
+                                view, &views, dispatch, &call, contract, raw, raw_digest, report, expansions,
                             );
                         }
                         ResultAdmission::SuccessRaw { body: raw.clone() }
@@ -1301,26 +1336,7 @@ impl Engine {
                             Evidence::Sanitizer { .. } | Evidence::Cast { .. } | Evidence::PendingCast { .. } => None,
                         });
                         let Some(derived) = derived else {
-                            let append = match checkpointed {
-                                Some(_) => None,
-                                None => {
-                                    let checkpoint = admit::observe_success(
-                                        &self.registry,
-                                        &views,
-                                        dispatch,
-                                        &call,
-                                        ObservedResult::Available(raw_digest),
-                                    )
-                                    .expect("an open, unreported dispatch checkpoints its observed success");
-                                    let advance = Sequence::advance_of(self, view, &checkpoint);
-                                    let batch = self.declaring(
-                                        crate::basis::DecidedAct::Outcome(dispatch.clone()),
-                                        advance,
-                                        checkpoint,
-                                    );
-                                    Some(self.seal(view, batch)?)
-                                }
-                            };
+                            let append = self.checkpoint_batch(view, &views, dispatch, &call, raw_digest)?;
                             return Ok(EngineDecision {
                                 append,
                                 follow_up: FollowUp::Outcome(OutcomeFollowUp::Resolve(EvidenceRequest::Sanitizer {
@@ -1373,7 +1389,6 @@ impl Engine {
                             &views,
                             dispatch,
                             &call,
-                            checkpointed.is_some(),
                             report.offer_nonce,
                             Fact::CandidateDerived {
                                 trajectory: views.trajectory().clone(),
@@ -1406,7 +1421,6 @@ impl Engine {
         raw: &ValueBody,
         raw_digest: RawResultDigest,
         report: &ToolReport,
-        checkpointed: bool,
         expansions: &Expansions,
     ) -> Result<EngineDecision, TransitionError> {
         let resolution = report.evidence.iter().find_map(|evidence| match evidence {
@@ -1445,23 +1459,7 @@ impl Engine {
                     },
                 })
                 .collect();
-            let append = match checkpointed {
-                true => None,
-                false => {
-                    let checkpoint = admit::observe_success(
-                        &self.registry,
-                        views,
-                        dispatch,
-                        call,
-                        ObservedResult::Available(raw_digest),
-                    )
-                    .expect("an open, unreported dispatch checkpoints its observed success");
-                    let advance = Sequence::advance_of(self, view, &checkpoint);
-                    let batch =
-                        self.declaring(crate::basis::DecidedAct::Outcome(dispatch.clone()), advance, checkpoint);
-                    Some(self.seal(view, batch)?)
-                }
-            };
+            let append = self.checkpoint_batch(view, views, dispatch, call, raw_digest)?;
             return Ok(EngineDecision {
                 append,
                 follow_up: FollowUp::Outcome(OutcomeFollowUp::Resolve(EvidenceRequest::PendingCast {
@@ -1506,7 +1504,6 @@ impl Engine {
             views,
             dispatch,
             call,
-            checkpointed,
             report.offer_nonce,
             Fact::CandidateDerived {
                 trajectory: views.trajectory().clone(),
@@ -1554,31 +1551,107 @@ impl Engine {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// The success checkpoint a still-open dispatch owes before any external step runs: its
+    /// declared effects commit now, while value finalization — an output sanitizer derivation, a
+    /// pending-cast resolution — is still in flight. Empty where the log already records the
+    /// observation.
+    /// The remedy menu a staged return offers, with the group requirement raised before the menu
+    /// reads anything. A `Resolve` answer is the caller's to continue: the three callers that can
+    /// see one continue differently, so this never decides for them.
+    fn return_menu(
+        &self,
+        views: &Views,
+        stage: ReturnStageInput<'_>,
+        expansions: &Expansions,
+    ) -> Result<plan::ReturnStagePlan, TransitionError> {
+        expansions.require(&plan::return_stage_groups(&self.registry, stage.lineage))?;
+        Ok(plan::return_stage(
+            &self.registry,
+            views,
+            stage.child,
+            stage.fold,
+            stage.label,
+            stage.body,
+            stage.residual,
+            stage.lineage,
+            expansions,
+        ))
+    }
+
+    /// The remedy menu a confined result's stage offers, with the group requirement raised before
+    /// the menu reads anything.
+    fn confined_menu(
+        &self,
+        contract: &ToolContract,
+        receiving: &EstablishedLabel,
+        label: &Label,
+        residual: &Narrowing,
+        lineage: &SanitizerLineage,
+        expansions: &Expansions,
+    ) -> Result<Vec<plan::ExecutableRemedyPlan>, TransitionError> {
+        expansions.require(&plan::confined_stage_groups(&self.registry, contract, lineage))?;
+        Ok(plan::confined_stage(
+            &self.registry,
+            contract,
+            receiving,
+            label,
+            residual,
+            lineage,
+            expansions,
+        ))
+    }
+
+    fn observed_checkpoint(
+        &self,
+        views: &Views,
+        dispatch: &DispatchId,
+        call: &ResolvedCall,
+        source: RawResultDigest,
+    ) -> Vec<Fact> {
+        if views.observed_result(dispatch).is_some() {
+            return Vec::new();
+        }
+        admit::observe_success(&self.registry, views, dispatch, call, ObservedResult::Available(source))
+            .expect("an open, unreported dispatch checkpoints its observed success")
+    }
+
+    /// [`Self::observed_checkpoint`] sealed as its own batch, for the paths that append it and
+    /// then hand the external step back to the runtime.
+    fn checkpoint_batch(
+        &self,
+        view: &EngineView,
+        views: &Views,
+        dispatch: &DispatchId,
+        call: &ResolvedCall,
+        source: RawResultDigest,
+    ) -> Result<Option<ValidatedFactBatch>, TransitionError> {
+        let checkpoint = self.observed_checkpoint(views, dispatch, call, source);
+        if checkpoint.is_empty() {
+            return Ok(None);
+        }
+        let advance = Sequence::advance_of(self, view, &checkpoint);
+        let batch = self.declaring(crate::basis::DecidedAct::Outcome(dispatch.clone()), advance, checkpoint);
+        Ok(Some(self.seal(view, batch)?))
+    }
+
     fn stage_candidate(
         &self,
         view: &EngineView,
         views: &Views,
         dispatch: &DispatchId,
         call: &ResolvedCall,
-        checkpointed: bool,
         nonce: crate::value::OfferNonce,
         derived: Fact,
         expansions: &Expansions,
     ) -> Result<EngineDecision, TransitionError> {
-        let mut facts = Vec::new();
-        if !checkpointed {
-            let source = match &derived {
-                Fact::CandidateDerived {
-                    derived: DerivedCandidate::Result { source, .. },
-                    ..
-                } => *source,
-                _ => unreachable!("a staged record is a derived candidate"),
-            };
-            facts.extend(
-                admit::observe_success(&self.registry, views, dispatch, call, ObservedResult::Available(source))
-                    .expect("an open, unreported dispatch checkpoints its observed success"),
-            );
-        }
+        let source = match &derived {
+            Fact::CandidateDerived {
+                derived: DerivedCandidate::Result { source, .. },
+                ..
+            } => *source,
+            _ => unreachable!("a staged record is a derived candidate"),
+        };
+        let mut facts = self.observed_checkpoint(views, dispatch, call, source);
         facts.push(derived);
         let (batch, confined) = self.staged(
             view,
@@ -1626,23 +1699,16 @@ impl Engine {
             .ok_or(TransitionError::UnknownDispatch)?
             .clone();
         let contract = self.dispatch_contract(views, dispatch)?;
-        expansions.require(&plan::confined_stage_groups(&self.registry, contract, &lineage))?;
-        let stage = plan::confined_stage(
-            &self.registry,
-            contract,
-            &receiving,
-            &value.label,
-            &residual,
-            &lineage,
-            expansions,
-        );
+        let stage = self.confined_menu(contract, &receiving, &value.label, &residual, &lineage, expansions)?;
         let advance = Sequence::advance_of(self, view, &facts);
         let (_, offers, opened) = self.open_offers(
             views,
-            &act,
-            &advance,
-            &nonce,
-            &subject,
+            Opening {
+                act: &act,
+                advance: &advance,
+                nonce: &nonce,
+                subject: &subject,
+            },
             dispatch.digest(),
             &stage,
             expansions,
@@ -1694,24 +1760,17 @@ impl Engine {
             .clone();
         let lineage = views.lineage(&subject);
         let contract = self.dispatch_contract(views, dispatch)?;
-        expansions.require(&plan::confined_stage_groups(&self.registry, contract, &lineage))?;
-        let stage = plan::confined_stage(
-            &self.registry,
-            contract,
-            &receiving,
-            &value.label,
-            &residual,
-            &lineage,
-            expansions,
-        );
+        let stage = self.confined_menu(contract, &receiving, &value.label, &residual, &lineage, expansions)?;
         let act = crate::basis::DecidedAct::Outcome(dispatch.clone());
         let advance = crate::basis::BasisAdvance::default();
         let (_, offers, opened) = self.open_offers(
             views,
-            &act,
-            &advance,
-            &nonce,
-            &subject,
+            Opening {
+                act: &act,
+                advance: &advance,
+                nonce: &nonce,
+                subject: &subject,
+            },
             dispatch.digest(),
             &stage,
             expansions,
@@ -1985,14 +2044,18 @@ impl Engine {
             };
             let (block, opened_offers) = self.surface_call_block(
                 &final_views,
-                &crate::basis::DecidedAct::Proposals(batch.id.clone()),
-                &advance,
-                &batch.offer_nonce,
-                &subject,
-                call,
-                &raw,
-                &CallStage::default(),
-                role,
+                Opening {
+                    act: &crate::basis::DecidedAct::Proposals(batch.id.clone()),
+                    advance: &advance,
+                    nonce: &batch.offer_nonce,
+                    subject: &subject,
+                },
+                BlockedCall {
+                    call,
+                    raw: &raw,
+                    stage: &CallStage::default(),
+                    role,
+                },
                 expansions,
             );
             facts.extend(opened_offers);
@@ -2093,27 +2156,18 @@ impl Engine {
         Ok(Some(self.seal(view, batch)?))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn surface_call_block(
         &self,
         views: &Views,
-        act: &crate::basis::DecidedAct,
-        advance: &crate::basis::BasisAdvance,
-        nonce: &crate::value::OfferNonce,
-        subject: &crate::basis::SubjectKey,
-        call: &ResolvedCall,
-        raw: &crate::check::RawBlock,
-        stage: &CallStage,
-        role: plan::CallRole,
+        opening: Opening<'_>,
+        blocked: BlockedCall<'_>,
         expansions: &Expansions,
     ) -> (Blocked, Vec<Fact>) {
+        let BlockedCall { call, raw, stage, role } = blocked;
         let planned = plan::plan(&self.registry, views, call, raw, stage, role, expansions);
         let (block_id, offers, opened) = self.open_offers(
             views,
-            act,
-            advance,
-            nonce,
-            subject,
+            opening,
             &call.digest(),
             &Engine::executable(&planned),
             expansions,
@@ -2129,14 +2183,10 @@ impl Engine {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn open_offers(
         &self,
         views: &Views,
-        act: &crate::basis::DecidedAct,
-        advance: &crate::basis::BasisAdvance,
-        nonce: &crate::value::OfferNonce,
-        subject: &crate::basis::SubjectKey,
+        opening: Opening<'_>,
         call: &crate::value::CanonicalDigest,
         plans: &[plan::ExecutableRemedyPlan],
         expansions: &Expansions,
@@ -2145,6 +2195,12 @@ impl Engine {
         Vec<(crate::value::OfferId, plan::PlanId)>,
         Vec<Fact>,
     ) {
+        let Opening {
+            act,
+            advance,
+            nonce,
+            subject,
+        } = opening;
         let basis = views.basis_after(advance, subject);
         let (trajectory, block_id) = match subject {
             crate::basis::SubjectKey::Call {
@@ -2402,16 +2458,7 @@ impl Engine {
         };
         let lineage = views.lineage(&subject);
         let contract = self.dispatch_contract(views, dispatch)?;
-        expansions.require(&plan::confined_stage_groups(&self.registry, contract, &lineage))?;
-        let stage = plan::confined_stage(
-            &self.registry,
-            contract,
-            &receiving,
-            &value.label,
-            &residual,
-            &lineage,
-            expansions,
-        );
+        let stage = self.confined_menu(contract, &receiving, &value.label, &residual, &lineage, expansions)?;
         if !stage.contains(&recorded.plan) {
             return self.invalidated(view, execution, recorded);
         }
@@ -2604,18 +2651,19 @@ impl Engine {
                 },
             ),
         };
-        expansions.require(&plan::return_stage_groups(&self.registry, &lineage))?;
-        let stage = match plan::return_stage(
-            &self.registry,
+        let menu = self.return_menu(
             views,
-            id.child(),
-            &fold,
-            &label,
-            &body,
-            &residual,
-            &lineage,
+            ReturnStageInput {
+                child: id.child(),
+                fold: &fold,
+                label: &label,
+                body: &body,
+                residual: &residual,
+                lineage: &lineage,
+            },
             expansions,
-        ) {
+        )?;
+        let stage = match menu {
             plan::ReturnStagePlan::Stage(plans) => plans,
             plan::ReturnStagePlan::Resolve { .. } => return self.invalidated(view, execution, recorded),
         };
@@ -2833,18 +2881,19 @@ impl Engine {
         // a consumed dimension resolvable now was resolvable when this stage's predecessor
         // opened; a fresh `Resolve` has no live path, and the empty stage it would leave
         // re-plans on the child's next report.
-        expansions.require(&plan::return_stage_groups(&self.registry, &lineage))?;
-        let stage = match plan::return_stage(
-            &self.registry,
+        let menu = self.return_menu(
             views,
-            id.child(),
-            fold,
-            &label,
-            body,
-            &residual,
-            &lineage,
+            ReturnStageInput {
+                child: id.child(),
+                fold,
+                label: &label,
+                body,
+                residual: &residual,
+                lineage: &lineage,
+            },
             expansions,
-        ) {
+        )?;
+        let stage = match menu {
             plan::ReturnStagePlan::Stage(plans) => plans,
             plan::ReturnStagePlan::Resolve { .. } => Vec::new(),
         };
@@ -2983,14 +3032,18 @@ impl Engine {
                 expansions.require(&plan::block_groups(&self.registry, contract, &raw, role))?;
                 let (block, opened) = self.surface_call_block(
                     views,
-                    &act,
-                    &staged,
-                    &execution.offer_nonce,
-                    &recorded.subject,
-                    &substituted,
-                    &raw,
-                    &next,
-                    role,
+                    Opening {
+                        act: &act,
+                        advance: &staged,
+                        nonce: &execution.offer_nonce,
+                        subject: &recorded.subject,
+                    },
+                    BlockedCall {
+                        call: &substituted,
+                        raw: &raw,
+                        stage: &next,
+                        role,
+                    },
                     expansions,
                 );
                 facts.extend(opened);
@@ -3367,16 +3420,21 @@ impl Engine {
         }
         let after = after.view(trajectory);
         let advance = Sequence::advance_of(self, view, &facts);
+        let role = after.call_role(&recorded.subject);
         let (block, opened) = self.surface_call_block(
             &after,
-            &crate::basis::DecidedAct::Offer(execution.offer),
-            &advance,
-            &execution.offer_nonce,
-            &recorded.subject,
-            call,
-            raw,
-            stage,
-            after.call_role(&recorded.subject),
+            Opening {
+                act: &crate::basis::DecidedAct::Offer(execution.offer),
+                advance: &advance,
+                nonce: &execution.offer_nonce,
+                subject: &recorded.subject,
+            },
+            BlockedCall {
+                call,
+                raw,
+                stage,
+                role,
+            },
             expansions,
         );
         facts.extend(opened);

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -200,6 +200,19 @@ impl Engine {
         ))
     }
 
+    /// One act's facts, declared and sealed into the batch a decision appends. The declaration
+    /// is derived from the same facts it is prepended to, so the two cannot disagree.
+    fn decided(
+        &self,
+        view: &EngineView,
+        act: crate::basis::DecidedAct,
+        facts: Vec<Fact>,
+    ) -> Result<ValidatedFactBatch, TransitionError> {
+        let advance = Sequence::advance_of(self, view, &facts);
+        let batch = self.declaring(act, advance, facts);
+        Ok(self.seal(view, batch)?)
+    }
+
     fn declaring(
         &self,
         act: crate::basis::DecidedAct,
@@ -445,13 +458,8 @@ impl Engine {
             trajectory: binding.child.clone(),
             fork: binding.fork.clone(),
         }];
-        let batch = self.declaring(
-            crate::basis::DecidedAct::Binding(binding.fork.clone()),
-            Sequence::advance_of(self, view, &batch),
-            batch,
-        );
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, crate::basis::DecidedAct::Binding(binding.fork.clone()), batch)?),
             follow_up: FollowUp::Fork {
                 child: binding.child.clone(),
             },
@@ -482,9 +490,8 @@ impl Engine {
         let body = match &report.submission {
             ChildSubmission::Void => {
                 let batch = branch::submit_void_return(&views, child).map_err(branch_refusal)?;
-                let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
                 return Ok(EngineDecision {
-                    append: Some(self.seal(view, batch)?),
+                    append: Some(self.decided(view, return_act(child), batch)?),
                     follow_up: FollowUp::Child(ChildFollowUp::Ended),
                 });
             }
@@ -616,10 +623,8 @@ impl Engine {
         match branch::submit_child_return(&self.registry, views, child, &body, expansions).map_err(branch_refusal)? {
             branch::RawCrossing::Merged(crossing) => {
                 facts.extend(crossing);
-                let batch = facts;
-                let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
                 Ok(EngineDecision {
-                    append: Some(self.seal(view, batch)?),
+                    append: Some(self.decided(view, return_act(child), facts)?),
                     follow_up: FollowUp::Child(ChildFollowUp::Merged { admitted: body }),
                 })
             }
@@ -776,10 +781,8 @@ impl Engine {
             _ => None,
         });
         let Some(derived) = derived else {
-            let batch = facts;
-            let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
             return Ok(EngineDecision {
-                append: Some(self.seal(view, batch)?),
+                append: Some(self.decided(view, return_act(child), facts)?),
                 follow_up: FollowUp::Child(ChildFollowUp::Resolve(EvidenceRequest::Sanitizer {
                     sanitizer: name.clone(),
                     source: digest,
@@ -853,10 +856,8 @@ impl Engine {
                 None,
                 self.registry.resolutions(expansions),
             ));
-            let batch = facts;
-            let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
             return Ok(EngineDecision {
-                append: Some(self.seal(view, batch)?),
+                append: Some(self.decided(view, return_act(child), facts)?),
                 follow_up: FollowUp::Child(ChildFollowUp::Merged { admitted: derived }),
             });
         };
@@ -917,10 +918,8 @@ impl Engine {
             reason: reason.clone(),
             resolutions: self.registry.resolutions(expansions),
         });
-        let batch = facts;
-        let batch = self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, return_act(child), facts)?),
             follow_up: FollowUp::Child(ChildFollowUp::Rejected { reason }),
         })
     }
@@ -942,11 +941,7 @@ impl Engine {
             .expect("a resolvable source retains its bytes and the cast the caller selected");
         let append = match facts.is_empty() {
             true => None,
-            false => {
-                let batch = facts;
-                let batch = self.declaring(act, Sequence::advance_of(self, view, &batch), batch);
-                Some(self.seal(view, batch)?)
-            }
+            false => Some(self.decided(view, act, facts)?),
         };
         Ok(EngineDecision {
             append,
@@ -1103,12 +1098,7 @@ impl Engine {
                     None => {
                         let append = match cast_facts.is_empty() {
                             true => None,
-                            false => {
-                                let batch = cast_facts;
-                                let batch =
-                                    self.declaring(return_act(child), Sequence::advance_of(self, view, &batch), batch);
-                                Some(self.seal(view, batch)?)
-                            }
+                            false => Some(self.decided(view, return_act(child), cast_facts)?),
                         };
                         Ok(EngineDecision {
                             append,
@@ -1539,13 +1529,8 @@ impl Engine {
             Fact::ValueAdmitted { value, .. } => Some(value.body.clone()),
             _ => None,
         });
-        let batch = self.declaring(
-            crate::basis::DecidedAct::Outcome(dispatch.clone()),
-            Sequence::advance_of(self, view, &batch),
-            batch,
-        );
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, crate::basis::DecidedAct::Outcome(dispatch.clone()), batch)?),
             follow_up: FollowUp::Outcome(OutcomeFollowUp::Closed { admitted }),
         })
     }
@@ -1629,9 +1614,11 @@ impl Engine {
         if checkpoint.is_empty() {
             return Ok(None);
         }
-        let advance = Sequence::advance_of(self, view, &checkpoint);
-        let batch = self.declaring(crate::basis::DecidedAct::Outcome(dispatch.clone()), advance, checkpoint);
-        Ok(Some(self.seal(view, batch)?))
+        Ok(Some(self.decided(
+            view,
+            crate::basis::DecidedAct::Outcome(dispatch.clone()),
+            checkpoint,
+        )?))
     }
 
     fn stage_candidate(
@@ -2506,10 +2493,8 @@ impl Engine {
         .unwrap_or_else(|error| unreachable!("the confined stage admits what the log already proved: {error}"));
         facts.extend(admitted);
         let value = crossed(&facts);
-        let advance = Sequence::advance_of(self, view, &facts);
-        let batch = self.declaring(crate::basis::DecidedAct::Offer(execution.offer), advance, facts);
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, crate::basis::DecidedAct::Offer(execution.offer), facts)?),
             follow_up: FollowUp::Offer(OfferFollowUp::Admitted { value }),
         })
     }
@@ -2607,10 +2592,8 @@ impl Engine {
         .unwrap_or_else(|error| unreachable!("the confined stage admits what this act just derived: {error}"));
         facts.extend(admitted);
         let value = crossed(&facts);
-        let advance = Sequence::advance_of(self, view, &facts);
-        let batch = self.declaring(crate::basis::DecidedAct::Offer(execution.offer), advance, facts);
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, crate::basis::DecidedAct::Offer(execution.offer), facts)?),
             follow_up: FollowUp::Offer(OfferFollowUp::Admitted { value }),
         })
     }
@@ -2783,10 +2766,8 @@ impl Engine {
             Some(residual),
             self.registry.resolutions(expansions),
         ));
-        let advance = Sequence::advance_of(self, view, &facts);
-        let batch = self.declaring(crate::basis::DecidedAct::Offer(execution.offer), advance, facts);
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, crate::basis::DecidedAct::Offer(execution.offer), facts)?),
             follow_up: FollowUp::Offer(OfferFollowUp::Admitted { value: admitted }),
         })
     }
@@ -2870,10 +2851,8 @@ impl Engine {
                 None,
                 self.registry.resolutions(expansions),
             ));
-            let advance = Sequence::advance_of(self, view, &facts);
-            let batch = self.declaring(crate::basis::DecidedAct::Offer(execution.offer), advance, facts);
             return Ok(EngineDecision {
-                append: Some(self.seal(view, batch)?),
+                append: Some(self.decided(view, crate::basis::DecidedAct::Offer(execution.offer), facts)?),
                 follow_up: FollowUp::Offer(OfferFollowUp::Admitted { value: body.clone() }),
             });
         };
@@ -3050,10 +3029,8 @@ impl Engine {
                 OfferFollowUp::Substituted { block: Box::new(block) }
             }
         };
-        let advance = Sequence::advance_of(self, view, &facts);
-        let batch = self.declaring(act, advance, facts);
         Ok(EngineDecision {
-            append: Some(self.seal(view, batch)?),
+            append: Some(self.decided(view, act, facts)?),
             follow_up: FollowUp::Offer(follow_up),
         })
     }
@@ -3429,12 +3406,7 @@ impl Engine {
                 nonce: &execution.offer_nonce,
                 subject: &recorded.subject,
             },
-            BlockedCall {
-                call,
-                raw,
-                stage,
-                role,
-            },
+            BlockedCall { call, raw, stage, role },
             expansions,
         );
         facts.extend(opened);

--- a/appa-engine/src/params.rs
+++ b/appa-engine/src/params.rs
@@ -790,16 +790,15 @@ pub struct CanonicalArguments {
 
 impl CanonicalArguments {
     /// The engine construction path: one raw JSON object, strictly scanned and
-    /// schema-validated. Runtime raw-byte adoption is `T01`; the engine path is complete.
+    /// schema-validated.
     pub(crate) fn from_raw(bytes: &[u8], parameters: &ToolParameters) -> Result<Self, ArgumentError> {
         let unchecked = Self::from_raw_unchecked(bytes)?;
         parameters.validate(&unchecked.value)?;
         Ok(unchecked)
     }
 
-    /// Compatibility constructor for callers that hold a parsed value (`T01` owns the
-    /// runtime raw-byte cutover). It funnels through the same scanner and validation as
-    /// [`Self::from_raw`], so the two paths cannot diverge.
+    /// The construction path for callers that hold a parsed value. It funnels through the
+    /// same scanner and validation as [`Self::from_raw`], so the two paths cannot diverge.
     #[cfg(test)]
     pub(crate) fn from_value(value: &Value, parameters: &ToolParameters) -> Result<Self, ArgumentError> {
         let bytes = serde_json::to_vec(value).map_err(|e| ArgumentError::Syntax(e.to_string()))?;

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -34,9 +34,9 @@
 //! (narrowing), `Sanitize` (an output sanitizer's relabel standing in for the raw crossing),
 //! `Derive` (an input sanitizer's substitution of the whole argument set), and `Redispatch` over direct `prior(k)` emitters and static cap-narrowing tools, in
 //! name order — the agent picks, and each redispatch is separately checked for real.
-//! **De-scoped, and spec-marked so the claim and the spec's enumeration coincide:** cast
-//! resolution of an Unknown (spec: attempted by the harness itself at check and at admission,
-//! never surfaced as a plan object). The empty-proof is complete over exactly this subset.
+//! Cast resolution of an Unknown is outside the subset: the harness attempts it itself at
+//! check and at admission, and it is never surfaced as a plan object. The empty-proof is
+//! complete over exactly this subset.
 //!
 //! **A sanitize step settles a narrowing and never a requirement gap**. The gaps are
 //! evaluated on the raw committed label even in a plan that sanitizes: a requirement gates the

--- a/appa-engine/src/projection.rs
+++ b/appa-engine/src/projection.rs
@@ -184,7 +184,6 @@ pub struct Projection {
     dispatch_resolutions: BTreeMap<DispatchId, Vec<GroupResolution>>,
     subject_dispatches: BTreeMap<crate::basis::SubjectKey, DispatchId>,
     observations: BTreeMap<DispatchId, ObservedResult>,
-    boundaries: Vec<TrajectoryId>,
     prepared: BTreeMap<ForkId, PreparedFork>,
     bound: BTreeMap<ForkId, TrajectoryId>,
     fork_of: BTreeMap<TrajectoryId, ForkId>,
@@ -232,7 +231,6 @@ impl Projection {
             dispatch_resolutions: BTreeMap::new(),
             subject_dispatches: BTreeMap::new(),
             observations: BTreeMap::new(),
-            boundaries: Vec::new(),
             prepared: BTreeMap::new(),
             bound: BTreeMap::new(),
             fork_of: BTreeMap::new(),
@@ -318,7 +316,6 @@ impl Projection {
             dispatch_resolutions,
             subject_dispatches,
             observations,
-            boundaries,
             prepared,
             bound,
             fork_of,
@@ -651,22 +648,19 @@ impl Projection {
                         },
                     );
                 }
-                Fact::Boundary { trajectory, kind } => {
-                    boundaries.push(trajectory.clone());
-                    match kind {
-                        BoundaryKind::Merge { .. } => {
-                            if !merge_absorption.is_empty() {
-                                let table = absorbed.entry(trajectory.clone()).or_default();
-                                for (id, dim) in &merge_absorption {
-                                    table.entry(*id).or_default().insert(*dim);
-                                }
+                Fact::Boundary { trajectory, kind } => match kind {
+                    BoundaryKind::Merge { .. } => {
+                        if !merge_absorption.is_empty() {
+                            let table = absorbed.entry(trajectory.clone()).or_default();
+                            for (id, dim) in &merge_absorption {
+                                table.entry(*id).or_default().insert(*dim);
                             }
                         }
-                        BoundaryKind::VoidReturn => {
-                            ended.insert(trajectory.clone());
-                        }
                     }
-                }
+                    BoundaryKind::VoidReturn => {
+                        ended.insert(trajectory.clone());
+                    }
+                },
             }
         }
     }
@@ -1315,17 +1309,6 @@ impl Views<'_> {
         self.projection.subject_dispatches.get(subject)
     }
 
-    /// How many boundaries this trajectory has recorded. Punctuation is counted for the tests
-    /// that pin it; no decision reads it.
-    #[cfg(test)]
-    pub(crate) fn boundary_count(&self) -> usize {
-        self.projection
-            .boundaries
-            .iter()
-            .filter(|t| *t == self.trajectory)
-            .count()
-    }
-
     /// The authorities denied for this rendered call in this trajectory's scope:
     /// recorded here, or inherited from an ancestor at fork time. Plan enumeration is the one
     /// sanctioned consumer (the denial-exclusion consultation), so this stays crate-only.
@@ -1621,7 +1604,7 @@ mod tests {
             },
         ];
         assert_eq!(build(&log), build(&log));
-        assert_eq!(build(&log).view(&traj("a")).boundary_count(), 1);
+        assert!(build(&log).view(&traj("a")).has_ended(&traj("a")));
 
         let crossing = [
             vec![opened("root"), admit("root", labeled(2, Audience::Public))],

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -49,8 +49,8 @@ pub struct ProposalBatch {
     /// They are admitted before any sibling is checked, because the model has already read them.
     pub provider_results: Vec<ProviderResult>,
     pub proposals: Vec<ProposedCall>,
-    /// Which proposal, if any, the runtime marks as the deployment's context-controlled spawn
-    /// (`Q27`). Runtime names it — no configuration surface does — and the marked call is checked
+    /// Which proposal, if any, the runtime marks as the deployment's context-controlled spawn.
+    /// Runtime names it — no configuration surface does — and the marked call is checked
     /// and released like any other. The engine refuses the mark where the deployment declares no
     /// context control.
     pub spawn: Option<SpawnMark>,
@@ -111,9 +111,8 @@ impl SpawnMark {
 /// One act the engine decides. A closed enum: an external operational failure is not an
 /// event, and neither is a request, user turn, transcript, or host run.
 ///
-/// Tool outcome, offer execution and child return join it as they move off the composed
-/// operations; forking joins as `T39`'s `BindFork`, in its final shape rather than an interim
-/// child-start variant this boundary would have to unpublish.
+/// Tool outcome, offer execution, child return and fork binding join it as they move off the
+/// composed operations.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EngineEvent {
     Proposals(ProposalBatch),
@@ -345,7 +344,7 @@ pub enum OutcomeFollowUp {
 }
 
 /// One released call: the dispatch the engine opened for it, and the canonical call to invoke.
-/// The runtime never re-derives the identity — deriving it twice is what `T31` removes.
+/// The runtime never re-derives the identity.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Released {
     pub dispatch: DispatchId,
@@ -355,7 +354,7 @@ pub struct Released {
     pub fork: Option<ForkId>,
 }
 
-/// One proposal of a repeated batch whose dispatch has already been invoked (`Q24`). It cannot be
+/// One proposal of a repeated batch whose dispatch has already been invoked. It cannot be
 /// re-released — that would run the tool a second time — so the repeat hears what the log records
 /// for it instead of hearing nothing at all.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -396,7 +395,6 @@ pub enum FollowUp {
     Proposals {
         released: Vec<Released>,
         blocked: Vec<Blocked>,
-        forks: Vec<ForkId>,
         spent: Vec<ResolvedCall>,
         settled: Vec<Settled>,
     },


### PR DESCRIPTION
Behavior-preserving. Same decisions, same appended facts, same errors, same persisted formats. 434 engine tests green at every commit; workspace tests and `cargo clippy --workspace --all-targets -- -D warnings` clean.

## What changed

**Deletions.** `Projection.boundaries` and its `#[cfg(test)]` counter, the `FollowUp::Proposals.forks` channel, the free `advance_of` alias, and the `Engine::admit_result` / `observe_success` / `contract` pass-throughs. Two tests restate their property against durable state: the boundary count becomes `has_ended`, the fork channel becomes `fork_status(..) == ForkStatus::Prepared`. Spec-ticket and roadmap comments removed from `transition.rs`, `params.rs`, `plan.rs`, `contract.rs`.

**Three open-coded skeletons collapsed.** The return-stage menu was written out at five sites, the confined-stage menu at three, the success checkpoint at three. Each `expansions.require(..._groups(..))` now sits with the query it gates, in `return_menu` / `confined_menu` / `observed_checkpoint`, so the requirement cannot drift from the read. `return_menu` returns the plan and the five callers keep their own `match`: a `Resolve` answer means three different things (ask for the cast, invalidate a stale execution, leave the empty stage that re-plans). `observed_checkpoint` reads `views.observed_result` itself, so the `checkpointed` flag leaves two signatures.

**One declare-and-seal operation.** Fifteen decision arms spelled out the same epilogue; `Engine::decided` does it once. The arms that stamp offers keep their explicit `advance` — it is derived before the batch is complete and is not the advance over the finished batch.

**`decide_proposals` split.** Its guards, replay answer and proposal prevalidation are now `admissible_batch` / `replayed_batch` / `answered_proposals`, holding the same statements in the same order. The compose-and-surface tail stays inline: its `advance`, working projection and `final_views` are ordered against each other.

## Kept

`TrustChain::is_empty` satisfies `clippy::len_without_is_empty` beside the live `TrustChain::len`. `provider_results` and the provider-run admission path, `EngineView::advance` + `ViewMismatch`, and `#[serde(default)]` on the 13 `Fact` fields are untouched.

## Not done

The diff is +34 lines, not net-negative. An `Act { view, views, expansions }` context struct was built end to end and reverted: it removed 3 of 9 parameters from 16 signatures but cost 5 lines of struct-literal ceremony at each of 22 call sites, growing the diff by 206 lines while clearing 3 of 16 `too_many_arguments` suppressions. The parameters it bundled are distinct types, so the positional lists carry no real mis-ordering hazard. `Opening` and `BlockedCall` were kept because they bundle values that travel as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt6cMk8UvMMrk7sFgpP3EX