### PR TITLE
fix(website): state what happens to the reader-ping address

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -2410,18 +2410,11 @@ samp {
   color: var(--text-strong);
 }
 
-.ping-lede {
-  margin: 8px 0 0;
-  font-size: 13.5px;
-  line-height: 1.65;
-  color: var(--text-weak);
-}
-
 .ping-form {
   margin-top: 18px;
 }
 
-/* The lede and placeholder already name the field; a control still needs a
+/* The placeholder already names the field on screen; a control still needs a
    real label for assistive technology. */
 .ping-label {
   position: absolute;
@@ -2484,6 +2477,15 @@ samp {
 .ping-button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+/* Quieter than the title: the reader should be able to skip it and lose
+   nothing, but find it where they decide whether to type. */
+.ping-fine {
+  margin: 12px 0 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-weak);
 }
 
 /* Reserves its line so the dialog does not resize when a result arrives. */

--- a/website/components/ReaderPing.tsx
+++ b/website/components/ReaderPing.tsx
@@ -195,7 +195,7 @@ export function ReaderPing() {
         role="dialog"
         aria-modal="true"
         aria-labelledby="ping-title"
-        aria-describedby="ping-lede"
+        aria-describedby="ping-fine"
       >
         {/* Matches the badge beside the wordmark in the header, so the prompt
             reads as part of the project rather than a bolted-on capture form. */}
@@ -203,11 +203,6 @@ export function ReaderPing() {
         <h2 className="ping-title" id="ping-title">
           Say hello before you read
         </h2>
-        <p className="ping-lede" id="ping-lede">
-          OpenAPPA is in preview and the model is still open for argument. We would love to know who
-          is checking it out.
-        </p>
-
         <form className="ping-form" onSubmit={onSubmit}>
           <label className="ping-label" htmlFor="ping-email">
             Email address
@@ -235,6 +230,15 @@ export function ReaderPing() {
             </button>
           </div>
         </form>
+
+        {/* The promise the route in `app/api/reader-ping/route.ts` keeps: the
+            address is posted to one Slack channel and never written down. It
+            sits under the field, where a reader decides whether to type, and
+            is the dialog's description — there is no other prose. */}
+        <p className="ping-fine" id="ping-fine">
+          Not saved, and not used for a mailing list. Your address is posted to the OpenAPPA core
+          team&rsquo;s Slack channel, and that is it.
+        </p>
 
         {/* Reserves its line so the dialog does not jump when a result lands. */}
         <p


### PR DESCRIPTION
The first-visit prompt now says the address is not saved, is not used for a mailing list, and goes to the core team's Slack channel — which is what `app/api/reader-ping/route.ts` already does. The lede is gone; the eyebrow already carries the preview framing.