### PR TITLE
feat(website): consent-gated PostHog analytics, and a consented install count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
             integrations/claude-code/plugin/statusline.sh
 
       - name: Lint plugin shell scripts
-        run: shellcheck -s sh integrations/claude-code/plugin/hooks/ensure-runtime.sh
+        run: |
+          shellcheck -s sh integrations/claude-code/plugin/hooks/ensure-runtime.sh
+          shellcheck -s sh integrations/claude-code/plugin/report-install.sh
 
       - name: Validate plugin JSON
         run: |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ plain `claude` sessions stay untouched. Run `/appa-tool-sync` in a plain
 `claude` session to bring your MCP servers into the policy, then start `clappa`
 to try the protected flow.
 
+Setup asks once whether it may count the install — version, OS and architecture,
+nothing that identifies you or your machine. Decline, or say nothing, and it
+sends nothing; `APPA_TELEMETRY=0` refuses it without being asked. The runtime
+never reports anything.
+
 ![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](website/public/images/claude-code-blocked-flow.png)
 
 Setup, upgrade and uninstall: [Claude Code

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -267,3 +267,13 @@ every statusline refresh:
   unprotected session.
 - **The plugin adds roughly zero tokens to a session.** The protection
   is hooks and an MCP server, not prompt text.
+- **The install asks once whether it may be counted.** On yes, `/appa-setup`
+  sends a single event naming the version, OS and architecture, and nothing
+  else — no identifier for you or the machine, and nothing kept on disk to
+  recognise you later. On no, or on no answer, it sends nothing. Set
+  `APPA_TELEMETRY=0` to refuse it without being asked, which is the way to
+  handle a scripted or fleet install. The runtime itself never reports
+  anything: it still binds loopback only and makes no outbound call of its
+  own. The reporters are `report-install.sh` and `report-install.ps1` in the
+  plugin directory; read them before you answer if you would rather see it
+  than take our word.

--- a/integrations/claude-code/plugin/report-install.ps1
+++ b/integrations/claude-code/plugin/report-install.ps1
@@ -1,0 +1,56 @@
+# Windows counterpart of report-install.sh. Keep the two in step: same event
+# name, same properties, same refusals. A property added on one side and not
+# the other silently splits the data by platform.
+#
+# The appa-setup skill runs this as its last step, after asking the user
+# whether to send it. Nothing here fires unless a person said yes to a question
+# they were shown. See report-install.sh for why the installer reports this and
+# the runtime does not.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$Version,
+  [Parameter(Mandatory = $true)][string]$Os,
+  [Parameter(Mandatory = $true)][string]$Arch
+)
+
+# Failure here never becomes a problem for the install.
+$ErrorActionPreference = 'SilentlyContinue'
+
+# See report-install.sh: public, write-only project key, overridable by forks.
+$posthogKey = if ($env:APPA_POSTHOG_KEY) { $env:APPA_POSTHOG_KEY } else { 'phc_v9AQ9LsFdiQoiPSR7GMW7qJYmazqzRFpad4D3KoidGB6' }
+$posthogHost = if ($env:APPA_POSTHOG_HOST) { $env:APPA_POSTHOG_HOST } else { 'https://eu.i.posthog.com' }
+
+# The non-interactive way to say no, for scripted or fleet installs.
+if ($env:APPA_TELEMETRY -eq '0') { exit 0 }
+
+# Constrained rather than trusted, matching the sh version: anything outside
+# this set is dropped rather than escaped.
+function Get-Sanitized([string]$value) {
+  $clean = ($value -replace '[^A-Za-z0-9._-]', '')
+  if ($clean.Length -gt 64) { $clean = $clean.Substring(0, 64) }
+  return $clean
+}
+
+# Random per run and written nowhere, so two installs on one machine cannot be
+# linked and no later event can be tied back to this one.
+$payload = @{
+  api_key     = $posthogKey
+  event       = 'appa_installed'
+  distinct_id = [guid]::NewGuid().ToString()
+  properties  = @{
+    '$process_person_profile' = $false
+    appa_version              = Get-Sanitized $Version
+    os                        = Get-Sanitized $Os
+    arch                      = Get-Sanitized $Arch
+    install_method            = 'claude-code-plugin'
+  }
+} | ConvertTo-Json -Compress -Depth 4
+
+try {
+  Invoke-RestMethod -Method Post -Uri "$posthogHost/i/v0/e/" `
+    -ContentType 'application/json' -Body $payload -TimeoutSec 5 | Out-Null
+} catch {
+  # A slow or unreachable endpoint must not hold up the end of an install.
+}
+
+exit 0

--- a/integrations/claude-code/plugin/report-install.ps1
+++ b/integrations/claude-code/plugin/report-install.ps1
@@ -6,11 +6,17 @@
 # whether to send it. Nothing here fires unless a person said yes to a question
 # they were shown. See report-install.sh for why the installer reports this and
 # the runtime does not.
+# Deliberately not Mandatory. A missing or empty value on a Mandatory
+# parameter makes PowerShell stop and prompt for it — "Supply values for the
+# following parameters" — which, at the end of an install with nothing on
+# stdin, hangs and then dies instead of returning. The check below does the
+# same job and keeps the promise the rest of this file makes: never block the
+# install, always exit 0.
 [CmdletBinding()]
 param(
-  [Parameter(Mandatory = $true)][string]$Version,
-  [Parameter(Mandatory = $true)][string]$Os,
-  [Parameter(Mandatory = $true)][string]$Arch
+  [string]$Version,
+  [string]$Os,
+  [string]$Arch
 )
 
 # Failure here never becomes a problem for the install.
@@ -22,6 +28,14 @@ $posthogHost = if ($env:APPA_POSTHOG_HOST) { $env:APPA_POSTHOG_HOST } else { 'ht
 
 # The non-interactive way to say no, for scripted or fleet installs.
 if ($env:APPA_TELEMETRY -eq '0') { exit 0 }
+
+# Written straight to stderr: $ErrorActionPreference above would swallow
+# Write-Error, and a caller that passed the wrong arguments should still see why
+# nothing was sent.
+if (-not $Version -or -not $Os -or -not $Arch) {
+  [Console]::Error.WriteLine('usage: report-install.ps1 -Version <version> -Os <os> -Arch <arch>')
+  exit 0
+}
 
 # Constrained rather than trusted, matching the sh version: anything outside
 # this set is dropped rather than escaped.

--- a/integrations/claude-code/plugin/report-install.sh
+++ b/integrations/claude-code/plugin/report-install.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Reports one anonymous "appa was installed" event, and only ever that.
+#
+# The appa-setup skill runs this as its last step, after asking the user
+# whether to send it. That ordering is the whole design: nothing here fires
+# unless a person said yes to a question they were shown, in a terminal they
+# were watching, under the session's normal command approval.
+#
+# Why the installer and not the runtime. appa-runtime refuses to bind
+# anything but loopback and makes no outbound call of its own; a product
+# whose claim is deterministic control over where data goes should not quietly
+# become an exception to it. The installer is a better fit anyway — it runs
+# once per install, and it already knows the version, OS and architecture
+# because it just used them to pick the release asset.
+#
+# What is sent: the release version, the OS and architecture from the asset
+# name, and how it was installed. What is not sent: any identifier that
+# survives this script. The distinct id below is random per run and stored
+# nowhere, so two installs on one machine cannot be linked to each other, and
+# no later event can be tied back to this one.
+#
+# Failure here is never the install's problem. Every path exits 0.
+set -u
+
+# Public, write-only project key for the OpenAPPA PostHog project. This is the
+# same class of key that ships in openappa.com's JavaScript, where anyone can
+# read it; it can add events and can read nothing back. Forks and self-hosted
+# deployments override the two variables below rather than editing this file.
+posthog_key=${APPA_POSTHOG_KEY:-phc_v9AQ9LsFdiQoiPSR7GMW7qJYmazqzRFpad4D3KoidGB6}
+posthog_host=${APPA_POSTHOG_HOST:-https://eu.i.posthog.com}
+
+# A second, non-interactive way to say no, for anyone scripting an install or
+# setting it once for a whole fleet. Checked even though the skill has already
+# asked, so that a machine configured to stay quiet stays quiet regardless of
+# what any future caller of this script decides to do.
+if [ "${APPA_TELEMETRY:-1}" = 0 ]; then
+  exit 0
+fi
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: report-install.sh <version> <os> <arch>" >&2
+  exit 0
+fi
+
+# uname output and the contents of version.txt reach us as arguments, so they
+# are constrained rather than trusted: anything outside this set is dropped
+# instead of escaped, which keeps the JSON below correct without a quoting
+# routine written in sh.
+sanitize() {
+  printf '%s' "$1" | tr -cd 'A-Za-z0-9._-' | cut -c1-64
+}
+
+version=$(sanitize "$1")
+os=$(sanitize "$2")
+arch=$(sanitize "$3")
+
+# Random per run, never written to disk. PostHog wants a distinct id on every
+# event; this satisfies that without creating something that identifies the
+# machine across time.
+if command -v uuidgen >/dev/null 2>&1; then
+  install_id=$(uuidgen | tr '[:upper:]' '[:lower:]')
+else
+  install_id=$(od -An -tx1 -N16 /dev/urandom 2>/dev/null | tr -d ' \n')
+fi
+[ -n "$install_id" ] || install_id="unknown-$$"
+
+# $process_person_profile:false keeps this an event and nothing more — PostHog
+# counts it without building a person record behind it, which is all a count of
+# installs needs.
+payload=$(cat <<JSON
+{"api_key":"$posthog_key","event":"appa_installed","distinct_id":"$install_id","properties":{"\$process_person_profile":false,"appa_version":"$version","os":"$os","arch":"$arch","install_method":"claude-code-plugin"}}
+JSON
+)
+
+# Short deadline and silenced output: a slow or unreachable endpoint must not
+# hold up the end of an install, and a stack trace from curl is not something
+# the person installing a security tool needs to read.
+curl -sf -m 5 -X POST \
+  -H 'Content-Type: application/json' \
+  -d "$payload" \
+  "$posthog_host/i/v0/e/" >/dev/null 2>&1 || true
+
+exit 0

--- a/integrations/claude-code/plugin/skills/appa-setup/SKILL.md
+++ b/integrations/claude-code/plugin/skills/appa-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: appa-setup
-description: Install or upgrade the OpenAPPA runtime for this Claude Code plugin - download the appa-runtime release binary, verify its checksum and version, install the clappa command and the APPA statusline, and start the runtime. Use when the user asks to set up APPA, install or upgrade appa-runtime, or when a session reports that the runtime binary is not installed.
+description: Install or upgrade the OpenAPPA runtime for this Claude Code plugin - download the appa-runtime release binary, verify its checksum and version, install the clappa command and the APPA statusline, start the runtime, and ask whether the install may be counted. Use when the user asks to set up APPA, install or upgrade appa-runtime, or when a session reports that the runtime binary is not installed.
 ---
 
 # appa-setup
@@ -59,6 +59,35 @@ Resolve both paths in a shell; do not guess.
 
    If the starter exits non-zero, the runtime is not running. Report that, quote the last lines of `runtime.stderr.log` in the data directory, and stop. Do not describe the setup as finished.
 
-9. Finish by telling the user that the runtime is running and that `clappa` starts a protected session. Add a tip on the next line: run the `/appa-tool-sync` skill in the `clappa` session to build the initial security policy. Format both `clappa` and `/appa-tool-sync` as inline code.
+9. Ask whether to report the install, and send nothing unless the answer is
+   yes. Ask in one short question, in your own words, covering exactly this:
+   the project counts installs, one event says which version and which OS and
+   architecture, nothing that identifies them or their machine is included or
+   stored, and `APPA_TELEMETRY=0` refuses it permanently.
+
+   Treat only a clear yes as yes. Silence, a shrug, "whatever", or moving on to
+   another question are all no. Do not ask twice, do not argue with a no, and
+   do not report it later in the session. A no costs the user nothing else: the
+   install is already finished either way.
+
+   On a yes, run the reporter once, taking `<version>` from the `version.txt`
+   downloaded in step 2 and `<os>` and `<arch>` from the asset you picked in
+   step 1:
+
+   ```sh
+   sh "<plugin files>/report-install.sh" <version> <os> <arch>
+   ```
+
+   On native Windows:
+
+   ```powershell
+   powershell.exe -NoProfile -File "<plugin files>\report-install.ps1" -Version <version> -Os <os> -Arch <arch>
+   ```
+
+   It exits 0 whether or not the event reaches anyone. Do not check it, retry
+   it, or mention it again — a failed count is not the user's problem, and an
+   install that worked must not be reported as broken because a metric missed.
+
+10. Finish by telling the user that the runtime is running and that `clappa` starts a protected session. Add a tip on the next line: run the `/appa-tool-sync` skill in the `clappa` session to build the initial security policy. Format both `clappa` and `/appa-tool-sync` as inline code.
 
 If the `curl` download fails, ask the user to install the GitHub CLI, then try again with `gh release download`.

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,0 +1,11 @@
+# PostHog project API key (the public, write-only one — safe to ship to the
+# browser, which is why it carries the NEXT_PUBLIC_ prefix).
+#
+# Leave it unset and the site behaves exactly as it did before analytics
+# existed: no PostHog, no consent notice. That is the intended state for forks
+# and for local development, so there is nothing to fill in to run the site.
+#
+# Production reads it from the Vercel project's environment variables, not from
+# a file — deploys run `vercel deploy` from CI (see
+# .github/workflows/deploy-to-vercel.yml) and build on Vercel's infrastructure.
+NEXT_PUBLIC_POSTHOG_KEY=

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -2669,6 +2669,130 @@ samp {
   }
 }
 
+/* ————————————————————————————————————————————————
+   Analytics consent notice
+   ———————————————————————————————————————————————— */
+
+/* A bar rather than a dialog: unanswered, it must still leave the docs
+   readable. It sits below the search overlay (50) so a search the reader
+   opened deliberately is never covered by a notice that arrived on a timer. */
+.cookie-notice {
+  position: fixed;
+  z-index: 45;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  width: calc(100% - 32px);
+  max-width: 620px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 16px 14px 20px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.16);
+  animation: cookie-notice-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.cookie-notice.is-closing {
+  animation: cookie-notice-out 160ms ease both;
+}
+
+.cookie-notice-text {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-weak);
+}
+
+.cookie-notice-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Declining is a plain control, not a styled button: the two answers carry the
+   same weight here, and dressing only one of them would be a thumb on the
+   scale of a question the reader is meant to answer freely. */
+.cookie-notice-skip {
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--text-weak);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 120ms ease;
+}
+
+.cookie-notice-skip:hover {
+  color: var(--text-strong);
+}
+
+.cookie-notice-accept {
+  padding: 8px 16px;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-inverted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 120ms ease;
+}
+
+.cookie-notice-accept:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.cookie-notice-skip:focus-visible,
+.cookie-notice-accept:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@keyframes cookie-notice-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(12px);
+  }
+}
+
+@keyframes cookie-notice-out {
+  to {
+    opacity: 0;
+    transform: translateX(-50%) translateY(6px);
+  }
+}
+
+@media (max-width: 560px) {
+  .cookie-notice {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .cookie-notice-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cookie-notice,
+  .cookie-notice.is-closing {
+    animation: none;
+  }
+}
+
 /* Tailwind utility names for the shadcn tokens. Two remaps on purpose:
    `--color-accent` reads the ui hover-surface token (the site's `--accent`
    is the strong green and stays out of component hover backgrounds), and

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 
+import { Analytics } from "@/components/Analytics";
+import { CookieNotice } from "@/components/CookieNotice";
 import { MobileNavProvider } from "@/components/MobileNav";
 import { ReaderPing } from "@/components/ReaderPing";
 import { SearchProvider } from "@/components/SearchProvider";
@@ -41,6 +43,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* Mounted at the root so it greets a reader landing on any page, not
             only the home page. Shows once per browser, then never again. */}
         <ReaderPing />
+        {/* PostHog is not fetched, started, or given anything to store until
+            the notice below is answered, so an undecided reader is never
+            measured. The notice waits for ReaderPing so that a first visit asks
+            one thing at a time. */}
+        <Analytics apiKey={process.env.NEXT_PUBLIC_POSTHOG_KEY ?? ""} />
+        <CookieNotice />
       </body>
     </html>
   );

--- a/website/components/Analytics.tsx
+++ b/website/components/Analytics.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+import { readConsent, subscribeToConsent } from "@/lib/analytics-consent";
+
+/* PostHog, started only once the reader has said yes.
+
+   The obvious way to write this is to import the library at the top of the
+   file, initialise it on load, and rely on `opt_out_capturing_by_default` to
+   hold events back until consent. That is not enough, in two separate ways.
+
+   Initialising fetches remote config and evaluates feature flags straight away,
+   and those requests reach PostHog — carrying the reader's IP — whether or not
+   capturing is opted out. It also writes the `ph_*` cookie and localStorage
+   entry unless persistence is separately opted out of. Any of that happening
+   before the notice is answered would make the notice decorative.
+
+   A static import is also not free: the library is around 240 kB of JavaScript,
+   and importing it from the root layout means every reader downloads it on
+   every page, including the ones who decline. So consent gates the `import`
+   itself, not just `init`. A reader who says no, or never answers, never
+   fetches the chunk, never has a request made on their behalf, and never has
+   anything written to their device.
+
+   There is no React context here on purpose. `posthog-js` is a singleton, so a
+   component that wants to record something can await the same module:
+
+     const { default: posthog } = await import("posthog-js");
+     posthog.capture("curl_copied", { page: "/contracts" });
+
+   Wrapping the tree in a provider would buy nothing and put a re-render
+   boundary around every page. */
+
+type PostHogClient = Awaited<typeof import("posthog-js")>["default"];
+
+/* Events go to PostHog's EU region, reached through the same-origin `/ingest`
+   path rewritten in `next.config.ts`. `ui_host` plays no part in ingestion: it
+   only tells the toolbar and the "view this in PostHog" links where the app
+   lives. */
+const UI_HOST = "https://eu.posthog.com";
+
+const CONFIG = {
+  api_host: "/ingest",
+  ui_host: UI_HOST,
+  /* Route changes in the App Router are not page loads, so PostHog's own
+     pageview detection would miss every navigation after the first. The
+     pageview effect below sends them instead. */
+  capture_pageview: false,
+  capture_pageleave: true,
+  /* Both of these record far more about a reader than counting them requires,
+     which is all this site is trying to do. */
+  capture_heatmaps: false,
+  disable_session_recording: true,
+  /* The site drives none of these. Turning them off is not a privacy control —
+     consent has already been given by the time we get here — it just avoids
+     requests and runtime work for features nothing on the site consumes. */
+  advanced_disable_flags: true,
+  disable_surveys: true,
+  disable_web_experiments: true,
+} as const;
+
+/* Module scope, so it survives the remount React performs in development and is
+   shared by both effects below. Holding the promise rather than the client is
+   what makes concurrent callers safe: the second one waits on the same import
+   and `init` instead of racing a second one. */
+let client: Promise<PostHogClient> | null = null;
+
+function startPostHog(apiKey: string): Promise<PostHogClient> {
+  if (!client) {
+    client = import("posthog-js").then(({ default: posthog }) => {
+      posthog.init(apiKey, CONFIG);
+      return posthog;
+    });
+  }
+  return client;
+}
+
+export function Analytics({ apiKey }: { apiKey: string }) {
+  /* No key configured — a fork, or a preview deployment without the env var.
+     The site must work untouched in that case rather than throwing. */
+  if (!apiKey) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <AnalyticsInner apiKey={apiKey} />
+    </Suspense>
+  );
+}
+
+/* Split out because `useSearchParams` opts its whole component into client-side
+   rendering, and Next requires that boundary to be a Suspense child. */
+function AnalyticsInner({ apiKey }: { apiKey: string }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [granted, setGranted] = useState(false);
+
+  useEffect(() => {
+    const sync = () => setGranted(readConsent() === "granted");
+    sync();
+    return subscribeToConsent(sync);
+  }, []);
+
+  useEffect(() => {
+    if (!granted) {
+      /* Withdrawal — the reader cleared their decision, or answered "no" in
+         another tab after having agreed in this one. If `client` is null the
+         library was never fetched, so there is nothing to switch off. */
+      client?.then((ph) => ph.opt_out_capturing()).catch(ignore);
+      return;
+    }
+
+    /* Covers re-granting after a withdrawal: PostHog remembers the opt-out
+       across reloads, so a freshly initialised client can come back silenced. */
+    startPostHog(apiKey)
+      .then((ph) => {
+        if (!ph.has_opted_in_capturing()) ph.opt_in_capturing();
+      })
+      .catch(ignore);
+  }, [granted, apiKey]);
+
+  useEffect(() => {
+    if (!granted) return;
+
+    /* Read now rather than inside the callback. The import may still be in
+       flight, and by the time it lands the reader could have moved on — the
+       pageview belongs to the page that was open when the effect ran. */
+    const url = window.location.href;
+
+    startPostHog(apiKey)
+      .then((ph) => ph.capture("$pageview", { $current_url: url }))
+      .catch(ignore);
+  }, [granted, pathname, searchParams, apiKey]);
+
+  return null;
+}
+
+/* A blocked or failed chunk fetch means no analytics, which is a perfectly fine
+   state for this site to be in. It must never surface to the reader. */
+function ignore() {}

--- a/website/components/CookieNotice.tsx
+++ b/website/components/CookieNotice.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { readConsent, subscribeToConsent, writeConsent } from "@/lib/analytics-consent";
+import { isReaderPingPending, READER_PING_RESOLVED_EVENT } from "./ReaderPing";
+
+/* The one question this site asks about measurement. Until it is answered
+   PostHog stays opted out (see `Analytics.tsx`), so the notice is a request
+   rather than an announcement of something already happening.
+
+   It is a bar, not a modal: the docs are the product surface here, and a reader
+   who ignores this should still be able to read every word on the page. That is
+   also why there is no close button — dismissing without answering would just
+   be "no" wearing a disguise, and "No thanks" already says it plainly. */
+
+/* Long enough that the notice arrives after the page has painted and the reader
+   has their bearings. Deliberately longer than ReaderPing's own delay so that
+   on a first visit the two are sequenced rather than racing. */
+const APPEAR_DELAY_MS = 900;
+
+export function CookieNotice() {
+  const [visible, setVisible] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+
+  useEffect(() => {
+    if (readConsent() !== null) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const show = () => {
+      timer = setTimeout(() => setVisible(true), APPEAR_DELAY_MS);
+    };
+
+    if (isReaderPingPending()) {
+      /* Wait our turn. If the reader never answers that prompt they never see
+         this one either, which is the correct outcome: they are not being
+         measured, and nothing is being stored about them. */
+      window.addEventListener(READER_PING_RESOLVED_EVENT, show, { once: true });
+      return () => {
+        window.removeEventListener(READER_PING_RESOLVED_EVENT, show);
+        clearTimeout(timer);
+      };
+    }
+
+    show();
+    return () => clearTimeout(timer);
+  }, []);
+
+  /* Answering in one tab should retire the notice in the others too. */
+  useEffect(() => {
+    return subscribeToConsent(() => {
+      if (readConsent() !== null) setVisible(false);
+    });
+  }, []);
+
+  if (!visible) return null;
+
+  const answer = (decision: "granted" | "denied") => {
+    /* Recorded first: the state below is only how this tab stops drawing the
+       bar, while the write is what actually settles the question. */
+    writeConsent(decision);
+    setLeaving(true);
+    setTimeout(() => setVisible(false), 160);
+  };
+
+  return (
+    <div
+      className={`cookie-notice${leaving ? " is-closing" : ""}`}
+      role="region"
+      aria-label="Analytics consent"
+    >
+      <p className="cookie-notice-text">
+        We would like to count visits to these pages so we know which parts of OpenAPPA people
+        actually read. No advertising, no session recording, no third-party sharing.
+      </p>
+      <div className="cookie-notice-actions">
+        <button type="button" className="cookie-notice-skip" onClick={() => answer("denied")}>
+          No thanks
+        </button>
+        <button type="button" className="cookie-notice-accept" onClick={() => answer("granted")}>
+          Allow
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/website/components/ReaderPing.tsx
+++ b/website/components/ReaderPing.tsx
@@ -67,12 +67,35 @@ function rememberSuppression() {
   document.cookie = `${OFF_COOKIE}=1; Max-Age=${OFF_MAX_AGE_S}; Path=/; SameSite=Lax${secure}`;
 }
 
+/* Fired once the reader has answered this prompt, so the cookie notice knows it
+   is free to appear. Both want the first visit, and this one gets it: it is a
+   modal with a backdrop, and stacking a second prompt underneath would leave
+   the reader answering two questions through a blur. */
+export const READER_PING_RESOLVED_EVENT = "openappa:reader-ping-resolved";
+
+/** Whether this prompt still owes the reader a first-visit appearance.
+
+    Mirrors the open decision in the effect below, and has to keep mirroring it:
+    the cookie notice waits on this, so a case that returns true here but never
+    opens the dialog would leave the notice waiting for an event that never
+    comes. In particular a reader who arrived with ?popup=no is not pending —
+    that prompt is gone for them, and the notice should just show. */
+export function isReaderPingPending(): boolean {
+  if (suppressionRequested()) return false;
+  if (forcedOpen()) return true;
+  return !alreadySeen() && !suppressedByCookie();
+}
+
 function remember(outcome: "sent" | "skipped") {
   try {
     localStorage.setItem(SEEN_KEY, outcome);
   } catch {
     /* Nothing to do: the prompt simply may appear again next visit. */
   }
+
+  /* Announced even when the write above failed. The cookie notice is waiting on
+     the reader having answered, not on our having recorded it. */
+  window.dispatchEvent(new Event(READER_PING_RESOLVED_EVENT));
 }
 
 export function ReaderPing() {

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -17,6 +17,8 @@ claude plugin marketplace add archestra-ai/OpenAPPA &&
 
 The setup installs the local runtime and adds `clappa`, a protected way to start Claude Code. It does not replace `claude` or change how your ordinary sessions start.
 
+Setup asks once whether it may count the install. If you agree, it sends one event with the version, operating system and architecture. It sends nothing that identifies you or your machine, and it stores nothing to recognise you later. If you decline, or say nothing, it sends nothing. `APPA_TELEMETRY=0` refuses it without being asked. The runtime never reports anything at any point.
+
 ## 1. Teach OpenAPPA about your tools
 
 :::claude-policy-timing:::

--- a/website/lib/analytics-consent.ts
+++ b/website/lib/analytics-consent.ts
@@ -1,0 +1,94 @@
+/* Whether the reader has agreed to be counted.
+
+   PostHog is loaded on every page but starts opted out, so nothing is sent and
+   nothing is stored on the device until this module says otherwise. That order
+   matters: a reader who never answers the notice, or who answers "no", is never
+   measured, and the only thing we keep about them is the one key below
+   recording that they were asked.
+
+   The value is deliberately a single string rather than the per-category object
+   a full consent manager would use. This site runs one analytics tool and no ad
+   or marketing tags, so there is exactly one question to ask; inventing
+   categories nobody can act on would misrepresent what the choice does. */
+
+const STORAGE_KEY = "openappa-analytics-consent";
+
+/* Bump when the answer stops meaning what it meant — a new tool, a new purpose
+   — so previous answers lapse and readers are asked again about the new thing.
+   Do not bump for copy or styling changes; that would nag readers who already
+   answered the same question. */
+const CONSENT_VERSION = "1";
+
+export type ConsentDecision = "granted" | "denied";
+
+/* Fired on the window when the decision changes in this tab. `storage` covers
+   other tabs but never the tab that wrote the value, so both are needed for a
+   reader with the site open twice to see one consistent state. */
+const CHANGE_EVENT = "openappa:analytics-consent-change";
+
+type StoredConsent = {
+  version: string;
+  decision: ConsentDecision;
+  /* Kept so we can answer "when did they agree, and to what version" without
+     reconstructing it from server logs we do not have. */
+  decidedAt: string;
+};
+
+/** The reader's answer, or `null` if they have not been asked yet — or were
+    asked under an older version, which counts as not asked. */
+export function readConsent(): ConsentDecision | null {
+  if (typeof window === "undefined") return null;
+
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    /* Private-mode or blocked storage. We cannot record an answer, so we cannot
+       honour one either; treating that as "no decision" keeps the reader opted
+       out, which is the side to fail to. */
+    return null;
+  }
+  if (raw === null) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredConsent>;
+    if (parsed.version !== CONSENT_VERSION) return null;
+    if (parsed.decision !== "granted" && parsed.decision !== "denied") return null;
+    return parsed.decision;
+  } catch {
+    return null;
+  }
+}
+
+export function writeConsent(decision: ConsentDecision): void {
+  const payload: StoredConsent = {
+    version: CONSENT_VERSION,
+    decision,
+    decidedAt: new Date().toISOString(),
+  };
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* The answer applies to this page view even if it cannot be remembered for
+       the next one, so fall through to the notification rather than returning. */
+  }
+
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+/** Calls `onChange` whenever the decision may have changed, in this tab or
+    another one. Returns the unsubscribe function. */
+export function subscribeToConsent(onChange: () => void): () => void {
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) onChange();
+  };
+
+  window.addEventListener(CHANGE_EVENT, onChange);
+  window.addEventListener("storage", onStorage);
+
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onChange);
+    window.removeEventListener("storage", onStorage);
+  };
+}

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -7,6 +7,29 @@ const nextConfig: NextConfig = {
     "/mcp": ["./content/**/*"],
     "/llms.txt": ["./content/**/*"],
   },
+  // PostHog is reached through this origin rather than directly. Two reasons:
+  // requests to a posthog.com hostname are blocked by most content blockers,
+  // which silently loses a large share of a technical audience, and keeping the
+  // traffic first-party means no third-party cookie is involved at all.
+  // Ingestion is the EU region, so reader data does not leave it.
+  async rewrites() {
+    return [
+      // Static assets and the array config are served from the assets host,
+      // which is a different hostname than the ingestion endpoint below.
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
+    ];
+  },
   // Doc pages live at the root (/contracts, not /docs/contracts). Links
   // already shared under the old prefix keep working.
   async redirects() {

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "mcp-handler": "^2.1.0",
     "nanoid": "^6.0.1",
     "next": "^15.5.0",
+    "posthog-js": "^1.417.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       next:
         specifier: ^15.5.0
         version: 15.5.20(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      posthog-js:
+        specifier: ^1.417.3
+        version: 1.417.3
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -617,6 +620,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@posthog/browser-common@0.5.0':
+    resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
+
+  '@posthog/core@1.48.2':
+    resolution: {integrity: sha512-zZNvsEg+YCezvJKeWdaZ77ngjKJvGnAEo31DIy2guYeDtZ5kNjJ4c6CkwqtmXmwNXjzOFGJyshzv3Fv2gHVJYA==}
+
+  '@posthog/types@1.404.1':
+    resolution: {integrity: sha512-i2Gei6ARfOSBeTN4s2yUP1p97s2UNI+1NWmtLjhnR/V6t3RFOfI1sBWKcJNWHjtoOCCWoAFU+PNPY6SgT2VtEQ==}
 
   '@radix-ui/primitive@1.1.7':
     resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
@@ -1328,6 +1340,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -1726,6 +1741,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
@@ -2674,9 +2692,20 @@ packages:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.417.3:
+    resolution: {integrity: sha512-F+73VV31nNCyHmDSB5IycWhQ9qhWIwC81GIS2mXz1m0VfWwvGIVu56OKxH2ZbkiXsD5VgE032cC/5ZzuAX0pwg==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -2696,6 +2725,9 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3197,6 +3229,12 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3729,6 +3767,17 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@posthog/browser-common@0.5.0':
+    dependencies:
+      '@posthog/core': 1.48.2
+      '@posthog/types': 1.404.1
+
+  '@posthog/core@1.48.2':
+    dependencies:
+      '@posthog/types': 1.404.1
+
+  '@posthog/types@1.404.1': {}
 
   '@radix-ui/primitive@1.1.7': {}
 
@@ -4425,6 +4474,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.50.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -4851,6 +4902,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.4.9: {}
 
   fflate@0.8.3: {}
 
@@ -6014,7 +6067,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.417.3:
+    dependencies:
+      '@posthog/browser-common': 0.5.0
+      '@posthog/core': 1.48.2
+      '@posthog/types': 1.404.1
+      core-js: 3.50.0
+      dompurify: 3.4.13
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   powershell-utils@0.1.0: {}
+
+  preact@10.29.8: {}
 
   pretty-ms@9.3.0:
     dependencies:
@@ -6036,6 +6106,8 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -6681,6 +6753,10 @@ snapshots:
       vfile-message: 4.0.3
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Closes both halves of T-1144: PostHog on openappa.com, and an event on installation. Nothing is measured in either place until a person says yes.

## 1. PostHog on openappa.com

### Consent gates the import, not just capturing

The obvious implementation initialises PostHog on load and relies on `opt_out_capturing_by_default` to hold events back. I started there, then checked in a browser — it leaks in two ways:

- **Requests before consent.** Starting PostHog immediately fetches remote config and evaluates feature flags. Those requests reach PostHog carrying the reader's IP whether or not capturing is opted out.
- **Storage before consent.** It writes its `ph_*` cookie and localStorage entry unless persistence is *separately* opted out of via `opt_out_persistence_by_default`.

Either one would have made the notice decorative. So consent gates the dynamic `import()` of `posthog-js` itself. As a bonus this keeps the library's ~240 kB off the wire for readers who decline or never answer — it is no longer referenced by the initial HTML at all.

### Other decisions

- **Same-origin `/ingest` rewrite** to PostHog's EU region. No third-party request, and content blockers do not silently drop a large share of a technical audience.
- **The notice waits for the reader-ping prompt.** Both want the first visit. The ping is a modal with a backdrop, so stacking a second question underneath would leave the reader answering through a blur. `ReaderPing` now announces when it has been answered; the notice listens. A reader arriving with `?popup=no` is not pending, so the notice shows immediately rather than waiting for a prompt that never comes.
- **A bar, not a modal, and no close button.** The docs are the product surface, so an unanswered notice must still leave every word readable. Dismissing without answering would just be "no" in disguise, and "No thanks" already says it plainly.
- **One question, not consent categories.** The site runs one analytics tool and no ad or marketing tags.
- Session recording, heatmaps, surveys, feature flags and web experiments are all off.

`NEXT_PUBLIC_POSTHOG_KEY` is set in the Vercel project (Production). Without it the site behaves exactly as before — no PostHog, no notice — which is the intended state for forks and local development.

## 2. The install count

`/appa-setup` asks once whether it may report the install. On yes it sends one event naming the version, OS and architecture. On no, **or on no answer**, it sends nothing. `APPA_TELEMETRY=0` refuses it without being asked, for scripted and fleet installs.

**The installer reports this, not the runtime, and that is the point.** This is the first outbound call anything in the project makes on its own behalf, and a product whose claim is deterministic control over where data goes should not quietly become an exception to it. `appa-runtime` still binds loopback only and calls nothing. The installer is a better fit anyway: it runs once per install, and it already knows the version, OS and architecture because it just used them to pick the release asset.

**`ensure-runtime.sh` was the obvious place and is the wrong one.** `hooks.json` wires it to `SessionStart`, so instrumenting it would emit an event on *every protected session for the life of the installation* rather than once per install.

Nothing identifying is sent and nothing is stored. The distinct id is random per run and written nowhere, so two installs on one machine cannot be linked and no later event can be tied back to one of them. The event carries `$process_person_profile:false` so PostHog counts it without building a person record behind it.

Documented in the root README, the integration README, and the public install page — a phone-home that is not written down is the actual problem.

## Verification

**Website**, driven in a real browser against a dev server, checking network and storage at each step:

| State | `/ingest` requests | Cookies | localStorage |
|---|---|---|---|
| Undecided (incl. across a navigation) | none | 0 | 0 |
| Declined, on a fresh load | none | 0 | 0 |
| Allowed | chunk fetched, then `/e/` → `200` | set | set |

Also confirmed: the notice holds back until the ping is answered, appears directly for returning readers and for `?popup=no`, and navigation fires exactly one pageview. A real pageview landed in the PostHog project end-to-end through the EU rewrite.

**Install reporter**, exercised directly against a local listener and then against PostHog:

| Case | Result |
|---|---|
| Normal run | valid JSON, correct properties, event lands in PostHog |
| `APPA_TELEMETRY=0` | no request, exit 0 |
| Missing arguments | usage on stderr, no request, exit 0 |
| Unreachable endpoint | exit 0 in ~0.02s, no hang |
| `'0.2.0","evil":"yes'` as version | sanitised to `0.2.0evilyes`; no injected key, JSON still valid |
| Two consecutive runs | different `distinct_id`, confirming nothing persistent |

`shellcheck -s sh` is clean and now runs on the new script in CI. `pnpm typecheck` and `pnpm build` pass; all pages still prerender static.

**`report-install.ps1` is executed too**, in `mcr.microsoft.com/powershell` (PowerShell 7.4.2) — Windows containers need a Windows host, but this script is pure PowerShell Core. Doing that caught a real bug: the parameters were `Mandatory`, so a missing value made PowerShell stop and prompt (`Supply values for the following parameters: Version:`), which at the end of an install with nothing on stdin hangs and then dies. Fixed in 847c726; it now prints usage and exits 0 like the shell version. Its payload is field-for-field identical to the shell one.

See the two file comments on `report-install.sh` and `report-install.ps1` for what the install looks like from the terminal, including the captured before/after output.

**Remaining gap:** that run was PowerShell 7 on Linux, so it exercises the logic but not Windows itself — notably `powershell.exe` (5.1) rather than `pwsh`. Nothing here uses 7-only syntax, but a run on a real Windows box is still worth doing.

