### PR TITLE
docs: propose composable tool batteries

### DIFF
--- a/examples/claude-code-battery/README.md
+++ b/examples/claude-code-battery/README.md
@@ -1,0 +1,91 @@
+# Complete battery composition example
+
+This is a self-contained proposal example. Matcher rows, complete-configuration
+includes, and per-resolver `command` bindings are not implemented yet.
+
+The example contains one deployment and two included batteries:
+
+```text
+claude-code-battery/
+├── appa.toml
+├── local/
+│   └── read-sensitivity.py
+└── batteries/
+    ├── claude-code/
+    │   ├── appa.toml
+    │   ├── bash-review.py
+    │   └── read-sensitivity.py
+    └── slack/
+        └── appa.toml
+```
+
+The root `appa.toml` supplies deployment-wide settings and includes both
+shipped battery configurations. Root matcher rows always run before included
+files. Included files run in `include` order, and rows within each file retain
+source order. This gives the root explicit precedence without depending on the
+physical position of its `include` key. The root also defines the one `hitl`
+Authority used by every battery.
+
+The root demonstrates two customizations. It changes the shipped `cargo test`
+rule to require fresh `hitl` attention. It also replaces the shipped `Read`
+default with `local.read-sensitivity`, implemented by the script in `local/`.
+The local resolver keeps `.env.example` Public, restricts other dot-prefixed
+paths, and additionally restricts `clients/`.
+
+The Claude Code battery uses first-match Bash contracts. Exact common commands
+avoid a resolver call. The default contract invokes `bash-review.py` for one
+call. OpenAPPA writes one JSON request to standard input, reads one JSON answer
+from standard output, and waits for the command to exit. A resolver receives
+the complete tool argument object in `args` unless the binding selects a
+specific argument. Its declared `returns` apply directly to the tool contract.
+No schema, input mapping, or result expression is needed for this default.
+
+The resolver controls only whether a command needs fresh human review. It does
+not make Bash a network boundary and it never labels Bash output Public. A
+Claude Code deployment using this battery must run Bash in an OS sandbox that
+denies network access and protects credentials and OpenAPPA files. Network
+ingress should use `WebFetch` instead of Bash `curl`.
+
+The Claude Code battery also labels `Read` results through
+`read-sensitivity.py`. For this deliberately small example, a path beginning
+with `.` is restricted to `claude-session`; every other path is Public. This is
+only an example rule. A production resolver must canonicalize paths and account
+for hidden path components, symlinks, Git state, and files outside the working
+directory.
+
+The Slack battery needs no script. Messages to engineering channels match a
+channel pattern and need only the trust gate. Every other destination requires
+fresh `hitl` attention. Channel-history results from engineering are
+restricted to `slack-internal`; unmatched channel history receives a separate,
+more conservative reader.
+
+Run the resolver directly:
+
+```sh
+cd examples/claude-code-battery
+printf '%s\n' '{"version":1,"resolver":"claude-code.bash-review","args":{"command":"python scripts/release.py"}}' \
+  | python3 ./batteries/claude-code/bash-review.py
+```
+
+The result requires `hitl`. Replace the command with `cargo check` to
+get an empty attention requirement.
+
+Run the Read resolver directly:
+
+```sh
+printf '%s\n' '{"version":1,"resolver":"claude-code.read-sensitivity","args":{"file_path":".env"}}' \
+  | python3 ./batteries/claude-code/read-sensitivity.py
+```
+
+The result restricts `.env` to `claude-session`. Replace `.env` with
+`README.md` to get a Public audience.
+
+Run the local replacement resolver directly:
+
+```sh
+printf '%s\n' '{"version":1,"resolver":"local.read-sensitivity","args":{"file_path":"clients/acme.txt"}}' \
+  | python3 ./local/read-sensitivity.py
+```
+
+The result restricts `clients/acme.txt`. `.env.example` is the explicit local
+exception and returns a Public audience.

--- a/examples/claude-code-battery/appa.toml
+++ b/examples/claude-code-battery/appa.toml
@@ -1,0 +1,48 @@
+# Proposal example: compose complete Claude Code and Slack battery configurations.
+
+include = [
+  "./batteries/claude-code/appa.toml",
+  "./batteries/slack/appa.toml",
+]
+
+[policy]
+version = 1
+
+[policy.deployment]
+dispatch = "enforced"
+
+[[policy.authority]]
+name = "hitl"
+hint = "Ask the person running the session."
+
+[policy.authority.mandate]
+attends = ["hitl"]
+
+[externals]
+timeout_ms = 5000
+review_timeout_ms = 600000
+max_body_bytes = 65536
+
+[externals.authorities.hitl]
+builtin = "hitl"
+
+# Root contracts run before every included battery. This local rule overrides
+# the shipped exact `cargo test` rule with a fresh approval step.
+[[policy.tool]]
+name = "Bash(command:cargo test)"
+requires = { trust = "trusted", attention = ["hitl"] }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
+
+# A root contract can also replace a battery's fallback with a local resolver.
+[[policy.dynamic_resolver]]
+name = "local.read-sensitivity"
+returns = ["delta.audience"]
+
+[[policy.tool]]
+name = "Read"
+description = "Reads a file and returns its contents."
+uses = [{ resolver = "local.read-sensitivity" }]
+delta = { trust = "suspicious" }
+
+[externals.dynamic."local.read-sensitivity"]
+command = ["python3", "./local/read-sensitivity.py"]

--- a/examples/claude-code-battery/batteries/claude-code/appa.toml
+++ b/examples/claude-code-battery/batteries/claude-code/appa.toml
@@ -1,0 +1,56 @@
+# Included proposal battery: first matching Bash contract wins.
+
+[policy]
+version = 1
+
+# Exact common commands do not start the resolver.
+[[policy.tool]]
+name = "Bash(command:cargo test)"
+requires = { trust = "trusted" }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
+
+[[policy.tool]]
+name = "Bash(command:git status --short)"
+requires = { trust = "trusted" }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
+
+# An obviously destructive command always requires fresh approval.
+[[policy.tool]]
+name = "Bash(command:rm -rf *)"
+requires = { trust = "trusted", attention = ["hitl"] }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
+
+# Everything not matched above asks one resolver whether approval is needed.
+[[policy.dynamic_resolver]]
+name = "claude-code.bash-review"
+returns = ["requires.attention"]
+
+[[policy.tool]]
+name = "Bash"
+description = "Runs one shell command and returns its output."
+uses = [{ resolver = "claude-code.bash-review" }]
+requires = { trust = "trusted" }
+
+# Command text cannot prove that output is safe to release. Every Bash result
+# is suspicious and restricted to this local session.
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
+
+# Read labels a path through a separate one-shot resolver. This example uses a
+# deliberately simple rule: a path beginning with `.` is Private.
+[[policy.dynamic_resolver]]
+name = "claude-code.read-sensitivity"
+returns = ["delta.audience"]
+
+[[policy.tool]]
+name = "Read"
+description = "Reads a file and returns its contents."
+uses = [{ resolver = "claude-code.read-sensitivity" }]
+delta = { trust = "suspicious" }
+
+# One implementation binding per resolver name. Paths are relative to this
+# battery configuration.
+[externals.dynamic."claude-code.bash-review"]
+command = ["python3", "./bash-review.py"]
+
+[externals.dynamic."claude-code.read-sensitivity"]
+command = ["python3", "./read-sensitivity.py"]

--- a/examples/claude-code-battery/batteries/claude-code/bash-review.py
+++ b/examples/claude-code-battery/batteries/claude-code/bash-review.py
@@ -1,0 +1,37 @@
+import json
+import sys
+
+
+NO_REVIEW_COMMANDS = {
+    "cargo check",
+    "cargo fmt --check",
+    "git diff --check",
+    "git status --short",
+}
+
+
+def main():
+    request = json.load(sys.stdin)
+
+    if request.get("version") != 1:
+        raise ValueError("unsupported request version")
+    if request.get("resolver") != "claude-code.bash-review":
+        raise ValueError("unexpected resolver name")
+
+    args = request.get("args")
+    if not isinstance(args, dict) or not isinstance(args.get("command"), str):
+        raise ValueError("args.command must be a string")
+
+    attention = [] if args["command"] in NO_REVIEW_COMMANDS else ["hitl"]
+    json.dump(
+        {"version": 1, "result": {"requires.attention": attention}},
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+try:
+    main()
+except Exception as error:
+    print(f"bash-review: {error}", file=sys.stderr)
+    raise SystemExit(1)

--- a/examples/claude-code-battery/batteries/claude-code/read-sensitivity.py
+++ b/examples/claude-code-battery/batteries/claude-code/read-sensitivity.py
@@ -1,0 +1,30 @@
+import json
+import sys
+
+
+def main():
+    request = json.load(sys.stdin)
+
+    if request.get("version") != 1:
+        raise ValueError("unsupported request version")
+    if request.get("resolver") != "claude-code.read-sensitivity":
+        raise ValueError("unexpected resolver name")
+
+    args = request.get("args")
+    file_path = args.get("file_path") if isinstance(args, dict) else None
+    if not isinstance(file_path, str) or not file_path:
+        raise ValueError("args.file_path must be a non-empty string")
+
+    audience = ["claude-session"] if file_path.startswith(".") else "public"
+    json.dump(
+        {"version": 1, "result": {"delta.audience": audience}},
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+try:
+    main()
+except Exception as error:
+    print(f"read-sensitivity: {error}", file=sys.stderr)
+    raise SystemExit(1)

--- a/examples/claude-code-battery/batteries/slack/appa.toml
+++ b/examples/claude-code-battery/batteries/slack/appa.toml
@@ -1,0 +1,28 @@
+# Included proposal battery: first matching Slack contract wins.
+
+[policy]
+version = 1
+
+# Engineering channels accept trusted internal flows without a fresh prompt.
+[[policy.tool]]
+name = "mcp__slack__slack_send_message(channel_id:C123*)"
+requires = { trust = "trusted" }
+effects = ["egress", "mutation"]
+delta = {}
+
+# Every unmatched channel requires fresh approval.
+[[policy.tool]]
+name = "mcp__slack__slack_send_message"
+requires = { trust = "trusted", attention = ["hitl"] }
+effects = ["egress", "mutation"]
+delta = {}
+
+# Engineering history is private to the Slack-internal audience.
+[[policy.tool]]
+name = "mcp__slack__slack_get_channel_history(channel_id:C123*)"
+delta = { trust = "suspicious", audience = { exactly = ["slack-internal"] } }
+
+# An unmatched channel stays conservatively restricted.
+[[policy.tool]]
+name = "mcp__slack__slack_get_channel_history"
+delta = { trust = "suspicious", audience = { exactly = ["slack-unclassified"] } }

--- a/examples/claude-code-battery/local/read-sensitivity.py
+++ b/examples/claude-code-battery/local/read-sensitivity.py
@@ -1,0 +1,33 @@
+import json
+import sys
+
+
+def main():
+    request = json.load(sys.stdin)
+
+    if request.get("version") != 1:
+        raise ValueError("unsupported request version")
+    if request.get("resolver") != "local.read-sensitivity":
+        raise ValueError("unexpected resolver name")
+
+    args = request.get("args")
+    file_path = args.get("file_path") if isinstance(args, dict) else None
+    if not isinstance(file_path, str) or not file_path:
+        raise ValueError("args.file_path must be a non-empty string")
+
+    sensitive = file_path != ".env.example" and (
+        file_path.startswith(".") or file_path.startswith("clients/")
+    )
+    audience = ["claude-session"] if sensitive else "public"
+    json.dump(
+        {"version": 1, "result": {"delta.audience": audience}},
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+try:
+    main()
+except Exception as error:
+    print(f"local-read-sensitivity: {error}", file=sys.stderr)
+    raise SystemExit(1)

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -821,6 +821,22 @@ samp {
   color: inherit;
 }
 
+.battery-figure {
+  width: 100%;
+  max-width: 45rem;
+  margin: 1rem 0 2rem;
+}
+
+.battery-order-figure {
+  max-width: 32.5rem;
+}
+
+.battery-figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
 .prose blockquote {
   border-left: 2px solid var(--border);
   padding-left: 1rem;

--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -14,6 +14,7 @@ import {
   ClaudeSessionChoice,
 } from "@/components/ClaudeCodeStory";
 import { CodeBlock } from "@/components/CodeBlock";
+import { BatteryRuleOrderFigure } from "@/components/figures/BatteriesFigures";
 import { ClaudeCodeHooksFigure } from "@/components/figures/ClaudeCodeHooksFigure";
 import { ConnectedAgentFigure } from "@/components/figures/ConnectedAgentFigure";
 import { ExfiltrationFigure } from "@/components/figures/ExfiltrationFigure";
@@ -33,6 +34,7 @@ import { termDefinition } from "@/lib/terms";
    the mapped component in place. */
 const DIRECTIVES: Record<string, () => ReactNode> = {
   "advisory-signup": () => <AdvisorySignup />,
+  "battery-rule-order": () => <BatteryRuleOrderFigure />,
   "benchmark-highlight": () => <BenchmarkHighlight />,
   "brand-assets": () => <BrandAssets />,
   "claude-policy-timing": () => <ClaudePolicyTiming />,

--- a/website/components/figures/BatteriesFigures.tsx
+++ b/website/components/figures/BatteriesFigures.tsx
@@ -1,0 +1,38 @@
+const arrow = (id: string) => (
+  <marker id={id} viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <path d="M 0 0 L 8 4 L 0 8 z" fill="var(--icon)" />
+  </marker>
+);
+
+export function BatteryRuleOrderFigure() {
+  const rows = [
+    [20, "Root appa.toml"],
+    [113, "First file in include"],
+    [206, "Next file in include"],
+  ] as const;
+
+  return (
+    <div className="battery-figure battery-order-figure">
+      <svg viewBox="0 0 520 290" role="img" aria-label="Root rules run first, followed by each included battery. Rules in every file run from top to bottom.">
+        <defs>{arrow("battery-order-arrow")}</defs>
+
+        <g fill="none" stroke="var(--icon)" strokeWidth="1.4" markerEnd="url(#battery-order-arrow)">
+          <path d="M 260 84 V 105" />
+          <path d="M 260 177 V 198" />
+        </g>
+
+        {rows.map(([y, label]) => (
+          <g key={label}>
+            <rect x="80" y={y} width="360" height="64" rx="6" fill="var(--bg-weak)" stroke="var(--border)" />
+            <text x="100" y={y + 27} fill="var(--text-strong)" fontFamily="var(--font-mono)" fontSize="15">
+              {label}
+            </text>
+            <text x="100" y={y + 48} fill="var(--text-weak)" fontFamily="var(--font-mono)" fontSize="12">
+              Rules run from top to bottom
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -1,197 +1,227 @@
 ---
-title: Betteries
-category: Deep Dive
+title: Batteries
+category: Integration
 order: 7
-description: Our vision for reusable security coverage, and the deliberately small first implementation.
+description: A proposal for combining OpenAPPA configs and running resolver scripts.
 ---
 
-:::proposal
-name: Betteries
-date: 2026-08-21
-author: Ildar Iskhakov
+> **Proposal:** Batteries are not implemented yet.
 
-Security rules should travel with the tools they protect. A team should not have to rebuild the same Claude Code or Grain policy for every deployment.
+A battery is an OpenAPPA config for a set of tools, such as Claude Code or Slack. It may include small scripts that make decisions for each tool call.
 
-That is our vision for APPA batteries. A battery will package ready-made OpenAPPA coverage for one agent harness or toolset. It will own the contracts and default judgments that are common to every deployment. Local settings will keep deployment-specific trust decisions under the deployer's control.
+```text
+batteries/
+|-- claude-code/
+|   |-- appa.toml
+|   |-- bash-review.py
+|   `-- read-sensitivity.py
+`-- slack/
+    `-- appa.toml
+```
 
+A battery is ordinary OpenAPPA config. It needs no extra format or server.
 
-This page starts with the product and security principles behind batteries. It then walks through policy composition, local resolver processes, customization, failure behavior, and installation. It ends with the boundaries we are deliberately keeping around the first release. If OpenAPPA's flow model is new to you, read [How it works](/how-it-works) first. If you want to see today's harness integration, start with [Claude Code](/claude-code).
+## Add batteries
 
-## Our vision: coverage should travel with the integration
-
-Today, a deployment that covers several toolsets must collect their declarations in one policy file. That works, but it puts the wrong person in charge of repeated details.
-
-The maintainer of a Claude Code integration knows its tool names and argument schemas. The maintainer of a meeting-notes integration knows which calls read transcripts and which calls can publish them. A deployer should review those contracts, not reconstruct them line by line.
-
-We think a security feature that begins with copying hundreds of lines into `appa.toml` will not survive contact with real tools. Batteries will move reusable declarations back to the people who understand the integration, without moving local trust decisions out of the deployment.
-
-Four principles shape the design:
-
-1. **Integration maintainers define reusable coverage once.** Tool names, argument schemas, source restrictions, and outbound walls belong beside the integration.
-2. **Deployers keep control of trust.** Private paths, workspaces, and trusted destinations remain local settings.
-3. **Review stays explicit.** APPA will show the complete effective policy and reject ambiguous conflicts. Includes will not create hidden override precedence.
-4. **Failure never becomes permission.** A broken include, resolver, or settings file will refuse activation or supply no answer. It will not silently weaken the serving policy.
-
-This is not a vision for a policy marketplace or a general package manager. The first version will add only enough composition and process management to make reusable coverage practical.
-
-## What a battery will contain
-
-Each battery has two parts:
-
-1. A policy document declares tools, input schemas, source restrictions, outbound requirements, resolver names, and review hints.
-2. Resolver functions make the dynamic judgments that static policy cannot make, such as whether a file path is private or a destination is trusted.
-
-The policy remains declarative. Resolver code supplies bounded answers to declarations; it cannot add a tool or change a tool contract.
-
-This division is important. Contracts define what a tool can read or release. Resolver functions answer only the questions those contracts registered. A battery author cannot hide a new tool contract inside executable resolver code.
-
-## How policy composition will work
-
-The first version will add one-level policy includes. A deployment will select batteries beside its local policy:
+List batteries in the root `appa.toml`:
 
 ```toml
-[policy]
 include = [
-  "batteries/claude-code.toml",
-  "batteries/grain.toml",
-  "./my-policy.toml",
+  "./batteries/claude-code/appa.toml",
+  "./batteries/slack/appa.toml",
 ]
 
-[externals]
-timeout_ms = 5000
-max_body_bytes = 65536
-
-[externals.dynamic]
-command = ["node", "./resolvers.js"]
+[policy]
+version = 1
 ```
 
-An include is deliberately less powerful than a package system:
+OpenAPPA combines these files into one config.
 
-- Paths are local. APPA does not fetch policy from a URL.
-- An included document cannot include another document.
-- Every document must use the same policy version.
-- Declarations merge additively. A duplicate tool, Authority, Transformer, cast, or resolver name refuses the complete load.
-- A singleton setting, such as the trust chain or deployment profile, can appear in only one source.
-- Include order controls display and diagnostic order. It does not create override precedence.
+| Item | Rule |
+|---|---|
+| `include` | Only the root file can use it. |
+| Paths | Paths are local and relative to the root file. |
+| Version | Every file uses the same version. |
+| Resolvers | Each resolver name must be unique. |
+| Script path | A script path is relative to the config file that names it. |
 
-APPA will combine the source documents and validate one effective policy. A trajectory will record that effective policy, so replay will never depend on an included file that later changes or disappears.
+OpenAPPA checks the combined config before using it. If a reload fails, the current config keeps running.
 
-Reload will follow the same rule. APPA will read and validate every source before swapping deployments. A missing file, syntax error, version mismatch, or name conflict will leave the currently serving deployment unchanged.
+## Rule order
 
-The included files will remain the human review surface. The effective policy will be deterministic and available for diagnostics, but nobody will have to maintain the generated result.
+OpenAPPA checks root rules from top to bottom. It then checks each battery in `include` order, also from top to bottom.
 
-## How dynamic judgment will run
+:::battery-rule-order:::
 
-A tool contract can depend on a proposed call's actual value. A file reader may need to know whether `/work/public/readme.md` or `~/.ssh/config` is being opened. A messaging tool may need to know whether a channel is internal.
+The first match wins. The position of `include` in the root file does not change this order.
 
-OpenAPPA already supports these judgments through an HTTP dynamic resolver. Batteries will add a second binding: one child process managed by the runtime.
+Trusted messages can go to engineering channels. Messages to other channels need fresh human approval.
 
 ```toml
-[externals.dynamic]
-command = ["node", "./resolvers.js"]
+[[policy.tool]]
+name = "mcp__slack__slack_send_message(channel_id:C123*)"
+requires = { trust = "trusted" }
+effects = ["egress", "mutation"]
+delta = {}
+
+[[policy.tool]]
+name = "mcp__slack__slack_send_message"
+requires = { trust = "trusted", attention = ["hitl"] }
+effects = ["egress", "mutation"]
+delta = {}
 ```
 
-`command` will contain an executable followed by its arguments. APPA will not invoke a shell or embed a language runtime. The process can be JavaScript, Python, or a compiled program. It will start in the directory containing `appa.toml`, so relative paths will have one predictable base.
+Text inside parentheses matches one argument. `*` matches any text.
 
-The deployment will choose which battery functions that process serves:
+A bare tool name is the default. It matches when no earlier rule did.
 
-```javascript
-import { claudeCode, grain, run } from "@appa/batteries"
-
-run({
-  ...claudeCode(),
-  ...grain(),
-})
-```
-
-The process will announce its resolver names when it starts. APPA will compare them with the effective policy before activating the deployment. A missing, duplicate, or unknown name will refuse activation instead of leaving part of the policy unwired.
-
-Requests and responses will use versioned, newline-delimited JSON over standard input and output. The first version will serialize requests, so the protocol will need no correlation identifier. Standard error will remain available for bounded operational logs; standard output will contain protocol messages only.
-
-## How deployments will customize a battery
-
-Most customization should be data, not a fork of shipped code. A battery will read one obvious settings file:
+Slack history uses the same first-match rule. Engineering history stays inside Slack. Other history is kept separate.
 
 ```toml
-[grain]
-private_workspaces = ["customer-research"]
+[[policy.tool]]
+name = "mcp__slack__slack_get_channel_history(channel_id:C123*)"
+delta = { trust = "suspicious", audience = { exactly = ["slack-internal"] } }
 
-[claude_code]
-private_paths = ["~/clients", "~/.ssh"]
-trusted_domains = ["docs.internal.example"]
+[[policy.tool]]
+name = "mcp__slack__slack_get_channel_history"
+delta = { trust = "suspicious", audience = { exactly = ["slack-unclassified"] } }
 ```
 
-The resolver will validate fresh settings before it answers each request, or detect changes with the same next-request behavior. This matters during revocation. If someone replaces a valid file with malformed settings, the resolver will return no answer. It will never keep using the older, more permissive configuration.
+## Use resolvers in batteries
 
-Deployers will be able to replace one judgment without editing battery code:
+A battery can ship a resolver script beside its config. See [Dynamic resolvers](/contracts#dynamic-resolvers) for what resolvers receive and return.
 
-```javascript
-const defaultGrain = grain()
+The battery binds the resolver name to its script:
 
-run({
-  ...claudeCode(),
-  ...defaultGrain,
-  "grain.transcript": async (request) => {
-    if (request.value.startsWith("public-demo/")) return []
-    return defaultGrain["grain.transcript"](request)
-  },
-})
+```toml
+[[policy.dynamic_resolver]]
+name = "claude-code.read-sensitivity"
+returns = ["delta.audience"]
+
+[[policy.tool]]
+name = "Read"
+uses = [{ resolver = "claude-code.read-sensitivity" }]
+delta = { trust = "suspicious" }
+
+[externals.dynamic."claude-code.read-sensitivity"]
+command = ["python3", "./read-sensitivity.py"]
 ```
 
-That escape hatch will be intentionally visible. Custom resolver code will join the deployer's trusted base and can weaken protection. Review will have to cover the entry file as well as the local policy and settings.
+### Proposed local command runner
 
-## How private-data walls will preserve public work
+> **Proposal:** Running a resolver as a local command is part of this proposal. It is not implemented.
 
-Blanket outbound blocks are easy to build and hard to live with. We want a battery to stop a private transcript from reaching an external channel without stopping an agent from posting ordinary public text to that same channel.
+OpenAPPA starts the command only when the selected tool rule uses the resolver. It writes one JSON request, reads one JSON result, then waits for the script to exit.
 
-The design will compose two dynamic judgments:
+Request:
 
-- A source resolver will leave ordinary content unrestricted and assign restrictive readers to private content.
-- An outbound resolver will require nothing for a trusted destination. For an untrusted destination, it will require a reader that only Public data can satisfy.
+```json
+{"version":1,"resolver":"claude-code.read-sensitivity","args":{"file_path":".env"}}
+```
 
-Suppose a Grain battery marks transcripts from `customer-research` as private. The agent reads one of those transcripts and then proposes a post to `#external-partners`. The source restriction and destination requirement will not match, so OpenAPPA will refuse the call before the transcript leaves the harness.
+Result:
 
-The refusal should explain the next move in ordinary language:
+```json
+{"version":1,"result":{"delta.audience":["claude-session"]}}
+```
 
-> This Grain transcript is private, so APPA did not post it to `#external-partners`. Remove the private content, choose a trusted destination, or add the destination to `battery-settings.toml`.
+The resolver can be any program. Here is a Python example:
 
-A clean trajectory that contains only Public data will still be able to post to the same destination. Installing the wall will not make the tool useless.
+```python
+import json
+import sys
 
-## How resolver failure will stay closed
+request = json.load(sys.stdin)
+file_path = request["args"]["file_path"]
+audience = ["claude-session"] if file_path.startswith(".") else "public"
 
-The resolver process is part of the decision path, so failure behavior matters more than convenience.
+json.dump(
+    {"version": 1, "result": {"delta.audience": audience}},
+    sys.stdout,
+)
+```
 
-Startup and every judgment will share the deployment's external timeout. If the process times out, exits, emits malformed output, or exceeds the response-size limit, APPA will treat that as no answer. It will not turn an operational failure into permission or an Engine fact.
+A battery resolver must check the version, name, and argument types. It must exit with an error for bad input.
 
-The runtime will terminate the failed process and start a fresh one before the next judgment. Calls already waiting on the failed process will receive no answer rather than waiting behind a restart. Feedback will name the command, failure class, and repair action without exposing the value being resolved:
+OpenAPPA runs the command without a shell. The script path is relative to the battery config. Its folder is the working folder.
 
-> APPA could not check the Grain destination because `resolvers.js` exited. The call was not run. Fix the resolver and reload the deployment.
+Script changes apply on the next call. No restart is needed.
 
-Reload will be equally conservative. APPA will start the replacement process, check its readiness and resolver names, and only then activate the new deployment. The old process will stay live if replacement validation fails.
+## Resolver precedence
 
-## Where the battery boundary will remain
+Resolvers do not have their own order. The first matching tool rule decides which resolver, if any, runs.
 
-A battery will judge the values that reach its declared tools. It will not see every fact about the operating system.
+This Claude Code battery handles `cargo test` directly. Other Bash commands go to the resolver:
 
-Globs can conceal paths. Shell commands can invoke interpreters, process launchers, or command substitution. One tool can stage content on disk for another tool to send later. The first batteries will take the restrictive path when text is ambiguous, and their review material will state these limits.
+```toml
+[[policy.tool]]
+name = "Bash(command:cargo test)"
+requires = { trust = "trusted" }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
 
-Operating-system sandboxing will remain the access-prevention boundary. It must also stop the agent from changing APPA policy, resolver code, or live settings. Batteries and sandboxing will solve different parts of the same problem; neither will make the other optional.
+[[policy.dynamic_resolver]]
+name = "claude-code.bash-review"
+returns = ["requires.attention"]
 
-## How installation will work
+[[policy.tool]]
+name = "Bash"
+uses = [{ resolver = "claude-code.bash-review" }]
+requires = { trust = "trusted" }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
 
-Installation should still be one action. The installer will place trusted battery files, update the short include list, create default resolver and settings files when they are absent, bind the managed command, and validate the complete deployment. It will not overwrite local customization.
+[externals.dynamic."claude-code.bash-review"]
+command = ["python3", "./bash-review.py"]
+```
 
-The completion summary will name the installed batteries, covered tools, resolver names, settings location, and known limits. An unknown harness tool will remain blocked until its battery is updated or a local policy declares it.
+`cargo test` matches the first rule, so `bash-review.py` does not run.
 
-The installer will perform mechanical setup only. It will not decide which local paths are private or which destinations deserve trust. Those decisions stay visible in the settings and policy that the deployer reviews.
+The resolver returns an empty list when no approval is needed. It returns `["hitl"]` for all other commands.
 
-## What we are deliberately not building yet
+This only controls approval. It does not make Bash output Public. The output stays inside the Claude session.
 
-The first implementation will not add nested includes, remote packages, dependency resolution, inheritance, policy overrides, automatic updates, concurrent process requests, or in-process scripts.
+Bash can read files and open network connections on its own. Use an operating-system sandbox to protect credentials and network access.
 
-We want evidence from real battery use before adding any of those mechanisms. More composition power would also create more precedence rules, supply-chain questions, and failure modes. None is necessary to prove the first idea.
+## Customise batteries for your own setup
 
-Our goal is simple: installing coverage for a known integration should be one action, reviewing it should remain straightforward, and customizing local trust should not require editing shipped code. We can reach that goal with local policy includes and one managed resolver process.
+Put your rules in the root config. They run before battery rules, even when they appear below `include`.
 
-That is the first version we intend to build: reusable coverage without hidden precedence, local judgment without another service to operate, and failure that never quietly becomes permission.
-:::
+```toml
+include = [
+  "./batteries/claude-code/appa.toml",
+  "./batteries/slack/appa.toml",
+]
+
+[policy]
+version = 1
+
+[[policy.tool]]
+name = "Bash(command:cargo test)"
+requires = { trust = "trusted", attention = ["hitl"] }
+delta = { trust = "suspicious", audience = { exactly = ["claude-session"] } }
+
+[[policy.dynamic_resolver]]
+name = "local.read-sensitivity"
+returns = ["delta.audience"]
+
+[[policy.tool]]
+name = "Read"
+uses = [{ resolver = "local.read-sensitivity" }]
+delta = { trust = "suspicious" }
+
+[externals.dynamic."local.read-sensitivity"]
+command = ["python3", "./local/read-sensitivity.py"]
+```
+
+The root asks for approval before `cargo test`. It also uses a local script for `Read`.
+
+The battery files stay unchanged.
+
+## Block when a script fails
+
+OpenAPPA blocks the tool call when a resolver script is missing, crashes, times out, or returns bad data.
+
+The error names the resolver and the problem. It does not show the data the resolver was checking.
+
+Resolver scripts run as trusted local code. Review what they can read, run, and send.
+
+A production file resolver must check full paths, hidden folders, symbolic links, files ignored by Git, and files outside the project.


### PR DESCRIPTION
## Summary

- define batteries as ordinary OpenAPPA configs composed with root-level `include`
- define simple, first-match rule order: root first, then included files in list order
- propose one-shot resolver commands over stdin/stdout
- add a complete Claude Code and Slack example with a local override

## Scope

This is a proposal only. It does not implement config includes, tool matchers, or local resolver commands in the engine or runtime.

## Verification

- `pnpm build` in `website`
- parsed every example TOML file with Python `tomllib`
- exercised all three resolver scripts, including fail-closed input cases
- `git diff --check openappa/main...HEAD`