### PR TITLE
fix(batteries): check the file name, not the path, in read-sensitivity

### DIFF
--- a/batteries/claude-code/README.md
+++ b/batteries/claude-code/README.md
@@ -15,7 +15,7 @@ approve. Bash output is always treated as untrusted and private. Every
 **`read-sensitivity.py`** — called on every `Read` tool call, before the
 file is read. Receives the tool name and its arguments (`file_path`,
 plus `offset` and `limit` if given) and decides who may see the file's
-contents: a `file_path` that starts with `.` (such as `.env`) is
+contents: a `file_path` whose file name starts with `.` (such as `.env`) is
 private; any other path is public. A deliberately simple starting rule;
 replace it with one that knows your project.
 

--- a/batteries/claude-code/appa.toml
+++ b/batteries/claude-code/appa.toml
@@ -60,7 +60,7 @@ trust = "suspicious"
 audience = ["private"]
 
 # Read labels a path through a one-shot resolver. This example uses a
-# deliberately simple rule: a path beginning with `.` is private.
+# deliberately simple rule: a file whose name begins with `.` is private.
 [[policy.dynamic_resolver]]
 name = "claude-code.read-sensitivity"
 returns = ["delta.audience"]

--- a/batteries/claude-code/read-sensitivity.py
+++ b/batteries/claude-code/read-sensitivity.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from pathlib import PurePath
 
 
 def main():
@@ -18,7 +19,8 @@ def main():
     if not isinstance(file_path, str) or not file_path:
         raise ValueError("args.arguments.file_path must be a non-empty string")
 
-    audience = ["private"] if file_path.startswith(".") else "public"
+    # Claude Code sends an absolute path, so test the file name, not the path.
+    audience = ["private"] if PurePath(file_path).name.startswith(".") else "public"
     json.dump(
         {"version": 1, "result": {"delta.audience": audience}},
         sys.stdout,

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -132,10 +132,11 @@ The resolver can be any program. Here is a Python example:
 ```python
 import json
 import sys
+from pathlib import PurePath
 
 request = json.load(sys.stdin)
 file_path = request["args"]["arguments"]["file_path"]
-audience = ["private"] if file_path.startswith(".") else "public"
+audience = ["private"] if PurePath(file_path).name.startswith(".") else "public"
 
 json.dump(
     {"version": 1, "result": {"delta.audience": audience}},
@@ -175,7 +176,7 @@ command = ["python3", "./read-sensitivity.py"]
 
 `README.md` matches the first rule, so `read-sensitivity.py` does not run.
 
-The resolver returns `["private"]` for a path that starts with `.` and `"public"` for any other path.
+The resolver returns `["private"]` for a file whose name starts with `.` and `"public"` for any other path. It checks the file name, not the whole path: Claude Code passes absolute paths, which always start with `/`.
 
 This only controls approval. It does not make Bash output Public. The output stays inside the Claude session.
 


### PR DESCRIPTION
## What

`batteries/claude-code/read-sensitivity.py` decided audience with `file_path.startswith(".")`. Claude Code passes `Read` an absolute `file_path`, which always starts with `/`, so the rule never matched: every read, `.env` included, resolved to `public`. The resolver now tests `PurePath(file_path).name`, and the README, the rule comment in `appa.toml`, and the docs snippet say "file name" instead of "path".

## Notes

- Deliberately keeps the one-line rule. A dot-prefixed *directory* (`.ssh/id_rsa`, `.git/config`) still resolves to public; widening to every path component is a separate decision.
- `examples/claude-code-battery/local/read-sensitivity.py` has the same relative-path assumption (`startswith(".")`, `startswith("clients/")`, `== ".env.example"`); not touched here since its README documents those exact relative paths.

## Testing

```
printf '{"version":1,"resolver":"claude-code.read-sensitivity","args":{"name":"Read","arguments":{"file_path":"/Users/me/repo/.env_demo"}}}' \
  | python3 batteries/claude-code/read-sensitivity.py
# {"version": 1, "result": {"delta.audience": ["private"]}}   (was "public")
```

`/Users/me/repo/public` → `"public"`, `.env_demo` → `["private"]`. `cargo test -p appa-runtime --test examples_load` passes. Observed in a live session on runtime 0.2.0: `.env_demo` was admitted with `audience: Public` before this change (`ValueAdmitted` fact in `appa.db`).

https://claude.ai/code/session_01QMJ4e56yxxKZMr3e1xYrrX
