### PR TITLE
engine: bounded advisory recovery-route search (RMD-20)

### DIFF
--- a/appa-engine/src/check.rs
+++ b/appa-engine/src/check.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeSet;
 use serde::{Deserialize, Serialize};
 
 use crate::candidate::CallStage;
-use crate::contract::{AudienceRequirement, HistoryRequirement, RecipientSpec, ToolContract, ToolResolverUse};
+use crate::contract::{
+    AudienceRequirement, HistoryRequirement, PinnedToolResolution, RecipientSpec, StaticContract, ToolContract,
+    ToolResolverUse,
+};
 use crate::fact::EffectKind;
 use crate::groups::Expansions;
 use crate::label::{Adequacy, Audience, Dimension, EstablishedLabel, PartialLabel, ReaderId, Trust};
@@ -84,14 +87,53 @@ pub(crate) fn committed_label(
     committed
 }
 
+/// What the check reads from the call it evaluates: the resolver answers pinned to it and the
+/// arguments its placeholders spell. `Static` is the argument-independent case — a
+/// [`StaticContract`] evaluated with no call at hand, which by construction reads nothing.
+#[derive(Clone, Copy)]
+pub(crate) enum CallReads<'a> {
+    Resolved(&'a ResolvedCall),
+    Static,
+}
+
+impl<'a> CallReads<'a> {
+    fn tool_resolutions(self) -> &'a [PinnedToolResolution] {
+        match self {
+            CallReads::Resolved(call) => call.tool_resolutions(),
+            CallReads::Static => &[],
+        }
+    }
+}
+
+/// The state-only evaluation of an argument-independent contract — the one path a recovery
+/// route may check a tool over before any call to it exists (RMD-20). Same gap logic as
+/// [`evaluate_state`], at the origin stage, reading no call.
+pub(crate) fn evaluate_static(
+    contract: &StaticContract<'_>,
+    current: &PartialLabel,
+    has_committed: &impl Fn(&EffectKind) -> bool,
+    has_reserved: &impl Fn(&EffectKind) -> bool,
+    expansions: &Expansions,
+) -> StateEval {
+    evaluate_state(
+        contract.contract(),
+        current,
+        has_committed,
+        has_reserved,
+        CallReads::Static,
+        &CallStage::default(),
+        expansions,
+    )
+}
+
 pub(crate) fn committed_label_for_call(
     contract: &ToolContract,
     current: &PartialLabel,
-    call: &ResolvedCall,
+    reads: CallReads<'_>,
     expansions: &Expansions,
 ) -> PartialLabel {
     let mut committed = committed_label(contract, current, expansions);
-    for resolution in call.tool_resolutions() {
+    for resolution in reads.tool_resolutions() {
         committed.narrow_bound(&EstablishedLabel::new(
             resolution.trust().unwrap_or(Trust::new(u8::MAX)),
             resolution.audience().cloned().unwrap_or(Audience::Public),
@@ -116,7 +158,7 @@ pub(crate) fn evaluate(
         &current,
         &|kind| views.has_effect(kind),
         &|kind| views.has_reservation(kind),
-        call,
+        CallReads::Resolved(call),
         stage,
         expansions,
     );
@@ -144,12 +186,12 @@ pub(crate) fn evaluate_state(
     current: &PartialLabel,
     has_committed: &impl Fn(&EffectKind) -> bool,
     has_reserved: &impl Fn(&EffectKind) -> bool,
-    call: &ResolvedCall,
+    reads: CallReads<'_>,
     stage: &CallStage,
     expansions: &Expansions,
 ) -> StateEval {
-    let committed = committed_label_for_call(contract, current, call, expansions);
-    let consumed = consumed_unknown(contract, &committed, call, stage, expansions);
+    let committed = committed_label_for_call(contract, current, reads, expansions);
+    let consumed = consumed_unknown(contract, &committed, reads, stage, expansions);
 
     let narrowing = (committed.bound() != current.bound()).then(|| Narrowing {
         from: current.bound().clone(),
@@ -157,10 +199,11 @@ pub(crate) fn evaluate_state(
     });
 
     let mut gaps = Vec::new();
-    label_gaps(contract, &committed, call, stage, expansions, &mut gaps);
+    label_gaps(contract, &committed, reads, stage, expansions, &mut gaps);
     history_gaps(contract, has_committed, has_reserved, &mut gaps);
     for mark in contract.requires.attention.iter().chain(
-        call.tool_resolutions()
+        reads
+            .tool_resolutions()
             .iter()
             .flat_map(|resolution| resolution.attention()),
     ) {
@@ -183,12 +226,12 @@ pub(crate) fn evaluate_state(
 fn consumed_unknown(
     contract: &ToolContract,
     committed: &PartialLabel,
-    call: &ResolvedCall,
+    reads: CallReads<'_>,
     stage: &CallStage,
     expansions: &Expansions,
 ) -> Vec<Dimension> {
     let mut dims = Vec::new();
-    if effective_trust_floors(contract, call).any(|floor| committed.meets_floor(floor) == Adequacy::Unresolved) {
+    if effective_trust_floors(contract, reads).any(|floor| committed.meets_floor(floor) == Adequacy::Unresolved) {
         dims.push(Dimension::Trust);
     }
     let audience_unresolved = contract
@@ -197,13 +240,13 @@ fn consumed_unknown(
         .audience
         .iter()
         .any(|requirement| match requirement {
-            AudienceRequirement::Includes(spec) => match resolve_recipients(spec, call, expansions) {
+            AudienceRequirement::Includes(spec) => match resolve_recipients(spec, reads, expansions) {
                 Some(recipients) => released_covers(stage, committed, &recipients) == Adequacy::Unresolved,
                 None => !released_established(stage, committed),
             },
             AudienceRequirement::Cap(cap) => committed.within_cap(&cap.resolve(expansions)) == Adequacy::Unresolved,
         })
-        || pinned_audience_requirements(call).any(|required| {
+        || pinned_audience_requirements(reads).any(|required| {
             required
                 .includes
                 .as_ref()
@@ -222,17 +265,21 @@ fn consumed_unknown(
 /// Every trust floor this call must meet: the contract's static floor, then each floor a
 /// tool-level resolver pinned to the call — one stream, so the static and dynamic halves
 /// cannot drift on how a floor is judged.
-fn effective_trust_floors<'a>(contract: &'a ToolContract, call: &'a ResolvedCall) -> impl Iterator<Item = Trust> + 'a {
+fn effective_trust_floors<'a>(contract: &'a ToolContract, reads: CallReads<'a>) -> impl Iterator<Item = Trust> + 'a {
     contract.requires.label.trust_floor.into_iter().chain(
-        call.tool_resolutions()
+        reads
+            .tool_resolutions()
             .iter()
             .filter_map(|resolution| resolution.required_trust()),
     )
 }
 
 /// Every audience requirement pinned to the call by a tool-level resolver.
-fn pinned_audience_requirements(call: &ResolvedCall) -> impl Iterator<Item = &crate::contract::RequiredAudience> {
-    call.tool_resolutions()
+fn pinned_audience_requirements<'a>(
+    reads: CallReads<'a>,
+) -> impl Iterator<Item = &'a crate::contract::RequiredAudience> {
+    reads
+        .tool_resolutions()
         .iter()
         .filter_map(|resolution| resolution.required_audience())
 }
@@ -271,12 +318,12 @@ fn released_established(stage: &CallStage, committed: &PartialLabel) -> bool {
 fn label_gaps(
     contract: &ToolContract,
     committed: &PartialLabel,
-    call: &ResolvedCall,
+    reads: CallReads<'_>,
     stage: &CallStage,
     expansions: &Expansions,
     gaps: &mut Vec<Gap>,
 ) {
-    for floor in effective_trust_floors(contract, call) {
+    for floor in effective_trust_floors(contract, reads) {
         if committed.meets_floor(floor) == Adequacy::Fails {
             gaps.push(Gap::TrustFloor {
                 required: floor,
@@ -286,7 +333,7 @@ fn label_gaps(
     }
     for requirement in &contract.requires.label.audience {
         match requirement {
-            AudienceRequirement::Includes(spec) => match resolve_recipients(spec, call, expansions) {
+            AudienceRequirement::Includes(spec) => match resolve_recipients(spec, reads, expansions) {
                 Some(recipients) => {
                     if released_covers(stage, committed, &recipients) == Adequacy::Fails {
                         gaps.push(Gap::Includes { recipients });
@@ -313,7 +360,7 @@ fn label_gaps(
             }
         }
     }
-    for required in pinned_audience_requirements(call) {
+    for required in pinned_audience_requirements(reads) {
         if let Some(recipients) = &required.includes
             && released_covers(stage, committed, recipients) == Adequacy::Fails
         {
@@ -351,10 +398,13 @@ fn history_gaps(
     }
 }
 
-fn resolve_recipients(spec: &RecipientSpec, call: &ResolvedCall, expansions: &Expansions) -> Option<Audience> {
-    match spec {
-        RecipientSpec::Static(audience) => Some(audience.resolve(expansions)),
-        RecipientSpec::Placeholder(key) => match placeholder_argument(key, call)? {
+fn resolve_recipients(spec: &RecipientSpec, reads: CallReads<'_>, expansions: &Expansions) -> Option<Audience> {
+    match (spec, reads) {
+        (RecipientSpec::Static(audience), _) => Some(audience.resolve(expansions)),
+        (RecipientSpec::Placeholder(_), CallReads::Static) => {
+            unreachable!("`StaticContract::of` refuses a placeholder, so a static read never meets one")
+        }
+        (RecipientSpec::Placeholder(key), CallReads::Resolved(call)) => match placeholder_argument(key, call)? {
             AudienceArgument::Public => Some(Audience::Public),
             AudienceArgument::Reader(reader) => Some(Audience::restricted([reader])),
             AudienceArgument::Group(_) => call
@@ -620,7 +670,7 @@ mod tests {
             &current,
             &|_| false,
             &|_| false,
-            &call,
+            CallReads::Resolved(&call),
             &CallStage::default(),
             &Expansions::default(),
         );
@@ -700,7 +750,7 @@ mod tests {
             &PartialLabel::established(EstablishedLabel::top()),
             &|_| false,
             &|_| false,
-            &call,
+            CallReads::Resolved(&call),
             &CallStage::default(),
             &Expansions::default(),
         );

--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -538,6 +538,52 @@ impl Delta {
     }
 }
 
+/// A contract the check can evaluate with no call at hand: nothing it reads comes from a call —
+/// no resolver answers (`uses`), no placeholder recipients, every group it names already
+/// expanded — and its output contribution is declared and established (not unannotated, no
+/// pending-cast dimension), so the label a successful call commits is known before the call
+/// exists. This is the only shape a recovery route plans a preceding tool over (RMD-20): its
+/// check and its successor state are argument-independent facts of the registry.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct StaticContract<'a>(&'a ToolContract);
+
+/// Why a contract is not [`StaticContract`]: what a call to it would first have to supply.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum NotStatic {
+    /// A resolver answer or a placeholder recipient reads the call's arguments.
+    Arguments,
+    /// The result label is established only at admission — unannotated or pending-cast.
+    Unestablished,
+    /// Groups the contract names that these expansions do not answer.
+    Membership(Vec<crate::names::GroupName>),
+}
+
+impl<'a> StaticContract<'a> {
+    pub(crate) fn of(contract: &'a ToolContract, expansions: &Expansions) -> Result<StaticContract<'a>, NotStatic> {
+        let placeholder = contract.requires.label.audience.iter().any(|requirement| {
+            matches!(
+                requirement,
+                AudienceRequirement::Includes(RecipientSpec::Placeholder(_))
+            )
+        });
+        if !contract.uses.is_empty() || placeholder {
+            return Err(NotStatic::Arguments);
+        }
+        match &contract.delta {
+            Some(delta) if delta.pending_cast_dim().is_none() => {}
+            Some(_) | None => return Err(NotStatic::Unestablished),
+        }
+        expansions
+            .require(contract.groups())
+            .map_err(|needed| NotStatic::Membership(needed.needed))?;
+        Ok(StaticContract(contract))
+    }
+
+    pub(crate) fn contract(&self) -> &'a ToolContract {
+        self.0
+    }
+}
+
 /// The recipients of an audience `includes` requirement — a static set, or a placeholder resolved
 /// from the call's arguments (`$recipient` → the value of argument `recipient`).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -292,10 +292,33 @@ impl Engine {
         }
     }
 
-    fn recorded_expansions(&self, resolutions: &[GroupResolution]) -> Expansions {
+    pub(crate) fn recorded_expansions(&self, resolutions: &[GroupResolution]) -> Expansions {
         self.registry
             .expansions_from_resolutions(resolutions)
             .expect("a validated log persists only groups the policy writes")
+    }
+
+    /// Every recovery route for a blocked call within `depth` (RMD-20), least mandate power
+    /// first: advisory only. Nothing is appended, no offer is minted, and `remedy_plans` stand as
+    /// surfaced; `answers` are the expansions the caller can supply now, behind the ones the log
+    /// already recorded for this subject. `RouteDepth::ONE` yields exactly the block's plans. An
+    /// empty list asserts only that no route exists within this abstraction and `depth`.
+    pub fn recovery_routes(
+        &self,
+        view: &EngineView,
+        subject: &crate::basis::SubjectKey,
+        answers: &[GroupExpansion],
+        depth: crate::route::RouteDepth,
+    ) -> Result<Vec<crate::route::RecoveryRoute>, crate::route::RouteError> {
+        if view.policy() != self.identity {
+            return Err(crate::route::RouteError::ForeignView);
+        }
+        let crate::basis::SubjectKey::Call { trajectory, .. } = subject else {
+            return Err(crate::route::RouteError::NotACallSubject);
+        };
+        let views = view.projection().view(trajectory);
+        let context = crate::route::BlockContext::reconstruct(self, &views, subject, answers)?;
+        crate::route::search(&self.registry, &views, &context, depth)
     }
 
     /// What the runtime must resolve before it can execute one live offer.
@@ -3758,9 +3781,14 @@ pub(crate) fn opened_dispatch(
         dispatch: dispatch.clone(),
         tool: call.tool().clone(),
         arguments: call.canonical_arguments().clone(),
-        proposed_label: check::committed_label_for_call(contract, &current, call, expansions)
-            .bound()
-            .clone(),
+        proposed_label: check::committed_label_for_call(
+            contract,
+            &current,
+            check::CallReads::Resolved(call),
+            expansions,
+        )
+        .bound()
+        .clone(),
         receiving: current.bound().clone(),
         proposed_effects: contract.emits.clone(),
         tool_resolutions: call.tool_resolutions().to_vec(),
@@ -14846,6 +14874,108 @@ mod tests {
         assert_eq!(e.validate_replay(&ended), Ok(()));
     }
 
+    mod recovery_routes {
+        use super::*;
+        use crate::route::{Certainty, Contingency, RecoveryRoute, RouteDepth, RouteError, RouteOutcome, RouteStep};
+        use std::collections::BTreeSet;
+
+        fn subject(batch: &str) -> crate::basis::SubjectKey {
+            crate::basis::SubjectKey::Call {
+                trajectory: traj(),
+                batch: crate::transition::ProposalBatchId::new(batch),
+                position: 0,
+            }
+        }
+
+        #[test]
+        fn depth_one_through_the_engine_is_the_offers_the_block_opened() {
+            let e = two_officer_engine();
+            let log = vec![opened(&e)];
+            let wire = call("wire", json!({}));
+            let blocked = appended_facts(proposed(&e, &log, "b1", nonce(), wire.clone()).expect("the call blocks"));
+            let offered: Vec<RecoveryRoute> = opened_offers(&blocked)
+                .into_iter()
+                .map(|(_, plan)| RecoveryRoute {
+                    steps: plan
+                        .required
+                        .iter()
+                        .map(|required| RouteStep::Authorize {
+                            authority: required.authority.clone(),
+                            covers: required.covers.clone(),
+                            call: wire.digest(),
+                        })
+                        .collect(),
+                    outcome: RouteOutcome::Complete,
+                })
+                .collect();
+            assert_eq!(offered.len(), 2);
+            for route in &offered {
+                let [RouteStep::Authorize { authority, .. }] = &route.steps[..] else {
+                    panic!("one ruling per offer: {route:?}");
+                };
+                assert_eq!(
+                    route.certainty(),
+                    Certainty::Contingent(BTreeSet::from([Contingency::AuthorityDecision {
+                        authority: authority.clone(),
+                    }]))
+                );
+            }
+            let log = [log, blocked].concat();
+            let view = e.view(&traj(), log.clone(), log.len() as u64).expect("the log replays");
+
+            for depth in [RouteDepth::ONE, RouteDepth::new(4).unwrap()] {
+                let found = e
+                    .recovery_routes(&view, &subject("b1"), &[], depth)
+                    .expect("a blocked call has a route search");
+                assert_eq!(found, offered, "no tool clears a trust floor, so depth adds nothing");
+            }
+            assert_eq!(
+                e.view(&traj(), log.clone(), log.len() as u64).map(|_| ()),
+                Ok(()),
+                "the search appended nothing"
+            );
+        }
+
+        #[test]
+        fn only_a_blocked_standing_call_has_routes() {
+            let e = two_officer_engine();
+            let log = vec![opened(&e)];
+            let view = e.view(&traj(), log.clone(), log.len() as u64).expect("the log replays");
+            let at = |subject: &crate::basis::SubjectKey| e.recovery_routes(&view, subject, &[], RouteDepth::ONE);
+
+            assert_eq!(at(&subject("never")), Err(RouteError::UnknownSubject));
+            assert_eq!(
+                engine(vec![neutral_tool()]).recovery_routes(&view, &subject("never"), &[], RouteDepth::ONE),
+                Err(RouteError::ForeignView),
+                "a view built under another policy is refused before anything is read"
+            );
+            assert_eq!(
+                at(&crate::basis::SubjectKey::Return(ChildReturnId::new(
+                    TrajectoryId::new("child"),
+                    0
+                ))),
+                Err(RouteError::NotACallSubject)
+            );
+
+            let e = engine_at(
+                vec![crm_tool()],
+                known(TRUSTED, Audience::restricted([ReaderId::new("internal")])),
+            );
+            let log = vec![opened(&e)];
+            let released = appended_facts(
+                proposed(&e, &log, "b1", nonce(), call("get_ticket", json!({}))).expect("the batch decides"),
+            );
+            assert!(released.iter().any(|fact| matches!(fact, Fact::DispatchOpened { .. })));
+            let log = [log, released].concat();
+            let view = e.view(&traj(), log.clone(), log.len() as u64).expect("the log replays");
+            assert_eq!(
+                e.recovery_routes(&view, &subject("b1"), &[], RouteDepth::ONE),
+                Err(RouteError::NotBlocked),
+                "a released call stands decided but passes its check, so there is nothing to plan"
+            );
+        }
+    }
+
     mod configured_groups {
         use super::*;
         use crate::contract::AudienceDelta;
@@ -14950,6 +15080,155 @@ mod tests {
         fn assert_no_group_names(facts: &[Fact]) {
             let json = serde_json::to_string(facts).expect("facts serialize");
             assert!(!json.contains("\"@"), "a serialized record holds a group name: {json}");
+        }
+
+        #[test]
+        fn a_planned_state_that_reads_an_unanswered_group_refuses_the_search_instead_of_resolving_it() {
+            use crate::route::{RouteDepth, RouteError, RouteOutcome, RouteStep};
+
+            let mut backup = plain_tool("backup");
+            backup.emits = EffectSet::new([EffectKind::new("backup")]).unwrap();
+            backup.delta = Some(Delta {
+                trust: None,
+                audience: Some(Dim::Known(readers(&["internal"])).into()),
+            });
+            let mut wire = plain_tool("wire");
+            wire.requires = Requires {
+                label: LabelRequirements {
+                    trust_floor: None,
+                    audience: vec![AudienceRequirement::Includes(RecipientSpec::Static(
+                        DeclaredAudience::literal(readers(&["partner"])),
+                    ))],
+                },
+                history: vec![HistoryRequirement::Prior(EffectKind::new("backup"))],
+                ..Requires::default()
+            };
+            let officer = crate::authority::Authority {
+                name: AuthorityName::new("officer"),
+                mandate: crate::authority::Mandate {
+                    reader_ceiling: Some(grouped(&["partner"], &["board"])),
+                    ..crate::authority::Mandate::default()
+                },
+                scope: crate::authority::Scope::default(),
+                hint: None,
+            };
+            let e = grouped_engine(
+                config(vec![backup, wire], vec![officer]),
+                &[],
+                known(TRUSTED, Audience::Public),
+            );
+            let log = vec![opened(&e)];
+            let decided = e
+                .handle(
+                    &viewing(&e, &log),
+                    batch_with("b1", vec![], vec![raw(&call("wire", json!({})))], vec![]),
+                )
+                .expect("a `prior` gap alone reads no group");
+            let log = [log, appended_facts(decided)].concat();
+            let view = e.view(&traj(), log.clone(), log.len() as u64).expect("the log replays");
+            let subject = crate::basis::SubjectKey::Call {
+                trajectory: traj(),
+                batch: crate::transition::ProposalBatchId::new("b1"),
+                position: 0,
+            };
+            let routes =
+                |answers: &[GroupExpansion]| e.recovery_routes(&view, &subject, answers, RouteDepth::new(2).unwrap());
+
+            assert_eq!(
+                routes(&[]),
+                Err(RouteError::MembershipNeeded(vec![GroupName::new("board")])),
+                "after `backup` narrows the audience, the `includes` gap makes the officer's ceiling a read"
+            );
+            let planned = routes(&[expansion("board", &[])]).expect("the answer lets the state plan");
+            assert_eq!(planned.len(), 1);
+            assert_eq!(planned[0].outcome, RouteOutcome::Complete);
+            assert!(
+                matches!(
+                    &planned[0].steps[..],
+                    [RouteStep::Precede { tool, .. }, RouteStep::Authorize { authority, .. }]
+                        if tool.as_str() == "backup" && authority.as_str() == "officer"
+                ),
+                "{:?}",
+                planned[0].steps
+            );
+        }
+
+        #[test]
+        fn a_route_reads_the_resolutions_the_block_recorded_over_any_fresh_answer() {
+            use crate::route::{RouteDepth, RouteOutcome, RouteStep};
+
+            let mut seen = plain_tool("seen");
+            seen.delta = Some(Delta {
+                trust: None,
+                audience: Some(AudienceDelta::Static(grouped(&[], &["board"]))),
+            });
+            let e = grouped_engine(
+                config(vec![capped_send(), seen], vec![]),
+                &[],
+                known(TRUSTED, readers(&["alice"])),
+            );
+            let log = vec![opened(&e)];
+            let decided = e
+                .handle(
+                    &viewing(&e, &log),
+                    batch_with(
+                        "b1",
+                        vec![],
+                        vec![raw(&call("send", json!({})))],
+                        vec![expansion("board", &[]), expansion("team", &[])],
+                    ),
+                )
+                .expect("the tool plans of the block read `board`, so the batch answers it too");
+            let log = [log, appended_facts(decided)].concat();
+            let view = e.view(&traj(), log.clone(), log.len() as u64).expect("the log replays");
+            let subject = crate::basis::SubjectKey::Call {
+                trajectory: traj(),
+                batch: crate::transition::ProposalBatchId::new("b1"),
+                position: 0,
+            };
+            let cap = crate::check::Gap::Cap {
+                cap: readers(&["auditor"]),
+            };
+            let routes = |answers: Vec<GroupExpansion>| {
+                e.recovery_routes(&view, &subject, &answers, RouteDepth::new(2).unwrap())
+                    .expect("the recorded answer for `team` stands")
+            };
+
+            let recorded = routes(vec![]);
+            assert_eq!(recorded.len(), 1);
+            assert_eq!(recorded[0].outcome, RouteOutcome::Complete);
+            assert!(
+                matches!(
+                    &recorded[0].steps[..],
+                    [RouteStep::Precede { tool, clears, accepts: Some(narrowing) }]
+                        if tool.as_str() == "seen"
+                            && clears == &vec![cap.clone()]
+                            && narrowing.to.audience == readers(&[])
+                ),
+                "the recorded empty `board` narrows `alice` to nobody, within the cap the recorded empty \
+                 `team` leaves at `auditor`: {:?}",
+                recorded[0].steps
+            );
+            assert_eq!(
+                routes(vec![
+                    expansion("board", &["alice"]),
+                    expansion("team", &["alice", "bob"])
+                ]),
+                recorded,
+                "fresh answers that would leave `alice` in the audience and lift the cap change nothing: \
+                 the answers the block consumed stand"
+            );
+            assert_eq!(
+                e.recovery_routes(
+                    &view,
+                    &subject,
+                    &[expansion("team", &["alice"]), expansion("team", &["bob"])],
+                    RouteDepth::ONE
+                ),
+                Err(crate::route::RouteError::Expansion(ExpansionRefusal::Duplicate(
+                    GroupName::new("team")
+                )))
+            );
         }
 
         fn with_resolutions(fact: &Fact, resolutions: serde_json::Value) -> Result<Fact, serde_json::Error> {

--- a/appa-engine/src/lib.rs
+++ b/appa-engine/src/lib.rs
@@ -33,6 +33,7 @@ pub mod plan;
 pub mod profile;
 pub mod projection;
 pub mod registry;
+pub mod route;
 pub mod shape;
 pub mod transition;
 pub mod value;

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -233,12 +233,23 @@ pub(crate) fn plan(
     let no_denials = BTreeSet::new();
     let denied = views.denied_authorities(&call.digest()).unwrap_or(&no_denials);
 
+    let has_committed = |kind: &EffectKind| views.has_effect(kind);
+    let has_reserved = |kind: &EffectKind| views.has_reservation(kind);
     let mut plans: Vec<RemedyPlan> = match raw.unestablished.is_empty() {
-        true => enumerate_plans(registry, &current, views, call, stage, role, expansions)
-            .into_iter()
-            .filter(|plan| !denied.iter().any(|authority| plan.names_authority(authority)))
-            .map(RemedyPlan::Executable)
-            .collect(),
+        true => enumerate_plans(
+            registry,
+            &current,
+            &has_committed,
+            &has_reserved,
+            call,
+            stage,
+            role,
+            expansions,
+        )
+        .into_iter()
+        .filter(|plan| !denied.iter().any(|authority| plan.names_authority(authority)))
+        .map(RemedyPlan::Executable)
+        .collect(),
         false => Vec::new(),
     };
 
@@ -268,10 +279,15 @@ pub(crate) fn plan(
     }
 }
 
-fn enumerate_plans(
+/// The executable plans of one stage over an explicit state: the branch's label and the
+/// history predicates. The log supplies them for a live block; a recovery route supplies the
+/// state it has reached (RMD-20).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn enumerate_plans(
     registry: &Registry,
     current: &PartialLabel,
-    views: &Views,
+    has_committed: &impl Fn(&EffectKind) -> bool,
+    has_reserved: &impl Fn(&EffectKind) -> bool,
     call: &ResolvedCall,
     stage: &CallStage,
     role: CallRole,
@@ -280,14 +296,12 @@ fn enumerate_plans(
     let Some(contract) = registry.tool(call.tool()) else {
         return Vec::new();
     };
-    let has_committed = |kind: &EffectKind| views.has_effect(kind);
-    let has_reserved = |kind: &EffectKind| views.has_reservation(kind);
     let block = check::evaluate_state(
         contract,
         current,
-        &has_committed,
-        &has_reserved,
-        call,
+        has_committed,
+        has_reserved,
+        check::CallReads::Resolved(call),
         stage,
         expansions,
     );
@@ -403,7 +417,7 @@ fn plan_precedes(gaps: &[Gap], a: &[GapPower<'_>], b: &[GapPower<'_>]) -> bool {
     strictly_less
 }
 
-enum GapPower<'a> {
+pub(crate) enum GapPower<'a> {
     None,
     Substitution(&'a Audience),
     Ruling {
@@ -494,7 +508,7 @@ fn assigned_power<'a>(
     }
 }
 
-fn gap_power_cmp(gap: &Gap, a: &GapPower<'_>, b: &GapPower<'_>) -> Option<Ordering> {
+pub(crate) fn gap_power_cmp(gap: &Gap, a: &GapPower<'_>, b: &GapPower<'_>) -> Option<Ordering> {
     let ((a, a_readers), (b, b_readers)) = match (a, b) {
         (GapPower::None, GapPower::None) => return Some(Ordering::Equal),
         (GapPower::None, _) => return Some(Ordering::Less),
@@ -539,7 +553,7 @@ fn gap_power_cmp(gap: &Gap, a: &GapPower<'_>, b: &GapPower<'_>) -> Option<Orderi
     }
 }
 
-fn inclusion_cmp(a_in_b: bool, b_in_a: bool) -> Option<Ordering> {
+pub(crate) fn inclusion_cmp(a_in_b: bool, b_in_a: bool) -> Option<Ordering> {
     match (a_in_b, b_in_a) {
         (true, true) => Some(Ordering::Equal),
         (true, false) => Some(Ordering::Less),
@@ -1128,23 +1142,32 @@ fn direct_redispatches(
     expansions: &Expansions,
 ) -> Vec<RedispatchPlan> {
     let mut direct = Vec::new();
-    let has_cap = raw.requirement_gaps.iter().any(|gap| matches!(gap, Gap::Cap { .. }));
     for tool in registry.tools() {
-        let committed = has_cap.then(|| check::committed_label(tool, current, expansions));
-        let clears: Vec<Gap> = raw
-            .requirement_gaps
-            .iter()
-            .filter(|gap| match (gap, &committed) {
-                (Gap::Prior(kind), _) => tool.emits.contains(kind),
-                (Gap::Cap { cap }, Some(committed)) => committed.within_cap(cap) == Adequacy::Holds,
-                _ => false,
-            })
-            .cloned()
-            .collect();
+        let clears = direct_clears(tool, &raw.requirement_gaps, current, expansions);
         // The constructor is also the emptiness filter: a tool clearing nothing yields `None`.
         direct.extend(RedispatchPlan::new(tool.name.clone(), clears));
     }
     direct
+}
+
+/// The gaps a successful call to `tool` clears by itself (RMD-13): a `prior` it emits, or a cap
+/// the label it commits from `current` stays within.
+pub(crate) fn direct_clears(
+    tool: &ToolContract,
+    gaps: &[Gap],
+    current: &PartialLabel,
+    expansions: &Expansions,
+) -> Vec<Gap> {
+    let has_cap = gaps.iter().any(|gap| matches!(gap, Gap::Cap { .. }));
+    let committed = has_cap.then(|| check::committed_label(tool, current, expansions));
+    gaps.iter()
+        .filter(|gap| match (gap, &committed) {
+            (Gap::Prior(kind), _) => tool.emits.contains(kind),
+            (Gap::Cap { cap }, Some(committed)) => committed.within_cap(cap) == Adequacy::Holds,
+            _ => false,
+        })
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]
@@ -3796,9 +3819,10 @@ mod tests {
                 &state.partial(),
                 &has_committed,
                 &has_reserved,
-                &call,
-            &CallStage::default(),
-             &Expansions::default());
+                check::CallReads::Resolved(&call),
+                &CallStage::default(),
+                &Expansions::default(),
+            );
             if !eval.consumed.is_empty() || (eval.requirement_gaps.is_empty() && eval.narrowing.is_none()) {
                 return Ok(());
             }
@@ -3885,9 +3909,10 @@ mod tests {
                 &state.partial(),
                 &has_committed,
                 &has_reserved,
-                &call,
+                check::CallReads::Resolved(&call),
                 &CallStage::default(),
-             &Expansions::default());
+                &Expansions::default(),
+            );
             if !eval.consumed.is_empty() || (eval.requirement_gaps.is_empty() && eval.narrowing.is_none()) {
                 return Ok(());
             }
@@ -4024,9 +4049,10 @@ mod tests {
                 &state.partial(),
                 &has_committed,
                 &has_reserved,
-                &call,
-            &CallStage::default(),
-             &Expansions::default());
+                check::CallReads::Resolved(&call),
+                &CallStage::default(),
+                &Expansions::default(),
+            );
             if !eval.consumed.is_empty() || (eval.requirement_gaps.is_empty() && eval.narrowing.is_none()) {
                 return Ok(());
             }

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -1,0 +1,1917 @@
+//! Recovery routes: the advisory, bounded search over the remedies a block stands in (`RMD-20`).
+//!
+//! A remedy plan is one stage (`RMD-4`, `RMD-19`): the sound next alternatives from the live
+//! candidate, each an executable offer. A **recovery route** looks further, over an abstract state
+//! rather than the log: it composes the same steps — acceptance, rulings, an output sanitizer, an
+//! input hop, and the tools an `RMD-13` plan names — and re-checks every later step in the state
+//! the earlier steps produce. It appends no fact, mints no offer, and changes nothing in
+//! `remedy_plans`, their order, or the emptiness assertion of `RMD-10`; every step it names still
+//! passes its ordinary check when the agent attempts it.
+//!
+//! **What a route may plan over.** Call-bound decisions — a ruling, an acceptance of the blocked
+//! call's narrowing, an input hop, a denial — bind the exact rendered call (`RUL-3`, `RMD-16`),
+//! so they are planned for the blocked call only. A tool run first ([`RouteStep::Precede`]) has
+//! no call yet: it contributes only what its registered contract fixes before any call exists —
+//! [`StaticContract`]: no resolver answers, no placeholder recipients, a declared and established
+//! delta — evaluated in the success branch, where its `emits` are committed effects and its
+//! declared narrowing has folded. Anything less determined ends the route as a
+//! [`RouteOutcome::Prefix`] naming what must land before planning resumes ([`Resume`]).
+//!
+//! **Bound and totality.** [`RouteDepth`] is the number of calls a route spans, the blocked call
+//! included. At `RouteDepth::ONE` the routes are exactly the RMD plans. A tool enters a route
+//! only for a `prior` or cap gap of the call it immediately serves — the blocked call, or a
+//! preceding tool that needs it first — as `RMD-13` names tool plans; a tool that clears nothing
+//! for the call in front of it is never dispatched. A set of preceding tools is planned once, in
+//! the first order the search meets (tool-name order): every order of the same tools folds the
+//! same deltas and commits the same effects, so it reaches the same state and continues alike.
+//! Within that shape enumeration is total: nothing is truncated, and an empty result asserts
+//! only that no route exists within this abstraction and this depth, never that the block is
+//! unliftable. Termination: the depth bounds the preceding tools, and no tool recurs on one
+//! path. Cost grows with the sets of at most `depth − 1` registered tools, not their orderings;
+//! the depth is the operator's bound (`CFG-26`), and the engine clamps nothing.
+//!
+//! **Order** (`RMD-20`). Least mandate power first, as `RMD-15` compares plans, then least
+//! disclosure — the readers outside the committed audience that the route's rulings admit a flow
+//! to — then fewer steps, then canonical bytes. The first two form a strict partial order; the
+//! last two make the extraction total, so the list is deterministic.
+
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::num::NonZeroU32;
+
+use serde::{Deserialize, Serialize};
+
+use crate::basis::SubjectKey;
+use crate::candidate::CallStage;
+use crate::check::{self, CallReads, CheckOutcome, Gap, Narrowing, RawBlock, StateEval, UnestablishedFact};
+use crate::contract::{NotStatic, StaticContract, ToolContract};
+use crate::engine::Engine;
+use crate::fact::EffectKind;
+use crate::groups::{ExpansionRefusal, Expansions, GroupExpansion, MembershipNeeded};
+use crate::label::{Audience, PartialLabel};
+use crate::names::{AuthorityName, GroupName, SanitizerName};
+use crate::plan::{self, CallRole, ExecutableRemedyPlan, GapPower, RemedyStep};
+use crate::projection::Views;
+use crate::registry::Registry;
+use crate::value::{CanonicalDigest, ResolvedCall, ToolName};
+
+/// How many calls a route may span, the blocked call included. `ONE` is today's direct
+/// recovery: the RMD plans and nothing beyond them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RouteDepth(NonZeroU32);
+
+impl RouteDepth {
+    pub const ONE: RouteDepth = RouteDepth(NonZeroU32::MIN);
+
+    pub fn new(calls: u32) -> Option<RouteDepth> {
+        NonZeroU32::new(calls).map(RouteDepth)
+    }
+
+    pub fn calls(self) -> u32 {
+        self.0.get()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoveryRoute {
+    pub steps: Vec<RouteStep>,
+    pub outcome: RouteOutcome,
+}
+
+impl RecoveryRoute {
+    /// `Guaranteed` when every requirement of the route is already determined — the agent's
+    /// own acceptance and nothing external; otherwise the runtime outcomes it depends on.
+    pub fn certainty(&self) -> Certainty {
+        let contingencies: BTreeSet<Contingency> = self
+            .steps
+            .iter()
+            .filter_map(|step| match step {
+                RouteStep::Precede { tool, .. } => Some(Contingency::ToolOutcome { tool: tool.clone() }),
+                RouteStep::Authorize { authority, .. } => Some(Contingency::AuthorityDecision {
+                    authority: authority.clone(),
+                }),
+                RouteStep::Derive(sanitizer) | RouteStep::Sanitize(sanitizer) => Some(Contingency::SanitizerResult {
+                    sanitizer: sanitizer.clone(),
+                }),
+                RouteStep::Accept(_) => None,
+            })
+            .collect();
+        if contingencies.is_empty() {
+            Certainty::Guaranteed
+        } else {
+            Certainty::Contingent(contingencies)
+        }
+    }
+}
+
+/// One step of a route, in the order the agent takes them. `Precede` runs another tool first;
+/// the rest are the remedy steps of the blocked call's own stage, in their plan order.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RouteStep {
+    /// Dispatch this tool first: its own check passes in the state the route has reached, and
+    /// on success its `emits` clear `clears` for the blocked call. `accepts` is the narrowing its
+    /// declared delta commits, accepted at its own block (`RMD-13`).
+    Precede {
+        tool: ToolName,
+        clears: Vec<Gap>,
+        accepts: Option<Narrowing>,
+    },
+    Derive(SanitizerName),
+    Accept(Narrowing),
+    /// A ruling over `covers` for exactly this rendered call (`RUL-3`): the digest binds it.
+    Authorize {
+        authority: AuthorityName,
+        covers: Vec<Gap>,
+        call: CanonicalDigest,
+    },
+    Sanitize(SanitizerName),
+}
+
+/// `Complete` ends with the blocked call's release. `Prefix` stops earlier, where the next state
+/// is not yet determined; the agent takes the prefix, and planning resumes from the realized log.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RouteOutcome {
+    Complete,
+    Prefix(Resume),
+}
+
+/// What must land before planning can continue past a prefix.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Resume {
+    /// The input hop's derived candidate: the next stage plans from it (`RMD-19`).
+    DerivedCandidate { sanitizer: SanitizerName },
+    /// The agent proposes `tool`, which clears `clears` for the blocked call; `halt` says why the
+    /// search could not plan past that proposal.
+    Propose {
+        tool: ToolName,
+        clears: Vec<Gap>,
+        halt: Halt,
+    },
+}
+
+/// Why a route stops at a tool it cannot plan across.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Halt {
+    /// Its check reads the call's arguments (a resolver answer or a placeholder recipient).
+    Arguments,
+    /// Its result label is established only at admission (unannotated or pending-cast).
+    Unestablished,
+    /// Its check consumes an unresolved dimension; a registered cast can establish each source
+    /// (`CHK-16`), and the resolved label decides the rest.
+    Cast(Vec<UnestablishedFact>),
+    /// Its own block carries call-bound gaps; its rulings or hops are planned at that block.
+    Block(Vec<Gap>),
+    /// The depth bound ends here.
+    Depth,
+}
+
+/// A runtime outcome a route depends on. Planning assumes none of them: a ruling may deny, a tool
+/// may fail, a sanitizer may derive nothing helpful.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Contingency {
+    AuthorityDecision { authority: AuthorityName },
+    ToolOutcome { tool: ToolName },
+    SanitizerResult { sanitizer: SanitizerName },
+}
+
+/// What [`RecoveryRoute::certainty`] reports.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Certainty {
+    Guaranteed,
+    Contingent(BTreeSet<Contingency>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum RouteError {
+    #[error("only a call subject stands in a block routes can be planned for")]
+    NotACallSubject,
+    #[error("no decided call stands for this subject in this trajectory")]
+    UnknownSubject,
+    #[error("the call passes its check; there is nothing to recover from")]
+    NotBlocked,
+    #[error("planning this block reads groups no expansion answers: {0:?}")]
+    MembershipNeeded(Vec<GroupName>),
+    #[error(transparent)]
+    Expansion(#[from] ExpansionRefusal),
+    #[error("the view was built under another policy")]
+    ForeignView,
+}
+
+impl From<MembershipNeeded> for RouteError {
+    fn from(needed: MembershipNeeded) -> RouteError {
+        RouteError::MembershipNeeded(needed.needed)
+    }
+}
+
+/// The blocked call as the engine would re-plan it: the standing candidate, its stage and role,
+/// the denials bound to its digest, and the expansions the surfacing act consumed plus what the
+/// caller answers now.
+pub(crate) struct BlockContext<'a> {
+    contract: &'a ToolContract,
+    call: ResolvedCall,
+    stage: CallStage,
+    role: CallRole,
+    denied: BTreeSet<AuthorityName>,
+    expansions: Expansions,
+    raw: RawBlock,
+}
+
+impl<'a> BlockContext<'a> {
+    pub(crate) fn reconstruct(
+        engine: &'a Engine,
+        views: &Views,
+        subject: &SubjectKey,
+        answers: &[GroupExpansion],
+    ) -> Result<BlockContext<'a>, RouteError> {
+        let SubjectKey::Call { batch, .. } = subject else {
+            return Err(RouteError::NotACallSubject);
+        };
+        let registry = engine.registry();
+        let call = views.standing_call(subject).ok_or(RouteError::UnknownSubject)?.clone();
+        let decided = views.decided_batch(batch).ok_or(RouteError::UnknownSubject)?;
+        let contract = registry.tool(call.tool()).ok_or(RouteError::UnknownSubject)?;
+
+        let mut expansions = registry.expansions_from_event(answers)?;
+        if let Some((_, offers)) = views.pending_block(subject) {
+            for (offer, _) in &offers {
+                if let Some(recorded) = views.offer(offer) {
+                    expansions = expansions.inheriting(&engine.recorded_expansions(&recorded.resolutions));
+                }
+            }
+        }
+        expansions = expansions.inheriting(&engine.recorded_expansions(&decided.resolutions));
+        expansions.require(contract.groups())?;
+
+        let stage = views.call_stage(subject);
+        let role = views.call_role(subject);
+        let raw = match check::evaluate(contract, views, &call, &stage, &expansions) {
+            CheckOutcome::Allow => return Err(RouteError::NotBlocked),
+            CheckOutcome::Block(raw) => raw,
+        };
+        expansions.require(plan::block_groups(registry, contract, &raw, role).iter())?;
+        let denied = views.denied_authorities(&call.digest()).cloned().unwrap_or_default();
+        Ok(BlockContext {
+            contract,
+            call,
+            stage,
+            role,
+            denied,
+            expansions,
+            raw,
+        })
+    }
+}
+
+/// The abstract security state a route has reached: the branch's partial label — bound and
+/// unresolved sources — and the effect kinds the route's preceding tools have committed on top of
+/// the log. Reservations are the log's own and never move: a tool the route runs is taken in its
+/// success branch, where its reservation has become effects.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RouteState {
+    label: PartialLabel,
+    committed: BTreeSet<EffectKind>,
+}
+
+impl RouteState {
+    fn after(&self, tool: &StaticContract<'_>, expansions: &Expansions) -> RouteState {
+        let contract = tool.contract();
+        RouteState {
+            label: check::committed_label(contract, &self.label, expansions),
+            committed: self.committed.iter().chain(contract.emits.iter()).cloned().collect(),
+        }
+    }
+}
+
+/// The steps taken so far — the tools the route has run are the `Precede` steps among them —
+/// and the tools it is planning to run (the goal stack). Together they are the no-repeat rule
+/// that, with the depth bound, ends the search; apart, they identify a visit (see
+/// [`Search::first_visit`]).
+#[derive(Clone, Default)]
+struct Path {
+    steps: Vec<RouteStep>,
+    goals: BTreeSet<ToolName>,
+}
+
+impl Path {
+    fn run(&self) -> BTreeSet<ToolName> {
+        self.steps
+            .iter()
+            .filter_map(|step| match step {
+                RouteStep::Precede { tool, .. } => Some(tool.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn excludes(&self, tool: &ToolName) -> bool {
+        self.goals.contains(tool) || self.run().contains(tool)
+    }
+
+    fn extend(&self, steps: &[RouteStep]) -> Path {
+        let mut next = self.clone();
+        next.steps.extend_from_slice(steps);
+        next
+    }
+
+    fn with_goal(&self, tool: &ToolName) -> Path {
+        let mut next = self.clone();
+        next.goals.insert(tool.clone());
+        next
+    }
+}
+
+/// One planning point: the call being planned (`None` for the blocked call), the tools run so
+/// far, and the goals above it. The state and the budget at a point are functions of the tools
+/// run, and the continuation past it of the goals, so a second visit adds only another order of
+/// the same preceding tools.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct Visit {
+    tool: Option<ToolName>,
+    run: BTreeSet<ToolName>,
+    goals: BTreeSet<ToolName>,
+}
+
+/// One attempt to run a preceding tool: it ran (in the success branch) and the state moved, or
+/// the route stops at it.
+enum Run {
+    Ran {
+        steps: Vec<RouteStep>,
+        state: RouteState,
+        budget: u32,
+    },
+    Halted {
+        steps: Vec<RouteStep>,
+        resume: Resume,
+    },
+}
+
+impl Run {
+    fn prefixed(self, mut before: Vec<RouteStep>) -> Run {
+        match self {
+            Run::Ran { steps, state, budget } => {
+                before.extend(steps);
+                Run::Ran {
+                    steps: before,
+                    state,
+                    budget,
+                }
+            }
+            Run::Halted { steps, resume } => {
+                before.extend(steps);
+                Run::Halted { steps: before, resume }
+            }
+        }
+    }
+}
+
+/// A route as found, with what its order needs: the audience the route's rulings disclose to and
+/// the mandate power it assigns per requirement.
+struct Found {
+    route: RecoveryRoute,
+    disclosure: Option<Audience>,
+    powers: Vec<(Gap, Power)>,
+    /// The block's requirement keys plus every key `powers` assigns.
+    keys: Vec<Gap>,
+}
+
+enum Power {
+    Substitution(Audience),
+    Ruling {
+        authority: AuthorityName,
+        reader_ceiling: Option<Audience>,
+    },
+}
+
+/// Every route within `depth`, least mandate power first; empty asserts only that no route
+/// exists within this abstraction and `depth`. `Err` names the groups a planned state reads
+/// that no expansion answers — the caller answers them and asks again, as the engine refuses a
+/// batch.
+pub(crate) fn search(
+    registry: &Registry,
+    views: &Views,
+    context: &BlockContext<'_>,
+    depth: RouteDepth,
+) -> Result<Vec<RecoveryRoute>, RouteError> {
+    // A fact clears an unestablished source, never a plan or a route (RMD-10, CHK-16).
+    if !context.raw.unestablished.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut search = Search {
+        registry,
+        views,
+        context,
+        visited: BTreeSet::new(),
+    };
+    let initial = RouteState {
+        label: views.current_label(),
+        committed: BTreeSet::new(),
+    };
+    let mut found = Vec::new();
+    search.target(&initial, &Path::default(), depth.calls() - 1, &mut found)?;
+    Ok(search.ordered(found))
+}
+
+struct Search<'a> {
+    registry: &'a Registry,
+    views: &'a Views<'a>,
+    context: &'a BlockContext<'a>,
+    visited: BTreeSet<Visit>,
+}
+
+impl Search<'_> {
+    fn first_visit(&mut self, tool: Option<&ToolName>, path: &Path) -> bool {
+        let mut goals = path.goals.clone();
+        if let Some(tool) = tool {
+            goals.remove(tool);
+        }
+        self.visited.insert(Visit {
+            tool: tool.cloned(),
+            run: path.run(),
+            goals,
+        })
+    }
+
+    fn has_committed<'s>(&'s self, state: &'s RouteState) -> impl Fn(&EffectKind) -> bool + 's {
+        move |kind| self.views.has_effect(kind) || state.committed.contains(kind)
+    }
+
+    fn has_reserved(&self) -> impl Fn(&EffectKind) -> bool + '_ {
+        |kind| self.views.has_reservation(kind)
+    }
+
+    /// The groups planning this block reads, required before any plan resolves them — the gate
+    /// the engine runs before it enumerates a live block's plans.
+    fn require_groups(
+        &self,
+        contract: &ToolContract,
+        eval: &StateEval,
+        role: CallRole,
+    ) -> Result<(), MembershipNeeded> {
+        let block = RawBlock {
+            requirement_gaps: eval.requirement_gaps.clone(),
+            narrowing: eval.narrowing.clone(),
+            unestablished: Vec::new(),
+        };
+        self.context
+            .expansions
+            .require(plan::block_groups(self.registry, contract, &block, role).iter())
+    }
+
+    /// The blocked call's stage in `state`: its own plans, then every tool that may run first.
+    /// `budget` is how many preceding tools the depth still allows.
+    fn target(
+        &mut self,
+        state: &RouteState,
+        path: &Path,
+        budget: u32,
+        found: &mut Vec<Found>,
+    ) -> Result<(), MembershipNeeded> {
+        if !self.first_visit(None, path) {
+            return Ok(());
+        }
+        let context = self.context;
+        let eval = check::evaluate_state(
+            context.contract,
+            &state.label,
+            &self.has_committed(state),
+            &self.has_reserved(),
+            CallReads::Resolved(&context.call),
+            &context.stage,
+            &context.expansions,
+        );
+        // Unresolved sources never move along a route, so what the block did not consume at
+        // its check it does not consume here; the initial block is gated in `search`.
+        if !eval.consumed.is_empty() {
+            return Ok(());
+        }
+        self.require_groups(context.contract, &eval, context.role)?;
+        if eval.requirement_gaps.is_empty() && eval.narrowing.is_none() {
+            found.push(self.found(
+                path.steps.clone(),
+                RouteOutcome::Complete,
+                state,
+                &eval.requirement_gaps,
+            ));
+        } else {
+            for plan in plan::enumerate_plans(
+                self.registry,
+                &state.label,
+                &self.has_committed(state),
+                &self.has_reserved(),
+                &context.call,
+                &context.stage,
+                context.role,
+                &context.expansions,
+            ) {
+                if context.denied.iter().any(|authority| plan.names_authority(authority)) {
+                    continue;
+                }
+                let mut steps = path.steps.clone();
+                match plan.hop() {
+                    Some(sanitizer) => {
+                        steps.push(RouteStep::Derive(sanitizer.clone()));
+                        let resume = Resume::DerivedCandidate {
+                            sanitizer: sanitizer.clone(),
+                        };
+                        found.push(self.found(steps, RouteOutcome::Prefix(resume), state, &eval.requirement_gaps));
+                    }
+                    None => {
+                        steps.extend(self.plan_steps(&plan));
+                        found.push(self.found(steps, RouteOutcome::Complete, state, &eval.requirement_gaps));
+                    }
+                }
+            }
+        }
+        // A terminal plan covers every gap and no ruling covers `prior` or a cap (CHK-12), so a
+        // tool that clears something exists only where no terminal plan does: the RMD-13
+        // condition on tool plans holds here by construction, at every depth.
+        for tool in self.registry.tools() {
+            if path.excludes(&tool.name) {
+                continue;
+            }
+            let clears = plan::direct_clears(tool, &eval.requirement_gaps, &state.label, &context.expansions);
+            if clears.is_empty() {
+                continue;
+            }
+            for run in self.run(tool, clears, state, path, budget)? {
+                match run {
+                    Run::Ran {
+                        steps,
+                        state: next,
+                        budget: left,
+                    } => self.target(&next, &path.extend(&steps), left, found)?,
+                    Run::Halted { steps, resume } => {
+                        let mut all = path.steps.clone();
+                        all.extend(steps);
+                        found.push(self.found(all, RouteOutcome::Prefix(resume), state, &eval.requirement_gaps));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Every way `tool` runs first from `state`, with `budget` preceding tools still allowed,
+    /// this one included. Its own `prior`/cap gaps recurse into the tools that clear them; any
+    /// other gap, an unresolved dimension, or a call-dependent contract halts the route here.
+    fn run(
+        &mut self,
+        tool: &ToolContract,
+        clears: Vec<Gap>,
+        state: &RouteState,
+        path: &Path,
+        budget: u32,
+    ) -> Result<Vec<Run>, MembershipNeeded> {
+        if !self.first_visit(Some(&tool.name), path) {
+            return Ok(Vec::new());
+        }
+        let halt = |halt: Halt| {
+            Ok(vec![Run::Halted {
+                steps: Vec::new(),
+                resume: Resume::Propose {
+                    tool: tool.name.clone(),
+                    clears: clears.clone(),
+                    halt,
+                },
+            }])
+        };
+        if budget == 0 {
+            return halt(Halt::Depth);
+        }
+        let expansions = &self.context.expansions;
+        let static_contract = match StaticContract::of(tool, expansions) {
+            Ok(static_contract) => static_contract,
+            Err(NotStatic::Arguments) => return halt(Halt::Arguments),
+            Err(NotStatic::Unestablished) => return halt(Halt::Unestablished),
+            Err(NotStatic::Membership(needed)) => return Err(MembershipNeeded { needed }),
+        };
+        let eval = check::evaluate_static(
+            &static_contract,
+            &state.label,
+            &self.has_committed(state),
+            &self.has_reserved(),
+            expansions,
+        );
+        self.require_groups(tool, &eval, CallRole::Ordinary)?;
+        if !eval.consumed.is_empty() {
+            let sources = check::unestablished_facts(&state.label, &eval.consumed);
+            for source in &sources {
+                expansions.require(&plan::constant_groups_reaching(self.registry, self.views, source.value))?;
+            }
+            let castable = sources
+                .iter()
+                .all(|source| plan::castable_sources(self.registry, self.views, source.value, expansions).is_some());
+            return if castable {
+                halt(Halt::Cast(sources))
+            } else {
+                Ok(Vec::new())
+            };
+        }
+        if eval
+            .requirement_gaps
+            .iter()
+            .any(|gap| !matches!(gap, Gap::Prior(_) | Gap::Cap { .. }))
+        {
+            return halt(Halt::Block(eval.requirement_gaps));
+        }
+        if eval.requirement_gaps.is_empty() {
+            return Ok(vec![Run::Ran {
+                steps: vec![RouteStep::Precede {
+                    tool: tool.name.clone(),
+                    clears,
+                    accepts: eval.narrowing,
+                }],
+                state: state.after(&static_contract, expansions),
+                budget: budget - 1,
+            }]);
+        }
+        let goal = path.with_goal(&tool.name);
+        let mut runs = Vec::new();
+        for first in self.registry.tools() {
+            if goal.excludes(&first.name) {
+                continue;
+            }
+            let first_clears = plan::direct_clears(first, &eval.requirement_gaps, &state.label, expansions);
+            if first_clears.is_empty() {
+                continue;
+            }
+            for run in self.run(first, first_clears, state, &goal, budget - 1)? {
+                match run {
+                    Run::Ran {
+                        steps,
+                        state: mid,
+                        budget: left,
+                    } => {
+                        for then in self.run(tool, clears.clone(), &mid, &goal.extend(&steps), left + 1)? {
+                            runs.push(then.prefixed(steps.clone()));
+                        }
+                    }
+                    halted @ Run::Halted { .. } => runs.push(halted),
+                }
+            }
+        }
+        Ok(runs)
+    }
+
+    fn plan_steps(&self, plan: &ExecutableRemedyPlan) -> Vec<RouteStep> {
+        plan.steps
+            .iter()
+            .map(|step| match step {
+                RemedyStep::Accept(narrowing) => RouteStep::Accept(narrowing.clone()),
+                RemedyStep::Authorize(authority) => RouteStep::Authorize {
+                    authority: authority.clone(),
+                    covers: plan
+                        .required
+                        .iter()
+                        .find(|required| &required.authority == authority)
+                        .map(|required| required.covers.clone())
+                        .unwrap_or_default(),
+                    call: self.context.call.digest(),
+                },
+                RemedyStep::Sanitize(sanitizer) => RouteStep::Sanitize(sanitizer.clone()),
+                RemedyStep::Derive(sanitizer) => RouteStep::Derive(sanitizer.clone()),
+            })
+            .collect()
+    }
+
+    /// A route as emitted from `state`, whose requirement gaps are `gaps`.
+    fn found(&self, steps: Vec<RouteStep>, outcome: RouteOutcome, state: &RouteState, gaps: &[Gap]) -> Found {
+        let disclosure = self.disclosure(&steps, &state.label.bound().audience);
+        let powers = self.powers(&steps, gaps);
+        let mut keys: Vec<Gap> = self.context.raw.requirement_gaps.iter().map(requirement_key).collect();
+        for (key, _) in &powers {
+            if !keys.contains(key) {
+                keys.push(key.clone());
+            }
+        }
+        Found {
+            route: RecoveryRoute { steps, outcome },
+            disclosure,
+            powers,
+            keys,
+        }
+    }
+
+    /// The readers outside `audience` that the route's rulings admit a flow to: the union over
+    /// every ruling-covered `includes` gap. Nothing else discloses — a trust floor or a waiver
+    /// escalates without widening the readership, and a hop clears its gap with derived bytes.
+    fn disclosure(&self, steps: &[RouteStep], audience: &Audience) -> Option<Audience> {
+        let mut disclosed: Option<Audience> = None;
+        for step in steps {
+            let RouteStep::Authorize { covers, .. } = step else {
+                continue;
+            };
+            for gap in covers {
+                let Gap::Includes { recipients } = gap else {
+                    continue;
+                };
+                let outside = match (recipients, audience) {
+                    (Audience::Public, _) => Audience::Public,
+                    (Audience::Restricted(readers), Audience::Public) => Audience::Restricted(readers.clone()),
+                    (Audience::Restricted(readers), Audience::Restricted(held)) => {
+                        Audience::Restricted(readers.difference(held).cloned().collect())
+                    }
+                };
+                disclosed = Some(match (disclosed, outside) {
+                    (None, outside) => outside,
+                    (Some(Audience::Public), _) | (_, Audience::Public) => Audience::Public,
+                    (Some(Audience::Restricted(mut all)), Audience::Restricted(more)) => {
+                        all.extend(more);
+                        Audience::Restricted(all)
+                    }
+                });
+            }
+        }
+        disclosed
+    }
+
+    /// The mandate power the route assigns per requirement it clears by a ruling or a hop, as
+    /// `RMD-15` assigns it to a plan: a ruling's mandate, or the hop's `to` for each `includes`
+    /// among `gaps` — the gaps of the state the hop was chosen in — it improves. Tools run first
+    /// and acceptance assign none.
+    fn powers(&self, steps: &[RouteStep], gaps: &[Gap]) -> Vec<(Gap, Power)> {
+        let expansions = &self.context.expansions;
+        let mut powers = Vec::new();
+        for step in steps {
+            match step {
+                RouteStep::Authorize { authority, covers, .. } => {
+                    let mandate = &self
+                        .registry
+                        .authority(authority)
+                        .expect("a route names only registered authorities")
+                        .mandate;
+                    for gap in covers {
+                        let reader_ceiling = match gap {
+                            Gap::Includes { .. } => mandate
+                                .reader_ceiling
+                                .as_ref()
+                                .map(|ceiling| ceiling.resolve(expansions)),
+                            _ => None,
+                        };
+                        powers.push((
+                            requirement_key(gap),
+                            Power::Ruling {
+                                authority: authority.clone(),
+                                reader_ceiling,
+                            },
+                        ));
+                    }
+                }
+                RouteStep::Derive(sanitizer) => {
+                    let transition = &self
+                        .registry
+                        .sanitizer(sanitizer)
+                        .expect("a route names only registered sanitizers")
+                        .transition;
+                    let crate::authority::DeclaredTransition::Audience { to, .. } = transition else {
+                        continue;
+                    };
+                    let to = to.resolve(expansions);
+                    for gap in gaps {
+                        if let Gap::Includes { recipients } = gap
+                            && to.includes(recipients)
+                        {
+                            powers.push((requirement_key(gap), Power::Substitution(to.clone())));
+                        }
+                    }
+                }
+                RouteStep::Precede { .. } | RouteStep::Accept(_) | RouteStep::Sanitize(_) => {}
+            }
+        }
+        powers
+    }
+
+    fn power_of<'f>(&'f self, found: &'f Found, key: &Gap) -> GapPower<'f> {
+        match found.powers.iter().find(|(gap, _)| gap == key) {
+            None => GapPower::None,
+            Some((_, Power::Substitution(to))) => GapPower::Substitution(to),
+            Some((
+                _,
+                Power::Ruling {
+                    authority,
+                    reader_ceiling,
+                },
+            )) => GapPower::Ruling {
+                mandate: &self
+                    .registry
+                    .authority(authority)
+                    .expect("a route names only registered authorities")
+                    .mandate,
+                reader_ceiling: reader_ceiling.as_ref(),
+            },
+        }
+    }
+
+    /// Route `a` strictly precedes `b`: no requirement assigns more power in `a`, `a` discloses
+    /// no reader `b` does not, and at least one of those is strict. Requirements compared are the
+    /// block's own plus any either route clears by a ruling (a route needing an extra ruling
+    /// assigns power where the other assigns none).
+    fn precedes(&self, a: &Found, b: &Found) -> bool {
+        let mut strictly_less = false;
+        for key in a.keys.iter().chain(b.keys.iter().filter(|key| !a.keys.contains(key))) {
+            match plan::gap_power_cmp(key, &self.power_of(a, key), &self.power_of(b, key)) {
+                Some(Ordering::Less) => strictly_less = true,
+                Some(Ordering::Equal) => {}
+                Some(Ordering::Greater) | None => return false,
+            }
+        }
+        match disclosure_cmp(a.disclosure.as_ref(), b.disclosure.as_ref()) {
+            Some(Ordering::Less) => strictly_less = true,
+            Some(Ordering::Equal) => {}
+            Some(Ordering::Greater) | None => return false,
+        }
+        strictly_less
+    }
+
+    /// The total order: repeatedly place the route no unplaced route precedes, breaking ties by
+    /// step count, then the steps' canonical bytes, then the whole route's.
+    fn ordered(&self, found: Vec<Found>) -> Vec<RecoveryRoute> {
+        let ties: Vec<(usize, Vec<u8>, Vec<u8>)> = found
+            .iter()
+            .map(|found| {
+                (
+                    found.route.steps.len(),
+                    serde_json_canonicalizer::to_vec(&found.route.steps).expect("steps canonicalize"),
+                    serde_json_canonicalizer::to_vec(&found.route).expect("a route canonicalizes"),
+                )
+            })
+            .collect();
+        let mut after: Vec<Vec<usize>> = vec![Vec::new(); found.len()];
+        let mut unplaced_before = vec![0usize; found.len()];
+        for (j, before) in found.iter().enumerate() {
+            for (i, later) in found.iter().enumerate() {
+                if self.precedes(before, later) {
+                    after[j].push(i);
+                    unplaced_before[i] += 1;
+                }
+            }
+        }
+        let mut slots: Vec<Option<Found>> = found.into_iter().map(Some).collect();
+        let mut ordered = Vec::with_capacity(slots.len());
+        for _ in 0..slots.len() {
+            let minimal = (0..slots.len())
+                .filter(|&i| slots[i].is_some() && unplaced_before[i] == 0)
+                .min_by_key(|&i| &ties[i])
+                .expect("a strict partial order has a minimal element");
+            for &i in &after[minimal] {
+                unplaced_before[i] -= 1;
+            }
+            ordered.push(slots[minimal].take().expect("chosen among the unplaced").route);
+        }
+        ordered
+    }
+}
+
+/// A requirement's identity for comparing power across routes: a trust floor names its floor
+/// only, since the `actual` rank moves with the state a route reaches.
+fn requirement_key(gap: &Gap) -> Gap {
+    match gap {
+        Gap::TrustFloor { required, .. } => Gap::TrustFloor {
+            required: *required,
+            actual: *required,
+        },
+        other => other.clone(),
+    }
+}
+
+fn disclosure_cmp(a: Option<&Audience>, b: Option<&Audience>) -> Option<Ordering> {
+    match (a, b) {
+        (None, None) => Some(Ordering::Equal),
+        (None, Some(_)) => Some(Ordering::Less),
+        (Some(_), None) => Some(Ordering::Greater),
+        (Some(a), Some(b)) => plan::inclusion_cmp(a.within(b), b.within(a)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority::{
+        Authority, Cast, CastResolution, DeclaredLabel, Mandate, Sanitizer, SanitizerPoints, Scope,
+    };
+    use crate::contract::{AudienceRequirement, Delta, HistoryRequirement, RecipientSpec, Requires, ToolContract};
+    use crate::fact::{CloseOutcome, EffectSet, Fact};
+    use crate::groups::DeclaredAudience;
+    use crate::label::{Dim, EstablishedLabel, Label, ReaderId, Trust};
+    use crate::names::CastName;
+    use crate::projection::Projection;
+    use crate::registry::{RegistryConfig, TrustChain};
+    use crate::value::{DispatchId, LabeledValue, Provenance, TrajectoryId, ValueBody};
+    use serde_json::json;
+
+    const SUSPICIOUS: Trust = Trust::new(0);
+    const TRUSTED: Trust = Trust::new(1);
+    const VETTED: Trust = Trust::new(2);
+
+    fn traj() -> TrajectoryId {
+        TrajectoryId::new("t")
+    }
+
+    fn readers(names: &[&str]) -> Audience {
+        Audience::restricted(names.iter().map(|name| ReaderId::new(*name)))
+    }
+
+    fn effect(kind: &str) -> EffectKind {
+        EffectKind::new(kind)
+    }
+
+    fn tool(name: &str) -> ToolContract {
+        ToolContract {
+            description: Some("A test tool.".to_string()),
+            uses: vec![],
+            name: ToolName::new(name),
+            tags: vec![],
+            delta: Some(Delta::NONE),
+            parameters: crate::params::ToolParameters::open(),
+            emits: EffectSet::default(),
+            requires: Requires::default(),
+        }
+    }
+
+    fn emitting(name: &str, kinds: &[&str]) -> ToolContract {
+        let mut contract = tool(name);
+        contract.emits = EffectSet::new(kinds.iter().map(|kind| effect(kind))).unwrap();
+        contract
+    }
+
+    fn requiring_prior(mut contract: ToolContract, kinds: &[&str]) -> ToolContract {
+        contract
+            .requires
+            .history
+            .extend(kinds.iter().map(|kind| HistoryRequirement::Prior(effect(kind))));
+        contract
+    }
+
+    fn requiring_no_prior(mut contract: ToolContract, kind: &str) -> ToolContract {
+        contract
+            .requires
+            .history
+            .push(HistoryRequirement::NoPrior(effect(kind)));
+        contract
+    }
+
+    fn requiring_trust(mut contract: ToolContract, floor: Trust) -> ToolContract {
+        contract.requires.label.trust_floor = Some(floor);
+        contract
+    }
+
+    fn requiring_includes(mut contract: ToolContract, recipients: Audience) -> ToolContract {
+        contract
+            .requires
+            .label
+            .audience
+            .push(AudienceRequirement::Includes(RecipientSpec::Static(
+                DeclaredAudience::literal(recipients),
+            )));
+        contract
+    }
+
+    fn requiring_cap(mut contract: ToolContract, cap: Audience) -> ToolContract {
+        contract
+            .requires
+            .label
+            .audience
+            .push(AudienceRequirement::Cap(DeclaredAudience::literal(cap)));
+        contract
+    }
+
+    fn narrowing_to(mut contract: ToolContract, trust: Option<Trust>, audience: Option<Audience>) -> ToolContract {
+        contract.delta = Some(Delta {
+            trust: trust.map(Dim::Known),
+            audience: audience.map(|audience| Dim::Known(audience).into()),
+        });
+        contract
+    }
+
+    fn authority(name: &str, mandate: Mandate) -> Authority {
+        Authority {
+            name: AuthorityName::new(name),
+            mandate,
+            scope: Scope::default(),
+            hint: None,
+        }
+    }
+
+    fn trust_authority(name: &str, ceiling: Trust) -> Authority {
+        authority(
+            name,
+            Mandate {
+                trust_ceiling: Some(ceiling),
+                ..Mandate::default()
+            },
+        )
+    }
+
+    fn reader_authority(name: &str, ceiling: Audience) -> Authority {
+        authority(
+            name,
+            Mandate {
+                reader_ceiling: Some(DeclaredAudience::literal(ceiling)),
+                ..Mandate::default()
+            },
+        )
+    }
+
+    fn input_redaction(name: &str, from: Audience, to: Audience) -> Sanitizer {
+        Sanitizer {
+            name: SanitizerName::new(name),
+            on: SanitizerPoints {
+                input: true,
+                output: false,
+            },
+            transition: crate::authority::DeclaredTransition::Audience {
+                from_includes: DeclaredAudience::literal(from),
+                to: DeclaredAudience::literal(to),
+            },
+            scope: Scope::default(),
+            hint: None,
+        }
+    }
+
+    struct Deployment {
+        tools: Vec<ToolContract>,
+        authorities: Vec<Authority>,
+        sanitizers: Vec<Sanitizer>,
+        casts: Vec<Cast>,
+        membership: Option<crate::names::MembershipResolverName>,
+    }
+
+    impl Deployment {
+        fn of(tools: Vec<ToolContract>) -> Deployment {
+            Deployment {
+                tools,
+                authorities: vec![],
+                sanitizers: vec![],
+                casts: vec![],
+                membership: None,
+            }
+        }
+
+        fn grouped(mut self) -> Deployment {
+            self.membership = Some(crate::names::MembershipResolverName::new("directory"));
+            self
+        }
+
+        fn authorities(mut self, authorities: Vec<Authority>) -> Deployment {
+            self.authorities = authorities;
+            self
+        }
+
+        fn sanitizers(mut self, sanitizers: Vec<Sanitizer>) -> Deployment {
+            self.sanitizers = sanitizers;
+            self
+        }
+
+        fn casts(mut self, casts: Vec<Cast>) -> Deployment {
+            self.casts = casts;
+            self
+        }
+
+        fn registry(self) -> Registry {
+            Registry::build_covered(RegistryConfig {
+                trust_chain: TrustChain::new(vec!["suspicious".into(), "trusted".into(), "vetted".into()]),
+                tools: self.tools,
+                authorities: self.authorities,
+                sanitizers: self.sanitizers,
+                casts: self.casts,
+                membership: self.membership,
+            })
+            .unwrap()
+        }
+    }
+
+    fn opened(trust: Trust, audience: Audience) -> Fact {
+        crate::profile::opening_at(traj(), Label::new(Dim::Known(trust), Dim::Known(audience)))
+    }
+
+    fn seed_call(tag: &str) -> ResolvedCall {
+        ResolvedCall::new(
+            ToolName::new("seed"),
+            crate::params::test_arguments(&json!({ "k": tag })),
+        )
+    }
+
+    fn committed(kind: &str) -> Fact {
+        Fact::DispatchClosed {
+            trajectory: traj(),
+            dispatch: DispatchId::new(traj(), seed_call(kind).digest(), 0),
+            outcome: CloseOutcome::Success {
+                effects: EffectSet::new([effect(kind)]).unwrap(),
+            },
+        }
+    }
+
+    fn dispatched(tag: &str, kinds: &[&str]) -> Fact {
+        let seed = seed_call(tag);
+        Fact::DispatchOpened {
+            trajectory: traj(),
+            dispatch: DispatchId::new(traj(), seed.digest(), 0),
+            tool: seed.tool().clone(),
+            arguments: seed.canonical_arguments().clone(),
+            proposed_label: EstablishedLabel::new(TRUSTED, Audience::Public),
+            receiving: EstablishedLabel::new(TRUSTED, Audience::Public),
+            proposed_effects: EffectSet::new(kinds.iter().map(|kind| effect(kind))).unwrap(),
+            tool_resolutions: vec![],
+            memberships: Vec::new(),
+            subject: crate::basis::fixture_subject(&traj()),
+            resolutions: vec![],
+        }
+    }
+
+    fn reserved(kind: &str) -> Fact {
+        dispatched(kind, &[kind])
+    }
+
+    fn admitted(label: Label) -> Fact {
+        Fact::ValueAdmitted {
+            trajectory: traj(),
+            value: LabeledValue::new(ValueBody::new("body"), label),
+            provenance: Provenance::ToolResult {
+                dispatch: DispatchId::new(traj(), seed_call("admitted").digest(), 0),
+            },
+        }
+    }
+
+    fn call(name: &str, args: serde_json::Value) -> ResolvedCall {
+        ResolvedCall::new(ToolName::new(name), crate::params::test_arguments(&args))
+    }
+
+    fn depth(calls: u32) -> RouteDepth {
+        RouteDepth::new(calls).unwrap()
+    }
+
+    fn raw_block(registry: &Registry, views: &Views, call: &ResolvedCall) -> RawBlock {
+        let contract = registry.tool(call.tool()).unwrap();
+        match check::evaluate(contract, views, call, &CallStage::default(), &Expansions::default()) {
+            CheckOutcome::Block(raw) => raw,
+            other => panic!("expected a block, got {other:?}"),
+        }
+    }
+
+    /// The routes of a blocked call, planned as the engine reconstructs the block from a log.
+    fn routes(registry: &Registry, log: &[Fact], call: &ResolvedCall, depth: RouteDepth) -> Vec<RecoveryRoute> {
+        routes_with(registry, log, call, depth, &[]).expect("no planned state reads a group")
+    }
+
+    fn routes_with(
+        registry: &Registry,
+        log: &[Fact],
+        call: &ResolvedCall,
+        depth: RouteDepth,
+        answers: &[GroupExpansion],
+    ) -> Result<Vec<RecoveryRoute>, RouteError> {
+        let projection = Projection::build(log, log.len() as u64);
+        let trajectory = traj();
+        let views = projection.view(&trajectory);
+        let context = BlockContext {
+            contract: registry.tool(call.tool()).unwrap(),
+            call: call.clone(),
+            stage: CallStage::default(),
+            role: CallRole::Ordinary,
+            denied: views.denied_authorities(&call.digest()).cloned().unwrap_or_default(),
+            expansions: registry.expansions_from_event(answers).expect("well-formed answers"),
+            raw: raw_block(registry, &views, call),
+        };
+        search(registry, &views, &context, depth)
+    }
+
+    fn precede(name: &str, clears: Vec<Gap>) -> RouteStep {
+        RouteStep::Precede {
+            tool: ToolName::new(name),
+            clears,
+            accepts: None,
+        }
+    }
+
+    fn prior(kind: &str) -> Gap {
+        Gap::Prior(effect(kind))
+    }
+
+    fn propose(name: &str, clears: Vec<Gap>, halt: Halt) -> RouteOutcome {
+        RouteOutcome::Prefix(Resume::Propose {
+            tool: ToolName::new(name),
+            clears,
+            halt,
+        })
+    }
+
+    fn contingent(contingencies: impl IntoIterator<Item = Contingency>) -> Certainty {
+        Certainty::Contingent(contingencies.into_iter().collect())
+    }
+
+    fn tool_outcome(name: &str) -> Contingency {
+        Contingency::ToolOutcome {
+            tool: ToolName::new(name),
+        }
+    }
+
+    fn decision(name: &str) -> Contingency {
+        Contingency::AuthorityDecision {
+            authority: AuthorityName::new(name),
+        }
+    }
+
+    /// An expected route; its certainty follows from its steps, so the expectation states it and
+    /// the helper checks it.
+    fn route(steps: Vec<RouteStep>, outcome: RouteOutcome, certainty: Certainty) -> RecoveryRoute {
+        let route = RecoveryRoute { steps, outcome };
+        assert_eq!(route.certainty(), certainty);
+        route
+    }
+
+    fn shape(route: &RecoveryRoute) -> Vec<String> {
+        route
+            .steps
+            .iter()
+            .map(|step| match step {
+                RouteStep::Precede { tool, .. } => format!("precede:{}", tool.as_str()),
+                RouteStep::Derive(sanitizer) => format!("derive:{}", sanitizer.as_str()),
+                RouteStep::Authorize { authority, .. } => format!("authorize:{}", authority.as_str()),
+                RouteStep::Accept(_) => "accept".to_string(),
+                RouteStep::Sanitize(sanitizer) => format!("sanitize:{}", sanitizer.as_str()),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_prior_gap_finds_the_emitter_as_a_preceding_call_beyond_depth_one() {
+        let registry = Deployment::of(vec![
+            emitting("backup", &["backup"]),
+            requiring_prior(tool("wipe"), &["backup"]),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+        let wipe = call("wipe", json!({}));
+
+        assert_eq!(
+            routes(&registry, &log, &wipe, RouteDepth::ONE),
+            vec![route(
+                vec![],
+                propose("backup", vec![prior("backup")], Halt::Depth),
+                Certainty::Guaranteed
+            )],
+            "depth one stops at the redispatch the block already names"
+        );
+        assert_eq!(
+            routes(&registry, &log, &wipe, depth(2)),
+            vec![route(
+                vec![precede("backup", vec![prior("backup")])],
+                RouteOutcome::Complete,
+                contingent([tool_outcome("backup")])
+            )],
+            "depth two plans across the emitter's successful call"
+        );
+    }
+
+    #[test]
+    fn prior_derivations_compose_until_the_depth_ends_them() {
+        let registry = Deployment::of(vec![
+            emitting("snapshot", &["snapshot"]),
+            requiring_prior(emitting("backup", &["backup"]), &["snapshot"]),
+            requiring_prior(tool("wipe"), &["backup"]),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+        let wipe = call("wipe", json!({}));
+
+        assert_eq!(
+            routes(&registry, &log, &wipe, depth(3)),
+            vec![route(
+                vec![
+                    precede("snapshot", vec![prior("snapshot")]),
+                    precede("backup", vec![prior("backup")]),
+                ],
+                RouteOutcome::Complete,
+                contingent([tool_outcome("snapshot"), tool_outcome("backup")])
+            )]
+        );
+        assert_eq!(
+            routes(&registry, &log, &wipe, depth(2)),
+            vec![route(
+                vec![],
+                propose("snapshot", vec![prior("snapshot")], Halt::Depth),
+                Certainty::Guaranteed
+            )],
+            "the prerequisite of the prerequisite is where depth two ends: the honest prefix names it"
+        );
+
+        let realized = [log, vec![committed("snapshot")]].concat();
+        assert_eq!(
+            routes(&registry, &realized, &wipe, depth(2)),
+            vec![route(
+                vec![precede("backup", vec![prior("backup")])],
+                RouteOutcome::Complete,
+                contingent([tool_outcome("backup")])
+            )],
+            "re-planning from the realized log continues where the prefix stopped"
+        );
+    }
+
+    #[test]
+    fn mutually_prerequisite_emitters_end_the_search_with_no_route() {
+        let registry = Deployment::of(vec![
+            requiring_prior(emitting("a", &["a"]), &["b"]),
+            requiring_prior(emitting("b", &["b"]), &["a"]),
+            requiring_prior(emitting("self", &["self"]), &["self"]),
+            requiring_prior(tool("wipe"), &["a", "self"]),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+
+        assert!(routes(&registry, &log, &call("wipe", json!({})), depth(50)).is_empty());
+    }
+
+    #[test]
+    fn a_preceding_call_that_drops_the_trust_floor_invalidates_the_route_it_would_complete() {
+        let tools = vec![
+            narrowing_to(emitting("backup", &["backup"]), Some(SUSPICIOUS), None),
+            requiring_trust(requiring_prior(tool("wipe"), &["backup"]), TRUSTED),
+        ];
+        let log = vec![opened(TRUSTED, Audience::Public)];
+        let wipe = call("wipe", json!({}));
+
+        let unruled = Deployment::of(tools.clone()).registry();
+        assert!(
+            routes(&unruled, &log, &wipe, depth(2)).is_empty(),
+            "after the emitter runs, the floor no longer holds and nothing covers it"
+        );
+
+        let ruled = Deployment::of(tools)
+            .authorities(vec![trust_authority("officer", TRUSTED)])
+            .registry();
+        assert_eq!(
+            routes(&ruled, &log, &wipe, depth(2)),
+            vec![route(
+                vec![
+                    RouteStep::Precede {
+                        tool: ToolName::new("backup"),
+                        clears: vec![prior("backup")],
+                        accepts: Some(Narrowing {
+                            from: EstablishedLabel::new(TRUSTED, Audience::Public),
+                            to: EstablishedLabel::new(SUSPICIOUS, Audience::Public),
+                        }),
+                    },
+                    RouteStep::Authorize {
+                        authority: AuthorityName::new("officer"),
+                        covers: vec![Gap::TrustFloor {
+                            required: TRUSTED,
+                            actual: SUSPICIOUS,
+                        }],
+                        call: wipe.digest(),
+                    },
+                ],
+                RouteOutcome::Complete,
+                contingent([tool_outcome("backup"), decision("officer")])
+            )],
+            "the gap the preceding call opens is re-planned in the state it produces"
+        );
+    }
+
+    #[test]
+    fn a_reservation_holds_across_the_route_and_a_narrowing_delta_reopens_an_audience_gap() {
+        let partner = readers(&["partner"]);
+        let internal = readers(&["internal"]);
+        let wipe = call("wipe", json!({}));
+
+        let reserving = Deployment::of(vec![
+            emitting("backup", &["backup"]),
+            requiring_no_prior(requiring_prior(tool("wipe"), &["backup"]), "email.sent"),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public), reserved("email.sent")];
+        assert!(
+            routes(&reserving, &log, &wipe, depth(2)).is_empty(),
+            "an open reservation blocks `no_prior` on every state a route reaches"
+        );
+
+        let tools = vec![
+            narrowing_to(emitting("backup", &["backup"]), None, Some(internal.clone())),
+            requiring_includes(requiring_prior(tool("wipe"), &["backup"]), partner.clone()),
+        ];
+        let log = vec![opened(TRUSTED, Audience::Public)];
+        let unruled = Deployment::of(tools.clone()).registry();
+        assert!(
+            routes(&unruled, &log, &wipe, depth(2)).is_empty(),
+            "the emitter narrows the audience below the recipients, and nothing vouches for them"
+        );
+        let ruled = Deployment::of(tools)
+            .authorities(vec![reader_authority("officer", Audience::Public)])
+            .registry();
+        assert_eq!(
+            routes(&ruled, &log, &wipe, depth(2)),
+            vec![route(
+                vec![
+                    RouteStep::Precede {
+                        tool: ToolName::new("backup"),
+                        clears: vec![prior("backup")],
+                        accepts: Some(Narrowing {
+                            from: EstablishedLabel::new(TRUSTED, Audience::Public),
+                            to: EstablishedLabel::new(TRUSTED, internal),
+                        }),
+                    },
+                    RouteStep::Authorize {
+                        authority: AuthorityName::new("officer"),
+                        covers: vec![Gap::Includes { recipients: partner }],
+                        call: wipe.digest(),
+                    },
+                ],
+                RouteOutcome::Complete,
+                contingent([tool_outcome("backup"), decision("officer")])
+            )]
+        );
+    }
+
+    #[test]
+    fn a_cap_gap_is_cleared_by_the_call_whose_committed_label_stays_within_it() {
+        let internal = readers(&["internal"]);
+        let registry = Deployment::of(vec![
+            narrowing_to(tool("read_internal"), None, Some(internal.clone())),
+            requiring_cap(tool("wipe"), internal.clone()),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+
+        assert_eq!(
+            routes(&registry, &log, &call("wipe", json!({})), depth(2)),
+            vec![route(
+                vec![RouteStep::Precede {
+                    tool: ToolName::new("read_internal"),
+                    clears: vec![Gap::Cap { cap: internal.clone() }],
+                    accepts: Some(Narrowing {
+                        from: EstablishedLabel::new(TRUSTED, Audience::Public),
+                        to: EstablishedLabel::new(TRUSTED, internal),
+                    }),
+                }],
+                RouteOutcome::Complete,
+                contingent([tool_outcome("read_internal")])
+            )]
+        );
+    }
+
+    #[test]
+    fn every_way_a_preceding_call_stays_undetermined_ends_the_route_as_a_prefix() {
+        let wipe = call("wipe", json!({}));
+        let log = vec![opened(TRUSTED, Audience::Public)];
+        let prefix = |halt: Halt| {
+            vec![route(
+                vec![],
+                propose("backup", vec![prior("backup")], halt),
+                Certainty::Guaranteed,
+            )]
+        };
+
+        let mut unannotated = emitting("backup", &["backup"]);
+        unannotated.delta = None;
+        let registry = Deployment::of(vec![unannotated, requiring_prior(tool("wipe"), &["backup"])]).registry();
+        assert_eq!(routes(&registry, &log, &wipe, depth(2)), prefix(Halt::Unestablished));
+
+        let mut placeholder = emitting("backup", &["backup"]);
+        placeholder.parameters = crate::params::test_string_argument_schema("to");
+        placeholder
+            .requires
+            .label
+            .audience
+            .push(AudienceRequirement::Includes(RecipientSpec::Placeholder(
+                "to".to_string(),
+            )));
+        let registry = Deployment::of(vec![placeholder, requiring_prior(tool("wipe"), &["backup"])]).registry();
+        assert_eq!(routes(&registry, &log, &wipe, depth(2)), prefix(Halt::Arguments));
+
+        let partner = readers(&["partner"]);
+        let blocked = requiring_includes(emitting("backup", &["backup"]), partner.clone());
+        let registry = Deployment::of(vec![blocked, requiring_prior(tool("wipe"), &["backup"])]).registry();
+        let log_internal = vec![opened(TRUSTED, readers(&["internal"]))];
+        assert_eq!(
+            routes(&registry, &log_internal, &wipe, depth(2)),
+            prefix(Halt::Block(vec![Gap::Includes { recipients: partner }])),
+            "a call-bound gap of the preceding call is planned at its own block"
+        );
+
+        let consuming = requiring_trust(emitting("backup", &["backup"]), TRUSTED);
+        let tools = vec![tool("seed"), consuming, requiring_prior(tool("wipe"), &["backup"])];
+        let log_unknown = vec![
+            opened(TRUSTED, Audience::Public),
+            dispatched("admitted", &[]),
+            admitted(Label::new(Dim::Unknown, Dim::Known(Audience::Public))),
+        ];
+        let uncastable = Deployment::of(tools.clone()).registry();
+        assert!(
+            routes(&uncastable, &log_unknown, &wipe, depth(2)).is_empty(),
+            "an unresolved source nothing casts fails closed at the call that consumes it"
+        );
+        let castable = Deployment::of(tools)
+            .casts(vec![Cast {
+                name: CastName::new("vouch"),
+                resolution: CastResolution::Constant(DeclaredLabel {
+                    trust: TRUSTED,
+                    audience: DeclaredAudience::Public,
+                }),
+                scope: Scope::default(),
+            }])
+            .registry();
+        let found = routes(&castable, &log_unknown, &wipe, depth(2));
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].steps, vec![]);
+        assert!(
+            matches!(
+                &found[0].outcome,
+                RouteOutcome::Prefix(Resume::Propose { tool, halt: Halt::Cast(sources), .. })
+                    if tool.as_str() == "backup" && sources.len() == 1
+            ),
+            "got {:?}",
+            found[0].outcome
+        );
+    }
+
+    #[test]
+    fn a_grouped_constant_cast_on_a_preceding_call_reads_its_group_before_it_is_offered() {
+        let board = GroupName::new("board");
+        let consuming = requiring_trust(emitting("backup", &["backup"]), TRUSTED);
+        let registry = Deployment::of(vec![
+            tool("seed"),
+            consuming,
+            requiring_prior(tool("wipe"), &["backup"]),
+        ])
+        .casts(vec![Cast {
+            name: CastName::new("vouch"),
+            resolution: CastResolution::Constant(DeclaredLabel {
+                trust: TRUSTED,
+                audience: DeclaredAudience::declared([], [board.clone()]).unwrap(),
+            }),
+            scope: Scope::default(),
+        }])
+        .grouped()
+        .registry();
+        let log = vec![
+            opened(TRUSTED, Audience::Public),
+            dispatched("admitted", &[]),
+            admitted(Label::new(Dim::Unknown, Dim::Unknown)),
+        ];
+        let wipe = call("wipe", json!({}));
+
+        assert_eq!(
+            routes_with(&registry, &log, &wipe, depth(2), &[]),
+            Err(RouteError::MembershipNeeded(vec![board.clone()])),
+            "the cast that would establish `backup`'s source writes a group the search cannot resolve"
+        );
+        let answered = routes_with(
+            &registry,
+            &log,
+            &wipe,
+            depth(2),
+            &[GroupExpansion::new(board, []).unwrap()],
+        )
+        .expect("the answer lets the cast be judged");
+        assert!(
+            matches!(
+                &answered[..],
+                [RecoveryRoute {
+                    outcome: RouteOutcome::Prefix(Resume::Propose {
+                        halt: Halt::Cast(_),
+                        ..
+                    }),
+                    ..
+                }]
+            ),
+            "{answered:?}"
+        );
+    }
+
+    #[test]
+    fn an_input_hop_is_a_prefix_that_resumes_from_the_derived_candidate() {
+        let internal = readers(&["internal"]);
+        let partner = readers(&["partner"]);
+        let registry = Deployment::of(vec![requiring_includes(tool("wire"), partner.clone())])
+            .sanitizers(vec![input_redaction(
+                "redact",
+                internal.clone(),
+                readers(&["internal", "partner"]),
+            )])
+            .registry();
+        let log = vec![opened(TRUSTED, internal)];
+
+        assert_eq!(
+            routes(&registry, &log, &call("wire", json!({})), depth(3)),
+            vec![route(
+                vec![RouteStep::Derive(SanitizerName::new("redact"))],
+                RouteOutcome::Prefix(Resume::DerivedCandidate {
+                    sanitizer: SanitizerName::new("redact"),
+                }),
+                contingent([Contingency::SanitizerResult {
+                    sanitizer: SanitizerName::new("redact"),
+                }])
+            )]
+        );
+    }
+
+    #[test]
+    fn an_acceptance_alone_is_the_one_guaranteed_route() {
+        let internal = readers(&["internal"]);
+        let registry =
+            Deployment::of(vec![narrowing_to(tool("read_internal"), None, Some(internal.clone()))]).registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+
+        assert_eq!(
+            routes(&registry, &log, &call("read_internal", json!({})), depth(2)),
+            vec![route(
+                vec![RouteStep::Accept(Narrowing {
+                    from: EstablishedLabel::new(TRUSTED, Audience::Public),
+                    to: EstablishedLabel::new(TRUSTED, internal),
+                })],
+                RouteOutcome::Complete,
+                Certainty::Guaranteed
+            )]
+        );
+    }
+
+    #[test]
+    fn a_ruling_binds_to_the_rendered_call_and_a_denial_on_that_digest_excludes_its_authority() {
+        let registry = Deployment::of(vec![requiring_trust(tool("wire"), TRUSTED)])
+            .authorities(vec![trust_authority("officer", TRUSTED)])
+            .registry();
+        let first = call("wire", json!({ "to": "a" }));
+        let second = call("wire", json!({ "to": "b" }));
+        let log = vec![opened(SUSPICIOUS, Audience::Public)];
+
+        let bound = |call: &ResolvedCall| {
+            vec![route(
+                vec![RouteStep::Authorize {
+                    authority: AuthorityName::new("officer"),
+                    covers: vec![Gap::TrustFloor {
+                        required: TRUSTED,
+                        actual: SUSPICIOUS,
+                    }],
+                    call: call.digest(),
+                }],
+                RouteOutcome::Complete,
+                contingent([decision("officer")]),
+            )]
+        };
+        assert_eq!(routes(&registry, &log, &first, depth(2)), bound(&first));
+        assert_eq!(routes(&registry, &log, &second, depth(2)), bound(&second));
+        assert_ne!(first.digest(), second.digest());
+
+        let denied = [
+            log,
+            vec![Fact::Denial {
+                trajectory: traj(),
+                digest: first.digest(),
+                authority: AuthorityName::new("officer"),
+            }],
+        ]
+        .concat();
+        assert!(routes(&registry, &denied, &first, depth(2)).is_empty());
+        assert_eq!(
+            routes(&registry, &denied, &second, depth(2)),
+            bound(&second),
+            "a denial is sticky for its digest only"
+        );
+    }
+
+    #[test]
+    fn two_narrow_rulings_precede_one_broad_ruling_whatever_the_step_count() {
+        let registry = Deployment::of(vec![requiring_no_prior(
+            requiring_trust(tool("wire"), TRUSTED),
+            "email.sent",
+        )])
+        .authorities(vec![
+            authority(
+                "broad",
+                Mandate {
+                    trust_ceiling: Some(VETTED),
+                    waivers: vec![effect("email.sent")],
+                    ..Mandate::default()
+                },
+            ),
+            trust_authority("trust", TRUSTED),
+            authority(
+                "audit",
+                Mandate {
+                    waivers: vec![effect("email.sent")],
+                    ..Mandate::default()
+                },
+            ),
+        ])
+        .registry();
+        let log = vec![opened(SUSPICIOUS, Audience::Public), committed("email.sent")];
+
+        let found = routes(&registry, &log, &call("wire", json!({})), depth(2));
+        let shapes: Vec<Vec<String>> = found.iter().map(shape).collect();
+        assert_eq!(
+            shapes,
+            vec![
+                vec!["authorize:trust", "authorize:audit"],
+                vec!["authorize:trust", "authorize:broad"],
+                vec!["authorize:broad"],
+                vec!["authorize:broad", "authorize:audit"],
+            ],
+            "the two-ruling routes that keep the trust ceiling at the floor precede the one broad \
+             ruling despite their length; on the `no_prior` gap the broad waiver equals the narrow \
+             one, so those two tie by bytes"
+        );
+    }
+
+    #[test]
+    fn a_substitution_precedes_a_ruling_and_less_disclosure_precedes_more() {
+        let internal = readers(&["internal"]);
+        let registry = Deployment::of(vec![
+            emitting("zbackup", &["backup"]),
+            narrowing_to(emitting("abackup", &["backup"]), None, Some(readers(&["carol"]))),
+            requiring_includes(
+                requiring_prior(tool("wire"), &["backup"]),
+                readers(&["internal", "partner"]),
+            ),
+        ])
+        .authorities(vec![reader_authority("officer", Audience::Public)])
+        .sanitizers(vec![input_redaction(
+            "redact",
+            internal.clone(),
+            readers(&["internal", "partner"]),
+        )])
+        .registry();
+        let log = vec![opened(TRUSTED, internal)];
+
+        let found = routes(&registry, &log, &call("wire", json!({})), depth(2));
+        let shapes: Vec<Vec<String>> = found.iter().map(shape).collect();
+        assert_eq!(
+            shapes,
+            vec![
+                vec!["derive:redact"],
+                vec!["precede:zbackup", "derive:redact"],
+                vec!["precede:zbackup", "authorize:officer"],
+                vec!["precede:abackup", "authorize:officer"],
+            ],
+            "substitutions first; the ruling after `zbackup` discloses `partner` only, the one after \
+             `abackup` — whose delta empties the audience — discloses both recipients; and no hop \
+             applies once the audience no longer includes what the sanitizer takes"
+        );
+    }
+
+    #[test]
+    fn hops_over_a_gap_a_preceding_call_opens_rank_by_their_substitution_power() {
+        let internal = readers(&["internal"]);
+        let partner = readers(&["partner"]);
+        let registry = Deployment::of(vec![
+            narrowing_to(emitting("backup", &["backup"]), None, Some(internal.clone())),
+            requiring_includes(requiring_prior(tool("wire"), &["backup"]), partner),
+        ])
+        .sanitizers(vec![
+            input_redaction("broad", internal.clone(), Audience::Public),
+            input_redaction("narrow", internal, readers(&["internal", "partner"])),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+
+        let found = routes(&registry, &log, &call("wire", json!({})), depth(2));
+        let shapes: Vec<Vec<String>> = found.iter().map(shape).collect();
+        assert_eq!(
+            shapes,
+            vec![
+                vec!["precede:backup", "derive:narrow"],
+                vec!["precede:backup", "derive:broad"],
+            ],
+            "the `includes` gap exists only after `backup` narrows the audience; the hop that \
+             substitutes the smaller audience still ranks first"
+        );
+    }
+
+    #[test]
+    fn the_search_is_the_same_for_the_same_block_and_total_within_the_bound() {
+        let registry = Deployment::of(vec![
+            emitting("b1", &["backup"]),
+            emitting("b2", &["backup"]),
+            requiring_prior(emitting("s1", &["snapshot"]), &["seal"]),
+            emitting("seal", &["seal"]),
+            requiring_prior(tool("wipe"), &["backup", "snapshot"]),
+        ])
+        .registry();
+        let log = vec![opened(TRUSTED, Audience::Public)];
+        let wipe = call("wipe", json!({}));
+
+        let first = routes(&registry, &log, &wipe, depth(4));
+        let again = routes(&registry, &log, &wipe, depth(4));
+        assert_eq!(first, again);
+        let complete: Vec<Vec<String>> = first
+            .iter()
+            .filter(|route| route.outcome == RouteOutcome::Complete)
+            .map(shape)
+            .collect();
+        assert_eq!(
+            complete,
+            vec![
+                vec!["precede:b1", "precede:seal", "precede:s1"],
+                vec!["precede:b2", "precede:seal", "precede:s1"],
+            ],
+            "each backup once, in the first order met; `seal, s1, b1` reaches the same state and \
+             is not reported again"
+        );
+        assert!(
+            routes(&registry, &log, &wipe, depth(3))
+                .iter()
+                .all(|route| route.outcome != RouteOutcome::Complete),
+            "three calls cannot span seal, s1 and a backup beside the blocked call"
+        );
+    }
+
+    #[test]
+    fn depth_one_routes_are_exactly_the_stage_plans() {
+        let internal = readers(&["internal"]);
+        let partner = readers(&["partner"]);
+        let registry = Deployment::of(vec![
+            emitting("backup", &["backup"]),
+            requiring_includes(requiring_prior(tool("wire"), &["backup"]), partner.clone()),
+            requiring_trust(tool("gate"), TRUSTED),
+        ])
+        .authorities(vec![trust_authority("officer", TRUSTED)])
+        .sanitizers(vec![input_redaction(
+            "redact",
+            internal.clone(),
+            readers(&["internal", "partner"]),
+        )])
+        .registry();
+        let log = vec![opened(SUSPICIOUS, internal)];
+
+        for proposal in [call("wire", json!({})), call("gate", json!({}))] {
+            let projection = Projection::build(&log, log.len() as u64);
+            let trajectory = traj();
+            let views = projection.view(&trajectory);
+            let planned = plan::plan(
+                &registry,
+                &views,
+                &proposal,
+                &raw_block(&registry, &views, &proposal),
+                &CallStage::default(),
+                CallRole::Ordinary,
+                &Expansions::default(),
+            );
+            let expected: Vec<RecoveryRoute> = planned
+                .plans
+                .iter()
+                .map(|plan| match plan {
+                    plan::RemedyPlan::Executable(plan) => match plan.hop() {
+                        Some(sanitizer) => route(
+                            vec![RouteStep::Derive(sanitizer.clone())],
+                            RouteOutcome::Prefix(Resume::DerivedCandidate {
+                                sanitizer: sanitizer.clone(),
+                            }),
+                            contingent([Contingency::SanitizerResult {
+                                sanitizer: sanitizer.clone(),
+                            }]),
+                        ),
+                        None => route(
+                            plan.steps
+                                .iter()
+                                .map(|step| match step {
+                                    RemedyStep::Authorize(authority) => RouteStep::Authorize {
+                                        authority: authority.clone(),
+                                        covers: plan.required[0].covers.clone(),
+                                        call: proposal.digest(),
+                                    },
+                                    RemedyStep::Accept(narrowing) => RouteStep::Accept(narrowing.clone()),
+                                    RemedyStep::Sanitize(sanitizer) => RouteStep::Sanitize(sanitizer.clone()),
+                                    RemedyStep::Derive(sanitizer) => RouteStep::Derive(sanitizer.clone()),
+                                })
+                                .collect(),
+                            RouteOutcome::Complete,
+                            contingent(
+                                plan.required
+                                    .iter()
+                                    .map(|required| decision(required.authority.as_str())),
+                            ),
+                        ),
+                    },
+                    plan::RemedyPlan::Redispatch(redispatch) => route(
+                        vec![],
+                        propose(redispatch.tool().as_str(), redispatch.clears().to_vec(), Halt::Depth),
+                        Certainty::Guaranteed,
+                    ),
+                })
+                .collect();
+            assert!(!expected.is_empty());
+            let found = routes(&registry, &log, &proposal, RouteDepth::ONE);
+            assert_eq!(found.len(), expected.len());
+            assert!(expected.iter().all(|route| found.contains(route)), "{found:?}");
+            let executable = |routes: &[RecoveryRoute]| -> Vec<RecoveryRoute> {
+                routes
+                    .iter()
+                    .filter(|route| !matches!(route.outcome, RouteOutcome::Prefix(Resume::Propose { .. })))
+                    .cloned()
+                    .collect()
+            };
+            assert_eq!(executable(&found), executable(&expected));
+        }
+    }
+
+    #[test]
+    fn an_unestablished_source_at_the_block_leaves_no_route_at_any_depth() {
+        let registry = Deployment::of(vec![tool("seed"), requiring_trust(tool("gate"), TRUSTED)])
+            .authorities(vec![trust_authority("officer", VETTED)])
+            .registry();
+        let log = vec![
+            opened(TRUSTED, Audience::Public),
+            admitted(Label::new(Dim::Unknown, Dim::Known(Audience::Public))),
+        ];
+
+        assert!(routes(&registry, &log, &call("gate", json!({})), depth(4)).is_empty());
+    }
+}

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -1202,7 +1202,13 @@ impl<'a> Sequence<'a> {
                 }
                 let current = views.current_label();
                 if proposed_label
-                    != crate::check::committed_label_for_call(contract, &current, &call, &expansions).bound()
+                    != crate::check::committed_label_for_call(
+                        contract,
+                        &current,
+                        crate::check::CallReads::Resolved(&call),
+                        &expansions,
+                    )
+                    .bound()
                     || receiving != current.bound()
                 {
                     return Err(TransitionRefusal::ForgedLabel);


### PR DESCRIPTION
## Summary

- `Engine::recovery_routes(view, subject, answers, depth)`: for a blocked call, every recovery route within a `RouteDepth` — the RMD plans composed with the tools an RMD-13 plan names, each later step re-checked in the abstract state the earlier steps produce. Advisory only: nothing is appended, no offer is minted, `remedy_plans` are untouched.
- Call-bound decisions (rulings, acceptance, hops, denials) bind the blocked call's digest. A preceding tool contributes only what its `StaticContract` fixes (no resolver answers, no placeholder recipients, established delta), in the success branch; anything less determined ends the route as a `Prefix` naming what must land before planning resumes (`Resume::DerivedCandidate`, `Resume::Propose { halt }`).
- `RecoveryRoute::certainty()`: `Guaranteed` or `Contingent` over authority decisions, tool outcomes, sanitizer results.
- Order: least mandate power (RMD-15 per requirement), then least disclosure, then fewer steps, then canonical bytes. `RouteDepth::ONE` yields exactly the block's plans. An empty list asserts only that no route exists within the abstraction and depth.
- Termination: depth bound plus no repeated tool on a path; one order per set of preceding tools (visit memo). Group reads on the route path are gated like the engine's (`block_groups`, `constant_groups_reaching`) and surface as `RouteError::MembershipNeeded`.
- Supporting: `check::CallReads` / `evaluate_static`, `contract::StaticContract`, `plan::enumerate_plans` over history predicates, `plan::direct_clears` shared with redispatch plans.

Spec companion (RMD-20, CFG-25 `[limits] route_depth`) follows in the private repo.

## Test plan

- `cargo test -p appa-engine` (482; 21 new: multi-step discovery, prior-derivation composition and re-planning, cycle termination, invalid transitions, reservation/label constraints, every `Halt` kind, exact-call binding and per-digest denials, ranking, bounded-failure reporting, depth-one equivalence, expansions precedence, membership gating, foreign view)
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gHBB3snfJXkbfJmNeLdbf
