### PR TITLE
feat: suppress reader-ping via ?popup=no

### DIFF
--- a/website/components/ReaderPing.tsx
+++ b/website/components/ReaderPing.tsx
@@ -39,6 +39,34 @@ function forcedOpen(): boolean {
   return new URLSearchParams(window.location.search).get("reader-ping") === "1";
 }
 
+/* A link you can share without the prompt greeting whoever opens it: append
+   ?popup=no. Suppression is sticky, so a reader who arrives through such a
+   link is not asked on the pages they visit afterwards either — the person
+   who shared it already decided on their behalf, and re-asking one click
+   later would undo that decision.
+
+   A cookie rather than the localStorage key above: this is a property of how
+   the reader arrived, it has to survive independently of whether they were
+   ever shown and dismissed the prompt, and a cookie is the one browser store
+   a future server-rendered variant could read before first paint. */
+const OFF_COOKIE = "openappa-reader-ping-off";
+const OFF_MAX_AGE_S = 60 * 60 * 24 * 365;
+
+function suppressionRequested(): boolean {
+  return new URLSearchParams(window.location.search).get("popup") === "no";
+}
+
+function suppressedByCookie(): boolean {
+  return document.cookie.split("; ").some((entry) => entry === `${OFF_COOKIE}=1`);
+}
+
+function rememberSuppression() {
+  // `Secure` only where it can hold: setting it over plain http silently
+  // drops the cookie, which would break local preview.
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${OFF_COOKIE}=1; Max-Age=${OFF_MAX_AGE_S}; Path=/; SameSite=Lax${secure}`;
+}
+
 function remember(outcome: "sent" | "skipped") {
   try {
     localStorage.setItem(SEEN_KEY, outcome);
@@ -58,8 +86,15 @@ export function ReaderPing() {
   const restoreFocusTo = useRef<Element | null>(null);
 
   useEffect(() => {
+    /* Checked before the preview override: ?popup=no is a reader's explicit
+       "not this time", and it outranks a param whose only job is to make the
+       dialog easy to look at. */
+    if (suppressionRequested()) {
+      rememberSuppression();
+      return;
+    }
     const forced = forcedOpen();
-    if (!forced && alreadySeen()) return;
+    if (!forced && (alreadySeen() || suppressedByCookie())) return;
     // Forced previews skip the arrival delay: whoever added the param wants
     // to see the dialog, not wait for it.
     const timer = setTimeout(() => setOpen(true), forced ? 0 : APPEAR_DELAY_MS);


### PR DESCRIPTION
`?popup=no` on any page suppresses the first-visit reader-ping prompt and sets a year-long cookie, so a link shared with that param stays quiet on the reader's later visits too. Takes precedence over `?reader-ping=1`.

Default is unchanged: no param, no cookie, prompt appears.