### PR TITLE
fix(ci): unblock the release binary build

### DIFF
--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -40,7 +40,7 @@ jobs:
             executable: appa-runtime
             asset: appa-runtime-x86_64-unknown-linux-gnu
             archive: appa-runtime-x86_64-unknown-linux-gnu.tar.gz
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             os: Linux
             arch: arm64
             target: aarch64-unknown-linux-gnu
@@ -178,7 +178,8 @@ jobs:
               test -f claude-code/plugin/.mcp.json
               test -f claude-code/plugin/hooks/hooks.json
               test -f claude-code/plugin/hooks/session-context.md
-              test -f claude-code/plugin/skills/appa-tool-sync/SKILL.md
+              test -f claude-code/plugin/skills/appa-guide/SKILL.md
+              test -f claude-code/plugin/skills/appa-setup/SKILL.md
               test -x claude-code/plugin/statusline.sh
               exit 0
             fi
@@ -254,8 +255,11 @@ jobs:
             if (-not (Test-Path (Join-Path $package "claude-code/plugin/statusline.ps1"))) {
               throw "Extracted package does not contain the Windows Claude Code statusline"
             }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/skills/appa-tool-sync/SKILL.md"))) {
-              throw "Extracted package does not contain the Claude Code tool-sync skill"
+            if (-not (Test-Path (Join-Path $package "claude-code/plugin/skills/appa-guide/SKILL.md"))) {
+              throw "Extracted package does not contain the Claude Code appa-guide skill"
+            }
+            if (-not (Test-Path (Join-Path $package "claude-code/plugin/skills/appa-setup/SKILL.md"))) {
+              throw "Extracted package does not contain the Claude Code appa-setup skill"
             }
           } finally {
             $process.Refresh()


### PR DESCRIPTION
## What

The v0.3.0 release failed every `Build release binaries` job, so `Publish GitHub release` never ran and v0.3.0 is stuck as a draft with no assets ([run](https://github.com/archestra-ai/OpenAPPA/actions/runs/32963111978)).

Two causes:

- Both package-verification steps assert `claude-code/plugin/skills/appa-tool-sync/SKILL.md`. #85 replaced that skill with `appa-guide` and `appa-setup`, so the assertion can never pass. Now asserts the two skills that actually ship.
- Linux arm64 builds on `ubuntu-24.04-arm`, whose glibc 2.39 trips the 2.34 baseline check. Moved to `ubuntu-22.04-arm`, matching the amd64 job's glibc.

## Notes

The Unix verify step runs under `bash -e`, so the failing `test -f` aborted before `cat runtime.stderr.log` — which is why the failed jobs show no error text. The runtime binary itself was healthy in every job.

## Testing

Dispatched `Build appa-runtime binaries` against this branch.

https://claude.ai/code/session_018Hg5TbQV5M2Lam8UxeANhB