### PR TITLE
docs: clarify user-facing documentation in contracts and how-it-works

### DIFF
--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -32,7 +32,7 @@ A set declaration without an explicit operator causes a policy load error.
 
 ### Groups
 
-A reader list may name a **group**, written `@name`, and so may the actual argument an `includes($arg)` placeholder reads. The registered membership resolver turns the name into its literal reader set at the moment the engine first reads it for an operation — at the admission of an exposed provider-run result, at the pre-dispatch check, at mandate validation, at sanitizer application, at cast selection and the validation of a cast's answer. A name without the mark is a literal reader ID. A reader ID starting with `@` is a load error, as is a group mention in a policy with no `[membership]` registration.
+A reader list can name a **group**, written `@name`. An argument placeholder (`includes = ["$recipient"]`) can also resolve to a group. When OpenAPPA evaluates an operation, the registered `[membership]` resolver converts the group name into its literal list of readers. A name without `@` is a literal reader ID. Using `@` in a literal reader ID or referencing a group without registering `[membership]` causes a policy load error.
 
 ```toml
 [membership]                    # one per deployment; every @group resolves here
@@ -44,9 +44,9 @@ requires = { audience = { cap = ["finance", "@auditors"] } }  # group in a cap
 delta    = {}
 ```
 
-Resolution is fresh per operation, and pinned within one: the set resolved at a call's check is the set its block, its plan offers, its release and its admission use, and a written list means its literal readers plus the current members of each group it names. Directory updates take effect on the next policy check without a reload. Once resolved for a specific tool call, reader sets stay pinned to that call. Records keep the resolved readers, never the group name. `public` is reserved and never a group member; a directory answer containing it is malformed.
+Each tool call resolves group membership freshly, then pins that reader set for the duration of the call (including checks, remedy plans, dispatch, and logging). Directory updates apply to new calls immediately without reloading the policy. Execution records store the resolved reader IDs, never the group name. The reserved word `public` cannot be a group member.
 
-A resolver that produces no answer — a timeout, an error, malformed or oversized data — resumes nothing: the check does not complete and no engine fact is appended. An empty reader set is a successful answer. The endpoint accepts a versioned JSON POST request: `{version:1,resolver,group}`, with `group` the name without its `@` mark. It returns `{version:1,readers:[...]}`.
+If a membership resolver fails (timeout, network error, or invalid payload), OpenAPPA halts the check with an operational error and records nothing to the log. An empty reader list is a valid response. The resolver endpoint receives a JSON POST request (`{"version": 1, "resolver": "...", "group": "..."}`) and returns `{"version": 1, "readers": [...]}`.
 
 ### Dynamic resolvers
 
@@ -231,7 +231,15 @@ OpenAPPA rejects a missing result, an extra result, and a `null` result. It reje
 
 ### Deployment coverage
 
-The deployment declares what it covers in the policy file's `[deployment]` table — the starting label every root opens at, which tools have enforced execution, where raw results can be withheld, whether child branches are controlled. The policy loader validates the file against that declaration, and a construct that names an engine behavior the deployment cannot perform is a load error naming the missing coverage: a `tool_output` sanitizer with no covered application point, a pending-cast `delta` on a tool whose raw result the model would see anyway, a `[child]` section without child-context control, a `requires`, dynamic `delta`, or pending-cast `delta` on a provider-run tool. A weaker executor class is not a construct — it loads, and its weakness is the open vector. Writing a policy therefore starts from the deployment's coverage, not from the full feature list. What stays uncovered is an open vector the deployment names explicitly and auditably — nothing is removed or silently degraded.
+The `[deployment]` table declares the capabilities of your hosting environment—such as starting security labels, enforced execution points, raw output withholding, and child branch isolation.
+
+During policy load, OpenAPPA validates that all declared constructs are supported by the deployment. If a policy requires a capability the deployment lacks, loading fails with an explicit error:
+- A `tool_output` sanitizer requires a deployment that can withhold raw tool results.
+- A pending cast (`delta = { trust = "unknown" }`) requires raw results to be withheld until classified.
+- A `[child]` section requires child context isolation.
+- Provider-run tools (tools executed directly inside a provider inference call) cannot declare `requires`, dynamic resolvers, or pending casts.
+
+Uncovered vectors are explicitly declared in the deployment configuration so security leaders can audit them, rather than silently degrading guarantees.
 
 ## What to check when reviewing
 
@@ -243,11 +251,11 @@ A tool contract is typically four lines long. Use this checklist during policy r
 | **Unannotated Tools** | Omitting `delta` while declaring `requires`. | Use `delta = {}` if output carries no labels, or separate unannotated tools. | Loader refuses `requires` on unannotated tools; unannotated output enters as `Unknown`. |
 | **`effects` Completeness** | Mutation or deployment tool omits `effects`. | Declare all side effects, e.g., `effects = ["migration.applied", "mutation"]`. | Under-declared effects pass `no_prior` checks silently without triggering history constraints. |
 | **Dynamic Recipients** | Static readers when an ACL depends on an argument. | Use a placeholder for a recipient the call names — a literal reader, `public`, or an `@group` — or a dynamic resolver for an argument-derived reader set. | Static readers can ignore the proposed argument; placeholder groups and dynamic resolution pin their answer to the call. |
-| **Unread resolver** | A `uses` entry whose results no field of the tool reads. | Remove the entry, or point a field at one of its results. | It does not load. A consult that changes nothing but blocks the tool on failure is a policy mistake, and it costs a request on every call. |
-| **Input sanitizer over a resolver** | A `tool_input` sanitizer whose `scope` tags cover a resolver-backed tool. | Tag the tool so no `tool_input` sanitizer covers it, unless that sanitizer's rewrite is one you accept under the resolver's earlier answer. | The rewrite dispatches under the answer given before it: a rewrite that changes a recipient, path, or resource carries the classification of the original one. A sanitizer declares no write set, so only `scope` controls this. |
+| **Unread resolver** | A `uses` entry whose results no field of the tool reads. | Remove the entry, or point a field at one of its results. | It does not load. An unread resolver costs an unnecessary consult on every call and blocks execution if it fails. |
+| **Input sanitizer over a resolver** | A `tool_input` sanitizer whose `scope` tags cover a resolver-backed tool. | Tag the tool so no `tool_input` sanitizer covers it, unless that sanitizer's rewrite is one you accept under the resolver's earlier answer. | The rewrite runs under the resolver answer given for the original call. If a rewrite changes arguments (such as a recipient or file path), it retains the classification of the original input. |
 | **Combined Read & Release** | Single tool `share_doc(doc, recipient)` fetching and releasing in one step. | Split into `fetch_doc` (read) and `grant_doc_access` (release). | Combined tools force authorities to approve releases before content is fetched. |
 | **Authority Mandates** | Overly permissive mandates like `can_cover_readers = { may_add = ["public"] }`. | Restrict authority `mandate` and `scope.tags` to the minimum necessary desk. | Authorities cannot exceed mandates, but overly broad mandates weaken review gates. |
-| **Auto-Approval Wiring** | `builtin = "approve"` behind a wide mandate — an automated yes across everything the mandate covers. | Keep auto-approval mandates narrow; reserve wide mandates for `hitl` or a reviewed resolver. | Mandate powers do not depend on the implementation behind them: the open gate is legitimate, deliberate, and visible in review. |
+| **Auto-Approval Wiring** | `builtin = "approve"` behind a wide mandate — an automated yes across everything the mandate covers. | Keep auto-approval mandates narrow; reserve wide mandates for `hitl` or a reviewed resolver. | `builtin = "approve"` creates an automated open gate for all matching actions. Keep its scope minimal. |
 | **Hint Accuracy** | A `hint` describing a power the mandate does not hold, or content the sanitizer does not remove. | Restate the declared mandate in your own words: say what the entity covers or strips, and nothing more. | A hint reaches the agent with every plan naming the entity, and grants nothing. A misleading one steers plan choice wrongly and misleads review. |
 
 ## Tools
@@ -274,14 +282,14 @@ attention = ["sre-signoff"]                            # Fresh per-call demand
 
 ### Key contract rules
 
-- **`delta` is strictly restrictive**: A tool's delta can only narrow the audience or lower trust. Within an annotated `delta`, an omitted dimension defaults to identity.
+- **`delta` is strictly restrictive**: A tool's delta can only narrow the audience or lower trust. Within an annotated `delta`, an omitted dimension defaults to identity (unchanged).
 - **Pending-cast deltas (`delta = { trust = "unknown" }`)**: Holds a label dimension pending resolution by a registered `[[cast]]` at admission. Declaring both `requires` and `unknown` delta on the same dimension is a load error.
-- **Dynamic argument placeholders (`$arg`)**: `requires.audience = { includes = ["$recipient"] }` evaluates `$recipient` against the actual call argument at runtime, as one audience expression: an ordinary string is one literal reader ID, `public` is the Public audience — only a Public trajectory includes it — and `@name` is a group the membership resolver expands, pinned to that proposed call. Placeholders are valid only inside `includes`, and `recipient` must be a required top-level string property of the tool's `parameters` — an omitted `parameters`, an optional, non-string, or nested property is a load error. A call that omits the argument or passes a non-string fails schema validation as an `InvalidCall` before the check runs.
-- **Dynamic resolvers (`uses`)**: Each entry names a registered resolver and maps every input that resolver declares from `$tool_call`. The tool's own fields then read results by name. A mapped `$tool_call.arguments.<name>` must be a required top-level property of the tool's `parameters`, at any type; a resolver that declares no inputs reads the complete call and needs no `parameters`, but does need a `description`.
-- **A field has one owner**: `delta.trust` holds a written value or one resolver result, never both — the TOML key takes one value, so the two cannot be spelled together. Write a value for a field no resolver reads: a concrete one (`delta = { trust = "trusted" }`), `delta = {}` to make the output neutral (pass-through), or omit `delta` to leave it `Unknown` (fail-closed — the safe default). Because each field takes one result, requirements do not combine across resolvers, and a tool uses at most five.
-- **History checks (`requires.effects`)**: `has` verifies `prior(k)` against appended effects; `has_no` verifies `no_prior(k)` against appended effects plus unsettled reservations — emits reserved at release and not yet observed to succeed or fail.
-- **Attention demands (`requires.attention`)**: Forces fresh authority sign-off on *every* call, never satisfied by execution history.
-- **Dual-gate contracts**: When a contract defines both a restrictive `delta` and a `requires` check (e.g., `search_and_share`), the engine evaluates both gates.
+- **Dynamic argument placeholders (`$arg`)**: `requires.audience = { includes = ["$recipient"] }` evaluates `$recipient` against the actual call argument at runtime. The argument value can be a literal reader ID, the reserved word `public`, or an `@group` expanded by the membership resolver. Placeholders are supported only inside `includes`. The argument must be declared as a required top-level string in the tool's `parameters` schema.
+- **Dynamic resolvers (`uses`)**: Attaches registered resolvers to classify proposed calls. Each entry maps required inputs from `$tool_call`. Mapped arguments must be required top-level properties in the tool schema. A resolver with no inputs reads the entire tool call and requires a tool `description`.
+- **Single field ownership**: Each contract field has one source: a static policy value or a resolver result. You cannot configure both on the same field. Because each field accepts at most one resolver result, a tool uses at most five resolver outputs.
+- **History checks (`requires.effects`)**: `has` verifies `prior(k)` against recorded effects in the log; `has_no` verifies `no_prior(k)` against recorded effects plus unsettled reservations (effects reserved at release that have not yet succeeded or failed).
+- **Attention demands (`requires.attention`)**: Forces fresh authority sign-off on *every* call; never satisfied by execution history.
+- **Dual-gate contracts**: When a contract defines both a restrictive `delta` and a `requires` check (e.g., `search_and_share`), OpenAPPA evaluates both gates before dispatch.
 
 ## Authorities
 
@@ -362,11 +370,11 @@ A mandate binds exactly one dimension. Trust is declared on the same terms, as a
 trust = { from = "suspicious", to = "trusted" } # Instead of `audience`, never alongside it
 ```
 
-A registered `tool_output` sanitizer is offered at each narrowing its mandate can strictly improve. The deployment must be able to withhold the raw result at that point. Executing the plan binds the sanitizer to the dispatch and accepts no raw or guessed residual. On success, the host withholds the raw result and the engine validates the derivation. A derivation that no longer narrows enters the trajectory. Otherwise it remains confined and opens a new stage. That stage offers acceptance of the exact current residual and any further applicable, helpful sanitizers. A sanitizer whose declared transition cannot help is never offered.
+When a tool result would narrow the trajectory label, OpenAPPA checks if a registered `tool_output` sanitizer can improve the label. If selected, the host withholds the raw result and runs the sanitizer. If the cleaned derivation prevents narrowing, it enters the trajectory label. If residual narrowing remains, the agent can accept the residual or apply another compatible sanitizer. A sanitizer whose declared transition cannot improve the label is never offered.
 
 Like a cast or an authority, a sanitizer may scope itself by tags: it applies only to values whose originating tool carries a covered tag. A child sub-execution return originates from no tool, so only unscoped sanitizers apply at that crossing.
 
-At `tool_input`, the sanitizer derives a replacement for the whole argument set of one call, and the harness dispatches exactly the substituted bytes. The substitution can clear an `includes` gap — the derivation's `to` stands in for the argument contribution — but never a `cap` or trust gap: a cap bounds the run's own reach, and rewriting the bytes does not rewrite the decision to call. The rewritten call keeps the resolver answers pinned to the proposal it replaces, and it keeps a membership answer only where the argument naming that group is unchanged.
+At `tool_input`, the sanitizer derives a replacement for the whole argument set of one call, and the harness dispatches exactly the substituted bytes. This substitution can satisfy an unmet `includes` audience requirement, but cannot clear a `cap` or trust requirement (a cap bounds the run's own reach, and rewriting arguments does not change the decision to invoke the tool). The rewritten call keeps the resolver answers pinned to the proposal it replaces, and preserves a group membership answer only if the argument naming that group is unchanged.
 
 To enforce automated return sanitization across all child sub-executions, policies can bind a default return sanitizer:
 
@@ -375,7 +383,10 @@ To enforce automated return sanitization across all child sub-executions, polici
 return_sanitizer = "pii-redactor"   # Forces all child sub-execution returns through pii-redactor
 ```
 
-The reserved builtin `attest-schema` covers the quarantine exit without touching bytes. It raises trust on a structured child return when three conditions hold: every returned field is shape-bounded (values the schema declares and bounds — ranged numbers, booleans, closed enums, bounded formats, arrays under a length bound; no free text), the structure was bound at fork before the child read anything, and the parent's fork-time rank covers the mandate's `to`. It claims instruction-cleanliness only — a sink that acts on the returned value keeps its own gates.
+The reserved builtin `attest-schema` validates structured sub-agent returns without altering data bytes. It safely raises trust from `suspicious` to `trusted` when:
+1. All returned fields are strictly shape-bounded (numbers, booleans, fixed enums, bounded formats; no free text).
+2. The schema structure was bound before the sub-agent read untrusted data.
+3. The parent agent had trusted status when spawning the sub-agent.
 
 ```toml
 [[sanitizer]]
@@ -387,7 +398,7 @@ hint = "Verifies the sub-agent returned valid structured data matching the schem
 trust = { from = "suspicious", to = "trusted" }
 ```
 
-Registering the reserved name is the whole wiring: the engine applies `attest-schema` itself, so the deployment binds no `[externals]` entry for it — an explicit binding, builtin or resolver, is a load error.
+Registering `name = "attest-schema"` is sufficient; OpenAPPA applies it natively without requiring an `[externals]` entry (configuring one is a load error).
 
 ## Casts
 
@@ -414,10 +425,10 @@ constant = { trust = "suspicious",
 url = "https://classify.corp/label"
 ```
 
-A resolver is the only implementation a cast takes: the answer is a label the `may_cast` ceiling has to bound, not a stock transform, so `builtin` is refused. A constant is answered from the policy, so it binds nothing and an `[externals]` entry for it is a load error.
+A dynamic cast requires a resolver bounded by a `may_cast` ceiling (`builtin` is not supported for casts). A constant cast is defined directly in policy, so it requires no `[externals]` binding.
 
-Applicable casts — matched by scope tags — evaluate in registration order until one answers. A resolver that cannot answer — unreachable, timed out, malformed — is skipped, which is what makes a trailing constant the deployment's declared fallback. Register constant casts last: a cast placed after a constant that covers it can never run, and the loader refuses it.
+When resolving an `Unknown` value, OpenAPPA evaluates applicable casts (matched by `scope.tags`) in registration order until one returns an answer. If a resolver is unreachable or fails, OpenAPPA moves to the next registered cast. Place fallback constant casts last, as any cast registered after an unscoped constant will never be reached.
 
-The engine validates every resolver response against its declared `may_cast` ceiling before admitting the value. An answer over the ceiling is refused outright and falls through to nothing: a classifier answering wider than its policy allows is misbehaving, not silent, and the result stays withheld. A `public` audience cap is an open gate: it lets a single resolver answer resolve a value to `public` and lift its audience restriction entirely — review it like any covering mandate.
+OpenAPPA validates all resolver answers against the declared `may_cast` ceiling before admitting the value. If a resolver returns a label outside this ceiling, the answer is rejected and the value remains `Unknown`. A `public` audience cap allows a resolver to lift audience restrictions entirely; review such ceilings carefully.
 
-A tool that declares its own pending dimension — `delta = { trust = "unknown" }` — is held rather than annotated late: the deployment lists it in `confined_results`, the runtime keeps the raw result from the model, and the cast reads it first. A restricting answer reaches the agent as a narrowing offer, and the bytes are delivered only if it accepts.
+A tool contract can also declare a pending dimension with `delta = { trust = "unknown" }`. When configured in `confined_results`, the runtime withholds raw results from the model until the cast evaluates the payload. If the resolved label restricts the trajectory, OpenAPPA presents a narrowing prompt to the agent before delivering the data.

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -42,17 +42,15 @@ A resolver is implemented either by an HTTP endpoint or by an in-process builtin
 
 ### A resolver's answer is pinned to the call it classified
 
-Every contract field has one owner. A field the policy writes and a field a resolver establishes are the same field, so the two never overlap and requirements do not combine across resolvers. A dimension no owner describes stays fail-closed `Unknown`. History requirements are always static.
+Each contract field has a single source of truth. A field written in policy and a field supplied by a dynamic resolver cannot overlap, and requirements do not combine across resolvers. An unannotated dimension remains fail-closed (`Unknown`). History requirements (`effects`) are always static.
 
-Resolution occurs when a proposed call first checks. The validated answer is pinned to the exact `args` its resolver received. The pin holds through rechecks, remedy plans, rulings, dispatch, and admission. The dispatch record keeps the answer, and a replay checks it against the same call again instead of asking the resolver. A new proposal resolves again. An answer given about an unrelated call is never evidence here.
+When a tool call is proposed, OpenAPPA evaluates attached resolvers immediately. The validated answer is pinned to the exact inputs the resolver received. This pinned answer stays with the call through requirement checks, remedy evaluation, human approval, dispatch, and execution logging. Replaying an execution log verifies the recorded answer against the same call arguments rather than re-querying the resolver. New tool proposals always consult resolvers freshly.
 
-An input-substitution remedy rewrites the arguments of a proposal through a registered sanitizer. The pins survive the rewrite and the resolver is not consulted again: the answer is about the proposal, and the proposal stays on the record for the rebuild to compare against. This holds for every read shape, including a use that reads the complete call, `$tool_call`, or `$tool_call.arguments`. So a resolver-backed tool is offered input-substitution remedies like any other.
+If an input-substitution sanitizer rewrites the arguments of a tool call, the original resolver classification remains pinned to the call. The resolver is not consulted again after the rewrite.
 
-A `tool_input` sanitizer therefore holds one power more than its declared transition names. Its rewrite keeps the classification a resolver gave about the arguments before the rewrite, even where the rewrite changes exactly what that resolver read. A rewrite that turns one recipient, path, or resource into another one dispatches under the answer given for the first.
+Because a `tool_input` sanitizer rewrites the entire argument payload without specifying which fields changed, the rewrite retains the classification assigned to the original proposal. For example, if a rewrite changes a file path or recipient, the dispatched call runs under the classification given to the original input. You can restrict which tools a sanitizer can modify using `scope.tags`.
 
-A `tool_input` sanitizer replaces the whole argument object, and it declares no list of the arguments it writes. So the policy cannot state that a rewrite leaves one resolver input alone, and it has one control here: `scope`. Give a resolver-backed tool a tag no `tool_input` sanitizer covers, unless you accept that sanitizer's rewrite standing under the resolver's earlier answer. Scope permits the hop; it does not produce one. The engine offers it only where the call blocks on an `includes` gap the sanitizer's declared transition clears.
-
-A resolver that produces no answer — an unbound or unreachable implementation, a timeout, a process failure, a malformed, out-of-policy, unsupported-version, or oversized response — resumes nothing: the call was not checked, no engine fact is appended, and the answer is not a policy denial. The check fails operationally and the reason lands in the runtime's own log; the next proposal consults again.
+If a resolver fails to return a valid answer (e.g. timeout, network failure, or invalid response format), OpenAPPA halts execution with an operational error. It does not record a policy denial, and the tool does not execute.
 
 ## Labels only move one way
 
@@ -60,11 +58,11 @@ A tool contract declares a `delta` to define how fetching its result restricts t
 
 Because permissions only tighten over time, data cannot be laundered by passing it through intermediate steps or LLM calls. Reading internal system records permanently marks the execution context as internal, and ingesting unvetted web content permanently drops its trust level.
 
-Restricting permissions doesn't mean blocking external work: a component named `authority` can approve a specific outbound call without changing the overall label, or the agent can spin off a child execution to isolate sensitive reads from its main workflow.
+Restricting permissions doesn't mean blocking external work: an `authority` can approve a specific outbound call without changing the overall label, or the agent can spin off a child execution to isolate sensitive reads from its main workflow.
 
 :::fig-label-fold:::
 
-The current label is calculated directly as a functional fold over the labels of all previously admitted values — a tool result's declared restriction, or a sanitizer derivation's cleaner label when one was admitted in its place — eliminating the need to replay trajectory history:
+The current label is computed directly from all values admitted so far—combining tool result restrictions and sanitized derivations—eliminating the need to re-evaluate full trajectory history:
 
 ```ts
 label = admittedLabels.reduce(narrow, startingLabel)   // narrow only ever restricts
@@ -129,7 +127,7 @@ url = "https://pii.corp/redact"
 builtin = "hitl"                           # ask a person
 ```
 
-The trajectory begins at the deployment's starting label — `{public, trusted}` unless the `[deployment]` table declares otherwise — recorded once on the opening record; user input and other principal context admit nothing to the fold. When the agent calls `get_ticket_from_crm()`, OpenAPPA intercepts the dispatch before execution. The engine offers three operational paths, and the block names all of them:
+The trajectory begins at the deployment's starting label — `{public, trusted}` unless the `[deployment]` table declares otherwise — recorded once on the opening record; user prompts and other initial context introduce no additional label restrictions. When the agent calls `get_ticket_from_crm()`, OpenAPPA intercepts the dispatch before execution. The engine offers three operational paths, and the block names all of them:
 
 | Execution Path | Trajectory Label Impact | Downstream Dispatch Impact |
 |---|---|---|
@@ -145,7 +143,7 @@ If emailing raw CRM data to an external auditor is required, the agent accepts t
 
 ## Engine refusals enumerate every valid remedy
 
-When OpenAPPA refuses a flow, it doesn't leave the agent stranded. An empty remedy list proves that the call is unreachable within the planner's modeled transitions under the active policy configuration and log. When candidate paths exist, OpenAPPA returns a structured object enumerating every valid alternative available from the registered components and deployment capabilities: requesting a policy approval, cleaning data with a sanitizer, executing a prerequisite tool call, or accepting a narrowing prompt.
+When OpenAPPA refuses an action, it does not leave the agent stranded. If no remedy plans exist, the action is fundamentally unreachable under the current policy. When valid alternatives exist, OpenAPPA returns a structured refusal listing every available remedy: requesting authority approval, scrubbing data with a sanitizer, running a prerequisite tool, or accepting a narrowing prompt.
 
 :::fig-remedy-plan:::
 
@@ -159,13 +157,13 @@ Because every remedy except narrowing acceptance derives from a registered compo
   remedy_plans: [...] }     // valid remedy plans executable by id or tool call
 ```
 
-A non-empty remedy list indicates that candidate paths exist, though external components may still decline a requested ruling. When an authority denies a request, that denial is appended to the log. The refusal proof remains scoped to the current configuration, active component responses, and recorded denials for that specific call.
+A non-empty remedy list indicates that candidate paths exist, though external components may still decline a requested ruling. When an authority denies a request, that denial is appended to the log to prevent repeating the request for that specific call.
 
 ## Unknown labels propagate until a requirement checks them
 
-Real-world deployments can be difficult to annotate in a single pass. Similar to gradual typing in Python or TypeScript codebases, OpenAPPA supports partial annotation—delivering immediate value from day one. 
+Real-world systems rarely annotate every tool up front. Similar to gradual typing in TypeScript or Python, OpenAPPA supports partial annotation.
 
-Unannotated tools return data with an **Unknown** label state, representing unverified classification rather than a specific trust rank. Unknown labels propagate through trajectory operations, causing any trajectory that ingests an unknown value to become Unknown. Unregistered tool calls are refused directly rather than returning Unknown values.
+Unannotated tools return data with an **Unknown** label state, representing unverified classification rather than a specific trust rank. Unknown labels propagate through operations: if an execution ingests an unknown value, its label becomes Unknown. Unregistered tool calls are refused directly before execution.
 
 | Execution Context | Impact of Unknown State |
 |---|---|
@@ -174,37 +172,34 @@ Unannotated tools return data with an **Unknown** label state, representing unve
 | **Requirement Check (`requires`)** | Drives the cast registered for the value, then checks the label it established; fails closed when no cast answers. |
 | **Child Merge Boundary** | Unknown child returns merge like any read: unresolved identities cross while every known restriction holds. Registered casts resolve them where the return policy consumes the dimension. |
 
-An Unknown label state does not halt execution until a tool contract's `requires` clause explicitly checks the value. At that point the engine drives the **cast** registered for the value — a component that assigns its complete label from a fixed declaration or an external classifier — and decides on the answer it establishes. A value no registered cast reaches stays Unknown, and the call that needed it is refused. This design allows deployments to start with a few high-risk tool annotations and incrementally expand policy coverage over time.
+An Unknown label state does not halt execution until a tool contract's `requires` clause explicitly checks the value. At that point, OpenAPPA triggers the registered **cast** for that value—resolving the label using a fixed rule or an external classifier—and validates the result against the cast's declared ceiling. If no cast is configured or reachable, the value remains Unknown and the dependent call is refused. This allows teams to annotate high-risk tools first and expand policy coverage incrementally.
 
-A deployment that would rather inspect the data before the model sees it declares the pending dimension on the tool itself, with `delta = { trust = "unknown" }`. The tool runs, the runtime holds its raw result back, and the cast reads the bytes the model has not: a non-restricting label releases the result, and a restricting one is offered to the agent as a narrowing to accept.
+To inspect data before the LLM sees it, a tool contract can declare a pending dimension with `delta = { trust = "unknown" }`. When configured in `confined_results`, the runtime withholds the raw result while the cast evaluates the payload. If the cast resolves to a non-restricting label, the data is delivered directly; if it restricts the label, OpenAPPA offers the agent a narrowing choice before delivery.
 
 ## Deploy at the gateway alone, or add components for full coverage
 
-OpenAPPA's baseline host is an inference gateway: point every agent's model base URL at it and have the client carry one trajectory token — the only client-side changes. The engine checks each proposed tool call while it still holds the model's response, so a refused call never reaches the agent framework. The token ties each request to its conversation: the gateway mints one when a request starts a new trajectory, returns it in the response, and the client echoes it on every continuation. In this setup, input sanitizers work in full — the framework never sees pre-substitution arguments. Output sanitizers and pending casts keep raw results away from the model. Sub-agent spawning is governed by an ordinary contract on the spawn tool.
+OpenAPPA's baseline deployment is an inference gateway: configure your agent framework to route model requests through the gateway and pass a trajectory token on each request. The gateway intercepts tool calls before returning the model's response to the agent, preventing refused calls from ever executing.
 
-The pure gateway leaves some vectors open, and OpenAPPA's posture is to allow and declare rather than remove: tool execution is assumed faithful rather than enforced, raw results still exist on the framework's side, and sub-agent branching stays off. The deployment declaration names each open vector explicitly and auditably, so a technology leader can review exactly what remains. A policy construct that names a feature the deployment does not cover is refused at load with the missing coverage named, never degraded silently.
+The gateway mints a trajectory token at the start of a conversation, returns it in the response, and tracks accumulated labels across turns. In this mode, input sanitizers rewrite tool arguments transparently, while output sanitizers and pending casts withhold raw data from the model.
 
-Each optional component closes a named vector:
+A standalone gateway provides immediate protection, while optional deployment components can close remaining exposure vectors:
 
-| Feature | What it is and why | How it can be implemented |
+| Feature | Purpose | Implementation Options |
 |---|---|---|
-| **Session identity** | Bind each request to its trajectory; labels accumulate per trajectory, so a wrong bind forgets restrictions | A harness hook that names the session on every event, or a gateway-minted trajectory token echoed by the framework |
-| **Execution enforcement** | The executed call is the approved call, exactly once | A tool gateway that matches each call to a one-use grant (remote tools); pre-tool hooks (local tools); neither — execution stays assumed and is a declared open vector |
-| **Raw withholding** | Output sanitizing and pending casts: the model — or nobody — sees the raw result | Gateway swap on the next request (the model never sees it; the framework's machine does); tool-gateway rewrite (the raw never reaches the framework); a post-tool hook replaces it before storage, though the framework process briefly held it |
-| **Branching** | Children inherit the parent's restrictions and return only through a checked, sanitizable `submit_result` | Harness hooks plus an agent adapter; sub-agent traffic routed and registered through the gateway; neither — spawning is treated as egress and governed by contract |
-| **Provider-run tools** | Tools the model provider executes inside the inference call — no pre-dispatch gate is possible | List them in the declaration: each result the response exposes is admitted like a tool result under the tool's declared label, and their outbound queries are a declared open vector. A surface whose results the response hides cannot be mediated — it is refused or declared open. Any surface the declaration does not list is stripped from the request or the request is refused — either way the vector is closed |
+| **Session identity** | Binds requests to an execution trajectory so accumulated labels are tracked accurately | Harness hook identifying the session, or a gateway-minted trajectory token |
+| **Execution enforcement** | Ensures only approved tool calls execute, exactly once | Tool proxy validating one-time execution tokens (remote tools), or pre-tool execution hooks (local tools) |
+| **Raw withholding** | Prevents the model from seeing unsanitized outputs or unclassified data | Gateway payload replacement on the next request, tool proxy rewrites, or post-tool hooks |
+| **Branching** | Isolates sub-agent reads and controls returns via `submit_result` | Harness lifecycle hooks with an agent adapter, or gateway-routed sub-agent traffic |
+| **Provider-run tools** | Mediates tools executed directly inside provider inference calls | Declare tools in policy: exposed results are labeled upon admission, and outbound provider queries are audited as declared open vectors |
 
 ## Model guarantees depend on five explicit assumptions
 
-OpenAPPA guarantees hold strictly within defined system boundaries. The engine assumes a benign but confusable agent, untampered logs, valid component definitions, a well-behaved harness where execution is not enforced, and that untrusted input arrives via ingested data. These five explicit assumptions bound the scope of automated policy enforcement:
-
-| Assumption | Scope Boundary |
-|---|---|
-| **Benign but confusable agent** | Covert channels and intentional secret smuggling by the model are out of scope. |
-| **Attacks arrive via ingested data** | Pre-trusted sources are trusted by definition; compromised trusted data is not caught. |
-| **Registered components are correct** | Misconfigured authorities or permissive casts void their respective guarantees. |
-| **Log is durable and strictly ordered** | Trajectory verification depends on total ordering and persistence of log entries. |
-| **The harness executes faithfully where unenforced** | For tools without a tool gateway or hook, the framework is assumed to run approved calls unchanged, once, and to echo conversations honestly. A visible break is refused, with an operator alert recommended — not defended against. |
+OpenAPPA's guarantees hold within defined system boundaries:
+1. **Benign but confusable agent**: Protection focuses on preventing unintended data leaks and prompt injection exploits; intentional covert channel exfiltration by the model itself is out of scope.
+2. **Attacks arrive via ingested data**: Pre-vetted trusted sources are trusted by configuration; compromised internal data is not caught.
+3. **Registered components are correct**: Mandates and ceilings bound component power, but misconfigured endpoints void their specific guarantees.
+4. **Log is durable and strictly ordered**: Security tracking relies on a persistent, append-only log.
+5. **The harness executes faithfully where unenforced**: When tool proxies or hooks are not configured, the agent framework is expected to run approved calls as returned.
 
 In short: declarative tool contracts set automatic bounds, while registered components — services or builtins — handle dynamic cases like human approvals or content scanners. As long as the execution log is persisted, OpenAPPA ensures every decision remains provable and auditable under your team's security mandates.
 
@@ -224,7 +219,7 @@ Deployments migrate existing security controls into OpenAPPA by registering them
 
 Registering security controls as OpenAPPA components prevents prompt injections from bypassing policy. Because the engine evaluates structured tool dispatches at the boundary rather than model output text, a compromised model cannot talk its way past policy rules.
 
-Crucially, authorities, sanitizers, and casts are capped by registered mandates and ceilings: even if an ML classifier or third-party scanner makes a mistake, it cannot grant permissions beyond its pre-configured limit. Resolvers carry no mandate. A membership resolver's answers are trusted directory input, and a tool-level dynamic resolver's answers are trusted classifier input over attacker-influenced arguments — the engine validates both for shape and policy vocabulary only (literal reader IDs, declared trust ranks, attended attention marks), never against a ceiling. Register a resolver only for a service you trust as part of the deployment itself. Furthermore, declaring tool bounds in contracts removes scattered guardrail scripts and imperative `if` checks from your application code.
+Crucially, authorities, sanitizers, and casts are capped by registered mandates and ceilings: even if an ML classifier or third-party scanner makes a mistake, it cannot grant permissions beyond its pre-configured limit. Resolvers carry no mandate: a membership resolver supplies trusted directory data, and a dynamic resolver supplies trusted classification over call arguments. OpenAPPA validates resolver answers for valid schema and policy vocabulary (literal reader IDs, declared trust ranks, attended attention marks). Register resolvers only for services you trust as part of your deployment. Declaring tool bounds in contracts replaces scattered guardrail scripts and manual `if` checks across your codebase.
 
 ## Operational impact: How OpenAPPA simplifies security
 


### PR DESCRIPTION
## Summary
- Clarifies and simplifies user-facing documentation in `contracts.md` and `how-it-works.md`.
- Removes internal compiler jargon and dense academic phrasing in favor of direct, plain technical English.
- Refines explanations for dynamic resolvers, lifecycle pinning, groups, sanitizers, and casts while preserving technical precision and full agreement with golden files.