### PR TITLE
feat(engine): match several arguments in one tool selector

### DIFF
--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11327,6 +11327,14 @@ mod tests {
         assert_ne!(identity(&["read(path:private*)", "read"]), base);
         assert_eq!(identity(&["read(path:secret**)", "read"]), base);
         assert_eq!(identity(&["read", "send"]), identity(&["send", "read"]));
+
+        // A conjunction is commutative, so clause order is spelling, not policy: the two
+        // spellings are one matcher and one identity. Naming another argument is not.
+        let conjunction = identity(&["read(path:secret*,mode:rw)", "read"]);
+        assert_eq!(identity(&["read(mode:rw,path:secret*)", "read"]), conjunction);
+        assert_ne!(conjunction, base, "a second clause is a different predicate");
+        assert_ne!(identity(&["read(path:secret*,mode:ro)", "read"]), conjunction);
+        assert_ne!(identity(&["read(path:secret*,scope:rw)", "read"]), conjunction);
     }
 
     #[test]

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -15,10 +15,29 @@ use crate::value::{ToolContractId, ToolName};
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub(crate) enum ToolMatcher {
     Bare,
-    Argument {
-        argument: String,
-        pattern: Vec<PatternPart>,
-    },
+    Arguments(ArgumentPatterns),
+}
+
+/// A non-empty conjunction of argument patterns, keyed by argument name. The map is the
+/// normal form: a conjunction is commutative and one argument carries one pattern, so
+/// `tool(owner:x,repo:y)` and `tool(repo:y,owner:x)` are the same matcher and the same
+/// policy identity. Non-emptiness is the constructor's invariant, so a matcher that would
+/// match every call vacuously cannot be built — that is what [`ToolMatcher::Bare`] is.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct ArgumentPatterns(BTreeMap<String, Vec<PatternPart>>);
+
+impl ArgumentPatterns {
+    /// The clause that proves a conjunction holds at least one: a conjunction is built from
+    /// it outwards, so the empty state has no constructor at all.
+    fn first(argument: String, pattern: Vec<PatternPart>) -> ArgumentPatterns {
+        ArgumentPatterns(BTreeMap::from([(argument, pattern)]))
+    }
+
+    /// Add a conjunct. `None` when `argument` is already declared: one argument carries one
+    /// pattern, so a repeated name is an authoring mistake rather than a second conjunct.
+    fn and(&mut self, argument: String, pattern: Vec<PatternPart>) -> Option<()> {
+        self.0.insert(argument, pattern).is_none().then_some(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -28,13 +47,31 @@ pub(crate) enum PatternPart {
 }
 
 impl ToolMatcher {
+    /// Every declared clause must match: the argument is present, it is a string, and its
+    /// value matches that clause's pattern. A missing or non-string argument does not match.
     fn matches(&self, arguments: &serde_json::Value) -> bool {
         match self {
             ToolMatcher::Bare => true,
-            ToolMatcher::Argument { argument, pattern } => arguments
-                .get(argument)
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| wildcard_matches(pattern, value)),
+            ToolMatcher::Arguments(ArgumentPatterns(clauses)) => {
+                let clause_matches = |(argument, pattern): (&String, &Vec<PatternPart>)| {
+                    arguments
+                        .get(argument)
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|value| wildcard_matches(pattern, value))
+                };
+                // Clauses that reject on a lookup run before clauses that scan the value. A
+                // conjunction is commutative, so this moves cost and never the answer: an
+                // absent argument or a literal mismatch rejects the selector without reading
+                // a long value at all. Argument-name order is the normal form the identity
+                // digest reads, never an evaluation order, and normalizing it is exactly what
+                // takes this choice away from the policy author.
+                let scans = |pattern: &[PatternPart]| pattern.contains(&PatternPart::Wildcard);
+                clauses
+                    .iter()
+                    .filter(|(_, pattern)| !scans(pattern))
+                    .all(clause_matches)
+                    && clauses.iter().filter(|(_, pattern)| scans(pattern)).all(clause_matches)
+            }
         }
     }
 }
@@ -78,63 +115,67 @@ fn push_wildcard(parts: &mut Vec<PatternPart>, literal: &mut String) {
     }
 }
 
-fn parse_contract_name(authored: &str) -> Result<(ToolName, ToolMatcher), LoadError> {
-    if !authored.contains(['(', ')']) {
-        return (!authored.is_empty())
-            .then(|| (ToolName::new(authored), ToolMatcher::Bare))
-            .ok_or_else(|| LoadError::MalformedToolSelector(authored.to_string()));
-    }
-    let Some(open) = authored.find('(') else {
-        return Err(LoadError::MalformedToolSelector(authored.into()));
-    };
-    let tool = &authored[..open];
-    let rest = &authored[open + 1..];
-    let Some(colon) = rest.find(':') else {
-        return Err(LoadError::MalformedToolSelector(authored.into()));
-    };
-    let argument = &rest[..colon];
-    let pattern_source = &rest[colon + 1..];
-    if tool.is_empty()
-        || tool.contains(['(', ')'])
-        || argument.is_empty()
-        || argument
-            .chars()
-            .any(|c| matches!(c, ':' | '(' | ')' | '\\') || c.is_control())
-    {
-        return Err(LoadError::MalformedToolSelector(authored.into()));
-    }
-    let mut chars = pattern_source.chars().peekable();
-    let mut parts = Vec::new();
-    let mut literal = String::new();
-    let mut closed = false;
-    while let Some(ch) = chars.next() {
-        match ch {
-            '*' => push_wildcard(&mut parts, &mut literal),
-            '\\' => match chars.next() {
-                Some(next @ ('*' | ')' | '\\')) => literal.push(next),
-                _ => return Err(LoadError::MalformedToolSelector(authored.into())),
-            },
-            ')' if chars.peek().is_none() => {
-                closed = true;
-                break;
-            }
-            ')' => return Err(LoadError::MalformedToolSelector(authored.into())),
-            other => literal.push(other),
+/// One `argument:pattern` clause, read from `chars` up to an unescaped `,` or the selector's
+/// closing `)`. Returns the clause and whether the selector closed here; `None` is a
+/// malformed clause.
+fn parse_clause(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> Option<(String, Vec<PatternPart>, bool)> {
+    let mut argument = String::new();
+    loop {
+        match chars.next()? {
+            ':' => break,
+            // An argument name carries no escapes, so a backslash is malformed rather than
+            // an escape here, and the clause and selector delimiters cannot appear in one.
+            c if matches!(c, '(' | ')' | ',' | '\\') || c.is_control() => return None,
+            c => argument.push(c),
         }
     }
-    if !closed {
-        return Err(LoadError::MalformedToolSelector(authored.into()));
+    if argument.is_empty() {
+        return None;
     }
+    let mut parts = Vec::new();
+    let mut literal = String::new();
+    let closed = loop {
+        match chars.next()? {
+            '*' => push_wildcard(&mut parts, &mut literal),
+            '\\' => match chars.next()? {
+                next @ ('*' | ')' | '\\' | ',') => literal.push(next),
+                _ => return None,
+            },
+            ',' => break false,
+            ')' if chars.peek().is_none() => break true,
+            ')' => return None,
+            other => literal.push(other),
+        }
+    };
     if !literal.is_empty() {
         parts.push(PatternPart::Literal(literal));
     }
-    Ok((
-        ToolName::new(tool),
-        ToolMatcher::Argument {
-            argument: argument.into(),
-            pattern: parts,
-        },
-    ))
+    Some((argument, parts, closed))
+}
+
+/// Split an authored contract name into the tool it names and the matcher that selects it:
+/// `Tool` alone, or `Tool(argument:pattern[,argument:pattern...])`.
+fn parse_contract_name(authored: &str) -> Result<(ToolName, ToolMatcher), LoadError> {
+    let malformed = || LoadError::MalformedToolSelector(authored.to_string());
+    if !authored.contains(['(', ')']) {
+        return (!authored.is_empty())
+            .then(|| (ToolName::new(authored), ToolMatcher::Bare))
+            .ok_or_else(malformed);
+    }
+    let open = authored.find('(').ok_or_else(malformed)?;
+    let tool = &authored[..open];
+    if tool.is_empty() || tool.contains(')') {
+        return Err(malformed());
+    }
+    let mut chars = authored[open + 1..].chars().peekable();
+    let (argument, pattern, mut closed) = parse_clause(&mut chars).ok_or_else(malformed)?;
+    let mut clauses = ArgumentPatterns::first(argument, pattern);
+    while !closed {
+        let (argument, pattern, next) = parse_clause(&mut chars).ok_or_else(malformed)?;
+        clauses.and(argument, pattern).ok_or_else(malformed)?;
+        closed = next;
+    }
+    Ok((ToolName::new(tool), ToolMatcher::Arguments(clauses)))
 }
 
 #[cfg(test)]
@@ -1522,6 +1563,64 @@ mod tests {
 
         let multiple = parsed("read(path:*ab*bc)").expect("the selector is valid");
         assert!(multiple.matches(&arguments("xxabyyabzzbc")));
+
+        let dotted = parsed("read(a.b:x)").expect("a dotted argument name is valid");
+        assert!(dotted.matches(&serde_json::json!({ "a.b": "x" })));
+    }
+
+    /// The conjunction: a selector may name several arguments, and a call is selected only
+    /// when every one of them is present, a string, and matches its own pattern. The repo
+    /// case is `fork_repository(owner:archestra-ai,repo:website)`, which must not reach
+    /// another account's repository that happens to carry the same name.
+    #[test]
+    fn every_argument_clause_must_match_for_the_contract_to_select() {
+        let parsed = |name| parse_contract_name(name).map(|(_, matcher)| matcher);
+        let call = |owner, repo| serde_json::json!({ "owner": owner, "repo": repo });
+
+        // One clause still ignores every argument it does not name.
+        let repo_only = parsed("fork(repo:website)").expect("the selector is valid");
+        assert!(repo_only.matches(&call("archestra-ai", "website")));
+        assert!(repo_only.matches(&call("somebody-else", "website")));
+
+        let both = parsed("fork(owner:archestra-ai,repo:website)").expect("the selector is valid");
+        assert!(both.matches(&call("archestra-ai", "website")));
+        assert!(
+            !both.matches(&call("somebody-else", "website")),
+            "a foreign owner is out"
+        );
+        assert!(
+            !both.matches(&call("archestra-ai", "docs")),
+            "another repository is out"
+        );
+
+        // A clause whose argument is missing or is not a string fails the conjunction, the
+        // same as a single-argument selector does.
+        assert!(!both.matches(&serde_json::json!({ "repo": "website" })));
+        assert!(!both.matches(&serde_json::json!({ "owner": "archestra-ai" })));
+        assert!(!both.matches(&serde_json::json!({ "owner": 1, "repo": "website" })));
+        assert!(!both.matches(&serde_json::json!({ "owner": "archestra-ai", "repo": null })));
+
+        // Wildcards run independently per clause.
+        let wild = parsed("fork(owner:archestra-*,repo:web*)").expect("the selector is valid");
+        assert!(wild.matches(&call("archestra-ai", "website")));
+        assert!(wild.matches(&call("archestra-labs", "webhooks")));
+        assert!(!wild.matches(&call("archestra-ai", "docs")));
+        assert!(!wild.matches(&call("elsewhere", "website")));
+
+        // A comma separates clauses, so a literal comma is escaped. The clause after it is
+        // still read as a clause, not as pattern text.
+        let comma = parsed(r"search(query:a\,b)").expect("an escaped comma is valid");
+        assert!(comma.matches(&serde_json::json!({ "query": "a,b" })));
+        assert!(!comma.matches(&serde_json::json!({ "query": "ab" })));
+        let mixed = parsed(r"search(query:a\,b,scope:repo)").expect("the selector is valid");
+        assert!(mixed.matches(&serde_json::json!({ "query": "a,b", "scope": "repo" })));
+        assert!(!mixed.matches(&serde_json::json!({ "query": "a,b" })));
+
+        // Clause order carries no meaning, so the two spellings are one matcher.
+        assert_eq!(
+            parsed("fork(owner:archestra-ai,repo:website)").expect("the selector is valid"),
+            parsed("fork(repo:website,owner:archestra-ai)").expect("the selector is valid"),
+        );
     }
 
     #[test]
@@ -1540,6 +1639,20 @@ mod tests {
             "read(a(b:c)",
             "read(a\\:x)",
             "read(a\n:x)",
+            // A conjunction holds at least one clause, and every clause holds a name, a
+            // colon, and nothing empty between the commas.
+            "read()",
+            "read(a:x,)",
+            "read(,a:x)",
+            "read(a:x,,b:y)",
+            "read(a:x,b)",
+            "read(a:x,:y)",
+            "read(a:x,b(c:y)",
+            "read(a:x,b\\:y)",
+            // One argument carries one pattern, so a repeated name is refused rather than
+            // silently overwritten.
+            "read(a:x,a:y)",
+            "read(a:x,a:x)",
         ] {
             assert!(
                 matches!(parse_contract_name(malformed), Err(LoadError::MalformedToolSelector(_))),

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -73,7 +73,7 @@ requires = { trust = "trusted", attention = ["hitl"] }
 delta = {}
 ```
 
-Text inside parentheses matches one argument. `*` matches any text.
+Text inside parentheses matches arguments. Write one or more `argument:pattern` clauses and separate them with commas; every clause must match. `*` matches any text.
 
 A bare tool name is the default. It matches when no earlier rule did.
 

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -66,9 +66,25 @@ requires = { trust = "trusted", attention = ["hitl"] }
 delta = {}
 ```
 
-Text inside parentheses selects one top-level string argument. `*` matches any text. Use `\*`, `\)`, and `\\` for literal characters.
+Text inside parentheses selects top-level string arguments. Write one or more `argument:pattern` clauses and separate them with commas. The contract matches only when every clause matches.
 
-A missing or non-string argument does not match. A bare tool name matches every argument object and is typically the fallback.
+```toml
+[[tool]]
+name = "mcp__github__fork_repository(owner:archestra-ai,repo:website)"
+requires = { trust = "trusted" }
+delta = {}
+```
+
+`*` matches any text. Four escapes match a literal character: `\*`, `\)`, `\,`, and `\\`. A backslash before any other character is an error, and the policy does not load.
+
+TOML reads backslashes too, so a selector escape passes through two layers. A basic string, in double quotes, needs every selector backslash doubled: `\\*`, `\\)`, `\\,`, `\\\\`. A literal string, in single quotes, passes backslashes through unchanged, so write the selector escape directly.
+
+```toml
+name = "search(query:a\\,b)"   # a basic string doubles the backslash
+name = 'search(query:a\,b)'    # a literal string does not
+```
+
+A missing or non-string argument does not match. Clause order does not change the result: `tool(owner:x,repo:y)` and `tool(repo:y,owner:x)` are the same contract. A selector can name each argument only once. A bare tool name matches every argument object and is typically the fallback.
 
 OpenAPPA selects the contract before it validates that contract's `parameters` schema. A schema failure does not continue to a later contract. A `tool_input` rewrite is judged by the contract its rewritten arguments select: a rewrite that stays in its contract keeps the resolver answers of the call last consulted; one that selects another contract is a new call under that contract, and its resolvers are consulted for the rewritten arguments. Provider-run tools cannot use argument selectors.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -36,7 +36,7 @@ Policy definitions remain strictly declarative TOML configurations. Instead of w
 
 A root configuration can include reusable policy fragments. Root declarations run first. Included declarations follow in the listed order. Included files add declarations and named external bindings; they cannot replace root-wide settings or include more files.
 
-Several contracts can name the same tool. OpenAPPA checks them in declaration order and uses the first matching argument pattern. A bare name is the fallback.
+Several contracts can name the same tool. OpenAPPA checks them in declaration order and uses the first contract whose argument patterns all match. A selector can name several arguments: separate the `argument:pattern` clauses with commas. A bare name is the fallback.
 
 Dynamic judgment—such as regex filters, ML classifiers, or human approval queues—lives in registered components. Authorities and sanitizers run as HTTP endpoints (`resolver`) or in-process modules (`builtin`). Each declares what it `permits`, and that declaration bounds its power. Casts declare a fixed label or use a resolver under a `may_cast` ceiling. An authority may omit its deployment binding. It then returns no answer, so a remedy that names it cannot release a call.
 

--- a/website/lib/terms.ts
+++ b/website/lib/terms.ts
@@ -37,7 +37,7 @@ const TERMS = {
 
   /* Tool contracts */
   "Tool(argument:pattern)":
-    "An ordered tool contract selector. OpenAPPA uses the first contract whose top-level string argument matches the pattern. An asterisk matches any text; a bare tool name is the fallback. A sanitizer rewrite that selects another contract is judged as a new call under it.",
+    "An ordered tool contract selector. A selector holds one or more comma-separated argument:pattern clauses, and a contract matches only when every clause matches its own top-level string argument. OpenAPPA uses the first matching contract. An asterisk matches any text; a bare tool name is the fallback. A sanitizer rewrite that selects another contract is judged as a new call under it.",
   delta:
     "The label contribution of an admitted call result. A delta never expands permissions: it intersects reader sets, lowers the trust rank, or leaves the trajectory label unchanged.",
   requires:


### PR DESCRIPTION
## What changed

A tool contract selector matched one argument. Now it can match several.

Before, this rule matched a repository named `website` under **any** GitHub owner:

```toml
[[policy.tool]]
name = "mcp__github__fork_repository(repo:website)"
```

Somebody else can create a repository with the same name. The rule then applies
to their repository too.

Now you can name the owner and the repository together:

```toml
[[policy.tool]]
name = "mcp__github__fork_repository(owner:archestra-ai,repo:website)"
requires = { trust = "trusted" }
delta = {}
```

This rule matches:

```json
{"owner": "archestra-ai", "repo": "website"}
```

It does not match:

```json
{"owner": "somebody-else", "repo": "website"}
{"owner": "archestra-ai", "repo": "docs"}
```

## The rules

Write one or more `argument:pattern` clauses and separate them with commas.
A contract matches only when **every** clause matches.

A clause does not match when its argument is missing, or is not a string.

Wildcards work in each clause on its own:

```toml
name = "mcp__github__fork_repository(owner:archestra-*,repo:web*)"
```

Clause order does not matter. These two are the same contract, and they produce
the same policy identity:

```toml
name = "tool(owner:x,repo:y)"
name = "tool(repo:y,owner:x)"
```

Each argument can appear only once in a selector.

## Commas and escapes

A comma now separates clauses. To match a comma inside a pattern, escape it.

Four selector escapes match a literal character: `\*`, `\)`, `\,`, and `\\`.
A backslash before any other character is an error, and the policy does not
load.

TOML reads backslashes as well, so an escape passes through two layers. A basic
string, in double quotes, needs every selector backslash doubled. A literal
string, in single quotes, passes them through unchanged.

```toml
name = "search(query:a\\,b)"   # basic string, matches {"query": "a,b"}
name = 'search(query:a\,b)'    # literal string, the same rule
```

The page said to write `\*` and `\)` inside a double-quoted `name`. TOML
rejects those as invalid escapes, so such a policy never loaded. The page now
gives the two layers separately.

This is a break. A selector that used to hold a plain comma changes meaning:
`send(target:alice,mode:*)` used to be one pattern on `target` that matched
strings like `"alice,mode:external"`. It is now two clauses, on `target` and on
`mode`. No policy in this repository used a comma in a selector.

## Refused at load

- `read()` — no clauses
- `read(a:x,)` and `read(,a:x)` and `read(a:x,,b:y)` — an empty clause
- `read(a:x,b)` — no colon
- `read(a:x,:y)` — no argument name
- `read(a:x,a:y)` — the same argument twice

## Unchanged

A bare tool name still matches every call and is still the fallback. Contracts
are still tested in declaration order, and the first match wins. `*`, `\*`,
`\)`, and `\\` still work as before. A tool run by the provider still refuses an
argument selector.

## Testing

`cargo test --workspace` and `cargo clippy --workspace --all-targets` are clean.

New tests cover each rule above: one clause still matching any owner, the
owner-and-repository case, a foreign owner, a wrong repository, a missing value,
a value that is not a string, wildcards in separate clauses, the escaped comma,
every refused form, and clause order not moving the policy identity.
