### PR TITLE
refactor(runtime): collapse the engine test seam and the accretion around it

### DIFF
--- a/appa-runtime/CLAUDE.md
+++ b/appa-runtime/CLAUDE.md
@@ -23,9 +23,10 @@ one at the repository root:
   the `hooks` dispatcher, the HTTP server, the MCP endpoint, the
   externals, the builtin modules (`builtins.rs` — stock implementations
   plus the `--modules-dir` loader over the `appa-builtin` ABI crate at
-  the repo root), and the engine boundary (`src/engine.rs`, the one
-  module that names `appa-engine`). It keeps no durable state of its
-  own beside the log.
+  the repo root), and the engine boundary (`src/engine.rs`, which
+  translates and presents every engine decision; `api/mod.rs` and
+  `api/session.rs` also name `appa-engine`). It keeps no durable state
+  of its own beside the log.
 
 The Claude Code plugin, the marketplace manifest, and the example
 policies are not code and live in `integrations/claude-code/` at the

--- a/appa-runtime/README.md
+++ b/appa-runtime/README.md
@@ -93,13 +93,16 @@ what was recorded:
 sqlite3 appa.db "SELECT seq, facts FROM logs WHERE root = 'cc:<session-id>' ORDER BY seq;"
 ```
 
-The `appa-runtime status` and `audit` reads answer the same questions
-without SQL, and are the supported way to look.
+`GET /status?trajectory=cc:<session-id>` answers the same questions
+over HTTP without SQL, and is the supported way to look — it is what the
+statusline reads.
 
 ## Things to know
 
-- **A changed policy is a new deployment.** Edit `[policy]` and the
-  old database refuses to open; use a fresh `--db` path.
+- **A changed policy is a new deployment.** Edit `[policy]` and new
+  trajectories open under the edited one. Trajectories already open keep
+  running under the policy they opened with — the runtime recompiles it
+  from the copy stored in their log. The same `--db` path serves both.
 - **Stopping the process blocks protected sessions.** That is the design,
   not a fault. Uninstall the plugin if you want unprotected sessions back.
 - **This crate's `CLAUDE.md`** describes the layout: the process

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -21,13 +21,6 @@ use crate::engine::{EngineRefusal, Liveness, PolicyEngine, RuntimeEngine};
 use crate::external::ExternalServices;
 use appa_eventlog::{Backend, Log, LogStore};
 
-/// Identity of one open dispatch: a released call the harness is
-/// executing. Runtime-internal: outcomes correlate by the
-/// call's canonical bytes, never by an id an adapter
-/// carries.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct DispatchId(pub String);
-
 /// One remedy offer as it is quoted and carried.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OfferId(pub String);
@@ -665,6 +658,25 @@ impl Runtime {
         })
     }
 
+    /// One root's rebuilt view and the engine that decides for it, for
+    /// the test accessors that read a family the public surface does not
+    /// expose. Panics where production would refuse: a test that reaches
+    /// an unreadable log has already failed.
+    #[cfg(test)]
+    fn rebuilt<'a>(
+        &self,
+        deployment: &'a Deployment,
+        root: &TrajectoryId,
+    ) -> (PolicyEngine<'a>, crate::engine::EngineView) {
+        let log = self.inner.log(root).expect("the log reads");
+        let policy = self
+            .inner
+            .resolve_policy(deployment, &log)
+            .expect("the opening policy resolves");
+        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        (policy, view)
+    }
+
     #[cfg(test)]
     pub(crate) fn log_facts(&self, root: &TrajectoryId) -> Vec<appa_engine::fact::Fact> {
         self.inner.log(root).expect("the log reads").facts().to_vec()
@@ -681,13 +693,8 @@ impl Runtime {
         root: &TrajectoryId,
         trajectory: &TrajectoryId,
     ) -> Vec<crate::engine::OpenDispatch> {
-        let log = self.inner.log(root).expect("the log reads");
         let deployment = self.inner.deployment();
-        let policy = self
-            .inner
-            .resolve_policy(&deployment, &log)
-            .expect("the opening policy resolves");
-        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        let (policy, view) = self.rebuilt(&deployment, root);
         policy.engine().open_dispatches(&view, trajectory)
     }
 
@@ -695,13 +702,8 @@ impl Runtime {
     /// assert on whether a child opened.
     #[cfg(test)]
     pub(crate) fn names_trajectory(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> bool {
-        let log = self.inner.log(root).expect("the log reads");
         let deployment = self.inner.deployment();
-        let policy = self
-            .inner
-            .resolve_policy(&deployment, &log)
-            .expect("the opening policy resolves");
-        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        let (policy, view) = self.rebuilt(&deployment, root);
         policy.engine().liveness(&view, trajectory) != Liveness::Unopened
     }
 
@@ -713,13 +715,8 @@ impl Runtime {
         root: &TrajectoryId,
         trajectory: &TrajectoryId,
     ) -> Option<crate::engine::OpenDispatch> {
-        let log = self.inner.log(root).expect("the log reads");
         let deployment = self.inner.deployment();
-        let policy = self
-            .inner
-            .resolve_policy(&deployment, &log)
-            .expect("the opening policy resolves");
-        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        let (policy, view) = self.rebuilt(&deployment, root);
         policy.engine().substituted_release(&view, trajectory)
     }
 
@@ -727,13 +724,8 @@ impl Runtime {
     /// that read a branch the root-only public surface does not expose.
     #[cfg(test)]
     pub(crate) fn branch_status(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Option<TrajectoryStatus> {
-        let log = self.inner.log(root).expect("the log reads");
         let deployment = self.inner.deployment();
-        let policy = self
-            .inner
-            .resolve_policy(&deployment, &log)
-            .expect("the policy resolves");
-        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        let (policy, view) = self.rebuilt(&deployment, root);
         policy.engine().trajectory_status(&view, trajectory)
     }
 
@@ -746,13 +738,8 @@ impl Runtime {
         trajectory: &TrajectoryId,
         event: crate::engine::EngineEvent,
     ) -> EventError {
-        let log = self.inner.log(root).expect("the log reads");
         let deployment = self.inner.deployment();
-        let policy = self
-            .inner
-            .resolve_policy(&deployment, &log)
-            .expect("the policy resolves");
-        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        let (policy, view) = self.rebuilt(&deployment, root);
         EventError::from(
             policy
                 .engine()

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -957,32 +957,12 @@ fn compile_stored_policy(bytes: &[u8]) -> Result<appa_policy::Config, String> {
     appa_policy::Config::from_toml_str(&text).map_err(|error| format!("the stored policy does not load: {error}"))
 }
 
-/// Plain-data helpers for tests outside this module — the adapter and
-/// MCP tests — so they can drive the test seam without naming the
-/// boundary (the source-scan structural guard holds for test
-/// code too).
+/// Plain-data fixtures for tests outside this module, so they can name
+/// a fork the way the harness carries it without naming the engine
+/// boundary (the source-scan structural guard holds for test code
+/// too).
 #[cfg(test)]
 pub(crate) mod testing {
-    use crate::engine::{EngineDecision, Feedback, Next, ReleasedCall, TestSeam};
-
-    use super::{Config, DispatchId, OfferId, ProposedCall, Runtime};
-
-    pub(crate) fn runtime(config: Config, db: std::path::PathBuf) -> Runtime {
-        Runtime::open_with_engine(config, db, TestSeam::new()).expect("a fresh test runtime opens")
-    }
-
-    pub(crate) fn fail_next_commit(runtime: &Runtime) {
-        runtime.inner.store.fail_commit_after(0);
-    }
-
-    fn enqueue(runtime: &Runtime, then: Next) {
-        runtime.inner.engine.enqueue(EngineDecision { append: None, then });
-    }
-
-    pub(crate) fn enqueue_done(runtime: &Runtime) {
-        enqueue(runtime, Next::Done);
-    }
-
     fn engine_dispatch(label: &str) -> appa_engine::value::DispatchId {
         let policy = appa_policy::Config::from_toml_str("version = 1\n[[tool]]\nname = \"Bash\"\n")
             .expect("the fixture policy compiles");
@@ -996,41 +976,5 @@ pub(crate) mod testing {
     pub(crate) fn spawn_binding(label: &str) -> super::SpawnBinding {
         let fork = appa_engine::value::ForkId::of(&engine_dispatch(label));
         super::SpawnBinding(serde_json::to_string(&fork).expect("a fork id serializes"))
-    }
-
-    fn wire_dispatch(label: &str) -> DispatchId {
-        DispatchId(serde_json::to_string(&engine_dispatch(label)).expect("an engine dispatch id serializes"))
-    }
-
-    pub(crate) fn enqueue_release(runtime: &Runtime, dispatch: &str, tool: &str, arguments: &serde_json::Value) {
-        let call = ProposedCall {
-            tool: tool.to_string(),
-            arguments: super::raw(arguments.clone()),
-        };
-        enqueue(
-            runtime,
-            Next::ModelResponse {
-                invocations: vec![ReleasedCall {
-                    dispatch: wire_dispatch(dispatch),
-                    tool: call.tool.clone(),
-                    bytes: serde_json::to_vec(&call).expect("the test call serializes"),
-                    fork: None,
-                }],
-                feedback: Vec::new(),
-            },
-        );
-    }
-
-    pub(crate) fn enqueue_deny(runtime: &Runtime, feedback: &str, offers: &[&str]) {
-        enqueue(
-            runtime,
-            Next::ModelResponse {
-                invocations: Vec::new(),
-                feedback: vec![Feedback {
-                    text: feedback.to_string(),
-                    offers: offers.iter().map(|id| OfferId(id.to_string())).collect(),
-                }],
-            },
-        );
     }
 }

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use session::{LateOpen, Session, is_control_tool};
 
 use crate::config::Config;
 use crate::elicit::Elicitation;
-use crate::engine::{EngineRefusal, EngineSeam, Liveness, PolicyEngine, RuntimeEngine};
+use crate::engine::{EngineRefusal, Liveness, PolicyEngine, RuntimeEngine};
 use crate::external::ExternalServices;
 use appa_eventlog::{Backend, Log, LogStore};
 
@@ -302,7 +302,6 @@ struct Inner {
     deployment: std::sync::RwLock<Arc<Deployment>>,
     retired: std::sync::Mutex<std::collections::BTreeMap<String, Arc<RuntimeEngine>>>,
     store: LogStore,
-    engine: EngineSeam,
     modules: crate::builtins::ModuleRegistry,
     executing: std::sync::Mutex<std::collections::BTreeSet<String>>,
     permits: std::sync::Mutex<std::collections::BTreeMap<String, Vec<Actor>>>,
@@ -323,7 +322,7 @@ impl Inner {
         deployment: &'a Deployment,
         log: &Log,
     ) -> Result<PolicyEngine<'a>, EventError> {
-        let opened = self.engine.opened_under(log).ok_or_else(|| {
+        let opened = crate::engine::opened_under(log).ok_or_else(|| {
             EventError::PolicyUnavailable(format!(
                 "the log of {} does not open with its opening record",
                 log.root().as_str()
@@ -389,27 +388,6 @@ impl Runtime {
     /// a policy this deployment cannot honor is refused before
     /// anything opens.
     pub fn open(config: Config, db: PathBuf, modules: Option<PathBuf>) -> Result<Runtime, OpenError> {
-        Runtime::with_engine(config, db, modules, EngineSeam::Real)
-    }
-
-    /// The tests' entry: the same runtime with decisions from the
-    /// enqueued queue and no modules directory. Every gate `open` runs
-    /// runs here too — only the decisions are fake.
-    #[cfg(test)]
-    pub(crate) fn open_with_engine(
-        config: Config,
-        db: PathBuf,
-        seam: crate::engine::TestSeam,
-    ) -> Result<Runtime, OpenError> {
-        Runtime::with_engine(config, db, None, EngineSeam::Test(seam))
-    }
-
-    fn with_engine(
-        config: Config,
-        db: PathBuf,
-        modules: Option<PathBuf>,
-        engine: EngineSeam,
-    ) -> Result<Runtime, OpenError> {
         let modules =
             crate::builtins::load(modules.as_deref()).map_err(|error| OpenError::Modules(error.to_string()))?;
         let deployment = Deployment::load(config, &modules)?;
@@ -423,7 +401,6 @@ impl Runtime {
                 deployment: std::sync::RwLock::new(Arc::new(deployment)),
                 retired: std::sync::Mutex::new(std::collections::BTreeMap::new()),
                 store,
-                engine,
                 modules,
                 executing: std::sync::Mutex::new(std::collections::BTreeSet::new()),
                 permits: std::sync::Mutex::new(std::collections::BTreeMap::new()),
@@ -517,12 +494,11 @@ impl Runtime {
             .inner
             .resolve_policy(&deployment, &log)
             .map_err(|error| SessionError::Storage(error.to_string()))?;
-        let view = self
-            .inner
-            .engine
-            .rebuild_view(&policy, &log)
+        let view = policy
+            .engine()
+            .rebuild_view(&log)
             .map_err(|refusal| SessionError::Storage(refusal.to_string()))?;
-        match self.inner.engine.liveness(&view, trajectory) {
+        match policy.engine().liveness(&view, trajectory) {
             Liveness::Unopened => Err(SessionError::Unknown),
             Liveness::Ended => Err(SessionError::Ended),
             Liveness::Live => Ok(()),
@@ -532,14 +508,14 @@ impl Runtime {
     pub fn status(&self, id: &TrajectoryId) -> Option<TrajectoryStatus> {
         let deployment = self.inner.deployment();
         let (policy, log) = self.root_log(&deployment, id, "status")?;
-        let view = match self.inner.engine.rebuild_view(&policy, &log) {
+        let view = match policy.engine().rebuild_view(&log) {
             Ok(view) => view,
             Err(refusal) => {
                 tracing::warn!(trajectory = %id.0, %refusal, "status read refused the persisted log");
                 return None;
             }
         };
-        self.inner.engine.trajectory_status(&policy, &view, id)
+        policy.engine().trajectory_status(&view, id)
     }
 
     /// Every decision this family's log recorded, in log order.
@@ -550,7 +526,7 @@ impl Runtime {
     pub fn audit(&self, id: &TrajectoryId) -> Option<Vec<AuditEntry>> {
         let deployment = self.inner.deployment();
         let (policy, log) = self.root_log(&deployment, id, "audit")?;
-        match self.inner.engine.audit(&policy, &log) {
+        match policy.engine().audit(&log) {
             Ok(entries) => entries,
             Err(refusal) => {
                 tracing::warn!(trajectory = %id.0, %refusal, "audit read refused the persisted log");
@@ -639,8 +615,8 @@ impl Runtime {
         let offer = crate::engine::resolve_rendered(&log, quoted)?;
         let deployment = self.inner.deployment();
         let policy = self.inner.resolve_policy(&deployment, &log).ok()?;
-        let view = self.inner.engine.rebuild_view(&policy, &log).ok()?;
-        let pursuer = self.inner.engine.offer_pursuer(&view, &offer)?;
+        let view = policy.engine().rebuild_view(&log).ok()?;
+        let pursuer = policy.engine().offer_pursuer(&view, &offer)?;
         Some((offer, pursuer))
     }
 
@@ -711,8 +687,8 @@ impl Runtime {
             .inner
             .resolve_policy(&deployment, &log)
             .expect("the opening policy resolves");
-        let view = self.inner.engine.rebuild_view(&policy, &log).expect("the log rebuilds");
-        self.inner.engine.open_dispatches(&view, trajectory)
+        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        policy.engine().open_dispatches(&view, trajectory)
     }
 
     /// Does the root's log name this trajectory, for the tests that
@@ -725,8 +701,8 @@ impl Runtime {
             .inner
             .resolve_policy(&deployment, &log)
             .expect("the opening policy resolves");
-        let view = self.inner.engine.rebuild_view(&policy, &log).expect("the log rebuilds");
-        self.inner.engine.liveness(&view, trajectory) != Liveness::Unopened
+        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        policy.engine().liveness(&view, trajectory) != Liveness::Unopened
     }
 
     /// The substituted call a trajectory has standing, for the tests
@@ -743,13 +719,12 @@ impl Runtime {
             .inner
             .resolve_policy(&deployment, &log)
             .expect("the opening policy resolves");
-        let view = self.inner.engine.rebuild_view(&policy, &log).expect("the log rebuilds");
-        self.inner.engine.substituted_release(&view, trajectory)
+        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        policy.engine().substituted_release(&view, trajectory)
     }
 
     /// Rebuild one root's view, scoped to a trajectory in it, for the tests
-    /// that read a branch through the seam the root-only public surface does
-    /// not expose.
+    /// that read a branch the root-only public surface does not expose.
     #[cfg(test)]
     pub(crate) fn branch_status(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Option<TrajectoryStatus> {
         let log = self.inner.log(root).expect("the log reads");
@@ -758,8 +733,8 @@ impl Runtime {
             .inner
             .resolve_policy(&deployment, &log)
             .expect("the policy resolves");
-        let view = self.inner.engine.rebuild_view(&policy, &log).expect("the log rebuilds");
-        self.inner.engine.trajectory_status(&policy, &view, trajectory)
+        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
+        policy.engine().trajectory_status(&view, trajectory)
     }
 
     /// Drive one event straight at the engine and take its refusal, for the
@@ -777,11 +752,11 @@ impl Runtime {
             .inner
             .resolve_policy(&deployment, &log)
             .expect("the policy resolves");
-        let view = self.inner.engine.rebuild_view(&policy, &log).expect("the log rebuilds");
+        let view = policy.engine().rebuild_view(&log).expect("the log rebuilds");
         EventError::from(
-            self.inner
-                .engine
-                .handle(&policy, &view, trajectory, event)
+            policy
+                .engine()
+                .handle(&view, trajectory, event)
                 .expect_err("the moved subject refuses the event"),
         )
     }
@@ -801,16 +776,6 @@ impl Runtime {
     #[cfg(test)]
     pub(crate) fn minted_offers(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Vec<OfferId> {
         crate::engine::minted_offers(&self.inner.log(root).expect("the log reads"), trajectory)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn enqueue(&self, decision: crate::engine::EngineDecision) {
-        self.inner.engine.enqueue(decision);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn engine_seen(&self) -> Vec<crate::engine::EngineEvent> {
-        self.inner.engine.seen()
     }
 
     /// How long a human review may stay open before the runtime treats

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -588,7 +588,7 @@ impl Runtime {
                 detail: "this offer is already being executed".to_string(),
             };
         };
-        let mut session = match self.session(&root, &pursuer) {
+        let session = match self.session(&root, &pursuer) {
             Ok(session) => session,
             Err(error) => {
                 return RemedyOutcome::Refused {

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -3099,6 +3099,159 @@ confined_results = ["leak"]
         assert!(runtime.open_dispatches(&root(), &root()).pop().is_none());
     }
 
+    /// A tool whose result narrows on two dimensions with a sanitizer
+    /// that clears only one: the derivation is admitted and staged, and
+    /// the residual narrowing is what the model is told about.
+    const PARTLY_CLEARED: &str = r#"
+version = 1
+
+[[policy.tool]]
+name = "leak"
+parameters = { type = "object", properties = { q = { type = "string" } } }
+delta = { audience = { exactly = ["internal"] }, trust = "suspicious" }
+
+[[policy.sanitizer]]
+name = "scrub"
+on = ["tool_output"]
+[policy.sanitizer.mandate]
+audience = { from = { includes = ["internal"] }, to = { exactly = ["public"] } }
+
+[policy.deployment]
+confined_results = ["leak"]
+"#;
+
+    fn partly_cleared_config(url: &str) -> Config {
+        let text = format!(
+            "[policy]\n{PARTLY_CLEARED}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
+        );
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let path = dir.path().join("appa.toml");
+        std::fs::write(&path, text).expect("the fixture writes");
+        Config::load(&path).expect("the fixture validates")
+    }
+
+    #[tokio::test]
+    async fn a_partly_cleared_derivation_is_staged_with_its_own_remedies() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let url = stub(serde_json::json!({"body": "scrubbed"})).await;
+        let runtime =
+            Runtime::open(partly_cleared_config(&url), dir.path().join("appa.db"), None).expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        assert!(matches!(
+            session
+                .on_tool_call(leak(), false)
+                .await
+                .expect("the block is delivered"),
+            ToolCallDecision::Deny { .. },
+        ));
+        let before = runtime.minted_offers(&root(), &root()).len();
+        let ToolResultDecision::Replace { placeholder } = run_sanitize_offer(&runtime, &mut session).await else {
+            panic!("a staged derivation is delivered as a replacement, not kept");
+        };
+        assert!(
+            !placeholder.contains("raw with pii"),
+            "the raw body never reaches the model: {placeholder}",
+        );
+        assert!(
+            runtime.minted_offers(&root(), &root()).len() > before,
+            "the stage surfaced its own remedy for the narrowing the sanitizer left",
+        );
+    }
+
+    const PARTLY_CLEARED_CHILD: &str = r#"
+version = 1
+
+[[policy.tool]]
+name = "fetch"
+
+[[policy.tool]]
+name = "browse"
+delta = { trust = "suspicious" }
+
+[[policy.sanitizer]]
+name = "scrub"
+on = ["tool_output"]
+[policy.sanitizer.mandate]
+audience = { from = { includes = ["internal"] }, to = { exactly = ["public"] } }
+
+[policy.child]
+return_sanitizer = "scrub"
+
+[policy.deployment]
+context_control = true
+confined_child_return = true
+"#;
+
+    #[tokio::test]
+    async fn a_partly_cleared_child_return_is_staged_with_its_own_remedies() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let url = stub(serde_json::json!({"body": "scrubbed"})).await;
+        let text = format!(
+            "[policy]\n{PARTLY_CLEARED_CHILD}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
+        );
+        let path = dir.path().join("appa.toml");
+        std::fs::write(&path, text).expect("the fixture writes");
+        let config = Config::load(&path).expect("the fixture validates");
+        let runtime = Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let mut child = open_child(
+            &mut session,
+            fetch(serde_json::json!({})),
+            TrajectoryId("cc:child".to_string()),
+        )
+        .await;
+        let browse = ProposedCall {
+            tool: "browse".to_string(),
+            arguments: raw(serde_json::json!({})),
+        };
+        let child_id = TrajectoryId("cc:child".to_string());
+        assert!(matches!(
+            child.on_tool_call(browse.clone(), false).await,
+            Ok(ToolCallDecision::Deny { .. })
+        ));
+        let offer = surfaced_offer_for(&runtime, &root(), &child_id);
+        assert!(matches!(
+            child.on_remedy(offer, None).await,
+            Ok(RemedyDecision::Authorized { .. })
+        ));
+        assert_eq!(
+            child
+                .on_tool_call(browse.clone(), false)
+                .await
+                .expect("the accepted narrowing releases the call"),
+            ToolCallDecision::Allow { spawn: None },
+        );
+        assert_eq!(
+            child
+                .on_tool_result(
+                    browse,
+                    ToolOutcome::Success {
+                        body: OutcomeBody::Available("web page".to_string()),
+                    },
+                )
+                .await
+                .expect("the result admits into the child"),
+            ToolResultDecision::Keep,
+        );
+
+        let before = runtime.minted_offers(&root(), &root()).len();
+        let crossing = child
+            .on_child_end(Some("raw with pii".to_string()))
+            .await
+            .expect("the staged return is delivered");
+        let crate::api::ChildReturnDecision::Blocked { feedback } = crossing else {
+            panic!("a return the sanitizer only partly cleared is staged, not crossed: {crossing:?}");
+        };
+        assert!(
+            !feedback.contains("raw with pii"),
+            "the raw return never reaches the parent: {feedback}",
+        );
+        assert!(
+            runtime.minted_offers(&root(), &root()).len() > before,
+            "the stage surfaced the parent's own remedy for the residual narrowing",
+        );
+    }
+
     #[tokio::test]
     async fn a_bound_sanitizer_no_answer_withholds_and_stays_retryable() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -1403,6 +1403,8 @@ mod real_engine_tests {
     use super::*;
     use crate::api::{RemedyDecision, SpawnBinding, ToolCallDecision, ToolOutcome, ToolResultDecision};
     use crate::config::Config;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn config_with(policy: &str, authority_url: Option<&str>) -> Config {
         let binding = match authority_url {
@@ -4572,5 +4574,347 @@ context_control = true
             .on_tool_call(fetch(serde_json::json!({"a": 3})), false)
             .await
             .expect("the parent proposes again");
+    }
+
+    /// A loopback authority that answers the same ruling every time and
+    /// counts the requests it saw, so a test can pin how many
+    /// round-trips one event takes.
+    async fn counting_stub(answer: serde_json::Value) -> (String, Arc<AtomicUsize>) {
+        use axum::routing::post;
+
+        let seen = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&seen);
+        let app = axum::Router::new().route(
+            "/",
+            post(move || {
+                let answer = answer.clone();
+                let counter = Arc::clone(&counter);
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    axum::Json(serde_json::json!({"version": 1, "answer": answer}))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("a loopback stub binds");
+        let addr = listener.local_addr().expect("the stub has an address");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("the stub serves");
+        });
+        (format!("http://{addr}/"), seen)
+    }
+
+    fn open_runtime(dir: &tempfile::TempDir) -> Runtime {
+        Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
+            .expect("the deployment opens")
+    }
+
+    fn only_the_opening(runtime: &Runtime) -> bool {
+        matches!(
+            runtime.log_facts(&root()).as_slice(),
+            [appa_engine::fact::Fact::TrajectoryOpened { .. }]
+        )
+    }
+
+    #[test]
+    fn a_used_root_id_is_refused_and_a_persisted_one_reopens() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        runtime.create_session(root()).expect("a fresh id opens");
+        assert!(matches!(
+            runtime.create_session(root()),
+            Err(SessionError::AlreadyExists),
+        ));
+        assert!(runtime.session(&root(), &root()).is_ok());
+        assert!(matches!(
+            runtime.session(
+                &TrajectoryId("cc:ghost".to_string()),
+                &TrajectoryId("cc:ghost".to_string())
+            ),
+            Err(SessionError::Unknown),
+        ));
+    }
+
+    #[test]
+    fn a_damaged_database_is_refused_at_open() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let path = dir.path().join("appa.db");
+        std::fs::write(&path, b"not a sqlite database at all").expect("the file writes");
+        assert!(matches!(
+            Runtime::open(config_with(FETCH_AND_SEND, None), path, None),
+            Err(OpenError::Damaged(_)),
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_prompt_records_nothing() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        session
+            .on_prompt("read the report".to_string())
+            .expect("the prompt acks");
+        assert!(only_the_opening(&runtime));
+    }
+
+    #[tokio::test]
+    async fn a_decision_whose_append_fails_never_acts() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        runtime.store().fail_commit_after(0);
+        assert!(matches!(
+            session.on_tool_call(fetch(serde_json::json!({"a": 1})), false).await,
+            Err(EventError::Storage(_)),
+        ));
+        assert!(only_the_opening(&runtime), "the killed append left nothing");
+        assert!(
+            runtime.open_dispatches(&root(), &root()).is_empty(),
+            "a call whose release never committed is not open",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lost_race_discards_the_decision_and_replays() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        runtime.store().contend_next_appends(1);
+        assert_eq!(
+            session
+                .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
+                .await
+                .expect("the replay commits"),
+            ToolCallDecision::Allow { spawn: None },
+        );
+        assert_eq!(
+            runtime.log_basis(&root()),
+            3,
+            "the opening, the foreign append, and one committed attempt",
+        );
+        assert_eq!(
+            runtime.open_dispatches(&root(), &root()).len(),
+            1,
+            "the discarded attempt released nothing",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_permanently_contended_log_refuses_the_event() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        runtime.store().contend_next_appends(REPLAY_LIMIT as u64);
+        assert!(matches!(
+            session.on_tool_call(fetch(serde_json::json!({"a": 1})), false).await,
+            Err(EventError::Contended { attempts: REPLAY_LIMIT }),
+        ));
+        assert_eq!(runtime.log_basis(&root()), 1 + REPLAY_LIMIT as u64);
+        assert!(
+            runtime.open_dispatches(&root(), &root()).is_empty(),
+            "no attempt of a refused event acted",
+        );
+    }
+
+    fn control_call(name: &str) -> ProposedCall {
+        ProposedCall {
+            tool: name.to_string(),
+            arguments: raw(serde_json::json!({"offer_id": "o1:cc:root:ff"})),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_control_tool_passes_unchecked_under_every_shipped_name() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        for name in [
+            "execute_remedy_plan",
+            "mcp__appa__execute_remedy_plan",
+            "mcp__plugin_appa-runtime_appa__execute_remedy_plan",
+        ] {
+            assert_eq!(
+                session
+                    .on_tool_call(control_call(name), false)
+                    .await
+                    .expect("it passes"),
+                ToolCallDecision::Control,
+                "{name} is a control call",
+            );
+            assert_eq!(
+                session
+                    .on_tool_result(control_call(name), ToolOutcome::Indeterminate)
+                    .await
+                    .expect("its outcome is absorbed"),
+                ToolResultDecision::Keep,
+            );
+        }
+        assert!(only_the_opening(&runtime), "no control call reached the log");
+    }
+
+    #[tokio::test]
+    async fn a_lookalike_control_tool_is_an_undeclared_tool() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        assert!(matches!(
+            session
+                .on_tool_call(control_call("mcp__evil__execute_remedy_plan"), false)
+                .await
+                .expect("the lookalike is decided"),
+            ToolCallDecision::Deny { .. },
+        ));
+    }
+
+    #[test]
+    fn an_over_cap_success_body_is_carried_as_unavailable() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let session = runtime.create_session(root()).expect("a fresh id opens");
+        let success = |len: usize| ToolOutcome::Success {
+            body: OutcomeBody::Available("x".repeat(len)),
+        };
+        assert!(matches!(
+            session.cap_outcome(success(70_000)),
+            ToolOutcome::Success {
+                body: OutcomeBody::Unavailable
+            },
+        ));
+        assert_eq!(session.cap_outcome(success(8)), success(8));
+    }
+
+    #[tokio::test]
+    async fn an_unknown_offer_is_refused() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        assert!(matches!(
+            session.on_remedy(OfferId("o1:cc:root:never".to_string()), None).await,
+            Err(EventError::UnknownOffer),
+        ));
+        assert!(only_the_opening(&runtime), "a refused offer appends nothing");
+    }
+
+    #[tokio::test]
+    async fn an_external_answer_settles_the_event_in_one_round_trip() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let (url, seen) = counting_stub(serde_json::json!({"ruling": "approve"})).await;
+        let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), dir.path().join("appa.db"), None)
+            .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        assert!(matches!(
+            session
+                .on_tool_call(wire(500), false)
+                .await
+                .expect("the block is delivered"),
+            ToolCallDecision::Deny { .. },
+        ));
+        assert_eq!(seen.load(Ordering::SeqCst), 0, "a proposal consults no authority");
+
+        assert!(matches!(
+            session
+                .on_remedy(latest_offer(&runtime), None)
+                .await
+                .expect("the approval is delivered"),
+            RemedyDecision::Authorized { .. },
+        ));
+        assert_eq!(
+            seen.load(Ordering::SeqCst),
+            1,
+            "the event re-drove once, carrying the answer it asked for",
+        );
+    }
+
+    #[tokio::test]
+    async fn no_offer_id_repeats_within_a_trajectory() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = Runtime::open(
+            config_with(ATTENTION, Some("http://127.0.0.1:1/")),
+            dir.path().join("appa.db"),
+            None,
+        )
+        .expect("the deployment opens");
+        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        for _ in 0..5 {
+            assert!(matches!(
+                session
+                    .on_tool_call(wire(500), false)
+                    .await
+                    .expect("the block is delivered"),
+                ToolCallDecision::Deny { .. },
+            ));
+        }
+        let minted = runtime.minted_offers(&root(), &root());
+        let distinct: std::collections::HashSet<&str> = minted.iter().map(|offer| offer.0.as_str()).collect();
+        assert!(minted.len() >= 5, "each block surfaced an offer: {minted:?}");
+        assert_eq!(
+            distinct.len(),
+            minted.len(),
+            "five identical proposals minted five distinct ids: {minted:?}",
+        );
+    }
+
+    fn bash_call() -> ProposedCall {
+        ProposedCall {
+            tool: "Bash".to_string(),
+            arguments: raw(serde_json::json!({"command": "ls"})),
+        }
+    }
+
+    fn bash_dispatch(label: &str) -> appa_engine::value::DispatchId {
+        let policy = appa_policy::Config::from_toml_str(
+            r#"
+                version = 1
+                [[tool]]
+                name = "Bash"
+            "#,
+        )
+        .expect("the fixture policy compiles");
+        let call = policy
+            .engine()
+            .resolve_call(appa_engine::value::ToolName::new("Bash"), br#"{"command":"ls"}"#)
+            .expect("the fixture call resolves through the engine");
+        appa_engine::value::DispatchId::new(appa_engine::value::TrajectoryId::new(label), call.digest(), 0)
+    }
+
+    #[test]
+    fn an_outcome_report_is_classified_against_the_open_dispatches() {
+        let id = bash_dispatch("cc:root");
+        let open = |tool: &str, bytes: &[u8]| OpenDispatch {
+            id: id.clone(),
+            tool: tool.to_string(),
+            bytes: bytes.to_vec(),
+        };
+        let canonical = || Some(b"{}".to_vec());
+
+        assert_eq!(
+            classify_report(&bash_call(), canonical, &[]),
+            Err(UnreportableOutcome::NoOpenDispatch),
+        );
+        assert_eq!(
+            classify_report(&bash_call(), canonical, &[open("Bash", b"{}")]),
+            Ok(id.clone()),
+        );
+        assert_eq!(
+            classify_report(&bash_call(), canonical, &[open("Write", b"{}")]),
+            Err(UnreportableOutcome::ByteMismatch),
+            "another tool is another call",
+        );
+        assert_eq!(
+            classify_report(&bash_call(), canonical, &[open("Bash", b"{\"other\":1}")]),
+            Err(UnreportableOutcome::ByteMismatch),
+            "other bytes are another occurrence",
+        );
+        assert_eq!(
+            classify_report(&bash_call(), || None, &[open("Bash", b"{}")]),
+            Err(UnreportableOutcome::ByteMismatch),
+            "a call that cannot canonicalize matches nothing",
+        );
+        assert_eq!(
+            classify_report(&bash_call(), canonical, &[open("Bash", b"{}"), open("Bash", b"{}")]),
+            Err(UnreportableOutcome::NoOpenDispatch),
+            "several open dispatches name no one occurrence",
+        );
     }
 }

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -932,16 +932,23 @@ mod real_engine_tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// One fixture configuration, from its whole TOML text. The file has
+    /// to exist on disk because `Config::load` reads the policy file's
+    /// bytes, which the opening record keys the deployment by.
+    fn config_from(text: &str) -> Config {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let path = dir.path().join("appa.toml");
+        std::fs::write(&path, text).expect("the fixture writes");
+        Config::load(&path).expect("the fixture validates")
+    }
+
     fn config_with(policy: &str, authority_url: Option<&str>) -> Config {
         let binding = match authority_url {
             Some(url) => format!("[externals.authorities.approver]\nurl = \"{url}\"\n"),
             None => String::new(),
         };
         let text = format!("[policy]\n{policy}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n{binding}");
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     const FETCH_AND_SEND: &str = r#"
@@ -2333,10 +2340,7 @@ context_control = true
             "[policy]\n{policy}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n\
              [externals.sanitizers.redactor]\nbuiltin = \"redact-email\"\n{binding}"
         );
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     fn send(body: &str) -> ProposedCall {
@@ -2396,14 +2400,6 @@ context_control = true
 
     fn standing_release(runtime: &Runtime) -> Option<crate::engine::OpenDispatch> {
         runtime.substituted_release(&root(), &root())
-    }
-
-    fn last_offer(runtime: &Runtime) -> OfferId {
-        let quoted = runtime
-            .minted_offers(&root(), &root())
-            .pop()
-            .expect("the block surfaced an offer");
-        runtime.resolve_in(&root(), &quoted).expect("the quoted id resolves").0
     }
 
     #[tokio::test]
@@ -2530,7 +2526,7 @@ context_control = true
             .on_tool_call(send("mail alice@corp.example"), false)
             .await
             .expect("the send is decided");
-        let hop = last_offer(&runtime);
+        let hop = latest_offer(&runtime);
 
         for _ in 0..2 {
             assert!(matches!(
@@ -2692,7 +2688,7 @@ context_control = true
             Ok(RemedyDecision::Declined { .. }),
         ));
         assert!(runtime.open_dispatches(&root(), &root()).is_empty());
-        let approval = last_offer(&runtime);
+        let approval = latest_offer(&runtime);
         assert_eq!(
             session.on_remedy(approval, None).await.expect("the approval executes"),
             RemedyDecision::Authorized {
@@ -2742,10 +2738,7 @@ confined_child_return = true
         };
         let text =
             format!("[policy]\n{SANITIZED_CHILD}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n{binding}");
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     #[tokio::test]
@@ -2876,10 +2869,7 @@ confined_child_return = true
             None => String::new(),
         };
         let text = format!("[policy]\n{policy}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n{binding}");
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     fn bare_externals() -> crate::config::Externals {
@@ -2997,10 +2987,7 @@ confined_results = ["leak"]
         let text = format!(
             "[policy]\n{NARROWING}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
         );
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     const EMITTING_LEAK: &str = r#"
@@ -3026,10 +3013,7 @@ confined_results = ["leak"]
         let text = format!(
             "[policy]\n{EMITTING_LEAK}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
         );
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     fn leak() -> ProposedCall {
@@ -3113,10 +3097,7 @@ confined_results = ["leak"]
         let text = format!(
             "[policy]\n{PARTLY_CLEARED}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
         );
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the fixture validates")
+        config_from(&text)
     }
 
     #[tokio::test]
@@ -3171,17 +3152,18 @@ context_control = true
 confined_child_return = true
 "#;
 
+    fn partly_cleared_child_config(url: &str) -> Config {
+        config_from(&format!(
+            "[policy]\n{PARTLY_CLEARED_CHILD}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
+        ))
+    }
+
     #[tokio::test]
     async fn a_partly_cleared_child_return_is_staged_with_its_own_remedies() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let url = stub(serde_json::json!({"body": "scrubbed"})).await;
-        let text = format!(
-            "[policy]\n{PARTLY_CLEARED_CHILD}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.sanitizers.scrub]\nurl = \"{url}\"\n"
-        );
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        let config = Config::load(&path).expect("the fixture validates");
-        let runtime = Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens");
+        let runtime = Runtime::open(partly_cleared_child_config(&url), dir.path().join("appa.db"), None)
+            .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
         let child = open_child(
             &mut session,

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -269,7 +269,6 @@ impl Session {
                 ([released], []) => {
                     tracing::debug!(
                         trajectory = %self.trajectory.0,
-                        dispatch = %released.dispatch.0,
                         tool = %released.tool,
                         spawn = released.fork.is_some(),
                         "call released"
@@ -621,14 +620,7 @@ impl Session {
             )
             .await?;
 
-        match decision.then {
-            Next::PresentToModel(Presentation::Value { value }) => Ok(ChildReturnDecision::Returned { value }),
-            Next::PresentToModel(Presentation::NoValue) => Ok(ChildReturnDecision::NoValue),
-            Next::PresentToModel(Presentation::Blocked { feedback, .. }) => {
-                Ok(ChildReturnDecision::Blocked { feedback })
-            }
-            _ => Err(EventError::UnexpectedDecision),
-        }
+        return_decision(decision)
     }
 
     fn cap_outcome(&self, outcome: ToolOutcome) -> ToolOutcome {

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -185,7 +185,7 @@ impl Session {
     /// judgment — a stale offer declines at execution by live re-plan.
     /// The runtime keeps no transcript, so there is nothing
     /// left for this event to do.
-    pub fn on_prompt(&mut self, _text: String) -> Result<(), EventError> {
+    pub fn on_prompt(&self, _text: String) -> Result<(), EventError> {
         tracing::debug!(trajectory = %self.trajectory.0, "prompt acknowledged");
         Ok(())
     }
@@ -206,7 +206,7 @@ impl Session {
     ///
     /// Not an engine event when nothing is carried, which is every
     /// ordinary turn: the view is read, no fact is appended.
-    pub async fn on_turn_end(&mut self) -> Result<(), EventError> {
+    pub async fn on_turn_end(&self) -> Result<(), EventError> {
         let Some(open) = self.carried_call()? else {
             tracing::debug!(trajectory = %self.trajectory.0, "turn ended with no call outstanding");
             return Ok(());
@@ -242,7 +242,7 @@ impl Session {
         }
     }
 
-    pub async fn on_tool_call(&mut self, call: ProposedCall, spawn: bool) -> Result<ToolCallDecision, EventError> {
+    pub async fn on_tool_call(&self, call: ProposedCall, spawn: bool) -> Result<ToolCallDecision, EventError> {
         if is_control_tool(&call.tool) {
             tracing::debug!(trajectory = %self.trajectory.0, "control tool passes unchecked");
             return Ok(ToolCallDecision::Control);
@@ -362,11 +362,7 @@ impl Session {
         .await
     }
 
-    pub async fn on_tool_result(
-        &mut self,
-        call: ProposedCall,
-        o: ToolOutcome,
-    ) -> Result<ToolResultDecision, EventError> {
+    pub async fn on_tool_result(&self, call: ProposedCall, o: ToolOutcome) -> Result<ToolResultDecision, EventError> {
         if is_control_tool(&call.tool) {
             tracing::debug!(trajectory = %self.trajectory.0, "control tool outcome absorbed");
             return Ok(ToolResultDecision::Keep);
@@ -396,14 +392,16 @@ impl Session {
     }
 
     pub async fn on_spawn_result(
-        &mut self,
+        &self,
         call: ProposedCall,
         outcome: ToolOutcome,
         child: Option<TrajectoryId>,
         value: Option<String>,
     ) -> Result<SpawnResultDecision, EventError> {
         let outcome = self.cap_outcome(outcome);
-        let plan: std::sync::Mutex<Option<SpawnPlan>> = std::sync::Mutex::new(None);
+        // The attempt that commits is the one whose plan the delivery below
+        // follows, so each attempt overwrites what the last one wrote.
+        let mut plan: Option<SpawnPlan> = None;
         let decision = self
             .drive_with_evidence(
                 |context, evidence| {
@@ -446,13 +444,12 @@ impl Session {
                             entropy: fresh_entropy(),
                         },
                     };
-                    *plan.lock().expect("the spawn plan mutex is never poisoned") = Some(next);
+                    plan = Some(next);
                     Ok(event)
                 },
                 None,
             )
             .await;
-        let plan = plan.into_inner().expect("the spawn plan mutex is never poisoned");
         let decision = match (&plan, decision) {
             (_, Ok(decision)) => decision,
             (
@@ -498,7 +495,7 @@ impl Session {
     /// resolved from the quoted form before this point. An offer this
     /// trajectory does not pursue is refused.
     pub async fn on_remedy(
-        &mut self,
+        &self,
         offer: OfferId,
         elicitation: Option<&Elicitation>,
     ) -> Result<RemedyDecision, EventError> {
@@ -544,7 +541,7 @@ impl Session {
     /// reference to the spawn call — the family's one spawn in flight. The
     /// engine's `BindFork` opens the child before its first engine event; the
     /// child exists exactly when the log's `ForkOpened` does.
-    pub fn on_child_start(&mut self, id: TrajectoryId, spawn: SpawnRef) -> Result<Session, EventError> {
+    pub fn on_child_start(&self, id: TrajectoryId, spawn: SpawnRef) -> Result<Session, EventError> {
         self.bind_child(id, spawn).map(|(session, _)| session)
     }
 
@@ -553,11 +550,11 @@ impl Session {
     /// would. Whether this opened the child or found it already open tells the
     /// dispatcher whether the refused event was the missing start's, and is
     /// worth running once more, or the child's own answer.
-    pub(crate) fn open_late(&mut self, child: TrajectoryId) -> Result<LateOpen, EventError> {
+    pub(crate) fn open_late(&self, child: TrajectoryId) -> Result<LateOpen, EventError> {
         self.bind_child(child, SpawnRef::InFlight).map(|(_, opened)| opened)
     }
 
-    fn bind_child(&mut self, id: TrajectoryId, spawn: SpawnRef) -> Result<(Session, LateOpen), EventError> {
+    fn bind_child(&self, id: TrajectoryId, spawn: SpawnRef) -> Result<(Session, LateOpen), EventError> {
         let child = id.clone();
         let opened = self.inner.log(&self.root)?;
         let policy = self.inner.resolve_policy(&self.deployment, &opened)?;
@@ -605,7 +602,7 @@ impl Session {
     /// fork that opened the child, recovered from the log. A child
     /// with a call still open does not end: the end is refused, and the same
     /// end crosses once the call's outcome is reported (`ChildDispatchOpen`).
-    pub async fn on_child_end(&mut self, value: Option<String>) -> Result<ChildReturnDecision, EventError> {
+    pub async fn on_child_end(&self, value: Option<String>) -> Result<ChildReturnDecision, EventError> {
         let child = self.trajectory.clone();
         let decision = self
             .drive_with_evidence(
@@ -1207,7 +1204,7 @@ name = "execute_remedy_plan"
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let decision = session
             .on_tool_call(fetch(serde_json::json!({"b": 1, "a": 2})), false)
             .await
@@ -1232,7 +1229,7 @@ name = "execute_remedy_plan"
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let duplicated = ProposedCall {
             tool: "fetch".to_string(),
             arguments: serde_json::value::RawValue::from_string(r#"{"a":1,"a":2}"#.to_string())
@@ -1257,7 +1254,7 @@ name = "execute_remedy_plan"
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -1284,7 +1281,7 @@ name = "execute_remedy_plan"
         let url = stub(serde_json::json!({"body": "scrubbed"})).await;
         let runtime =
             Runtime::open(emitting_leak_config(&url), dir.path().join("appa.db"), None).expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let outcome = || ToolOutcome::Success {
             body: OutcomeBody::Available("raw with pii".to_string()),
         };
@@ -1379,7 +1376,7 @@ name = "execute_remedy_plan"
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -1412,7 +1409,7 @@ name = "execute_remedy_plan"
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let decision = session
             .on_tool_call(fetch(serde_json::json!({"a": "not a number"})), false)
             .await
@@ -1431,7 +1428,7 @@ name = "execute_remedy_plan"
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let decision = session
             .on_tool_call(
                 ProposedCall {
@@ -1469,7 +1466,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         {
             let runtime =
                 Runtime::open(config_with(FETCH_AND_SEND, None), db.clone(), None).expect("the deployment opens");
-            let mut session = runtime.create_session(root()).expect("a fresh id opens");
+            let session = runtime.create_session(root()).expect("a fresh id opens");
             session
                 .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
                 .await
@@ -1486,7 +1483,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         }
         let runtime = Runtime::open(config_with(READ_ONLY, None), db, None).expect("the edited deployment opens");
 
-        let mut old = runtime.session(&root(), &root()).expect("the old root reopens");
+        let old = runtime.session(&root(), &root()).expect("the old root reopens");
         let decision = old
             .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
             .await
@@ -1497,7 +1494,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
             "the old root keeps fetch"
         );
 
-        let mut new = runtime
+        let new = runtime
             .create_session(TrajectoryId("cc:new".to_string()))
             .expect("a fresh id opens");
         let denied = new
@@ -1530,7 +1527,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let db = dir.path().join("appa.db");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), db.clone(), None).expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         runtime.store().forget_policy_files();
         let error = session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
@@ -1544,7 +1541,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let db = dir.path().join("appa.db");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), db.clone(), None).expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let mut tampered = runtime.config_bytes();
         tampered.extend_from_slice(b"\n# tampered\n");
         runtime.store().corrupt_policy_files(&tampered);
@@ -1560,7 +1557,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let db = dir.path().join("appa.db");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), db.clone(), None).expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let tampered = serde_json::to_string(&runtime.log_facts(&root()))
             .expect("the opening serializes")
             .replace("cc:root", "cc:evil");
@@ -1585,7 +1582,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
                 None,
             )
             .expect("the deployment opens");
-            let mut session = runtime.create_session(root()).expect("a fresh id opens");
+            let session = runtime.create_session(root()).expect("a fresh id opens");
             session
                 .on_tool_call(wire(500), false)
                 .await
@@ -1595,7 +1592,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         {
             let runtime =
                 Runtime::open(config_with(READ_ONLY, None), db.clone(), None).expect("the edited deployment opens");
-            let mut session = runtime.session(&root(), &root()).expect("the old root reopens");
+            let session = runtime.session(&root(), &root()).expect("the old root reopens");
             session
                 .on_tool_call(wire(500), false)
                 .await
@@ -1618,7 +1615,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         let url = stub(serde_json::json!({"ruling": "approve"})).await;
         let runtime = Runtime::open(config_with(READ_ONLY, Some(&url)), db, None)
             .expect("the deployment with the restored binding opens");
-        let mut session = runtime.session(&root(), &root()).expect("the old root reopens");
+        let session = runtime.session(&root(), &root()).expect("the old root reopens");
         session
             .on_tool_call(wire(500), false)
             .await
@@ -1642,7 +1639,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         {
             let runtime =
                 Runtime::open(config_with(FETCH_AND_SEND, None), db.clone(), None).expect("the deployment opens");
-            let mut session = runtime.create_session(root()).expect("a fresh id opens");
+            let session = runtime.create_session(root()).expect("a fresh id opens");
             session
                 .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
                 .await
@@ -1658,7 +1655,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
                 .expect("the result is admitted");
         }
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), db, None).expect("the deployment reopens");
-        let mut session = runtime.session(&root(), &root()).expect("the trajectory reopens");
+        let session = runtime.session(&root(), &root()).expect("the trajectory reopens");
         let decision = session
             .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
             .await
@@ -1671,7 +1668,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         runtime
             .store()
             .corrupt_batch(&crate::engine::engine_id(&root()), 0, b"not engine records");
@@ -1686,7 +1683,7 @@ parameters = { type = "object", properties = { path = { type = "string" } } }
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -1750,7 +1747,7 @@ delta = { audience = { exactly = ["@team"] } }
         std::fs::write(&path, text).expect("the fixture writes");
         let config = Config::load(&path).expect("the fixture validates");
         let runtime = Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let read = ProposedCall {
             tool: "read".to_string(),
             arguments: raw(serde_json::json!({})),
@@ -1785,7 +1782,7 @@ delta = { audience = { exactly = ["@team"] } }
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -1830,7 +1827,7 @@ delta = { audience = { exactly = ["@team"] } }
             |trajectory: &TrajectoryId, event: crate::engine::EngineEvent| runtime.refuse(&root(), trajectory, event);
 
         let child = TrajectoryId("cc:root:child".to_string());
-        let mut child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child.clone()).await;
+        let child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child.clone()).await;
         child_session
             .on_child_end(Some("done".to_string()))
             .await
@@ -1884,7 +1881,7 @@ context_control = false
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(UNCONTROLLED, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let decision = session
             .on_tool_call(
                 ProposedCall {
@@ -1908,7 +1905,7 @@ context_control = false
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({"a": 1})),
             TrajectoryId("cc:child".to_string()),
@@ -1954,7 +1951,7 @@ context_control = false
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({"a": 9})),
             TrajectoryId("cc:child".to_string()),
@@ -2063,7 +2060,7 @@ attends = ["irreversible"]
         let url = stub(serde_json::json!({"ruling": "approve"})).await;
         let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
 
         let denied = session
             .on_tool_call(wire(500), false)
@@ -2117,7 +2114,7 @@ attends = ["irreversible"]
         let url = stub(serde_json::json!({"ruling": "deny", "reason": "no"})).await;
         let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
 
         session
             .on_tool_call(wire(500), false)
@@ -2148,8 +2145,8 @@ attends = ["irreversible"]
             .expect("the deployment opens");
         let first_id = root();
         let second_id = TrajectoryId("cc:second-root".to_string());
-        let mut first = runtime.create_session(first_id.clone()).expect("the first root opens");
-        let mut second = runtime
+        let first = runtime.create_session(first_id.clone()).expect("the first root opens");
+        let second = runtime
             .create_session(second_id.clone())
             .expect("the second root opens");
 
@@ -2193,7 +2190,7 @@ attends = ["irreversible"]
         let url = stub(serde_json::json!({"note": "still thinking"})).await;
         let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
 
         session
             .on_tool_call(wire(500), false)
@@ -2219,7 +2216,7 @@ attends = ["irreversible"]
         let url = stub(serde_json::json!({"ruling": "approve"})).await;
         let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
 
         session
             .on_tool_call(wire(500), false)
@@ -2245,7 +2242,7 @@ attends = ["irreversible"]
         let offer = {
             let runtime =
                 Runtime::open(config_with(ATTENTION, Some(&url)), db.clone(), None).expect("the deployment opens");
-            let mut session = runtime.create_session(root()).expect("a fresh id opens");
+            let session = runtime.create_session(root()).expect("a fresh id opens");
             session
                 .on_tool_call(wire(500), false)
                 .await
@@ -2253,7 +2250,7 @@ attends = ["irreversible"]
             surfaced_offer(&runtime)
         };
         let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), db, None).expect("the deployment reopens");
-        let mut session = runtime.session(&root(), &root()).expect("the trajectory reopens");
+        let session = runtime.session(&root(), &root()).expect("the trajectory reopens");
         assert!(matches!(
             session
                 .on_remedy(offer, None)
@@ -2511,7 +2508,7 @@ context_control = true
             None,
         )
         .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         let read = ProposedCall {
             tool: "read_hr".to_string(),
             arguments: raw(serde_json::json!({})),
@@ -2641,7 +2638,7 @@ context_control = true
         }
         let runtime =
             Runtime::open(substituting_config(SUBSTITUTED_SEND, None), db, None).expect("the deployment reopens");
-        let mut session = runtime.session(&root(), &root()).expect("the trajectory reopens");
+        let session = runtime.session(&root(), &root()).expect("the trajectory reopens");
         assert!(standing_release(&runtime).is_some());
         assert_eq!(
             session
@@ -2766,7 +2763,7 @@ confined_child_return = true
         let runtime = Runtime::open(sanitized_config(Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({})),
             TrajectoryId("cc:child".to_string()),
@@ -2791,7 +2788,7 @@ confined_child_return = true
         let runtime = Runtime::open(sanitized_config(Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({})),
             TrajectoryId("cc:child".to_string()),
@@ -2817,7 +2814,7 @@ confined_child_return = true
         let runtime = Runtime::open(sanitized_config(Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({})),
             TrajectoryId("cc:child".to_string()),
@@ -3194,7 +3191,7 @@ confined_child_return = true
         let config = Config::load(&path).expect("the fixture validates");
         let runtime = Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({})),
             TrajectoryId("cc:child".to_string()),
@@ -3424,7 +3421,7 @@ context_control = true
         let runtime =
             Runtime::open(config_with(MARKED, None), dir.path().join("appa.db"), None).expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child = open_child(
+        let child = open_child(
             &mut session,
             fetch(serde_json::json!({"a": 1})),
             TrajectoryId("cc:child".to_string()),
@@ -3569,7 +3566,7 @@ context_control = true
         std::thread::scope(|scope| {
             let starters: Vec<_> = (0..2)
                 .map(|_| {
-                    let mut handle = runtime.session(&root(), &root()).expect("the root reopens");
+                    let handle = runtime.session(&root(), &root()).expect("the root reopens");
                     let binding = binding.clone();
                     let barrier = &barrier;
                     scope.spawn(move || {
@@ -3779,7 +3776,7 @@ context_control = true
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
         release_spawn(&mut session, fetch(serde_json::json!({"a": 1}))).await;
-        let mut first = session
+        let first = session
             .on_child_start(child("c1"), SpawnRef::InFlight)
             .expect("the child opens");
         first
@@ -3814,7 +3811,7 @@ context_control = true
         );
 
         release_spawn(&mut session, fetch(serde_json::json!({"a": 3}))).await;
-        let mut second = session
+        let second = session
             .on_child_start(child("c2"), SpawnRef::InFlight)
             .expect("a second child opens");
         second
@@ -3927,7 +3924,7 @@ context_control = true
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -3997,7 +3994,7 @@ context_control = true
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child("c1")).await;
+        let child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child("c1")).await;
         child_session
             .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
             .await
@@ -4041,7 +4038,7 @@ context_control = true
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         assert_eq!(
             session
                 .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
@@ -4086,7 +4083,7 @@ context_control = true
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -4112,7 +4109,7 @@ context_control = true
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
             .await
@@ -4141,7 +4138,7 @@ context_control = true
         let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        let mut child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child("c1")).await;
+        let child_session = open_child(&mut session, fetch(serde_json::json!({"a": 1})), child("c1")).await;
         child_session
             .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
             .await
@@ -4221,7 +4218,7 @@ context_control = true
             .expect("the deployment opens");
         let mut session = runtime.create_session(root()).expect("a fresh id opens");
         release_spawn(&mut session, fetch(serde_json::json!({"a": 1}))).await;
-        let mut first = session
+        let first = session
             .on_child_start(child("c1"), SpawnRef::InFlight)
             .expect("the child opens");
         first
@@ -4341,7 +4338,7 @@ context_control = true
     async fn a_prompt_records_nothing() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         session
             .on_prompt("read the report".to_string())
             .expect("the prompt acks");
@@ -4352,7 +4349,7 @@ context_control = true
     async fn a_decision_whose_append_fails_never_acts() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         runtime.store().fail_commit_after(0);
         assert!(matches!(
             session.on_tool_call(fetch(serde_json::json!({"a": 1})), false).await,
@@ -4369,7 +4366,7 @@ context_control = true
     async fn a_lost_race_discards_the_decision_and_replays() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         runtime.store().contend_next_appends(1);
         assert_eq!(
             session
@@ -4394,7 +4391,7 @@ context_control = true
     async fn a_permanently_contended_log_refuses_the_event() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         runtime.store().contend_next_appends(REPLAY_LIMIT as u64);
         assert!(matches!(
             session.on_tool_call(fetch(serde_json::json!({"a": 1})), false).await,
@@ -4418,7 +4415,7 @@ context_control = true
     async fn the_control_tool_passes_unchecked_under_every_shipped_name() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         for name in [
             "execute_remedy_plan",
             "mcp__appa__execute_remedy_plan",
@@ -4447,7 +4444,7 @@ context_control = true
     async fn a_lookalike_control_tool_is_an_undeclared_tool() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         assert!(matches!(
             session
                 .on_tool_call(control_call("mcp__evil__execute_remedy_plan"), false)
@@ -4478,7 +4475,7 @@ context_control = true
     async fn an_unknown_offer_is_refused() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         assert!(matches!(
             session.on_remedy(OfferId("o1:cc:root:never".to_string()), None).await,
             Err(EventError::UnknownOffer),
@@ -4492,7 +4489,7 @@ context_control = true
         let (url, seen) = counting_stub(serde_json::json!({"ruling": "approve"})).await;
         let runtime = Runtime::open(config_with(ATTENTION, Some(&url)), dir.path().join("appa.db"), None)
             .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         assert!(matches!(
             session
                 .on_tool_call(wire(500), false)
@@ -4525,7 +4522,7 @@ context_control = true
             None,
         )
         .expect("the deployment opens");
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
+        let session = runtime.create_session(root()).expect("a fresh id opens");
         for _ in 0..5 {
             assert!(matches!(
                 session

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -234,15 +234,11 @@ impl Session {
     fn carried_call(&self) -> Result<Option<OpenDispatch>, EventError> {
         let log = self.inner.log(&self.root)?;
         let policy = self.inner.resolve_policy(&self.deployment, &log)?;
-        let view = self
-            .inner
-            .engine
-            .rebuild_view(&policy, &log)
-            .map_err(EventError::from)?;
-        match self.inner.engine.liveness(&view, &self.trajectory) {
+        let view = policy.engine().rebuild_view(&log).map_err(EventError::from)?;
+        match policy.engine().liveness(&view, &self.trajectory) {
             Liveness::Ended | Liveness::Unopened => Ok(None),
-            Liveness::Live if self.inner.engine.substituted_release(&view, &self.trajectory).is_some() => Ok(None),
-            Liveness::Live => Ok(self.inner.engine.open_dispatches(&view, &self.trajectory).pop()),
+            Liveness::Live if policy.engine().substituted_release(&view, &self.trajectory).is_some() => Ok(None),
+            Liveness::Live => Ok(policy.engine().open_dispatches(&view, &self.trajectory).pop()),
         }
     }
 
@@ -297,20 +293,16 @@ impl Session {
     fn substituted_release(&self, call: &ProposedCall) -> Result<Option<Standing>, EventError> {
         let log = self.inner.log(&self.root)?;
         let policy = self.inner.resolve_policy(&self.deployment, &log)?;
-        let view = self
-            .inner
-            .engine
-            .rebuild_view(&policy, &log)
-            .map_err(EventError::from)?;
-        match self.inner.engine.liveness(&view, &self.trajectory) {
+        let view = policy.engine().rebuild_view(&log).map_err(EventError::from)?;
+        match policy.engine().liveness(&view, &self.trajectory) {
             Liveness::Ended => return Err(EventError::TrajectoryEnded),
             Liveness::Unopened => return Err(EventError::SpawnNotTaken),
             Liveness::Live => {}
         }
-        let Some(open) = self.inner.engine.substituted_release(&view, &self.trajectory) else {
+        let Some(open) = policy.engine().substituted_release(&view, &self.trajectory) else {
             return Ok(None);
         };
-        let canonical = || self.inner.engine.canonical_bytes(&policy, call);
+        let canonical = || policy.engine().canonical_bytes(call);
         Ok(Some(if is_open_call(call, canonical, &open) {
             Standing::Runs(open)
         } else {
@@ -704,14 +696,14 @@ impl Session {
                 Some(log) => log,
                 None => self.inner.log(&self.root)?,
             };
-            let view = self.inner.engine.rebuild_view(policy, &log).map_err(EventError::from)?;
+            let view = policy.engine().rebuild_view(&log).map_err(EventError::from)?;
             let context = Decided {
                 session: self,
                 policy,
                 view: &view,
             };
             if entering {
-                match self.inner.engine.liveness(&view, &self.trajectory) {
+                match policy.engine().liveness(&view, &self.trajectory) {
                     Liveness::Ended => return Err(EventError::TrajectoryEnded),
                     Liveness::Unopened => return Err(EventError::SpawnNotTaken),
                     Liveness::Live => {}
@@ -719,24 +711,19 @@ impl Session {
             }
             let event = event(&context)?;
             if let EngineEvent::ChildReturn { child, .. } = &event
-                && !self.inner.engine.open_dispatches(&view, child).is_empty()
+                && !policy.engine().open_dispatches(&view, child).is_empty()
             {
                 return Err(EventError::ChildDispatchOpen);
             }
-            let decision = self
-                .inner
-                .engine
-                .handle(policy, &view, &self.trajectory, event)
+            let decision = policy
+                .engine()
+                .handle(&view, &self.trajectory, event)
                 .map_err(EventError::from)?;
 
             let Some(facts) = decision.append.as_ref() else {
                 return Ok(decision);
             };
-            if self
-                .inner
-                .engine
-                .opens_a_second_dispatch(&view, &self.trajectory, facts)
-            {
+            if policy.engine().opens_a_second_dispatch(&view, &self.trajectory, facts) {
                 return Err(EventError::CallOutstanding);
             }
             match self.inner.store.append(&log, facts) {
@@ -883,10 +870,10 @@ impl Session {
 }
 
 /// What one attempt of an event may read before it decides: the log as this
-/// attempt rebuilt it. Everything the runtime used to keep beside the log —
-/// a branch's parent, the dispatch it has open, the trajectory an offer
-/// belongs to — is answered from here, so a replay after a lost race reads
-/// the state that actually won rather than the state it first saw.
+/// attempt rebuilt it. A branch's parent, the dispatch it has open, the
+/// trajectory an offer belongs to — all are answered from here, so a
+/// replay after a lost race reads the state that actually won rather
+/// than the state it first saw.
 pub(crate) struct Decided<'a> {
     session: &'a Session,
     policy: &'a crate::engine::PolicyEngine<'a>,
@@ -894,35 +881,35 @@ pub(crate) struct Decided<'a> {
 }
 
 impl Decided<'_> {
+    fn engine(&self) -> &crate::engine::RuntimeEngine {
+        self.policy.engine()
+    }
+
     fn open_dispatches(&self) -> Vec<OpenDispatch> {
-        self.session
-            .inner
-            .engine
-            .open_dispatches(self.view, &self.session.trajectory)
+        self.engine().open_dispatches(self.view, &self.session.trajectory)
     }
 
     fn canonical_bytes(&self, call: &ProposedCall) -> Option<Vec<u8>> {
-        self.session.inner.engine.canonical_bytes(self.policy, call)
+        self.engine().canonical_bytes(call)
     }
 
     fn parent_of(&self, child: &TrajectoryId) -> Option<TrajectoryId> {
-        self.session.inner.engine.parent_of(self.view, child)
+        self.engine().parent_of(self.view, child)
     }
 
     fn offer_pursuer(&self, offer: &OfferId) -> Option<TrajectoryId> {
-        self.session.inner.engine.offer_pursuer(self.view, offer)
+        self.engine().offer_pursuer(self.view, offer)
     }
 
     fn fork_status(&self, fork: &appa_engine::value::ForkId) -> ForkStatus {
-        self.session.inner.engine.fork_status(self.policy, self.view, fork)
+        self.engine().fork_status(self.view, fork)
     }
 
     fn in_flight_fork(&self, child: &TrajectoryId) -> Result<appa_engine::value::ForkId, EventError> {
-        let engine = &self.session.inner.engine;
-        if let Some(fork) = engine.fork_of(self.policy, self.view, child) {
+        if let Some(fork) = self.engine().fork_of(self.view, child) {
             return Ok(fork);
         }
-        match engine.forks_in_flight(self.policy, self.view).as_slice() {
+        match self.engine().forks_in_flight(self.view).as_slice() {
             [fork] => Ok(fork.clone()),
             [] => Err(EventError::SpawnNotTaken),
             _ => Err(EventError::SpawnAmbiguous),
@@ -947,456 +934,6 @@ fn join_feedback(feedback: &[Feedback]) -> String {
 pub(crate) fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
     serde_json::value::to_raw_value(&value).expect("the fixture serializes")
 }
-#[cfg(test)]
-mod tests {
-    use super::super::{DispatchId, OpenError, OutcomeBody, Runtime, SessionError};
-    use super::*;
-    use crate::config::Config;
-    use crate::engine::{ReleasedCall, TestSeam};
-    use appa_engine::fact::{BoundaryKind, Fact};
-
-    fn config() -> Config {
-        let text = r#"
-            [policy]
-            version = 1
-            [externals]
-            timeout_ms = 1000
-            max_body_bytes = 65536
-        "#;
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.toml");
-        std::fs::write(&path, text).expect("the fixture writes");
-        Config::load(&path).expect("the minimal fixture validates")
-    }
-
-    fn open_test_runtime(dir: &tempfile::TempDir) -> Runtime {
-        Runtime::open_with_engine(config(), dir.path().join("appa.db"), TestSeam::new()).expect("a fresh runtime opens")
-    }
-
-    fn root() -> TrajectoryId {
-        TrajectoryId("cc:root".to_string())
-    }
-
-    fn decision(append: Option<Vec<Fact>>, then: Next) -> EngineDecision {
-        EngineDecision { append, then }
-    }
-
-    #[derive(Clone, Copy)]
-    enum Marker {
-        One,
-        Two,
-    }
-
-    fn batch(marker: Marker) -> Vec<Fact> {
-        let punctuation = match marker {
-            Marker::One => 1,
-            Marker::Two => 2,
-        };
-        (0..punctuation)
-            .map(|_| Fact::Boundary {
-                trajectory: appa_engine::value::TrajectoryId::new("cc:root"),
-                kind: BoundaryKind::VoidReturn,
-            })
-            .collect()
-    }
-
-    fn boundaries(runtime: &Runtime) -> usize {
-        runtime
-            .log_facts(&root())
-            .iter()
-            .filter(|fact| matches!(fact, Fact::Boundary { .. }))
-            .count()
-    }
-
-    fn call() -> ProposedCall {
-        ProposedCall {
-            tool: "Bash".to_string(),
-            arguments: raw(serde_json::json!({"command": "ls"})),
-        }
-    }
-
-    fn bash_dispatch(label: &str) -> appa_engine::value::DispatchId {
-        let policy = appa_policy::Config::from_toml_str(
-            r#"
-                version = 1
-                [[tool]]
-                name = "Bash"
-            "#,
-        )
-        .expect("the fixture policy compiles");
-        let call = policy
-            .engine()
-            .resolve_call(appa_engine::value::ToolName::new("Bash"), br#"{"command":"ls"}"#)
-            .expect("the fixture call resolves through the engine");
-        appa_engine::value::DispatchId::new(appa_engine::value::TrajectoryId::new(label), call.digest(), 0)
-    }
-
-    fn released(id: &str, call: &ProposedCall) -> ReleasedCall {
-        ReleasedCall {
-            dispatch: DispatchId(serde_json::to_string(&bash_dispatch(id)).expect("a dispatch id serializes")),
-            tool: call.tool.clone(),
-            bytes: serde_json::to_vec(call).expect("the test call serializes"),
-            fork: None,
-        }
-    }
-
-    fn deny_decision(text: &str, offers: &[&str]) -> EngineDecision {
-        decision(
-            None,
-            Next::ModelResponse {
-                invocations: Vec::new(),
-                feedback: vec![Feedback {
-                    text: text.to_string(),
-                    offers: offers.iter().map(|id| OfferId(id.to_string())).collect(),
-                }],
-            },
-        )
-    }
-
-    fn review() -> appa_engine::execute::AuthorityReview {
-        appa_engine::execute::AuthorityReview {
-            tool: appa_engine::value::ToolName::new("Bash"),
-            trajectory_label: appa_engine::label::PartialLabel::established(appa_engine::label::EstablishedLabel::top()),
-        }
-    }
-
-    #[test]
-    fn a_used_root_id_is_refused_and_a_persisted_one_reopens() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        runtime.create_session(root()).expect("a fresh id opens");
-        assert!(matches!(
-            runtime.create_session(root()),
-            Err(SessionError::AlreadyExists),
-        ));
-        assert!(runtime.session(&root(), &root()).is_ok());
-        assert!(matches!(
-            runtime.session(
-                &TrajectoryId("cc:ghost".to_string()),
-                &TrajectoryId("cc:ghost".to_string())
-            ),
-            Err(SessionError::Unknown),
-        ));
-    }
-
-    #[test]
-    fn a_damaged_database_is_refused_at_open() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let path = dir.path().join("appa.db");
-        std::fs::write(&path, b"not a sqlite database at all").expect("the file writes");
-        assert!(matches!(
-            Runtime::open_with_engine(config(), path, TestSeam::new()),
-            Err(OpenError::Damaged(_)),
-        ));
-    }
-
-    #[tokio::test]
-    async fn a_prompt_consults_no_engine_and_records_nothing() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        session
-            .on_prompt("read the report".to_string())
-            .expect("the prompt acks");
-        assert!(matches!(
-            runtime.log_facts(&root()).as_slice(),
-            [Fact::TrajectoryOpened { .. }]
-        ));
-        assert!(runtime.engine_seen().is_empty(), "the engine is never consulted");
-    }
-
-    #[tokio::test]
-    async fn a_decision_whose_append_fails_never_acts() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        runtime.enqueue(decision(
-            Some(batch(Marker::One)),
-            Next::ModelResponse {
-                invocations: vec![released("cc:root", &call())],
-                feedback: Vec::new(),
-            },
-        ));
-        runtime.store().fail_commit_after(0);
-        assert!(matches!(
-            session.on_tool_call(call(), false).await,
-            Err(EventError::Storage(_)),
-        ));
-        assert_eq!(boundaries(&runtime), 0, "the killed append left nothing");
-    }
-
-    #[tokio::test]
-    async fn a_lost_race_discards_the_decision_and_replays_with_a_fresh_random_number() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        runtime.store().contend_next_appends(1);
-        runtime.enqueue(decision(
-            Some(batch(Marker::One)),
-            Next::ModelResponse {
-                invocations: vec![released("cc:root", &call())],
-                feedback: Vec::new(),
-            },
-        ));
-        runtime.enqueue(decision(
-            Some(batch(Marker::Two)),
-            Next::ModelResponse {
-                invocations: vec![released("cc:root", &call())],
-                feedback: Vec::new(),
-            },
-        ));
-        assert_eq!(
-            session.on_tool_call(call(), false).await.expect("the replay commits"),
-            ToolCallDecision::Allow { spawn: None },
-        );
-        assert_eq!(boundaries(&runtime), 2);
-        assert_eq!(runtime.log_basis(&root()), 3);
-
-        let entropies: Vec<_> = runtime
-            .engine_seen()
-            .iter()
-            .filter_map(|event| match event {
-                EngineEvent::ModelResponse { entropy, .. } => Some(entropy.0),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(entropies.len(), 2);
-        assert_ne!(entropies[0], entropies[1], "each attempt carried a fresh number");
-    }
-
-    #[tokio::test]
-    async fn a_permanently_contended_log_refuses_the_event() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        runtime.store().contend_next_appends(REPLAY_LIMIT as u64);
-        for _ in 0..REPLAY_LIMIT {
-            runtime.enqueue(decision(
-                Some(batch(Marker::One)),
-                Next::ModelResponse {
-                    invocations: vec![released("cc:root", &call())],
-                    feedback: Vec::new(),
-                },
-            ));
-        }
-        assert!(matches!(
-            session.on_tool_call(call(), false).await,
-            Err(EventError::Contended { attempts: REPLAY_LIMIT }),
-        ));
-        assert_eq!(
-            runtime.engine_seen().len(),
-            REPLAY_LIMIT as usize,
-            "every attempt decided"
-        );
-        assert_eq!(boundaries(&runtime), 0);
-        assert_eq!(runtime.log_basis(&root()), 1 + REPLAY_LIMIT as u64);
-    }
-
-    fn control_call(name: &str) -> ProposedCall {
-        ProposedCall {
-            tool: name.to_string(),
-            arguments: raw(serde_json::json!({"offer_id": "o1:cc:root:ff"})),
-        }
-    }
-
-    #[tokio::test]
-    async fn the_control_tool_passes_unchecked_under_every_shipped_name() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        for name in [
-            "execute_remedy_plan",
-            "mcp__appa__execute_remedy_plan",
-            "mcp__plugin_appa-runtime_appa__execute_remedy_plan",
-        ] {
-            assert_eq!(
-                session
-                    .on_tool_call(control_call(name), false)
-                    .await
-                    .expect("it passes"),
-                ToolCallDecision::Control,
-                "{name} is a control call",
-            );
-            assert_eq!(
-                session
-                    .on_tool_result(control_call(name), ToolOutcome::Indeterminate)
-                    .await
-                    .expect("its outcome is absorbed"),
-                ToolResultDecision::Keep,
-            );
-        }
-        assert!(runtime.engine_seen().is_empty(), "no control call reached the engine");
-    }
-
-    #[tokio::test]
-    async fn a_lookalike_control_tool_reaches_the_engine() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        runtime.enqueue(deny_decision("blocked", &[]));
-        assert!(matches!(
-            session
-                .on_tool_call(control_call("mcp__evil__execute_remedy_plan"), false)
-                .await
-                .expect("the lookalike is decided"),
-            ToolCallDecision::Deny { .. },
-        ));
-        assert_eq!(runtime.engine_seen().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn a_denied_call_returns_its_feedback() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        runtime.enqueue(deny_decision(
-            "blocked; execute_remedy_plan(o1:cc:root:ab)",
-            &["o1:cc:root:ab"],
-        ));
-        assert_eq!(
-            session
-                .on_tool_call(call(), false)
-                .await
-                .expect("the deny is delivered"),
-            ToolCallDecision::Deny {
-                feedback: "blocked; execute_remedy_plan(o1:cc:root:ab)".to_string(),
-            },
-        );
-    }
-
-    #[test]
-    fn an_over_cap_success_body_is_carried_as_unavailable() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let session = runtime.create_session(root()).expect("a fresh id opens");
-        let success = |len: usize| ToolOutcome::Success {
-            body: OutcomeBody::Available("x".repeat(len)),
-        };
-        assert!(matches!(
-            session.cap_outcome(success(70_000)),
-            ToolOutcome::Success {
-                body: OutcomeBody::Unavailable
-            },
-        ));
-        assert_eq!(session.cap_outcome(success(8)), success(8));
-    }
-
-    #[tokio::test]
-    async fn an_unknown_offer_is_refused_without_an_engine_call() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        assert!(matches!(
-            session.on_remedy(OfferId("o1:cc:root:never".to_string()), None).await,
-            Err(EventError::UnknownOffer),
-        ));
-        assert!(runtime.engine_seen().is_empty());
-    }
-
-    #[tokio::test]
-    async fn evidence_round_trips_replay_the_same_event_and_no_answer_grants_nothing() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        runtime.enqueue(decision(
-            None,
-            Next::ResolveExternal(vec![ExternalRequest::Authority {
-                authority: "approver".to_string(),
-                payload: serde_json::json!({}),
-                review: review(),
-            }]),
-        ));
-        runtime.enqueue(deny_decision("no answer grants nothing", &[]));
-        assert!(matches!(
-            session.on_tool_call(call(), false).await.expect("the event settles"),
-            ToolCallDecision::Deny { .. },
-        ));
-        let carried: Vec<_> = runtime
-            .engine_seen()
-            .into_iter()
-            .filter_map(|event| match event {
-                EngineEvent::ModelResponse { evidence, .. } => Some(evidence),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(carried.len(), 2, "the same event replayed once with the answer");
-        assert!(carried[0].is_empty());
-        assert!(matches!(
-            carried[1].as_slice(),
-            [ExternalEvidence::Authority {
-                verdict: AuthorityVerdict::Abstain,
-                ..
-            }],
-        ));
-    }
-
-    #[tokio::test]
-    async fn the_random_number_never_repeats_in_a_session() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        let mut session = runtime.create_session(root()).expect("a fresh id opens");
-        for _ in 0..5 {
-            runtime.enqueue(deny_decision("blocked", &[]));
-            session
-                .on_tool_call(call(), false)
-                .await
-                .expect("the deny is delivered");
-        }
-        let mut entropies: Vec<_> = runtime
-            .engine_seen()
-            .iter()
-            .filter_map(|event| match event {
-                EngineEvent::ModelResponse { entropy, .. } => Some(entropy.0),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(entropies.len(), 5);
-        entropies.sort();
-        entropies.dedup();
-        assert_eq!(entropies.len(), 5, "a random number repeated within the session");
-    }
-
-    #[test]
-    fn an_outcome_report_is_classified_against_the_open_dispatches() {
-        let id = bash_dispatch("cc:root");
-        let open = |tool: &str, bytes: &[u8]| OpenDispatch {
-            id: id.clone(),
-            tool: tool.to_string(),
-            bytes: bytes.to_vec(),
-        };
-        let canonical = || Some(b"{}".to_vec());
-
-        assert_eq!(
-            classify_report(&call(), canonical, &[]),
-            Err(UnreportableOutcome::NoOpenDispatch),
-        );
-        assert_eq!(
-            classify_report(&call(), canonical, &[open("Bash", b"{}")]),
-            Ok(id.clone()),
-        );
-        assert_eq!(
-            classify_report(&call(), canonical, &[open("Write", b"{}")]),
-            Err(UnreportableOutcome::ByteMismatch),
-            "another tool is another call",
-        );
-        assert_eq!(
-            classify_report(&call(), canonical, &[open("Bash", b"{\"other\":1}")]),
-            Err(UnreportableOutcome::ByteMismatch),
-            "other bytes are another occurrence",
-        );
-        assert_eq!(
-            classify_report(&call(), || None, &[open("Bash", b"{}")]),
-            Err(UnreportableOutcome::ByteMismatch),
-            "a call that cannot canonicalize matches nothing",
-        );
-        assert_eq!(
-            classify_report(&call(), canonical, &[open("Bash", b"{}"), open("Bash", b"{}")]),
-            Err(UnreportableOutcome::NoOpenDispatch),
-            "several open dispatches name no one occurrence",
-        );
-    }
-}
-
 #[cfg(test)]
 mod real_engine_tests {
     use super::super::{OpenError, OutcomeBody, Runtime, SessionError};

--- a/appa-runtime/src/builtins.rs
+++ b/appa-runtime/src/builtins.rs
@@ -126,7 +126,6 @@ pub(crate) type AnswerFn = unsafe extern "C" fn(*const u8, usize, *mut u8, usize
 
 pub(crate) struct LoadedModule {
     _library: libloading::Library,
-    pub(crate) name: String,
     pub(crate) answer: AnswerFn,
     /// Serializes calls into one module: an ABI-v1 implementation need
     /// not be re-entrant. Held only inside the blocking call, never
@@ -223,8 +222,7 @@ pub(crate) fn load(dir: Option<&Path>) -> Result<ModuleRegistry, ModulesError> {
         {
             continue;
         }
-        let module = load_one(&path)?;
-        let name = module.0.name.clone();
+        let (name, kind, module) = load_one(&path)?;
         // Implementation names are one namespace across both kinds: a
         // sanitizer reusing an authority module's name would make
         // "which implementation answers" depend on the section, and
@@ -235,17 +233,17 @@ pub(crate) fn load(dir: Option<&Path>) -> Result<ModuleRegistry, ModulesError> {
                 name,
             });
         }
-        let table = match module.1 {
+        let table = match kind {
             ModuleKind::Authority => &mut registry.authorities,
             ModuleKind::Sanitizer => &mut registry.sanitizers,
         };
-        table.insert(name, Arc::new(module.0));
+        table.insert(name, Arc::new(module));
         tracing::debug!(path = %path.display(), "builtin module loaded");
     }
     Ok(registry)
 }
 
-fn load_one(path: &Path) -> Result<(LoadedModule, ModuleKind), ModulesError> {
+fn load_one(path: &Path) -> Result<(String, ModuleKind, LoadedModule), ModulesError> {
     let display = path.display().to_string();
     let extension = std::env::consts::DLL_EXTENSION;
     let is_regular = std::fs::symlink_metadata(path)
@@ -301,13 +299,13 @@ fn load_one(path: &Path) -> Result<(LoadedModule, ModuleKind), ModulesError> {
     )?;
 
     Ok((
+        name,
+        kind,
         LoadedModule {
             _library: library,
-            name,
             answer,
             gate: Mutex::new(()),
         },
-        kind,
     ))
 }
 

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -55,11 +55,10 @@ use appa_engine::transition::Blocked as CoreBlocked;
 /// the event or passed with the read.
 pub(crate) use appa_engine::transition::EngineView;
 use appa_engine::transition::{
-    ApplicableCast, ChildFollowUp, ChildReport, ChildSubmission, Confined, EngineDecision as CoreDecision,
-    EngineEvent as CoreEvent, Evidence, EvidenceRequest, FollowUp, ForkBinding, OfferConsult, OfferExecution,
-    OfferFollowUp, OfferOutcome, OutcomeBody as CoreOutcomeBody, OutcomeFollowUp, PendingReturnStage, ProposalBatch,
-    ProposalBatchId, ProposedCall as CoreProposedCall, Released, SpawnMark, ToolOutcome as CoreToolOutcome, ToolReport,
-    TransitionError, TransitionRefusal, ValidatedFactBatch,
+    ApplicableCast, ChildFollowUp, ChildReport, ChildSubmission, EngineEvent as CoreEvent, Evidence, EvidenceRequest,
+    FollowUp, ForkBinding, OfferConsult, OfferExecution, OfferFollowUp, OfferOutcome, OutcomeBody as CoreOutcomeBody,
+    OutcomeFollowUp, ProposalBatch, ProposalBatchId, ProposedCall as CoreProposedCall, Released, SpawnMark,
+    ToolOutcome as CoreToolOutcome, ToolReport, TransitionError, TransitionRefusal, ValidatedFactBatch,
 };
 use appa_engine::value::{
     DispatchId as EngineDispatchId, ForkId, OfferId as EngineOfferId, OfferNonce as EngineOfferNonce, Provenance,
@@ -886,16 +885,30 @@ impl RuntimeEngine {
             memberships,
         };
         let expansions = self.membership_evidence(evidence);
+        // A deployment that does not control context releases the marked call
+        // unmarked, so the batch may be decided twice. The mark is all that
+        // differs between the two attempts.
+        let decide = |proposed: CoreProposedCall, marked: bool| {
+            let batch = ProposalBatch {
+                id: batch_id(entropy),
+                trajectory: engine_id(trajectory),
+                provider_results: Vec::new(),
+                proposals: vec![proposed],
+                spawn: marked.then(|| SpawnMark::at(0)),
+                offer_nonce: engine_nonce(entropy),
+                evidence: cast_evidence(self.engine.registry().trust_chain(), evidence),
+                expansions: expansions.expansions(),
+            };
+            self.engine.handle(view, CoreEvent::Proposals(batch))
+        };
         let decided = if spawn {
-            match self.decide_proposal(view, trajectory, proposed.clone(), entropy, true, &expansions, evidence) {
+            match decide(proposed.clone(), true) {
                 Ok(decision) => Ok(decision),
-                Err(TransitionError::SpawnUncontrolled) => {
-                    self.decide_proposal(view, trajectory, proposed, entropy, false, &expansions, evidence)
-                }
+                Err(TransitionError::SpawnUncontrolled) => decide(proposed, false),
                 Err(error) => Err(error),
             }
         } else {
-            self.decide_proposal(view, trajectory, proposed, entropy, false, &expansions, evidence)
+            decide(proposed, false)
         };
         let decision = match decided {
             Ok(decision) => decision,
@@ -918,30 +931,6 @@ impl RuntimeEngine {
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
         let then = self.deliver_proposals(view, trajectory, decision.follow_up, evidence)?;
         Ok(EngineDecision { append, then })
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn decide_proposal(
-        &self,
-        view: &EngineView,
-        trajectory: &TrajectoryId,
-        proposed: CoreProposedCall,
-        entropy: &OfferNonce,
-        spawn: bool,
-        expansions: &MembershipEvidence,
-        external: &[ExternalEvidence],
-    ) -> Result<CoreDecision, TransitionError> {
-        let batch = ProposalBatch {
-            id: batch_id(entropy),
-            trajectory: engine_id(trajectory),
-            provider_results: Vec::new(),
-            proposals: vec![proposed],
-            spawn: spawn.then(|| SpawnMark::at(0)),
-            offer_nonce: engine_nonce(entropy),
-            evidence: cast_evidence(self.engine.registry().trust_chain(), external),
-            expansions: expansions.expansions(),
-        };
-        self.engine.handle(view, CoreEvent::Proposals(batch))
     }
 
     fn deliver_proposals(
@@ -1093,9 +1082,11 @@ impl RuntimeEngine {
                 evidence,
                 "[appa] no registered cast or sanitizer answered; the result is withheld and may be retried",
             )?,
-            FollowUp::Outcome(OutcomeFollowUp::Staged(confined)) => {
-                Next::PresentToModel(self.confined_delivery(&confined))
-            }
+            FollowUp::Outcome(OutcomeFollowUp::Staged(confined)) => Next::PresentToModel(self.stage_delivery(
+                "[appa] the cleaned result still narrows this session.",
+                &confined.residual,
+                &confined.offers,
+            )),
             other => {
                 return Err(EngineRefusal::Invariant {
                     detail: format!("an outcome produced a non-outcome follow-up: {other:?}"),
@@ -1222,10 +1213,16 @@ impl RuntimeEngine {
             FollowUp::Offer(OfferFollowUp::Substituted { block }) => {
                 Next::PresentToModel(self.offer_block_delivery(&views, &block))
             }
-            FollowUp::Offer(OfferFollowUp::Staged(confined)) => Next::PresentToModel(self.confined_delivery(&confined)),
-            FollowUp::Offer(OfferFollowUp::ReturnStaged(stage)) => {
-                Next::PresentToModel(self.return_stage_delivery(&stage))
-            }
+            FollowUp::Offer(OfferFollowUp::Staged(confined)) => Next::PresentToModel(self.stage_delivery(
+                "[appa] the cleaned result still narrows this session.",
+                &confined.residual,
+                &confined.offers,
+            )),
+            FollowUp::Offer(OfferFollowUp::ReturnStaged(stage)) => Next::PresentToModel(self.stage_delivery(
+                "[appa] the child's return still narrows this session.",
+                &stage.residual,
+                &stage.offers,
+            )),
             FollowUp::Offer(OfferFollowUp::Released(release)) => Next::InvokeTool(released(&release)),
             FollowUp::Offer(OfferFollowUp::Settled(_)) => Next::PresentToModel(Presentation::Declined {
                 feedback: "[appa] the call this offer released is already settled; propose a fresh call".to_string(),
@@ -1296,25 +1293,18 @@ impl RuntimeEngine {
         Presentation::Blocked { feedback, offers }
     }
 
-    fn confined_delivery(&self, confined: &Confined) -> Presentation {
-        let offers: Vec<OfferId> = confined.offers.iter().map(|(offer, _)| offer_id(offer)).collect();
-        let feedback = stage_feedback(
-            "[appa] the cleaned result still narrows this session.",
-            &confined.residual,
-            &offers,
-            self.engine.registry().trust_chain(),
-        );
-        Presentation::Blocked { feedback, offers }
-    }
-
-    fn return_stage_delivery(&self, stage: &PendingReturnStage) -> Presentation {
-        let offers: Vec<OfferId> = stage.offers.iter().map(|(offer, _)| offer_id(offer)).collect();
-        let feedback = stage_feedback(
-            "[appa] the child's return still narrows this session.",
-            &stage.residual,
-            &offers,
-            self.engine.registry().trust_chain(),
-        );
+    /// One staged delivery: the narrowing the model must still accept,
+    /// and the remedies the stage opened for it. The headline names
+    /// what was staged; below it a tool result and a child return read
+    /// the same.
+    fn stage_delivery(
+        &self,
+        headline: &str,
+        residual: &appa_engine::check::Narrowing,
+        staged: &[(EngineOfferId, PlanId)],
+    ) -> Presentation {
+        let offers: Vec<OfferId> = staged.iter().map(|(offer, _)| offer_id(offer)).collect();
+        let feedback = stage_feedback(headline, residual, &offers, self.engine.registry().trust_chain());
         Presentation::Blocked { feedback, offers }
     }
 
@@ -1410,7 +1400,11 @@ impl RuntimeEngine {
                 value: admitted.as_str().to_string(),
             }),
             FollowUp::Child(ChildFollowUp::Ended) => Next::PresentToModel(Presentation::NoValue),
-            FollowUp::Child(ChildFollowUp::Pending(stage)) => Next::PresentToModel(self.return_stage_delivery(&stage)),
+            FollowUp::Child(ChildFollowUp::Pending(stage)) => Next::PresentToModel(self.stage_delivery(
+                "[appa] the child's return still narrows this session.",
+                &stage.residual,
+                &stage.offers,
+            )),
             FollowUp::Child(ChildFollowUp::Rejected { reason }) => Next::PresentToModel(Presentation::Blocked {
                 feedback: format!("[appa] the child's return could not cross: {reason:?}"),
                 offers: Vec::new(),

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -68,7 +68,7 @@ use appa_eventlog::Log;
 use std::collections::BTreeMap;
 
 use crate::api::OutcomeBody;
-pub(crate) use crate::api::{DispatchId, OfferId, ProposedCall, SpawnBinding, ToolOutcome, TrajectoryId};
+pub(crate) use crate::api::{OfferId, ProposedCall, SpawnBinding, ToolOutcome, TrajectoryId};
 use crate::external::{CastAnswer, CastAudience};
 
 /// One fresh 256-bit random number per act that can surface offers; the
@@ -80,7 +80,6 @@ pub struct OfferNonce(pub [u8; 32]);
 /// execute, delivered verbatim.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReleasedCall {
-    pub dispatch: DispatchId,
     pub tool: String,
     pub bytes: Vec<u8>,
     /// The spawn binding, when this release prepared a fork: the
@@ -1702,13 +1701,6 @@ fn batch_id(entropy: &OfferNonce) -> ProposalBatchId {
     ProposalBatchId::new(hex(&entropy.0))
 }
 
-/// One engine dispatch id as the harness carries it (`T31`): the released call
-/// quotes it so the harness can name the call it is reporting. Nothing reads it
-/// back — an outcome is matched against the dispatches the log shows open.
-pub(crate) fn dispatch_wire(dispatch: &EngineDispatchId) -> String {
-    serde_json::to_string(dispatch).expect("an engine dispatch id serializes")
-}
-
 fn fork_binding(fork: &ForkId) -> SpawnBinding {
     SpawnBinding(serde_json::to_string(fork).expect("a fork id serializes"))
 }
@@ -1774,7 +1766,6 @@ pub(crate) fn minted_offers(log: &Log, trajectory: &TrajectoryId) -> Vec<OfferId
 
 fn released(release: &Released) -> ReleasedCall {
     ReleasedCall {
-        dispatch: DispatchId(dispatch_wire(&release.dispatch)),
         tool: release.call.tool().as_str().to_string(),
         bytes: release.call.canonical_arguments().canonical_bytes().to_vec(),
         fork: release.fork.as_ref().map(fork_binding),

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1,6 +1,6 @@
 //! The engine boundary: the one module that speaks to `appa-engine`.
 //!
-//! [`EngineSeam::rebuild_view`] turns the store's opaque batch rows back into
+//! [`RuntimeEngine::rebuild_view`] turns the store's opaque batch rows back into
 //! typed facts and refuses the log before it is trusted: the log opens under
 //! this root's own policy, and
 //! [`appa_engine::engine::Engine::view`] then admits every record through the
@@ -8,7 +8,7 @@
 //! not have followed one another never reaches a decision. Because
 //! this runtime stores no view and rebuilds from the durable log on every
 //! event, that decode step is the store-reopen trust
-//! gate. [`EngineSeam::handle`] then translates one runtime event onto
+//! gate. [`RuntimeEngine::handle`] then translates one runtime event onto
 //! [`appa_engine::engine::Engine::handle`], the engine's one mutation
 //! boundary, and translates its typed follow-up back into a delivery. It
 //! returns one decision: an optional fact batch to append under
@@ -16,10 +16,10 @@
 //! vocabulary here is delivery adaptation, not policy: every
 //! admissibility judgment is the engine's.
 //!
-//! Beside `handle` the seam makes projection reads — which branch has ended,
+//! Beside `handle` the boundary makes projection reads — which branch has ended,
 //! which dispatches it has open, what its label renders as. They gate nothing
 //! and append nothing. One of them is not a read at all:
-//! [`EngineSeam::opens_a_second_dispatch`] is this deployment's own host
+//! [`RuntimeEngine::opens_a_second_dispatch`] is this deployment's own host
 //! policy, which the engine deliberately does not enforce.
 //!
 //! External evidence is typed before it reaches an engine input:
@@ -34,10 +34,6 @@
 //! against the offers that trajectory's own log opened. Execution re-derives
 //! the plan from the live views and matches it by value, so an offer whose
 //! basis has moved declines instead of executing.
-
-use std::collections::BTreeMap;
-#[cfg(test)]
-use std::sync::Mutex;
 
 use appa_engine::candidate::DerivedVia;
 use appa_engine::check::UnestablishedFact;
@@ -70,6 +66,7 @@ use appa_engine::value::{
     RawResultDigest, ResolvedCall, ToolName, ValueBody, ValueId,
 };
 use appa_eventlog::Log;
+use std::collections::BTreeMap;
 
 use crate::api::OutcomeBody;
 pub(crate) use crate::api::{DispatchId, OfferId, ProposedCall, SpawnBinding, ToolOutcome, TrajectoryId};
@@ -213,8 +210,9 @@ impl AuthorityVerdict {
     }
 }
 
-/// One session event in the seam's vocabulary. The session constructs it; the
-/// seam translates it onto the engine's `handle` boundary and back.
+/// One session event in the engine boundary's vocabulary. The session
+/// constructs it; [`RuntimeEngine::handle`] translates it onto the
+/// engine's own `handle` boundary and back.
 #[derive(Debug, Clone)]
 pub enum EngineEvent {
     ModelResponse {
@@ -288,7 +286,7 @@ impl EngineDecision {
     }
 }
 
-/// Why the seam refused an event outright. Model-visible outcomes (a deny, a
+/// Why the engine boundary refused an event outright. Model-visible outcomes (a deny, a
 /// declined offer) are decisions, not refusals; a refusal means the event
 /// cannot be processed as it stands.
 #[derive(Debug, thiserror::Error)]
@@ -434,7 +432,7 @@ pub enum PolicyEngine<'a> {
 }
 
 impl PolicyEngine<'_> {
-    fn engine(&self) -> &RuntimeEngine {
+    pub(crate) fn engine(&self) -> &RuntimeEngine {
         match self {
             PolicyEngine::Resident(engine) => engine,
             PolicyEngine::Retired(engine) => engine,
@@ -448,50 +446,67 @@ impl PolicyEngine<'_> {
     }
 }
 
-/// The one engine boundary the session drives: who decides,
-/// and nothing else. The deciding engine arrives per call as a
-/// [`PolicyEngine`], because a family decides under the policy its root
-/// opened with, which a configuration reload does not change.
-/// The runtime holds no offer state — offers are the
-/// engine's durable facts, routed by id.
-pub enum EngineSeam {
-    Real,
-    #[cfg(test)]
-    Test(TestSeam),
+/// What a root's opening record binds it to: the policy file it
+/// opened under and the identity that file must still compile to. `None`
+/// when the log does not open with its opening record, which the trust
+/// gate refuses in full a moment later. Read before the deciding engine
+/// is known, because it is what names it.
+pub(crate) fn opened_under(log: &Log) -> Option<Opened> {
+    match log.facts().first() {
+        Some(Fact::TrajectoryOpened {
+            policy_digest,
+            policy_file_key,
+            ..
+        }) => Some(Opened {
+            policy_file_key: policy_file_key.as_str().to_string(),
+            policy_identity: hex(policy_digest.bytes()),
+        }),
+        _ => None,
+    }
 }
 
-impl EngineSeam {
+/// The one engine boundary the session drives: the immutable
+/// registry-backed decision core, plus the reads of one rebuilt view
+/// the runtime needs to route an event. It owns every judgment and
+/// every fact; the runtime holds no engine state, and offers are the
+/// engine's own durable facts. A family decides under the policy its
+/// root opened with, so the deciding engine arrives per event as a
+/// [`PolicyEngine`], which a configuration reload does not change.
+pub struct RuntimeEngine {
+    engine: Engine,
+}
+
+impl RuntimeEngine {
+    pub fn new(engine: Engine) -> RuntimeEngine {
+        RuntimeEngine { engine }
+    }
+
+    /// The opening of a fresh root: this engine's opening batch bound to the
+    /// exact bytes of the policy file the root opens under. It takes
+    /// the bytes, not a key, because the key on the opening record is the
+    /// engine's own type and is derived here — at the one boundary that names
+    /// the engine crate.
+    pub fn root_opening(&self, trajectory: &TrajectoryId, policy_file: &[u8]) -> Vec<Fact> {
+        self.engine
+            .open_trajectory(&engine_id(trajectory), EnginePolicyFileKey::of(policy_file))
+            .expect("the engine's own opening batch validates against the empty log")
+            .into_unsealed()
+    }
+
     /// Refuse one root's log before it is trusted, including the
     /// opening gate: the log's first record must be this root's opening under
     /// exactly the deciding engine's policy. The root is the log's own, so a
     /// view cannot be built against a log it does not describe.
-    pub fn rebuild_view(&self, policy: &PolicyEngine<'_>, log: &Log) -> Result<EngineView, EngineRefusal> {
-        policy.engine().rebuild_view(log)
-    }
-
-    /// What a root's opening record binds it to: the policy file it
-    /// opened under and the identity that file must still compile to. `None`
-    /// when the log does not open with its opening record, which the trust
-    /// gate refuses in full a moment later.
-    pub fn opened_under(&self, log: &Log) -> Option<Opened> {
-        match log.facts().first() {
-            Some(Fact::TrajectoryOpened {
-                policy_digest,
-                policy_file_key,
-                ..
-            }) => Some(Opened {
-                policy_file_key: policy_file_key.as_str().to_string(),
-                policy_identity: hex(policy_digest.bytes()),
-            }),
-            _ => None,
-        }
+    pub(crate) fn rebuild_view(&self, log: &Log) -> Result<EngineView, EngineRefusal> {
+        let root = TrajectoryId(log.root().as_str().to_string());
+        self.validated(log.facts().to_vec(), &root, log.basis())
     }
 
     /// Where this trajectory stands in the log:
     /// never opened — the root by its opening record, a child by its fork
     /// binding — still taking events, or ended. The one replay-derived
     /// answer; the runtime keeps no flag of its own.
-    pub fn liveness(&self, view: &EngineView, trajectory: &TrajectoryId) -> Liveness {
+    pub(crate) fn liveness(&self, view: &EngineView, trajectory: &TrajectoryId) -> Liveness {
         let id = engine_id(trajectory);
         match view.views(&id) {
             None => Liveness::Unopened,
@@ -500,7 +515,7 @@ impl EngineSeam {
         }
     }
 
-    pub fn parent_of(&self, view: &EngineView, child: &TrajectoryId) -> Option<TrajectoryId> {
+    pub(crate) fn parent_of(&self, view: &EngineView, child: &TrajectoryId) -> Option<TrajectoryId> {
         let child = engine_id(child);
         view.views(&child)?
             .parent_of(&child)
@@ -509,7 +524,7 @@ impl EngineSeam {
 
     /// Would applying this batch leave the trajectory with more than one
     /// dispatch open?
-    pub fn opens_a_second_dispatch(&self, view: &EngineView, trajectory: &TrajectoryId, facts: &[Fact]) -> bool {
+    pub(crate) fn opens_a_second_dispatch(&self, view: &EngineView, trajectory: &TrajectoryId, facts: &[Fact]) -> bool {
         let owner = engine_id(trajectory);
         let mut open: std::collections::BTreeSet<_> = view
             .views(&owner)
@@ -532,7 +547,7 @@ impl EngineSeam {
     }
 
     /// Which trajectory pursues this offer.
-    pub fn offer_pursuer(&self, view: &EngineView, offer: &OfferId) -> Option<TrajectoryId> {
+    pub(crate) fn offer_pursuer(&self, view: &EngineView, offer: &OfferId) -> Option<TrajectoryId> {
         let engine_offer = parse_offer(offer)?;
         let surfaced = view.offer_trajectory(&engine_offer)?.clone();
         let views = view.views(&surfaced)?;
@@ -548,7 +563,7 @@ impl EngineSeam {
     /// canonical bytes each released. The payload is
     /// persisted once, on the opening record, so this is where a live call is
     /// read back — the runtime keeps no row of its own.
-    pub fn open_dispatches(&self, view: &EngineView, trajectory: &TrajectoryId) -> Vec<OpenDispatch> {
+    pub(crate) fn open_dispatches(&self, view: &EngineView, trajectory: &TrajectoryId) -> Vec<OpenDispatch> {
         let owner = engine_id(trajectory);
         let Some(views) = view.views(&owner) else {
             return Vec::new();
@@ -569,7 +584,7 @@ impl EngineSeam {
     /// so that dispatch names a call the harness never proposed — which
     /// is exactly what tells the runtime to hand it out rather than to
     /// refuse the next proposal as a second call in flight.
-    pub fn substituted_release(&self, view: &EngineView, trajectory: &TrajectoryId) -> Option<OpenDispatch> {
+    pub(crate) fn substituted_release(&self, view: &EngineView, trajectory: &TrajectoryId) -> Option<OpenDispatch> {
         let owner = engine_id(trajectory);
         let views = view.views(&owner)?;
         views
@@ -582,129 +597,25 @@ impl EngineSeam {
             })
     }
 
-    pub fn handle(
-        &self,
-        policy: &PolicyEngine<'_>,
-        view: &EngineView,
-        trajectory: &TrajectoryId,
-        event: EngineEvent,
-    ) -> Result<EngineDecision, EngineRefusal> {
-        match self {
-            EngineSeam::Real => policy.engine().handle(view, trajectory, event),
-            #[cfg(test)]
-            EngineSeam::Test(seam) => Ok(seam.next(event)),
-        }
+    /// Where one fork stands in the rebuilt view. The runtime uses it
+    /// to find the family's forks still open for binding, and the child
+    /// a spawn's fork was bound to when that spawn's result arrives.
+    pub(crate) fn fork_status(&self, view: &EngineView, fork: &ForkId) -> ForkStatus {
+        self.engine.fork_status(view, fork)
     }
 
-    /// The canonical bytes of one proposed call, for the byte-exact dispatch
-    /// matching of provider-run tools. `None` when the call cannot canonicalize — an
-    /// unknown tool or schema-invalid arguments never match a dispatched
-    /// call, whose bytes the engine validated.
-    pub fn canonical_bytes(&self, policy: &PolicyEngine<'_>, call: &ProposedCall) -> Option<Vec<u8>> {
-        match self {
-            EngineSeam::Real => policy.engine().canonical_bytes(call),
-            #[cfg(test)]
-            EngineSeam::Test(_) => serde_json::to_vec(call).ok(),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn enqueue(&self, decision: EngineDecision) {
-        match self {
-            EngineSeam::Test(seam) => seam.enqueue(decision),
-            EngineSeam::Real => panic!("only the test seam takes enqueued decisions"),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn seen(&self) -> Vec<EngineEvent> {
-        match self {
-            EngineSeam::Test(seam) => seam.seen(),
-            EngineSeam::Real => panic!("only the test seam records seen events"),
-        }
-    }
-
-    /// Render one trajectory's current label from the rebuilt view, for the
-    /// statusline. A projection read: no engine event, no fact, nothing
-    /// gated.
-    pub fn trajectory_status(
-        &self,
-        policy: &PolicyEngine<'_>,
-        view: &EngineView,
-        trajectory: &TrajectoryId,
-    ) -> Option<TrajectoryStatus> {
-        match self {
-            EngineSeam::Real => policy.engine().trajectory_status(view, trajectory),
-            #[cfg(test)]
-            EngineSeam::Test(_) => Some(TrajectoryStatus {
-                trajectory: String::new(),
-                trust: String::new(),
-                audience: String::new(),
-            }),
-        }
-    }
-
-    /// Where one fork stands in the rebuilt view: a
-    /// projection read on the real compiled engine in both modes,
-    /// because what it reads is the log itself. The runtime uses it to find
-    /// the family's forks still open for binding, and the child a spawn's fork
-    /// was bound to when that spawn's result arrives.
-    pub fn fork_status(&self, policy: &PolicyEngine<'_>, view: &EngineView, fork: &ForkId) -> ForkStatus {
-        policy.engine().engine.fork_status(view, fork)
-    }
-
-    /// The family's forks in flight: prepared, bound to
-    /// no child, their spawn dispatch still open. A projection read
-    /// on the real compiled engine in both modes; the runtime binds a child
-    /// start that names no spawn to the one fork here.
-    pub fn forks_in_flight(&self, policy: &PolicyEngine<'_>, view: &EngineView) -> Vec<ForkId> {
-        policy.engine().engine.forks_in_flight(view)
+    /// The family's forks in flight: prepared, bound to no child, their
+    /// spawn dispatch still open. The runtime binds a child start that
+    /// names no spawn to the one fork here.
+    pub(crate) fn forks_in_flight(&self, view: &EngineView) -> Vec<ForkId> {
+        self.engine.forks_in_flight(view)
     }
 
     /// The fork one child was bound to, or `None` for a trajectory
-    /// the family never forked. A projection read on the real
-    /// compiled engine in both modes, for a child start the harness delivers
-    /// again: it names the fork it already bound.
-    pub fn fork_of(&self, policy: &PolicyEngine<'_>, view: &EngineView, child: &TrajectoryId) -> Option<ForkId> {
-        policy.engine().engine.fork_of(view, &engine_id(child))
-    }
-
-    /// Render the family's recorded decisions from its persisted log. Like
-    /// [`EngineSeam::trajectory_status`], a projection read — and
-    /// like the replay gates, it runs on the real compiled engine in both
-    /// modes, because what it renders is the log itself.
-    pub fn audit(&self, policy: &PolicyEngine<'_>, log: &Log) -> Result<Option<Vec<AuditEntry>>, EngineRefusal> {
-        policy.engine().audit(log)
-    }
-}
-
-/// The real engine behind the seam: the immutable registry-backed decision
-/// core. It owns every judgment and every fact; the runtime holds
-/// no engine state, and offers are the engine's own durable facts.
-pub struct RuntimeEngine {
-    engine: Engine,
-}
-
-impl RuntimeEngine {
-    pub fn new(engine: Engine) -> RuntimeEngine {
-        RuntimeEngine { engine }
-    }
-
-    /// The opening of a fresh root: this engine's opening batch bound to the
-    /// exact bytes of the policy file the root opens under. It takes
-    /// the bytes, not a key, because the key on the opening record is the
-    /// engine's own type and is derived here — at the one boundary that names
-    /// the engine crate.
-    pub fn root_opening(&self, trajectory: &TrajectoryId, policy_file: &[u8]) -> Vec<Fact> {
-        self.engine
-            .open_trajectory(&engine_id(trajectory), EnginePolicyFileKey::of(policy_file))
-            .expect("the engine's own opening batch validates against the empty log")
-            .into_unsealed()
-    }
-
-    fn rebuild_view(&self, log: &Log) -> Result<EngineView, EngineRefusal> {
-        let root = TrajectoryId(log.root().as_str().to_string());
-        self.validated(log.facts().to_vec(), &root, log.basis())
+    /// the family never forked — for a child start the harness
+    /// delivers again: it names the fork it already bound.
+    pub(crate) fn fork_of(&self, view: &EngineView, child: &TrajectoryId) -> Option<ForkId> {
+        self.engine.fork_of(view, &engine_id(child))
     }
 
     fn validated(&self, facts: Vec<Fact>, family: &TrajectoryId, revision: u64) -> Result<EngineView, EngineRefusal> {
@@ -720,7 +631,11 @@ impl RuntimeEngine {
             })
     }
 
-    fn canonical_bytes(&self, call: &ProposedCall) -> Option<Vec<u8>> {
+    /// The canonical bytes of one proposed call, for the byte-exact dispatch
+    /// matching of provider-run tools. `None` when the call cannot canonicalize — an
+    /// unknown tool or schema-invalid arguments never match a dispatched
+    /// call, whose bytes the engine validated.
+    pub(crate) fn canonical_bytes(&self, call: &ProposedCall) -> Option<Vec<u8>> {
         let resolved = self
             .engine
             .resolve_call(ToolName::new(call.tool.clone()), call.arguments.get().as_bytes())
@@ -728,7 +643,10 @@ impl RuntimeEngine {
         Some(resolved.canonical_arguments().canonical_bytes().to_vec())
     }
 
-    fn trajectory_status(&self, view: &EngineView, trajectory: &TrajectoryId) -> Option<TrajectoryStatus> {
+    /// Render one trajectory's current label from the rebuilt view, for the
+    /// statusline. A projection read: no engine event, no fact, nothing
+    /// gated.
+    pub(crate) fn trajectory_status(&self, view: &EngineView, trajectory: &TrajectoryId) -> Option<TrajectoryStatus> {
         let current = view.views(&engine_id(trajectory))?.current_label();
         let label = self.render_label(&as_label(&current))?;
         Some(TrajectoryStatus {
@@ -764,7 +682,9 @@ impl RuntimeEngine {
         })
     }
 
-    fn audit(&self, log: &Log) -> Result<Option<Vec<AuditEntry>>, EngineRefusal> {
+    /// Render the family's recorded decisions from its persisted log. Like
+    /// [`RuntimeEngine::trajectory_status`], a projection read.
+    pub(crate) fn audit(&self, log: &Log) -> Result<Option<Vec<AuditEntry>>, EngineRefusal> {
         let facts = log.facts().to_vec();
         let root = TrajectoryId(log.root().as_str().to_string());
         // The validator takes the records; this read keeps its own copy of
@@ -897,7 +817,7 @@ impl RuntimeEngine {
         Some(Some(event))
     }
 
-    fn handle(
+    pub(crate) fn handle(
         &self,
         view: &EngineView,
         trajectory: &TrajectoryId,
@@ -2474,46 +2394,6 @@ fn block_feedback(views: &Views, planned: &PlannedBlock, offers: &[(OfferId, Pla
         lines.push(format!("  {}", advice.replace('\n', "\n  ")));
     }
     lines.join("\n")
-}
-
-/// The tests' seam: a test enqueues the exact decision for each event; the
-/// queue is the behavior. Session tests pin orchestration — commit ordering,
-/// conflict replay, evidence loops — not engine policy, which the
-/// real-engine tests pin against compiled policies.
-#[cfg(test)]
-pub struct TestSeam {
-    queue: Mutex<std::collections::VecDeque<EngineDecision>>,
-    seen: Mutex<Vec<EngineEvent>>,
-}
-
-#[cfg(test)]
-impl TestSeam {
-    pub fn new() -> TestSeam {
-        TestSeam {
-            queue: Mutex::new(std::collections::VecDeque::new()),
-            seen: Mutex::new(Vec::new()),
-        }
-    }
-
-    pub fn enqueue(&self, decision: EngineDecision) {
-        self.queue
-            .lock()
-            .expect("the test queue mutex is never poisoned")
-            .push_back(decision);
-    }
-
-    pub fn seen(&self) -> Vec<EngineEvent> {
-        self.seen.lock().expect("the seen mutex is never poisoned").clone()
-    }
-
-    fn next(&self, event: EngineEvent) -> EngineDecision {
-        self.seen.lock().expect("the seen mutex is never poisoned").push(event);
-        self.queue
-            .lock()
-            .expect("the test queue mutex is never poisoned")
-            .pop_front()
-            .expect("a test enqueued a decision for every event it drives")
-    }
 }
 
 #[cfg(test)]

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -302,18 +302,21 @@ impl ExternalServices {
             name,
             payload,
         };
-        let body = match self.post(endpoint, &request).await {
-            Ok(body) => body,
-            Err(reason) => return ConsultOutcome::NoAnswer(reason),
+        let reason = match self.post(endpoint, &request).await {
+            Err(reason) => reason,
+            Ok(body) => match serde_json::from_slice::<ConsultResponse>(&body) {
+                Err(_) => NoAnswerReason::Malformed,
+                Ok(response) if response.version != 1 => NoAnswerReason::UnsupportedVersion,
+                Ok(response) => return ConsultOutcome::Answer(response.answer),
+            },
         };
-        let response: ConsultResponse = match serde_json::from_slice(&body) {
-            Ok(response) => response,
-            Err(_) => return ConsultOutcome::NoAnswer(NoAnswerReason::Malformed),
-        };
-        if response.version != 1 {
-            return ConsultOutcome::NoAnswer(NoAnswerReason::UnsupportedVersion);
-        }
-        ConsultOutcome::Answer(response.answer)
+        tracing::debug!(
+            kind = kind.wire_name(),
+            name,
+            ?reason,
+            "endpoint consult produced no answer"
+        );
+        ConsultOutcome::NoAnswer(reason)
     }
 
     async fn call_module(
@@ -391,7 +394,16 @@ impl ExternalServices {
         };
         match self.literal_readers(endpoint, &request).await {
             Ok(readers) => ReadersResolution::Resolved { readers },
-            Err(reason) => ReadersResolution::Unresolved(reason),
+            Err(reason) => {
+                tracing::debug!(
+                    resolver,
+                    tool,
+                    argument,
+                    ?reason,
+                    "dynamic resolution produced no answer"
+                );
+                ReadersResolution::Unresolved(reason)
+            }
         }
     }
 
@@ -409,7 +421,10 @@ impl ExternalServices {
         };
         match self.literal_readers(endpoint, &request).await {
             Ok(readers) => ReadersResolution::Resolved { readers },
-            Err(reason) => ReadersResolution::Unresolved(reason),
+            Err(reason) => {
+                tracing::debug!(resolver, group, ?reason, "membership resolution produced no answer");
+                ReadersResolution::Unresolved(reason)
+            }
         }
     }
 

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -40,7 +40,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             Err(error) => refuse(error.to_string()),
         },
         HookEvent::Prompt { actor, text } => {
-            match on_actor(runtime, &actor, |mut session| {
+            match on_actor(runtime, &actor, |session| {
                 let text = text.clone();
                 async move { session.on_prompt(text) }
             })
@@ -56,13 +56,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             // turn" on this hook, which would hold the harness in a turn
             // it has finished; a close that failed leaves the call open
             // and the next proposal refuses on its own.
-            if let Err(error) = on_actor(
-                runtime,
-                &actor,
-                |mut session| async move { session.on_turn_end().await },
-            )
-            .await
-            {
+            if let Err(error) = on_actor(runtime, &actor, |session| async move { session.on_turn_end().await }).await {
                 tracing::warn!(root = %actor.root.0, %error, "the turn end closed no abandoned call");
             }
             HookDecision::Ack
@@ -71,7 +65,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             if is_control_tool(&call.tool) {
                 return control_call(runtime, &actor, &call);
             }
-            match on_actor(runtime, &actor, |mut session| {
+            match on_actor(runtime, &actor, |session| {
                 let call = call.clone();
                 async move { session.on_tool_call(call, spawn).await }
             })
@@ -88,7 +82,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
                 tracing::debug!(trajectory = %actor.root.0, "control tool outcome absorbed");
                 return HookDecision::Ack;
             }
-            match on_actor(runtime, &actor, |mut session| {
+            match on_actor(runtime, &actor, |session| {
                 let (call, outcome) = (call.clone(), outcome.clone());
                 async move { session.on_tool_result(call, outcome).await }
             })
@@ -106,7 +100,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             value,
         } => {
             let said = value.clone();
-            match on_actor(runtime, &actor, |mut session| {
+            match on_actor(runtime, &actor, |session| {
                 let (call, outcome, child, value) = (call.clone(), outcome.clone(), child.clone(), value.clone());
                 async move { session.on_spawn_result(call, outcome, child, value).await }
             })
@@ -118,7 +112,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             }
         }
         HookEvent::ChildStart { root, child, spawn } => {
-            let mut root = match open_or_reopen(runtime, &root) {
+            let root = match open_or_reopen(runtime, &root) {
                 Ok(session) => session,
                 Err(error) => return refuse(error.to_string()),
             };
@@ -129,7 +123,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
         }
         HookEvent::ChildEnd { root, child, value } => {
             let said = value.clone();
-            match on_child(runtime, &root, &child, |mut session| {
+            match on_child(runtime, &root, &child, |session| {
                 let value = value.clone();
                 async move { session.on_child_end(value).await }
             })
@@ -216,7 +210,7 @@ async fn on_child<T, Run>(
 where
     Run: Future<Output = Result<T, EventError>>,
 {
-    let mut root_session = open_or_reopen(runtime, root)?;
+    let root_session = open_or_reopen(runtime, root)?;
     match event(runtime.session(root, child)?).await {
         Err(EventError::SpawnNotTaken) => match root_session.open_late(child.clone())? {
             LateOpen::Opened => {

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -254,7 +254,7 @@ mod tests {
     use super::*;
     use appa_runtime_api::SpawnRef;
 
-    use crate::api::{Runtime, testing};
+    use crate::api::Runtime;
     use crate::config::Config;
 
     fn codec() -> Codec {
@@ -297,11 +297,7 @@ mod tests {
         Config::load(&path).expect("the minimal fixture validates")
     }
 
-    fn open_test_runtime(dir: &tempfile::TempDir) -> Runtime {
-        testing::runtime(config(), dir.path().join("appa.db"))
-    }
-
-    fn open_real_runtime(dir: &tempfile::TempDir) -> Runtime {
+    fn open_runtime(dir: &tempfile::TempDir) -> Runtime {
         Runtime::open(config(), dir.path().join("appa.db"), None).expect("the fixture deployment opens")
     }
 
@@ -323,7 +319,7 @@ mod tests {
     #[tokio::test]
     async fn the_recorded_session_replays_end_to_end() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         for event in fixtures() {
             let name = event["hook_event_name"].as_str().expect("each fixture names its hook");
             let control = event["tool_name"] == CONTROL_TOOL_FIXTURE_NAME;
@@ -366,7 +362,7 @@ mod tests {
     #[tokio::test]
     async fn a_turn_end_answers_with_no_opinion_even_over_an_unknown_session() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         for hook in ["Stop", "StopFailure", "SubagentStop"] {
             let mut body = serde_json::json!({
                 "hook_event_name": hook,
@@ -390,7 +386,7 @@ mod tests {
     #[tokio::test]
     async fn a_turn_end_frees_a_trajectory_the_missing_outcome_wedged() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let propose = |command: &str| {
             serde_json::json!({
                 "hook_event_name": "PreToolUse",
@@ -427,33 +423,39 @@ mod tests {
     #[tokio::test]
     async fn a_deny_renders_in_the_pre_tool_use_wire() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        testing::enqueue_deny(&runtime, "blocked: the recipient cannot read this", &["offer-1"]);
+        let runtime = open_runtime(&dir);
         let event = serde_json::json!({
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
-            "tool_name": "Bash",
-            "tool_input": {"command": "ls"},
+            "tool_name": "Curl",
+            "tool_input": {"url": "https://example.invalid"},
             "tool_use_id": "toolu_1",
         });
         let (status, answer) = call_hook(&runtime, &serde_json::to_vec(&event).expect("serializes")).await;
         assert_eq!(status, 200);
+        let rendered = answer["hookSpecificOutput"]
+            .as_object()
+            .expect("a deny renders inside hookSpecificOutput");
         assert_eq!(
-            answer,
-            serde_json::json!({
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": "blocked: the recipient cannot read this",
-                }
-            }),
+            rendered.keys().collect::<Vec<_>>(),
+            ["hookEventName", "permissionDecision", "permissionDecisionReason"],
+            "the deny wire carries exactly these three fields: {answer}",
+        );
+        assert_eq!(rendered["hookEventName"], "PreToolUse");
+        assert_eq!(rendered["permissionDecision"], "deny");
+        assert!(
+            !rendered["permissionDecisionReason"]
+                .as_str()
+                .expect("the reason is a string")
+                .is_empty(),
+            "the deny carries the engine's feedback to the model",
         );
     }
 
     #[tokio::test]
     async fn an_event_error_renders_as_a_deny() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let event = serde_json::json!({
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
@@ -480,7 +482,7 @@ mod tests {
     #[tokio::test]
     async fn a_replaced_output_renders_as_a_block_with_the_placeholder() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let pre = serde_json::json!({
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
@@ -504,7 +506,7 @@ mod tests {
     #[tokio::test]
     async fn a_mid_run_input_rewrite_still_matches_its_dispatch() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let questions = serde_json::json!({"questions": [{"question": "Declare the tool?"}]});
         let pre = serde_json::json!({
             "hook_event_name": "PreToolUse",
@@ -542,7 +544,7 @@ mod tests {
     #[tokio::test]
     async fn the_control_tool_opens_no_dispatch() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let event = serde_json::json!({
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
@@ -556,7 +558,6 @@ mod tests {
             answer["hookSpecificOutput"]["permissionDecisionReason"],
             "appa: the runtime's own control tool",
         );
-        testing::enqueue_release(&runtime, "d1", "Bash", &serde_json::json!({"command": "ls"}));
         let call = serde_json::json!({
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
@@ -570,8 +571,7 @@ mod tests {
     #[tokio::test]
     async fn a_lookalike_control_tool_is_checked() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        testing::enqueue_deny(&runtime, "blocked: not the runtime's tool", &[]);
+        let runtime = open_runtime(&dir);
         let event = serde_json::json!({
             "hook_event_name": "PreToolUse",
             "session_id": "s1",
@@ -588,7 +588,7 @@ mod tests {
     #[tokio::test]
     async fn a_control_tools_post_hook_answers_with_no_opinion() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let event = serde_json::json!({
             "hook_event_name": "PostToolUse",
             "session_id": "s1",
@@ -604,7 +604,7 @@ mod tests {
     #[tokio::test]
     async fn a_control_call_answers_without_a_session_lookup() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
+        let runtime = open_runtime(&dir);
 
         let start = serde_json::json!({
             "hook_event_name": "SubagentStart",
@@ -650,7 +650,7 @@ mod tests {
     #[tokio::test]
     async fn a_child_return_that_crosses_unchanged_answers_with_no_opinion() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let root = appa_runtime_api::TrajectoryId("cc:s1".to_string());
         let child = appa_runtime_api::TrajectoryId("cc:s1:a1".to_string());
 
@@ -703,7 +703,7 @@ mod tests {
     #[tokio::test]
     async fn an_uncorrelated_child_return_blocks_rather_than_refusing() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let root = appa_runtime_api::TrajectoryId("cc:s1".to_string());
 
         let decision = handle(
@@ -724,7 +724,7 @@ mod tests {
     #[tokio::test]
     async fn a_spawn_result_on_an_unforked_call_answers_as_an_ordinary_outcome() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let root = appa_runtime_api::TrajectoryId("cc:s1".to_string());
         let call = || crate::api::ProposedCall {
             tool: "Agent".to_string(),
@@ -765,7 +765,7 @@ mod tests {
     #[tokio::test]
     async fn a_child_event_before_its_start_opens_the_child_to_the_one_spawn_in_flight() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_real_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let root = appa_runtime_api::TrajectoryId("cc:s1".to_string());
         let child = appa_runtime_api::TrajectoryId("cc:s1:a1".to_string());
         let released = handle(
@@ -846,8 +846,8 @@ mod tests {
     #[tokio::test]
     async fn an_operational_failure_refuses_instead_of_answering_the_model() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
-        testing::fail_next_commit(&runtime);
+        let runtime = open_runtime(&dir);
+        runtime.store().fail_commit_after(0);
         let prompt = serde_json::json!({
             "hook_event_name": "UserPromptSubmit",
             "session_id": "s1",
@@ -859,23 +859,12 @@ mod tests {
             answer.get("error").is_some(),
             "an operational failure renders as a refusal, never as model-facing feedback: {answer}",
         );
-
-        testing::enqueue_done(&runtime);
-        let call = serde_json::json!({
-            "hook_event_name": "PreToolUse",
-            "session_id": "s1",
-            "tool_name": "Bash",
-            "tool_input": {"command": "ls"},
-        });
-        let (status, answer) = call_hook(&runtime, &serde_json::to_vec(&call).expect("serializes")).await;
-        assert_eq!(status, 409, "an undeliverable decision refuses rather than denying");
-        assert!(answer.get("error").is_some(), "got {answer}");
     }
 
     #[tokio::test]
     async fn an_unreadable_hook_event_is_a_400() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let (status, answer) = call_hook(&runtime, b"not json").await;
         assert_eq!(status, 400);
         assert!(
@@ -889,7 +878,7 @@ mod tests {
     #[tokio::test]
     async fn a_malformed_hook_event_is_a_409() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_test_runtime(&dir);
+        let runtime = open_runtime(&dir);
         let event = serde_json::json!({"hook_event_name": "PreToolUse", "session_id": "s1"});
         let (status, answer) = call_hook(&runtime, &serde_json::to_vec(&event).expect("serializes")).await;
         assert_eq!(status, 409);

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -10,7 +10,6 @@ use std::process::ExitCode;
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use axum::routing::{get, post};
 use clap::Parser;
 
@@ -58,9 +57,6 @@ struct Args {
 
     #[arg(short, action = clap::ArgAction::Count)]
     verbose: u8,
-
-    #[arg(long, env = "APPA_INSTANCE_ID", hide = true)]
-    instance_id: Option<String>,
 }
 
 fn require_loopback(addr: &SocketAddr) -> Result<(), String> {
@@ -140,7 +136,6 @@ struct AppState {
     codec: Codec,
     config: PathBuf,
     adapter: Adapter,
-    instance_id: Option<HeaderValue>,
 }
 
 async fn hook(
@@ -152,26 +147,8 @@ async fn hook(
     (status, axum::Json(body))
 }
 
-fn instance_id_header(value: Option<&str>) -> Result<Option<HeaderValue>, &'static str> {
-    match value {
-        Some(value) if value.is_empty() || value.len() > 128 => Err("must contain 1 to 128 bytes"),
-        Some(value) => HeaderValue::try_from(value)
-            .map(Some)
-            .map_err(|_| "is not a valid HTTP header value"),
-        None => Ok(None),
-    }
-}
-
-fn health_headers(instance_id: Option<HeaderValue>) -> HeaderMap {
-    let mut headers = HeaderMap::new();
-    if let Some(instance_id) = instance_id {
-        headers.insert(HeaderName::from_static("x-appa-instance-id"), instance_id);
-    }
-    headers
-}
-
-async fn health(State(state): State<AppState>) -> (HeaderMap, &'static str) {
-    (health_headers(state.instance_id), "ok")
+async fn health() -> &'static str {
+    "ok"
 }
 
 async fn reload(State(state): State<AppState>) -> Result<axum::Json<Reloaded>, (axum::http::StatusCode, String)> {
@@ -219,13 +196,6 @@ async fn main() -> ExitCode {
         eprintln!("appa-runtime: {refusal}");
         return ExitCode::FAILURE;
     }
-    let instance_id = match instance_id_header(args.instance_id.as_deref()) {
-        Ok(instance_id) => instance_id,
-        Err(refusal) => {
-            eprintln!("appa-runtime: --instance-id {refusal}");
-            return ExitCode::FAILURE;
-        }
-    };
     match ensure_default_config(&args.config) {
         Ok(true) => tracing::info!(path = %args.config.display(), "created default configuration"),
         Ok(false) => {}
@@ -258,7 +228,6 @@ async fn main() -> ExitCode {
         codec: args.adapter.codec(),
         config: args.config,
         adapter: args.adapter,
-        instance_id,
     };
     let app = axum::Router::new()
         .route("/health", get(health))
@@ -351,19 +320,5 @@ mod tests {
         assert_eq!(log_level(0), "info");
         assert_eq!(log_level(1), "debug");
         assert_eq!(log_level(2), "trace");
-    }
-
-    #[test]
-    fn health_echoes_only_a_valid_installer_instance_id() {
-        let instance_id = instance_id_header(Some("installer-123"))
-            .expect("valid instance id")
-            .expect("present instance id");
-        let headers = health_headers(Some(instance_id));
-        assert_eq!(headers["x-appa-instance-id"], "installer-123");
-
-        assert!(health_headers(None).get("x-appa-instance-id").is_none());
-        assert!(instance_id_header(Some("")).is_err());
-        assert!(instance_id_header(Some("invalid\r\nheader")).is_err());
-        assert!(instance_id_header(Some(&"x".repeat(129))).is_err());
     }
 }

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -208,7 +208,7 @@ mod tests {
             crate::api::Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens");
 
         let root = crate::api::TrajectoryId("cc:mcp-test".to_string());
-        let mut session = runtime.create_session(root.clone()).expect("a fresh id opens");
+        let session = runtime.create_session(root.clone()).expect("a fresh id opens");
         let denied = session
             .on_tool_call(
                 ProposedCall {

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -112,7 +112,7 @@ pub fn service(runtime: Arc<Runtime>) -> StreamableHttpService<RemedyService, Lo
 mod tests {
     use super::*;
     use crate::api::raw;
-    use crate::api::{ProposedCall, ToolCallDecision, testing};
+    use crate::api::{ProposedCall, Runtime, ToolCallDecision};
     use crate::config::Config;
     use appa_runtime_api::HookDecision;
 
@@ -133,7 +133,7 @@ mod tests {
     #[tokio::test]
     async fn an_unknown_offer_gets_one_typed_refusal() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = testing::runtime(config(), dir.path().join("appa.db"));
+        let runtime = Runtime::open(config(), dir.path().join("appa.db"), None).expect("the fixture deployment opens");
         let outcome = runtime
             .execute_remedy(&acting("cc:mcp-test"), OfferId("never-surfaced".to_string()))
             .await;
@@ -149,7 +149,7 @@ mod tests {
     #[tokio::test]
     async fn one_offer_is_claimed_once_at_a_time() {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = testing::runtime(config(), dir.path().join("appa.db"));
+        let runtime = Runtime::open(config(), dir.path().join("appa.db"), None).expect("the fixture deployment opens");
         let offer = OfferId("offer-live".to_string());
 
         let claim = runtime.claim_offer(&offer).expect("a free offer is claimable");

--- a/appa-runtime/tests/audit_read.rs
+++ b/appa-runtime/tests/audit_read.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::raw;
+
 use std::sync::Arc;
 
 use appa_runtime::api::{AuditEntry, AuditEvent, AuditLabel, DispatchOutcome, OfferId, RemedyOutcome, Runtime};
@@ -41,10 +44,6 @@ max_body_bytes = 4096
 [externals.sanitizers.redactor]
 builtin = "redact-email"
 "#;
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
-}
 
 fn call(tool: &str) -> ProposedCall {
     ProposedCall {

--- a/appa-runtime/tests/cast.rs
+++ b/appa-runtime/tests/cast.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::{raw, serve};
+
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
@@ -155,18 +158,7 @@ async fn serve_classifier() -> (String, Classifier) {
             }),
         )
         .with_state(classifier.clone());
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("an ephemeral loopback port binds");
-    let addr = listener.local_addr().expect("the bound address is readable");
-    tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("the stub serves");
-    });
-    (format!("http://{addr}/classify"), classifier)
-}
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
+    (format!("{}/classify", serve(router).await), classifier)
 }
 
 fn root() -> TrajectoryId {

--- a/appa-runtime/tests/claude_code_subagent.rs
+++ b/appa-runtime/tests/claude_code_subagent.rs
@@ -1,17 +1,13 @@
-use std::path::{Path, PathBuf};
+mod common;
+use common::repo_root;
+
+use std::path::Path;
 
 use appa_runtime::api::{AuditEvent, Runtime, TrajectoryId};
 use appa_runtime::config::Config;
 use appa_runtime::hooks;
 
 const SESSION: &str = "18ebc556-b78f-452b-99ec-487a4f40e824";
-
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("the runtime crate sits one level below the repo root")
-        .to_path_buf()
-}
 
 fn recorded() -> Vec<serde_json::Value> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/hooks.jsonl");

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -1,0 +1,36 @@
+//! Fixtures every integration test binary that declares `mod common;`
+//! compiles into itself. Only what several suites need verbatim lives
+//! here; a stub's own routes and state stay with the suite that reads
+//! them.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+/// Fixture arguments, from a `json!` value to the bytes a harness would
+/// have sent. The adapter holds the harness's bytes already, so
+/// production never takes this direction.
+pub fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
+    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
+}
+
+/// The repository root, for the suites that read the shipped
+/// integration files rather than a fixture of their own.
+pub fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("the runtime crate sits one level below the repo root")
+        .to_path_buf()
+}
+
+/// Serve one router on an ephemeral loopback port for the rest of the
+/// test, and answer with its base URL.
+pub async fn serve(router: axum::Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("an ephemeral loopback port binds");
+    let addr = listener.local_addr().expect("the bound address is readable");
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.expect("the stub serves");
+    });
+    format!("http://{addr}")
+}

--- a/appa-runtime/tests/config_reload.rs
+++ b/appa-runtime/tests/config_reload.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::raw;
+
 use std::sync::Arc;
 
 use appa_runtime::api::{OpenError, Runtime};
@@ -63,10 +66,6 @@ fn write_config(dir: &tempfile::TempDir, policy: &str) -> Config {
     let path = dir.path().join("appa.toml");
     std::fs::write(&path, policy).expect("the fixture writes");
     Config::load(&path).expect("the fixture validates")
-}
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
 }
 
 fn notes() -> ProposedCall {

--- a/appa-runtime/tests/examples_load.rs
+++ b/appa-runtime/tests/examples_load.rs
@@ -1,14 +1,10 @@
+mod common;
+use common::repo_root;
+
 use std::path::{Path, PathBuf};
 
 use appa_runtime::api::Runtime;
 use appa_runtime::config::Config;
-
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("the runtime crate sits one level below the repo root")
-        .to_path_buf()
-}
 
 fn toml_files(dir: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();

--- a/appa-runtime/tests/hitl_elicitation.rs
+++ b/appa-runtime/tests/hitl_elicitation.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::raw;
+
 use std::sync::Arc;
 
 use appa_runtime::api::Runtime;
@@ -6,10 +9,6 @@ use appa_runtime_api::{Actor, HookDecision, HookEvent, ProposedCall, TrajectoryI
 use rmcp::model::{ElicitRequestParams, ElicitResult, ElicitationAction};
 use rmcp::service::{RequestContext, RoleClient};
 use rmcp::{ClientHandler, ServiceExt};
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
-}
 
 fn policy(review_timeout_ms: u64) -> String {
     POLICY.replace("REVIEW_TIMEOUT_MS", &review_timeout_ms.to_string())

--- a/appa-runtime/tests/input_substitution.rs
+++ b/appa-runtime/tests/input_substitution.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::raw;
+
 use std::sync::Arc;
 
 use appa_runtime::api::{AuditEvent, DispatchOutcome, OfferId, RemedyOutcome, Runtime};
@@ -34,17 +37,6 @@ builtin = "redact-email"
 
 const RAW_BODY: &str = "mail alice@corp.example today";
 const REDACTED_BODY: &str = "mail [redacted-email] today";
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
-}
-
-fn acting() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
-}
 
 fn root() -> TrajectoryId {
     TrajectoryId("substitution-test".to_string())
@@ -129,7 +121,7 @@ async fn narrowed_and_blocked(dir: &tempfile::TempDir) -> (Arc<Runtime>, OfferId
     let blocked = propose(&runtime, read_hr()).await;
     let accept = last_offer(&feedback_of(&blocked));
     assert!(matches!(
-        runtime.execute_remedy(&acting(), accept).await,
+        runtime.execute_remedy(&actor(), accept).await,
         RemedyOutcome::Authorized { .. }
     ));
     assert_eq!(
@@ -148,7 +140,7 @@ async fn the_replaced_call_runs_through_the_hooks_and_closes() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let (runtime, hop) = narrowed_and_blocked(&dir).await;
 
-    let RemedyOutcome::Substituted { call } = runtime.execute_remedy(&acting(), hop.clone()).await else {
+    let RemedyOutcome::Substituted { call } = runtime.execute_remedy(&actor(), hop.clone()).await else {
         panic!("the input sanitizer's hop substitutes the call");
     };
     assert_eq!(call.tool, "send");
@@ -164,7 +156,7 @@ async fn the_replaced_call_runs_through_the_hooks_and_closes() {
     assert_eq!(report(&runtime, send(REDACTED_BODY), "sent").await, HookDecision::Ack);
 
     assert!(matches!(
-        runtime.execute_remedy(&acting(), hop).await,
+        runtime.execute_remedy(&actor(), hop).await,
         RemedyOutcome::Declined { .. }
     ));
     assert!(matches!(
@@ -197,7 +189,7 @@ async fn another_call_abandons_the_standing_replaced_call() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let (runtime, hop) = narrowed_and_blocked(&dir).await;
     assert!(matches!(
-        runtime.execute_remedy(&acting(), hop).await,
+        runtime.execute_remedy(&actor(), hop).await,
         RemedyOutcome::Substituted { .. }
     ));
 
@@ -234,7 +226,7 @@ async fn the_standing_replaced_call_survives_a_reopen() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let (runtime, hop) = narrowed_and_blocked(&dir).await;
     assert!(matches!(
-        runtime.execute_remedy(&acting(), hop).await,
+        runtime.execute_remedy(&actor(), hop).await,
         RemedyOutcome::Substituted { .. }
     ));
     drop(runtime);

--- a/appa-runtime/tests/membership.rs
+++ b/appa-runtime/tests/membership.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::{raw, serve};
+
 use std::sync::{Arc, Mutex};
 
 use appa_runtime::api::{RemedyOutcome, Runtime};
@@ -82,25 +85,7 @@ async fn serve_directory() -> (String, Directory) {
             }),
         )
         .with_state(directory.clone());
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("an ephemeral loopback port binds");
-    let addr = listener.local_addr().expect("the bound address is readable");
-    tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("the stub serves");
-    });
-    (format!("http://{addr}/membership"), directory)
-}
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
-}
-
-fn acting() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
+    (format!("{}/membership", serve(router).await), directory)
 }
 
 fn root() -> TrajectoryId {
@@ -183,7 +168,7 @@ async fn narrowed(dir: &tempfile::TempDir, membership_url: &str) -> Arc<Runtime>
         panic!("the narrowing read is offered for acceptance, got {blocked:?}");
     };
     assert!(matches!(
-        runtime.execute_remedy(&acting(), last_offer(&feedback)).await,
+        runtime.execute_remedy(&actor(), last_offer(&feedback)).await,
         RemedyOutcome::Authorized { .. }
     ));
     assert_eq!(

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -1,3 +1,6 @@
+mod common;
+use common::serve;
+
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -141,20 +144,9 @@ async fn refused_url() -> String {
     url
 }
 
-async fn stub(router: Router) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("an ephemeral loopback port binds");
-    let addr = listener.local_addr().expect("the bound address is readable");
-    tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("the stub serves");
-    });
-    format!("http://{addr}")
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn a_2xx_answer_passes_its_body_through_with_exit_0() {
-    let url = stub(Router::new().route("/hook", post(|| async { r#"{"decision":"block","reason":"denied"}"# }))).await;
+    let url = serve(Router::new().route("/hook", post(|| async { r#"{"decision":"block","reason":"denied"}"# }))).await;
     let command = shipped_command();
     let (code, stdout) = tokio::task::spawn_blocking(move || run_hook(&command, &url))
         .await
@@ -165,7 +157,7 @@ async fn a_2xx_answer_passes_its_body_through_with_exit_0() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn a_server_error_exits_2_instead_of_failing_open() {
-    let url = stub(Router::new().route(
+    let url = serve(Router::new().route(
         "/hook",
         post(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
     ))


### PR DESCRIPTION
Behavior-preserving cleanup of `appa-runtime`: no change to hook decisions, HTTP
shapes, appended facts, MCP text, model-facing strings, or the config schema. The
one deliberate contract change is the removal of the hidden `--instance-id` /
`APPA_INSTANCE_ID` / `x-appa-instance-id` machinery, whose consumers were deleted in
c469698.

## The seam

`EngineSeam` was a two-variant enum — `Real`, and a `#[cfg(test)] Test(TestSeam)`
holding a queue of canned decisions — baked into the production type that every
session event went through. Twelve of its fourteen methods never looked at the
discriminator, and the engine that actually decides arrived separately as a
`PolicyEngine` argument.

Twenty-five tests drove that queue. They are rewritten against compiled policies
first, then the enum is deleted: `RuntimeEngine` absorbs the seven view-reading
methods, `Inner` loses its `engine` field, and `Runtime::open` becomes the only
constructor. `opened_under` is a free function — it reads the opening record to find
out which engine decides, so it cannot belong to one.

Assertions that observed the fake are replaced by observable consequences: the log
after a control call, the open dispatches after a discarded attempt, the minted offer
ids instead of the entropy each attempt carried, and a request-counting authority
instead of the recorded evidence rounds.

## Also

- `Session` handlers take `&self` — none ever mutated. `on_spawn_result` writes its
  plan into a local instead of a `Mutex` used as an out-parameter.
- `confined_delivery` and `return_stage_delivery` were the same ten lines under two
  headlines; `stage_delivery` serves all four call sites. Both staged deliveries had
  no test — they have one now, each checked against a panic planted in the arm it
  claims to reach.
- `decide_proposal` existed to be called twice with one argument different and needed
  a `too_many_arguments` allowance to say so. It is a closure.
- `ReleasedCall.dispatch` was a serialized engine dispatch id handed to the harness
  and never read back; its only reader was a `debug!` field.
- Every `external.rs` path that collapses to `NoAnswer` now traces the reason, as the
  module path already did.
- `tests/common/mod.rs` for the three fixtures copied across suites.
- Three README/CLAUDE.md claims the code contradicts.

## Verification

`cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings`
zero findings, `cargo test --workspace` 887 passed. The set of `"[appa]…"` literals
under `appa-runtime/src` is identical on `main` and at head (33 strings, empty
`sort -u` diff). Production lines 7145 → 7002.

`main` is merged in. Two conflicts: the `engine.rs` import line, and `resolve_tool`,
which #45 rewrote from `resolve_dynamic` — that one takes #45's body with the single
traced no-answer exit re-applied.
