### PR TITLE
feat: an audience that names a whole reader set is the list itself

### DIFF
--- a/appa-example-agent/tests/loop_e2e.rs
+++ b/appa-example-agent/tests/loop_e2e.rs
@@ -109,7 +109,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["staff"] } }
+delta = { audience = ["staff"] }
 
 [[policy.tool]]
 name = "send_email"
@@ -151,7 +151,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["staff"] } }
+delta = { audience = ["staff"] }
 
 [[policy.tool]]
 name = "send_email"
@@ -219,7 +219,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [policy.boundary]
 audience = { exactly = ["public"] }
@@ -403,7 +403,7 @@ parameters = { type = "object", properties = { task = { type = "string" } } }
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [policy.deployment]
 context_control = true
@@ -522,7 +522,7 @@ parameters = { type = "object", properties = { task = { type = "string" } } }
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["internal"] } }
+delta = { audience = ["internal"] }
 
 [[policy.sanitizer]]
 name = "scrub"
@@ -580,7 +580,7 @@ parameters = { type = "object", properties = { task = { type = "string" } } }
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["internal"] } }
+delta = { audience = ["internal"] }
 
 [policy.deployment]
 context_control = true
@@ -684,7 +684,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["staff"] } }
+delta = { audience = ["staff"] }
 
 [[policy.tool]]
 name = "send_email"
@@ -697,7 +697,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["staff"] } }
+delta = { audience = ["staff"] }
 
 [[policy.tool]]
 name = "send_email"
@@ -766,7 +766,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["staff"] } }
+delta = { audience = ["staff"] }
 
 [[policy.tool]]
 name = "send"

--- a/appa-example-agent/tests/loop_e2e.rs
+++ b/appa-example-agent/tests/loop_e2e.rs
@@ -222,7 +222,7 @@ name = "read_hr"
 delta = { audience = ["hr"] }
 
 [policy.boundary]
-audience = { exactly = ["public"] }
+audience = ["public"]
 "#;
     let host = ToolHost::default();
     host.answers("read_hr", "Alice Chen, SSN 4821-9930");

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -121,12 +121,6 @@ pub enum ConfigError {
     BadAttention { context: String, found: String },
     #[error("[limits] planner_cap is 0: a tool's worst case is at least one plan, so a zero cap refuses every tool")]
     ZeroPlannerCap,
-    #[error("[deployment] {field}: expected one of {expected}, found {found:?}")]
-    BadDeploymentToken {
-        field: &'static str,
-        expected: &'static str,
-        found: String,
-    },
     #[error("[deployment] names tool {tool} in both assumed_tools and provider_run_tools")]
     ConflictingExecutorException { tool: String },
     #[error("registry rejected: {0}")]
@@ -407,14 +401,26 @@ struct RawDeployment {
 #[serde(deny_unknown_fields)]
 struct RawStartingLabel {
     trust: Option<String>,
-    audience: Option<RawStartingAudience>,
+    audience: Option<RawWholeAudience>,
 }
 
+/// A field that names a whole reader set instead of bounding one: the list itself, or a bare
+/// string as its one-entry spelling. It carries no operator, because it leaves nothing for an
+/// operator to choose between.
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum RawStartingAudience {
-    Token(String),
-    Exactly(RawExactly),
+enum RawWholeAudience {
+    Reader(String),
+    Readers(Vec<String>),
+}
+
+impl RawWholeAudience {
+    fn list(&self) -> &[String] {
+        match self {
+            RawWholeAudience::Reader(reader) => std::slice::from_ref(reader),
+            RawWholeAudience::Readers(readers) => readers,
+        }
+    }
 }
 
 impl RawDeployment {
@@ -431,17 +437,7 @@ impl RawDeployment {
                 };
                 let audience = match label.audience {
                     None => Audience::Public,
-                    Some(RawStartingAudience::Token(token)) if token == "public" => Audience::Public,
-                    Some(RawStartingAudience::Token(token)) => {
-                        return Err(ConfigError::BadDeploymentToken {
-                            field: "starting_label audience",
-                            expected: r#""public" or { exactly = [...] }"#,
-                            found: token,
-                        });
-                    }
-                    Some(RawStartingAudience::Exactly(a)) => {
-                        parse_audience(&a.exactly, "deployment starting_label audience")?
-                    }
+                    Some(written) => parse_audience(written.list(), "deployment starting_label audience")?,
                 };
                 Label::new(Dim::Known(trust), Dim::Known(audience))
             }
@@ -522,7 +518,7 @@ struct RawChild {
 #[serde(deny_unknown_fields)]
 struct RawBoundary {
     trust: Option<String>,
-    audience: Option<RawExactly>,
+    audience: Option<RawWholeAudience>,
 }
 
 impl RawBoundary {
@@ -532,7 +528,7 @@ impl RawBoundary {
             None => top_trust(chain),
         };
         let audience = match self.audience {
-            Some(a) => parse_audience(&a.exactly, "boundary audience")?,
+            Some(written) => parse_audience(written.list(), "boundary audience")?,
             None => Audience::Public,
         };
         Ok(Label::new(Dim::Known(trust), Dim::Known(audience)))
@@ -786,13 +782,13 @@ impl RawDelta {
                         references.record(ResolverReturn::Audience, reference?);
                         None
                     }
-                    None => Some(AudienceDelta::Static(parse_delta_audience(
+                    None => Some(AudienceDelta::Static(parse_whole_audience(
                         std::slice::from_ref(&token),
                         &context,
                     )?)),
                 }
             }
-            Some(RawDeltaAudience::Readers(readers)) => Some(AudienceDelta::Static(parse_delta_audience(
+            Some(RawDeltaAudience::Readers(readers)) => Some(AudienceDelta::Static(parse_whole_audience(
                 &readers,
                 &format!("{ctx} delta audience"),
             )?)),
@@ -1220,8 +1216,10 @@ fn parse_trust(name: &str, chain: &TrustChain, context: &str) -> Result<Trust, C
     })
 }
 
+/// A whole reader set the algebra holds directly — the `[boundary]` label and the deployment's
+/// `starting_label`. A label names literal readers only, so a group mention is refused here.
 fn parse_audience(list: &[String], context: &str) -> Result<Audience, ConfigError> {
-    match parse_declared_audience(list, context)? {
+    match parse_whole_audience(list, context)? {
         DeclaredAudience::Public => Ok(Audience::Public),
         DeclaredAudience::Restricted { readers, groups } => match groups.into_iter().next() {
             None => Ok(Audience::Restricted(readers)),
@@ -1235,10 +1233,11 @@ fn parse_audience(list: &[String], context: &str) -> Result<Audience, ConfigErro
     }
 }
 
-/// The reader set a `delta.audience` declares. The empty list is legal here and nowhere else: a
-/// delta states what the result carries, and a result no reader may hold is a set with no members.
-/// Every other reader set bounds or extends an existing one, where an empty list says nothing.
-fn parse_delta_audience(list: &[String], context: &str) -> Result<DeclaredAudience, ConfigError> {
+/// The reader set a field that names a whole set declares: a `delta`, the `[boundary]` label, the
+/// deployment's `starting_label`. The empty list is legal here and nowhere else. A field that
+/// names the whole set can name one with no members; every other reader set bounds or extends a
+/// set that already exists, where an empty list says nothing.
+fn parse_whole_audience(list: &[String], context: &str) -> Result<DeclaredAudience, ConfigError> {
     if list.is_empty() {
         return Ok(DeclaredAudience::restricted(Vec::new()));
     }
@@ -1928,13 +1927,6 @@ delta = { trust = "resolver.one.trust", audience = "resolver.two.audience" }
             ));
         }
         assert!(matches!(
-            Config::from_toml_str(&with("starting_label = { audience = \"everyone\" }")),
-            Err(ConfigError::BadDeploymentToken {
-                field: "starting_label audience",
-                ..
-            })
-        ));
-        assert!(matches!(
             Config::from_toml_str(&with("assumed_tools = [\"t\"]\nprovider_run_tools = [\"t\"]")),
             Err(ConfigError::ConflictingExecutorException { tool }) if tool == "t"
         ));
@@ -2039,6 +2031,66 @@ delta = { trust = "resolver.one.trust", audience = "resolver.two.audience" }
         );
     }
 
+    /// The `[boundary]` label and the deployment's `starting_label` name a whole reader set the
+    /// same way a delta does, so each is written as the list itself. A label holds literal readers
+    /// only, so a group mention is still refused at both.
+    #[test]
+    fn a_label_audience_is_the_reader_list_itself() {
+        let base = "version = 1\n[[tool]]\nname = \"t\"\ndelta = {}\n";
+        let boundary = |written: &str| format!("{base}[boundary]\naudience = {written}\n");
+        let starting = |written: &str| format!("{base}[deployment]\nstarting_label = {{ audience = {written} }}\n");
+        let boundary_audience = |written: &str| {
+            Config::from_toml_str(&boundary(written))
+                .expect("the boundary label loads")
+                .boundary_label()
+                .audience
+                .clone()
+        };
+        let starting_audience = |written: &str| {
+            Config::from_toml_str(&starting(written))
+                .expect("the starting label loads")
+                .engine()
+                .profile()
+                .starting_label()
+                .audience
+                .clone()
+        };
+        for audience in [&boundary_audience as &dyn Fn(&str) -> Dim<Audience>, &starting_audience] {
+            assert_eq!(
+                audience(r#"["alice", "bob"]"#),
+                Dim::Known(Audience::restricted([ReaderId::new("alice"), ReaderId::new("bob")]))
+            );
+            assert_eq!(
+                audience(r#""alice""#),
+                Dim::Known(Audience::restricted([ReaderId::new("alice")])),
+                "a bare string is the one-entry list"
+            );
+            assert_eq!(audience(r#""public""#), Dim::Known(Audience::Public));
+            assert_eq!(audience(r#"["public"]"#), Dim::Known(Audience::Public));
+            assert_eq!(
+                audience("[]"),
+                Dim::Known(Audience::restricted(Vec::new())),
+                "the empty list is a label no reader holds"
+            );
+        }
+        for site in [&boundary as &dyn Fn(&str) -> String, &starting] {
+            assert!(
+                matches!(
+                    Config::from_toml_str(&site(r#""@team""#)),
+                    Err(ConfigError::BadAudience { .. })
+                ),
+                "a label names literal readers only"
+            );
+            assert!(
+                matches!(
+                    Config::from_toml_str(&site(r#"{ exactly = ["alice"] }"#)),
+                    Err(ConfigError::Parse(_))
+                ),
+                "a label names the whole set and takes no operator"
+            );
+        }
+    }
+
     #[test]
     fn a_group_written_in_a_declaration_registers_and_labels_refuse_it() {
         let policy = r#"
@@ -2127,8 +2179,8 @@ confined_results = ["read", "send"]
 
         let base = "version = 1\n[membership]\nname = \"directory\"\n[[tool]]\nname = \"t\"\ndelta = {}\n";
         for site in [
-            "[deployment]\nstarting_label = { audience = { exactly = [\"@team\"] } }\n",
-            "[boundary]\naudience = { exactly = [\"@team\"] }\n",
+            "[deployment]\nstarting_label = { audience = [\"@team\"] }\n",
+            "[boundary]\naudience = [\"@team\"]\n",
         ] {
             assert!(
                 matches!(

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -750,11 +750,16 @@ struct RawDelta {
     audience: Option<RawDeltaAudience>,
 }
 
+/// `delta.audience` is one field with one owner: the reader set the tool's result carries, the
+/// pending-cast token, or one resolver result. A delta names the whole set, so it takes the list
+/// itself and no operator. A bare string is the one-entry spelling of that list — `"@internal"`
+/// and `["@internal"]` declare the same set — which leaves `"unknown"` and a `resolver.` path
+/// free to keep their own meanings.
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum RawDeltaAudience {
     Token(String),
-    Exactly(RawExactly),
+    Readers(Vec<String>),
 }
 
 const UNKNOWN_TOKEN: &str = "unknown";
@@ -781,18 +786,14 @@ impl RawDelta {
                         references.record(ResolverReturn::Audience, reference?);
                         None
                     }
-                    None => {
-                        return Err(ConfigError::BadAudience {
-                            context,
-                            reason: format!(
-                                "expected {{ exactly = [...] }}, \"unknown\", or a resolver result, found {token:?}"
-                            ),
-                        });
-                    }
+                    None => Some(AudienceDelta::Static(parse_delta_audience(
+                        std::slice::from_ref(&token),
+                        &context,
+                    )?)),
                 }
             }
-            Some(RawDeltaAudience::Exactly(a)) => Some(AudienceDelta::Static(parse_declared_audience(
-                &a.exactly,
+            Some(RawDeltaAudience::Readers(readers)) => Some(AudienceDelta::Static(parse_delta_audience(
+                &readers,
                 &format!("{ctx} delta audience"),
             )?)),
             None => None,
@@ -1232,6 +1233,16 @@ fn parse_audience(list: &[String], context: &str) -> Result<Audience, ConfigErro
             }),
         },
     }
+}
+
+/// The reader set a `delta.audience` declares. The empty list is legal here and nowhere else: a
+/// delta states what the result carries, and a result no reader may hold is a set with no members.
+/// Every other reader set bounds or extends an existing one, where an empty list says nothing.
+fn parse_delta_audience(list: &[String], context: &str) -> Result<DeclaredAudience, ConfigError> {
+    if list.is_empty() {
+        return Ok(DeclaredAudience::restricted(Vec::new()));
+    }
+    parse_declared_audience(list, context)
 }
 
 fn parse_declared_audience(list: &[String], context: &str) -> Result<DeclaredAudience, ConfigError> {
@@ -1969,6 +1980,65 @@ delta = { trust = "resolver.one.trust", audience = "resolver.two.audience" }
         );
     }
 
+    /// A `delta.audience` names the whole reader set, so it is written as the list itself. A bare
+    /// string is the one-entry spelling of that list, which leaves `"unknown"` and a `resolver.`
+    /// path free to keep their own meanings.
+    #[test]
+    fn a_delta_audience_is_the_reader_list_itself() {
+        let policy = |audience: &str| {
+            format!(
+                "version = 1\n[membership]\nname = \"directory\"\n\
+                 [[tool]]\nname = \"t\"\ndelta = {{ audience = {audience} }}\n\
+                 [deployment]\ndispatch = \"enforced\"\nconfined_results = [\"t\"]\n"
+            )
+        };
+        let declared = |audience: &str| {
+            Config::from_toml_str(&policy(audience))
+                .expect("the delta loads")
+                .registry()
+                .tool(&ToolName::new("t"))
+                .expect("t registers")
+                .delta
+                .clone()
+                .expect("t is annotated")
+                .audience
+                .expect("the delta declares an audience")
+        };
+        let readers = |audience: &str| match declared(audience) {
+            AudienceDelta::Static(readers) => readers,
+            AudienceDelta::PendingCast => panic!("{audience} is a written reader set"),
+        };
+        assert_eq!(
+            readers(r#"["alice", "bob"]"#),
+            DeclaredAudience::restricted([ReaderId::new("alice"), ReaderId::new("bob")])
+        );
+        assert_eq!(
+            readers(r#""@internal""#),
+            DeclaredAudience::declared([], [GroupName::new("internal")]).unwrap(),
+            "a bare string is the one-entry list"
+        );
+        assert_eq!(readers(r#""public""#), DeclaredAudience::Public);
+        assert_eq!(readers(r#"["public"]"#), DeclaredAudience::Public);
+        assert_eq!(
+            readers("[]"),
+            DeclaredAudience::restricted(Vec::new()),
+            "the empty list declares a result no reader holds"
+        );
+        assert_eq!(declared(r#""unknown""#), AudienceDelta::PendingCast);
+        assert_eq!(
+            readers(r#"["unknown", "resolver.r.audience"]"#),
+            DeclaredAudience::restricted([ReaderId::new("unknown"), ReaderId::new("resolver.r.audience")]),
+            "a reserved bare string is an ordinary reader inside a list"
+        );
+        assert!(
+            matches!(
+                Config::from_toml_str(&policy(r#"{ exactly = ["alice"] }"#)),
+                Err(ConfigError::Parse(_))
+            ),
+            "a delta names the whole set and takes no operator"
+        );
+    }
+
     #[test]
     fn a_group_written_in_a_declaration_registers_and_labels_refuse_it() {
         let policy = r#"
@@ -1979,7 +2049,7 @@ name = "directory"
 
 [[tool]]
 name = "read"
-delta = { audience = { exactly = ["auditor", "@team"] } }
+delta = { audience = ["auditor", "@team"] }
 
 [[tool]]
 name = "send"

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -1766,7 +1766,7 @@ name = "directory"
 
 [[policy.tool]]
 name = "read"
-delta = { audience = { exactly = ["@team"] } }
+delta = { audience = ["@team"] }
 "#;
         let text = format!(
             "[policy]\n{policy}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.membership]\nurl = \"{directory}\"\n"
@@ -2294,7 +2294,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "send"
@@ -2314,7 +2314,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "send"
@@ -2339,7 +2339,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "send"
@@ -3002,7 +3002,7 @@ version = 1
 [[policy.tool]]
 name = "leak"
 parameters = { type = "object", properties = { q = { type = "string" } } }
-delta = { audience = { exactly = ["internal"] } }
+delta = { audience = ["internal"] }
 
 [[policy.sanitizer]]
 name = "scrub"
@@ -3028,7 +3028,7 @@ version = 1
 name = "leak"
 parameters = { type = "object", properties = { q = { type = "string" } } }
 effects = ["leak"]
-delta = { audience = { exactly = ["internal"] } }
+delta = { audience = ["internal"] }
 
 [[policy.sanitizer]]
 name = "scrub"
@@ -3112,7 +3112,7 @@ version = 1
 [[policy.tool]]
 name = "leak"
 parameters = { type = "object", properties = { q = { type = "string" } } }
-delta = { audience = { exactly = ["internal"] }, trust = "suspicious" }
+delta = { audience = ["internal"], trust = "suspicious" }
 
 [[policy.sanitizer]]
 name = "scrub"

--- a/appa-runtime/tests/audit_read.rs
+++ b/appa-runtime/tests/audit_read.rs
@@ -22,7 +22,7 @@ delta = {}
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "delegate"

--- a/appa-runtime/tests/input_substitution.rs
+++ b/appa-runtime/tests/input_substitution.rs
@@ -13,7 +13,7 @@ version = 1
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "send"

--- a/appa-runtime/tests/membership.rs
+++ b/appa-runtime/tests/membership.rs
@@ -19,7 +19,7 @@ name = "directory"
 
 [[policy.tool]]
 name = "read_hr"
-delta = { audience = { exactly = ["alice", "bob"] } }
+delta = { audience = ["alice", "bob"] }
 
 [[policy.tool]]
 name = "send"

--- a/bench/corp-agent-fides/README.md
+++ b/bench/corp-agent-fides/README.md
@@ -50,9 +50,9 @@ demo's labels are the same design expressed in two vocabularies:
 | Concept | OpenAPPA (`bench/corp/policies/appa.toml`) | FIDES (this demo) |
 |---|---|---|
 | Taint axis | `trust`: `suspicious` → `internal` | `integrity`: `untrusted` → `trusted` |
-| Audience axis | `audience = { exactly = ["hr"] }` | `confidentiality`: `private` |
+| Audience axis | `audience = ["hr"]` | `confidentiality`: `private` |
 | Forum read | `delta = { trust = "suspicious" }` | result label `integrity=untrusted` |
-| HR read | `delta = { audience = exactly ["hr"] }` | result label `confidentiality=private` |
+| HR read | `delta = { audience = ["hr"] }` | result label `confidentiality=private` |
 | Finance read | restricted reader set | `integrity=trusted, confidentiality=private` |
 | Task/vendor read | `delta = {}` (unconstrained) | `integrity=trusted, confidentiality=public` |
 | The taint fold | monoid fold over the trajectory | `combine_labels` (untrusted & most-private win) |

--- a/bench/corp-agent-fides/corp_fides/tools.py
+++ b/bench/corp-agent-fides/corp_fides/tools.py
@@ -78,7 +78,7 @@ resolves ``$to`` to the literal address at dispatch. A ceiling ranks
 sensitivity; a reader set answers "released to whom".
 
 The **hr** row still transcribes exactly, because its audience is one symbolic
-token: ``exactly = ["hr"]`` admits no address, so ``includes($to)`` degenerates
+token: ``audience = ["hr"]`` admits no address, so ``includes($to)`` degenerates
 there into "is this trajectory still ``Public``?" — which is precisely
 ``max_allowed_confidentiality=public``. Private-or-not is the whole question,
 and a ceiling can ask it.

--- a/bench/corp-agent/src/catalogue.rs
+++ b/bench/corp-agent/src/catalogue.rs
@@ -155,7 +155,7 @@ trust_chain = ["suspicious", "internal"]
 [[tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string" } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[tool]]
 name = "fork"

--- a/bench/corp/policies/appa.toml
+++ b/bench/corp/policies/appa.toml
@@ -64,12 +64,12 @@ delta = {}
 [[policy.tool]]
 name = "search_hr"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read, e.g. `alice-chen.md`." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "create_hr"
@@ -97,12 +97,12 @@ delta = {}
 [[policy.tool]]
 name = "search_finance"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["finance-lead@northwind.example", "ap@northwind.example"] } }
+delta = { audience = ["finance-lead@northwind.example", "ap@northwind.example"] }
 
 [[policy.tool]]
 name = "read_finance"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read, e.g. `alice-chen.md`." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["finance-lead@northwind.example", "ap@northwind.example"] } }
+delta = { audience = ["finance-lead@northwind.example", "ap@northwind.example"] }
 
 [[policy.tool]]
 name = "create_finance"
@@ -160,7 +160,7 @@ name = "share_legal_packet"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact finance file name to share." }, to = { type = "string", description = "Recipient email address." } }, required = ["file", "to"], additionalProperties = false }
 requires = { trust = "internal", audience = { includes = ["$to"] } }
 effects = ["egress"]
-delta = { audience = { exactly = ["finance-lead@northwind.example", "ap@northwind.example"] } }
+delta = { audience = ["finance-lead@northwind.example", "ap@northwind.example"] }
 
 # The one registered declassifier: the redaction service strips numeric
 # identifiers (SSNs, salaries, account digits) from an hr-audience derivation,

--- a/bench/corp/policies/appa.toml
+++ b/bench/corp/policies/appa.toml
@@ -27,7 +27,7 @@ trust_chain = ["suspicious", "vendor", "internal"]
 # default, spelled out because the boundary label is what forking preserves).
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/anonymous-complaint/policy/appa.toml
+++ b/bench/corp/scenarios/anonymous-complaint/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 [policy.child]
 return_sanitizer = "complainant-redactor"
 

--- a/bench/corp/scenarios/anonymous-complaint/policy/appa.toml
+++ b/bench/corp/scenarios/anonymous-complaint/policy/appa.toml
@@ -18,11 +18,11 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_hr"
 parameters = { type = "object", properties = { query = { type = "string" } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["quiet.wren@identity.example"] } }
+delta = { audience = ["quiet.wren@identity.example"] }
 [[policy.tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string" } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["quiet.wren@identity.example"] } }
+delta = { audience = ["quiet.wren@identity.example"] }
 [[policy.tool]]
 name = "create_hr"
 parameters = { type = "object", properties = { file = { type = "string" }, content = { type = "string" } }, required = ["file", "content"], additionalProperties = false }

--- a/bench/corp/scenarios/blind-promotion/policy/appa.toml
+++ b/bench/corp/scenarios/blind-promotion/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 [policy.child]
 return_sanitizer = "demographics-redactor"
 

--- a/bench/corp/scenarios/blind-promotion/policy/appa.toml
+++ b/bench/corp/scenarios/blind-promotion/policy/appa.toml
@@ -18,11 +18,11 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_hr"
 parameters = { type = "object", properties = { query = { type = "string" } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["promotion-review-private"] } }
+delta = { audience = ["promotion-review-private"] }
 [[policy.tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string" } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["promotion-review-private"] } }
+delta = { audience = ["promotion-review-private"] }
 [[policy.tool]]
 name = "create_hr"
 parameters = { type = "object", properties = { file = { type = "string" }, content = { type = "string" } }, required = ["file", "content"], additionalProperties = false }

--- a/bench/corp/scenarios/dual-control-wire/policy/appa.toml
+++ b/bench/corp/scenarios/dual-control-wire/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/joint-merger-brief/policy/appa.toml
+++ b/bench/corp/scenarios/joint-merger-brief/policy/appa.toml
@@ -17,12 +17,12 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_hr"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["cfo@northwind.example", "hr-director@northwind.example"] } }
+delta = { audience = ["cfo@northwind.example", "hr-director@northwind.example"] }
 
 [[policy.tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["cfo@northwind.example", "hr-director@northwind.example"] } }
+delta = { audience = ["cfo@northwind.example", "hr-director@northwind.example"] }
 
 [[policy.tool]]
 name = "create_hr"
@@ -32,12 +32,12 @@ delta = {}
 [[policy.tool]]
 name = "search_finance"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["cfo@northwind.example", "controller@northwind.example"] } }
+delta = { audience = ["cfo@northwind.example", "controller@northwind.example"] }
 
 [[policy.tool]]
 name = "read_finance"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["cfo@northwind.example", "controller@northwind.example"] } }
+delta = { audience = ["cfo@northwind.example", "controller@northwind.example"] }
 
 [[policy.tool]]
 name = "create_finance"
@@ -55,7 +55,7 @@ delta = {}
 name = "share_legal_packet"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact finance file name to share." }, to = { type = "string", description = "Recipient email address." } }, required = ["file", "to"], additionalProperties = false }
 requires = { trust = "internal", audience = { includes = ["$to"] } }
-delta = { audience = { exactly = ["cfo@northwind.example", "controller@northwind.example"] } }
+delta = { audience = ["cfo@northwind.example", "controller@northwind.example"] }
 effects = ["egress"]
 
 # --- deployment coverage -----------------------------------------------------

--- a/bench/corp/scenarios/joint-merger-brief/policy/appa.toml
+++ b/bench/corp/scenarios/joint-merger-brief/policy/appa.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "internal"]
 
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/legal-pre-clearance/policy/appa.toml
+++ b/bench/corp/scenarios/legal-pre-clearance/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/multi-tenant-egress/policy/appa.toml
+++ b/bench/corp/scenarios/multi-tenant-egress/policy/appa.toml
@@ -24,7 +24,7 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_vendor"
 parameters = { type = "object", properties = { query = { type = "string" } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["Client_Alpha"] } }
+delta = { audience = ["Client_Alpha"] }
 [[policy.tool]]
 name = "read_vendor"
 parameters = { type = "object", properties = { file = { type = "string" } }, required = ["file"], additionalProperties = false }

--- a/bench/corp/scenarios/multi-tenant-egress/policy/appa.toml
+++ b/bench/corp/scenarios/multi-tenant-egress/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 [[policy.dynamic_resolver]]
 name = "tenant-record-readers"
 inputs = ["subject"]

--- a/bench/corp/scenarios/one-release-only/policy/appa.toml
+++ b/bench/corp/scenarios/one-release-only/policy/appa.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "internal"]
 
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/one-release-only/policy/appa.toml
+++ b/bench/corp/scenarios/one-release-only/policy/appa.toml
@@ -22,7 +22,7 @@ delta = {}
 [[policy.tool]]
 name = "read_task_tracker"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["customer-success@northwind.example"] } }
+delta = { audience = ["customer-success@northwind.example"] }
 
 [[policy.tool]]
 name = "create_task_tracker"

--- a/bench/corp/scenarios/performance-feedback/policy/appa.toml
+++ b/bench/corp/scenarios/performance-feedback/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 [[policy.dynamic_resolver]]
 name = "personal-file-readers"
 inputs = ["subject"]

--- a/bench/corp/scenarios/performance-feedback/policy/appa.toml
+++ b/bench/corp/scenarios/performance-feedback/policy/appa.toml
@@ -24,7 +24,7 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_hr"
 parameters = { type = "object", properties = { query = { type = "string" } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["elena.morris@northwind.example", "marcus.lee@northwind.example"] } }
+delta = { audience = ["elena.morris@northwind.example", "marcus.lee@northwind.example"] }
 [[policy.tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string" } }, required = ["file"], additionalProperties = false }

--- a/bench/corp/scenarios/review-then-notify/policy/appa.toml
+++ b/bench/corp/scenarios/review-then-notify/policy/appa.toml
@@ -17,12 +17,12 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_hr"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "read_hr"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["hr"] } }
+delta = { audience = ["hr"] }
 
 [[policy.tool]]
 name = "create_hr"

--- a/bench/corp/scenarios/review-then-notify/policy/appa.toml
+++ b/bench/corp/scenarios/review-then-notify/policy/appa.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "internal"]
 
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/route-project-packet/policy/appa.toml
+++ b/bench/corp/scenarios/route-project-packet/policy/appa.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "internal"]
 
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # The benchmark runner replaces this non-routable URL with an isolated
 # loopback fixture for each episode. Both declarations use the EXT-2 protocol.

--- a/bench/corp/scenarios/share-legal-packet/policy/appa.toml
+++ b/bench/corp/scenarios/share-legal-packet/policy/appa.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "internal"]
 
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/share-legal-packet/policy/appa.toml
+++ b/bench/corp/scenarios/share-legal-packet/policy/appa.toml
@@ -17,12 +17,12 @@ parameters = { type = "object", properties = { task = { type = "string", descrip
 [[policy.tool]]
 name = "search_finance"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["legal@northwind.example"] } }
+delta = { audience = ["legal@northwind.example"] }
 
 [[policy.tool]]
 name = "read_finance"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["legal@northwind.example"] } }
+delta = { audience = ["legal@northwind.example"] }
 
 [[policy.tool]]
 name = "create_finance"
@@ -40,7 +40,7 @@ delta = {}
 name = "share_legal_packet"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact finance file name to share." }, to = { type = "string", description = "Recipient email address." } }, required = ["file", "to"], additionalProperties = false }
 requires = { trust = "internal", audience = { includes = ["$to"] } }
-delta = { audience = { exactly = ["legal@northwind.example"] } }
+delta = { audience = ["legal@northwind.example"] }
 effects = ["egress"]
 
 # --- deployment coverage -----------------------------------------------------

--- a/bench/corp/scenarios/suspicious-activity/policy/appa.toml
+++ b/bench/corp/scenarios/suspicious-activity/policy/appa.toml
@@ -3,7 +3,7 @@ version = 1
 trust_chain = ["suspicious", "internal"]
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/scenarios/suspicious-activity/policy/appa.toml
+++ b/bench/corp/scenarios/suspicious-activity/policy/appa.toml
@@ -28,11 +28,11 @@ delta = {}
 [[policy.tool]]
 name = "search_finance"
 parameters = { type = "object", properties = { query = { type = "string", description = "Keyword or phrase to match against file names and contents." } }, required = ["query"], additionalProperties = false }
-delta = { audience = { exactly = ["compliance@northwind.example"] } }
+delta = { audience = ["compliance@northwind.example"] }
 [[policy.tool]]
 name = "read_finance"
 parameters = { type = "object", properties = { file = { type = "string", description = "The exact file name to read." } }, required = ["file"], additionalProperties = false }
-delta = { audience = { exactly = ["compliance@northwind.example"] } }
+delta = { audience = ["compliance@northwind.example"] }
 [[policy.tool]]
 name = "create_finance"
 parameters = { type = "object", properties = { file = { type = "string", description = "The file name to create." }, content = { type = "string", description = "The full contents to write." } }, required = ["file", "content"], additionalProperties = false }

--- a/bench/corp/scenarios/vendor-trust-boundary/policy/appa.toml
+++ b/bench/corp/scenarios/vendor-trust-boundary/policy/appa.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "vendor", "internal"]
 
 [policy.boundary]
 trust = "internal"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # Branching is an ordinary registered tool: the runtime checks this call like
 # any other, and releasing it is what opens a child trajectory (`BRN-2`,

--- a/bench/corp/tests/test_policy.py
+++ b/bench/corp/tests/test_policy.py
@@ -66,7 +66,7 @@ def test_prune_preserves_tool_annotations() -> None:
     policy = AGENTS["appa"].policy_file.read_text()
     by_name = {tool["name"]: tool for tool in _tools_of(prune_policy(policy, ("hr", "public_forum", "email")))}
     assert by_name["read_public_forum"]["delta"] == {"trust": "suspicious"}
-    assert by_name["read_hr"]["delta"] == {"audience": {"exactly": ["hr"]}}
+    assert by_name["read_hr"]["delta"] == {"audience": ["hr"]}
     assert by_name["send_email"]["requires"]["trust"] == "internal"
     assert by_name["send_email"]["effects"] == ["egress"]
 

--- a/integrations/claude-code/live-gate-check.py
+++ b/integrations/claude-code/live-gate-check.py
@@ -45,7 +45,7 @@ version = 1
 
 [[policy.tool]]
 name = "Read"
-delta = { audience = { exactly = ["session"] } }
+delta = { audience = ["session"] }
 
 [[policy.tool]]
 name = "Write"

--- a/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-tool-sync/SKILL.md
@@ -99,7 +99,7 @@ Decide two things per tool, from its name and its description.
 from a private source narrows the audience:
 
 ```toml
-delta = { audience = { exactly = ["private"] } }
+delta = { audience = ["private"] }
 ```
 
 Every other tool carries nothing:
@@ -125,8 +125,9 @@ Two rules the loader enforces:
 
 - Write a `delta` key on every entry. A `requires` on an entry with no
   `delta` is refused at load.
-- Every audience mention carries its operator — `exactly`, `includes`,
-  `cap`, `may_add`. A bare list is a load error.
+- A `delta` writes its reader list directly. Every other audience
+  mention carries its operator — `includes`, `cap`, `may_add`,
+  `exactly`. A bare list there is a load error.
 
 A tool can be both. One that reads private data and sends it outward
 carries the private `delta` and the public `requires` together, and is

--- a/website-chat-playground/policies/default.toml
+++ b/website-chat-playground/policies/default.toml
@@ -20,7 +20,7 @@ returns = ["requires.audience"]
 
 [[tool]]
 name  = "list_customers"
-delta = { audience = { exactly = ["internal"] } }
+delta = { audience = ["internal"] }
 
 [[tool]]
 name  = "create_customer_data"
@@ -56,7 +56,7 @@ delta    = {}
 
 [[tool]]
 name  = "list_invoices"
-delta = { audience = { exactly = ["cfo@corp.example", "ap-lead@corp.example"] } }
+delta = { audience = ["cfo@corp.example", "ap-lead@corp.example"] }
 
 # Every transfer demands a human sign-off (an attention
 # mark): the treasurer must rule on the exact call before
@@ -70,7 +70,7 @@ delta    = {}
 
 [[tool]]
 name  = "list_recordings"
-delta = { audience = { exactly = ["internal"] } }
+delta = { audience = ["internal"] }
 
 # In this playground the human every authority consults is you: a transfer
 # pauses until you approve or deny it in the chat. No answer within the

--- a/website-chat-playground/policies/default.toml
+++ b/website-chat-playground/policies/default.toml
@@ -4,7 +4,7 @@ trust_chain = ["suspicious", "trusted"]
 # User turns enter at trusted with a public audience.
 [boundary]
 trust = "trusted"
-audience = { exactly = ["public"] }
+audience = ["public"]
 
 # A policy registers a component; the deployment binds who performs it.
 # You declare that recipients are resolved by a directory — the service

--- a/website-chat-playground/src/lint.rs
+++ b/website-chat-playground/src/lint.rs
@@ -240,7 +240,7 @@ version = 1
 
 [[tool]]
 name = "list_customers"
-delta = { audience = { exactly = ["crm"] } }
+delta = { audience = ["crm"] }
 
 [[sanitizer]]
 name = "leaky"

--- a/website-chat-playground/src/world.rs
+++ b/website-chat-playground/src/world.rs
@@ -214,7 +214,7 @@ mod tests {
 version = 1
 [[tool]]
 name  = "list_customers"
-delta = { audience = { exactly = ["crm"] } }
+delta = { audience = ["crm"] }
 "#,
             &systems("crm"),
         )
@@ -226,7 +226,7 @@ delta = { audience = { exactly = ["crm"] } }
             .iter()
             .find(|tool| tool["name"].as_str() == Some("list_customers"))
             .unwrap();
-        assert!(contract["delta"]["audience"].get("exactly").is_some(), "terms survive");
+        assert!(contract["delta"]["audience"].as_array().is_some(), "terms survive");
         assert!(contract.get("parameters").is_some(), "schema injected");
         assert_eq!(merged.defaulted, vec!["create_customer_data"]);
     }

--- a/website/app/landing2/landing-data.ts
+++ b/website/app/landing2/landing-data.ts
@@ -217,7 +217,7 @@ name = "confluence__get_issue"
 #   ← {
 #       "_meta": {
 ~#         "appa/contract": {
-~#           "delta": { "audience": { "exactly": ["legal"] } }
+~#           "delta": { "audience": ["legal"] }
 ~#         }
 #       }
 #     }`,
@@ -232,7 +232,7 @@ name = "confluence__get_issue"
 {
   "_meta": {
 ~    "appa/contract": {
-~      "delta": { "audience": { "exactly": ["legal"] } }
+~      "delta": { "audience": ["legal"] }
 ~    }
   }
 }`,
@@ -246,7 +246,7 @@ spec:
 ~  resolver:                     # contract fetched per call
 ~    endpoint: https://confluence.internal/appa/resolve
 ~    method: tools/resolve
-~  # ← delta: { audience: { exactly: [legal] } }`,
+~  # ← delta: { audience: [legal] }`,
       rego: `
 package appa.confluence
 
@@ -275,7 +275,7 @@ def confluence__get_issue(issue_key: str):
 ~        # out of Confluence's own ACLs, per call
 ~        endpoint="https://confluence.internal/appa/resolve",
 ~        method="tools/resolve",
-~    )   # ← delta: {"audience": {"exactly": ["legal"]}}`,
+~    )   # ← delta: {"audience": ["legal"]}`,
     },
   },
 ];

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -17,18 +17,29 @@ version = 1
 trust_chain = ["suspicious", "trusted"]
 ```
 
-### Set operators
+### Reader sets
 
-Every set specification in a policy requires an explicit **operator** to prevent ambiguity between exact matches and lower/upper bounds:
+A `delta` states the reader set the tool's own result carries. It names the whole set, so it is written as the list itself and takes no operator:
+
+| Form | Meaning | Example |
+|---|---|---|
+| A list | The result reaches exactly these readers. | `delta = { audience = ["support", "@auditors"] }` |
+| A bare string | The one-entry list. | `delta = { audience = "@support" }` |
+| `"public"` | The result reaches every reader. | `delta = { audience = "public" }` |
+| `[]` | No reader holds the result. Once it folds in, every `includes` check fails. | `delta = { audience = [] }` |
+
+Two bare strings are reserved and never read as a reader ID: `"unknown"` declares a pending cast, and a string starting with `resolver.` reads a dynamic resolver result. Write either name in a list to mean the reader.
+
+Every other reader set bounds or extends a set that already exists. Each one requires an explicit **operator** to prevent ambiguity between exact matches and lower/upper bounds:
 
 | Operator | Meaning | Example Use |
 |---|---|---|
-| **`exactly`** | Fixes the set to these exact members. | `delta = { audience = { exactly = ["support"] } }` |
+| **`exactly`** | Fixes the set to these exact members. | `[boundary]` `audience = { exactly = ["public"] }` |
 | **`includes`** | Requires at least these members (`audience ⊇ recipients`). | `requires = { audience = { includes = ["$recipient"] } }` |
 | **`cap`** | Bounds the allowed audience from above (`audience ⊆ C`). | `requires = { audience = { cap = ["internal"] } }` |
 | **`may_add`** | Bounds the readers an authority is permitted to cover. | `can_cover_readers = { may_add = ["public"] }` |
 
-A set declaration without an explicit operator causes a policy load error.
+One of these declarations written without its operator causes a policy load error.
 
 ### Groups
 
@@ -247,7 +258,7 @@ A tool contract is typically four lines long. Use this checklist during policy r
 
 | Review Area | Red Flag / Misconfiguration | Safe / Correct Pattern | Spec Invariant & Risk |
 |---|---|---|---|
-| **`delta` Accuracy** | Tool reads sensitive customer data but declares `delta = {}` or omits `delta`. | Declare explicit restriction, e.g. `delta = { audience = { exactly = ["support"] } }`. | Undermines downstream checks; over-restricting is safe (costs reach, doesn't leak). |
+| **`delta` Accuracy** | Tool reads sensitive customer data but declares `delta = {}` or omits `delta`. | Declare explicit restriction, e.g. `delta = { audience = ["support"] }`. | Undermines downstream checks; over-restricting is safe (costs reach, doesn't leak). |
 | **Unannotated Tools** | Omitting `delta` while declaring `requires`. | Use `delta = {}` if output carries no labels, or separate unannotated tools. | Loader refuses `requires` on unannotated tools; unannotated output enters as `Unknown`. |
 | **`effects` Completeness** | Mutation or deployment tool omits `effects`. | Declare all side effects, e.g., `effects = ["migration.applied", "mutation"]`. | Under-declared effects pass `no_prior` checks silently without triggering history constraints. |
 | **Dynamic Recipients** | Static readers when an ACL depends on an argument. | Use a placeholder for a recipient the call names — a literal reader, `public`, or an `@group` — or a dynamic resolver for an argument-derived reader set. | Static readers can ignore the proposed argument; placeholder groups and dynamic resolution pin their answer to the call. |
@@ -267,7 +278,7 @@ A `[[tool]]` entry defines its name and `description`, its output restrictions (
 name  = "fetch_support_ticket"
 tags  = ["support"]                                    # Scope tag for authority routing
 # CRM is trusted infrastructure; the ticket body is customer-written text
-delta = { trust = "suspicious", audience = { exactly = ["support"] } }
+delta = { trust = "suspicious", audience = ["support"] }
 
 [[tool]]
 name     = "apply_db_migration"

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -19,27 +19,27 @@ trust_chain = ["suspicious", "trusted"]
 
 ### Reader sets
 
-A `delta` states the reader set the tool's own result carries. It names the whole set, so it is written as the list itself and takes no operator:
+Three fields state a whole reader set on their own: `delta.audience`, the reader set a tool's result carries, and the `[boundary]` and `[deployment].starting_label` audiences, the reader set a turn enters at. Each is written as the list itself and takes no operator:
 
 | Form | Meaning | Example |
 |---|---|---|
-| A list | The result reaches exactly these readers. | `delta = { audience = ["support", "@auditors"] }` |
+| A list | Exactly these readers. | `delta = { audience = ["support", "@auditors"] }` |
 | A bare string | The one-entry list. | `delta = { audience = "@support" }` |
-| `"public"` | The result reaches every reader. | `delta = { audience = "public" }` |
-| `[]` | No reader holds the result. Once it folds in, every `includes` check fails. | `delta = { audience = [] }` |
+| `"public"` | Every reader. | `delta = { audience = "public" }` |
+| `[]` | No reader. Once an empty set folds in, every `includes` check fails. | `delta = { audience = [] }` |
 
-Two bare strings are reserved and never read as a reader ID: `"unknown"` declares a pending cast, and a string starting with `resolver.` reads a dynamic resolver result. Write either name in a list to mean the reader.
+A label holds literal readers, so `[boundary]` and `starting_label` refuse an `@group`; a `delta` accepts one and resolves it per call. In a `delta`, two bare strings are reserved and never read as a reader ID: `"unknown"` declares a pending cast, and a string starting with `resolver.` reads a dynamic resolver result. Write either name in a list to mean the reader.
 
-Every other reader set bounds or extends a set that already exists. Each one requires an explicit **operator** to prevent ambiguity between exact matches and lower/upper bounds:
+Every other reader set names an explicit **operator**, which prevents ambiguity between exact matches and lower/upper bounds:
 
 | Operator | Meaning | Example Use |
 |---|---|---|
-| **`exactly`** | Fixes the set to these exact members. | `[boundary]` `audience = { exactly = ["public"] }` |
 | **`includes`** | Requires at least these members (`audience ⊇ recipients`). | `requires = { audience = { includes = ["$recipient"] } }` |
 | **`cap`** | Bounds the allowed audience from above (`audience ⊆ C`). | `requires = { audience = { cap = ["internal"] } }` |
+| **`exactly`** | Fixes the set to these exact members. Only a sanitizer mandate's `to` and a cast's `constant` take it. | `to = { exactly = ["public"] }` |
 | **`may_add`** | Bounds the readers an authority is permitted to cover. | `can_cover_readers = { may_add = ["public"] }` |
 
-One of these declarations written without its operator causes a policy load error.
+Writing the wrong form for a field causes a policy load error.
 
 ### Groups
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -85,7 +85,7 @@ To illustrate policy enforcement, consider an agent configured with three tools:
 ```toml
 [[tool]]
 name  = "get_ticket_from_crm"
-delta = { audience = { exactly = ["internal"] } }   # "internal" is a single reader id
+delta = { audience = ["internal"] }   # "internal" is a single reader id
 
 [[tool]]
 name       = "send_email"                  # send_email(body, recipient)

--- a/website/lib/terms.ts
+++ b/website/lib/terms.ts
@@ -82,7 +82,8 @@ const TERMS = {
     "In a tool requires check: no_prior(k) — no matching effect may exist, appended to the log or under an unsettled reservation.",
   emits:
     "What a successful tool call appends to the log, declared as effects = [...] in the contract.",
-  exactly: "In an audience condition: the allowed reader set becomes precisely this list.",
+  exactly:
+    "In a boundary label, a starting label, a sanitizer mandate, or a cast constant: the reader set becomes precisely this list. A delta names the whole reader set already, so it writes its list directly and takes no operator.",
   includes: "In a requires condition: the run's allowed readers must contain these.",
   cap: "In a requires condition: the run's allowed readers must stay within this set. In may_cast: the ceiling a resolved audience must stay within; only a public cap admits a public resolution.",
   tags: "Routing names with no algebraic life; the currency of authority, cast, and sanitizer scope.",

--- a/website/lib/terms.ts
+++ b/website/lib/terms.ts
@@ -83,7 +83,7 @@ const TERMS = {
   emits:
     "What a successful tool call appends to the log, declared as effects = [...] in the contract.",
   exactly:
-    "In a boundary label, a starting label, a sanitizer mandate, or a cast constant: the reader set becomes precisely this list. A delta names the whole reader set already, so it writes its list directly and takes no operator.",
+    "In a sanitizer mandate's destination or a cast constant: the reader set becomes precisely this list. A field that states a whole reader set on its own — a delta, the boundary label, the starting label — writes its list directly and takes no operator.",
   includes: "In a requires condition: the run's allowed readers must contain these.",
   cap: "In a requires condition: the run's allowed readers must stay within this set. In may_cast: the ceiling a resolved audience must stay within; only a public cap admits a public resolution.",
   tags: "Routing names with no algebraic life; the currency of authority, cast, and sanitizer scope.",


### PR DESCRIPTION
## What changed

Three fields name a whole reader set rather than bounding one: `delta.audience`, `[boundary].audience`, and `[deployment].starting_label.audience`. Each carried an `exactly` operator that decided nothing — there was no second reading for it to choose between. All three now take the list itself.

```toml
# before
delta = { audience = { exactly = ["alice", "bob"] } }

[boundary]
audience = { exactly = ["public"] }

[deployment]
starting_label = { audience = { exactly = ["auditor"] } }
```

```toml
# after
delta = { audience = ["alice", "bob"] }

[boundary]
audience = ["public"]

[deployment]
starting_label = { audience = ["auditor"] }
```

A bare string is the one-entry spelling of that list:

```toml
delta = { audience = "@internal" }   # group
delta = { audience = "public" }      # every reader
delta = { audience = [] }            # no reader
audience = "alice"                   # in [boundary], the same as ["alice"]
```

The empty list is legal at these three fields and nowhere else. A field that names the whole set can name one with no members; every other reader set bounds or extends a set that already exists, where an empty list says nothing. Once an empty set folds in, every `includes` check fails.

## What stayed the same

`{ exactly = [...] }` at these three fields no longer loads — no shim, no deprecation path.

`exactly` itself survives at the two sites where it was never in scope: a sanitizer mandate's `to` and a cast's `constant`.

```toml
[sanitizer.mandate]
audience = { from = { includes = ["internal"] }, to = { exactly = ["public"] } }

[[cast]]
name     = "paranoid-default"
constant = { trust = "suspicious", audience = { exactly = ["public"] } }
```

`includes`, `cap`, and `may_add` are untouched, as are casts, sanitizers, and authority syntax.

Two behaviours are unchanged and still enforced: a label holds literal readers, so `[boundary]` and `starting_label` refuse an `@group` (a `delta` accepts one and resolves it per call); and in a `delta`, `"unknown"` still declares a pending cast while a string starting with `resolver.` still reads a dynamic resolver result. Write either name inside a list to mean the reader instead.

## Removed

`[deployment].starting_label` had a bespoke `"public"` token beside its `exactly` table. `"public"` is now the ordinary one-entry spelling, which left `ConfigError::BadDeploymentToken` with no construction site, so the variant is gone.

## Scope

- `appa-policy`: `RawWholeAudience` (a token or a reader list) serves the boundary and starting label; `RawDeltaAudience` keeps its own token check for the two reserved delta spellings. `parse_whole_audience` admits the empty list that `parse_declared_audience` still refuses everywhere else, and `parse_audience` layers the label's literal-readers-only rule on top.
- Golden files land together: `website/content/docs/contracts.md` replaces its "Set operators" section with a reader-set section separating the two grammars, `website/content/docs/how-it-works.md` updates its worked example, and `website/lib/terms.ts` restates `exactly` where it still applies.
- Every policy and documentation example in the repository moves to the new spelling: bench scenarios and their boundary labels, the chat playground, the Claude Code plugin skill, the runtime and example-agent tests.

## Tests

- `a_delta_audience_is_the_reader_list_itself` covers the list, the bare-string one-entry spelling, `"public"`, `[]`, the reserved `"unknown"`, a reserved name read as an ordinary reader inside a list, and the refusal of `{ exactly = [...] }`.
- `a_label_audience_is_the_reader_list_itself` covers the same forms at `[boundary]` and `starting_label`, plus the group refusal and the operator refusal at both.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets` (clean), `cargo test --workspace` (46 test binaries, 0 failures).
- `bench/corp` pytest: `test_prune_preserves_tool_annotations` passes. Two unrelated failures (`check-hr-record: no data/ directory`) reproduce on `main` without this change.