### PR TITLE
feat(batteries): classify sensitive read paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           jq -e .plugins .claude-plugin/marketplace.json >/dev/null
           jq -e .plugins integrations/claude-code/.claude-plugin/marketplace.json >/dev/null
 
+      - name: Test battery resolvers
+        run: python3 -m unittest discover -s batteries/claude-code -p 'test_*.py'
+
   rust-checks:
     name: Rust Checks
     runs-on: ubuntu-latest

--- a/batteries/claude-code/README.md
+++ b/batteries/claude-code/README.md
@@ -15,9 +15,10 @@ approve. Bash output is always treated as untrusted and private. Every
 **`read-sensitivity.py`** — called on every `Read` tool call, before the
 file is read. Receives the tool name and its arguments (`file_path`,
 plus `offset` and `limit` if given) and decides who may see the file's
-contents: a `file_path` whose file name starts with `.` (such as `.env`) is
-private; any other path is public. A deliberately simple starting rule;
-replace it with one that knows your project.
+contents. Hidden paths, credential and private-key files, system secret
+locations, and sensitive symlink targets are private. Other paths are
+public. The resolver only labels the returned value; it does not block
+the read.
 
 ## Change the behaviour
 

--- a/batteries/claude-code/read-sensitivity.py
+++ b/batteries/claude-code/read-sensitivity.py
@@ -1,6 +1,84 @@
 import json
 import sys
-from pathlib import PurePath
+from pathlib import Path
+
+
+PRIVATE_FILENAMES = frozenset(
+    {
+        "auth.json",
+        "credentials",
+        "credentials.json",
+        "gshadow",
+        "passwd",
+        "secrets",
+        "secrets.json",
+        "secrets.yaml",
+        "secrets.yml",
+        "service-account.json",
+        "service_account.json",
+        "shadow",
+        "token",
+        "token.json",
+    }
+)
+PRIVATE_KEY_FILENAMES = frozenset({"id_dsa", "id_ecdsa", "id_ed25519", "id_rsa"})
+PRIVATE_KEY_SUFFIXES = frozenset({".jks", ".key", ".keystore", ".p12", ".pem", ".pfx"})
+PRIVATE_SYSTEM_PATHS = (
+    Path("/etc/gshadow"),
+    Path("/etc/shadow"),
+    Path("/etc/ssh"),
+    Path("/etc/sudoers"),
+    Path("/etc/sudoers.d"),
+    Path("/run/secrets"),
+    Path("/var/run/secrets"),
+)
+
+
+def is_within(path, parent):
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def has_private_name(path):
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    if any(part.startswith(".") and part not in {".", ".."} for part in parts):
+        return True
+
+    name = path.name.casefold()
+    return (
+        name in PRIVATE_FILENAMES
+        or name in PRIVATE_KEY_FILENAMES
+        or path.suffix.casefold() in PRIVATE_KEY_SUFFIXES
+    )
+
+
+def is_private_system_path(path):
+    if any(is_within(path, parent) for parent in PRIVATE_SYSTEM_PATHS):
+        return True
+
+    parts = tuple(part.casefold() for part in path.parts)
+    process_data = len(parts) >= 3 and parts[1] == "proc" and parts[-1] in {"cmdline", "environ"}
+    keychain = any(
+        parts[index : index + 2] == ("library", "keychains")
+        for index in range(len(parts) - 1)
+    )
+    return process_data or keychain
+
+
+def is_sensitive(file_path):
+    path = Path(file_path)
+    try:
+        resolved = path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return True
+
+    for candidate in {path, resolved}:
+        if has_private_name(candidate) or is_private_system_path(candidate):
+            return True
+    return False
 
 
 def main():
@@ -19,8 +97,7 @@ def main():
     if not isinstance(file_path, str) or not file_path:
         raise ValueError("args.arguments.file_path must be a non-empty string")
 
-    # Claude Code sends an absolute path, so test the file name, not the path.
-    audience = ["private"] if PurePath(file_path).name.startswith(".") else "public"
+    audience = ["private"] if is_sensitive(file_path) else "public"
     json.dump(
         {"version": 1, "result": {"delta.audience": audience}},
         sys.stdout,
@@ -28,8 +105,9 @@ def main():
     sys.stdout.write("\n")
 
 
-try:
-    main()
-except Exception as error:
-    print(f"read-sensitivity: {error}", file=sys.stderr)
-    raise SystemExit(1)
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"read-sensitivity: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/batteries/claude-code/test_read_sensitivity.py
+++ b/batteries/claude-code/test_read_sensitivity.py
@@ -1,0 +1,75 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("read-sensitivity.py")
+SPEC = importlib.util.spec_from_file_location("read_sensitivity", SCRIPT)
+READ_SENSITIVITY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(READ_SENSITIVITY)
+
+
+class ReadSensitivityTests(unittest.TestCase):
+    def test_hidden_file_and_hidden_directory_are_private(self):
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/workspace/.env.example"))
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/workspace/.config/tool/settings.json"))
+
+    def test_credential_and_private_key_names_are_private(self):
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/workspace/config/credentials.json"))
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/workspace/certs/client.key"))
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/workspace/keys/id_ed25519"))
+
+    def test_system_secret_locations_are_private(self):
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/etc/ssh/ssh_host_ed25519_key"))
+        self.assertTrue(READ_SENSITIVITY.is_sensitive("/proc/self/environ"))
+        self.assertTrue(
+            READ_SENSITIVITY.is_sensitive("/Users/me/Library/Keychains/login.keychain-db")
+        )
+
+    def test_sensitive_symlink_target_is_private(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / ".credentials"
+            target.write_text("secret", encoding="utf-8")
+            link = root / "visible-name"
+            try:
+                link.symlink_to(target)
+            except OSError as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+
+            self.assertTrue(READ_SENSITIVITY.is_sensitive(link))
+
+    def test_ordinary_source_path_is_public(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "src" / "main.py"
+            source.parent.mkdir()
+            source.write_text("print('hello')\n", encoding="utf-8")
+
+            self.assertFalse(READ_SENSITIVITY.is_sensitive(source))
+
+    def test_protocol_returns_private_audience(self):
+        request = {
+            "version": 1,
+            "resolver": "claude-code.read-sensitivity",
+            "args": {"name": "Read", "arguments": {"file_path": "/workspace/.env"}},
+        }
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            check=True,
+            input=json.dumps(request),
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"version": 1, "result": {"delta.audience": ["private"]}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Classify hidden path components, credential and private-key filenames, system secret locations, and resolved symlink targets as private.
- Keep ordinary paths public and preserve the resolver's label-only behavior: sensitive reads are not blocked.
- Add standard-library unit coverage and run it in CI.

## Tests

- python3 -m unittest discover -s batteries/claude-code -p 'test_*.py' -v
- cargo test -p appa-runtime --test examples_load
- git diff --check