### PR TITLE
fix(runtime): compile Claude backend on Windows

### DIFF
--- a/appa-runtime/src/builtins.rs
+++ b/appa-runtime/src/builtins.rs
@@ -361,9 +361,12 @@ struct ClaudeResultEnvelope {
 /// consult's time budget.
 #[derive(Debug, Clone)]
 pub(crate) struct ClaudeCodeBackend {
+    #[cfg(unix)]
     pub(crate) command: std::path::PathBuf,
+    #[cfg(unix)]
     pub(crate) model: String,
     pub(crate) timeout: std::time::Duration,
+    #[cfg(unix)]
     pub(crate) max_body_bytes: usize,
 }
 

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -172,9 +172,12 @@ impl ExternalServices {
             .build()
             .expect("the reqwest client builds: no TLS or resolver overrides are set");
         let claude = ClaudeCodeBackend {
+            #[cfg(unix)]
             command: config.claude_code.command.clone(),
+            #[cfg(unix)]
             model: config.claude_code.model.clone(),
             timeout: config.claude_code.timeout.unwrap_or(config.timeout),
+            #[cfg(unix)]
             max_body_bytes: config.max_body_bytes,
         };
         let llm = config


### PR DESCRIPTION
Compile the Claude Code process-only backend fields only on Unix, where they are consumed. Windows retains the shared timeout field and continues refusing the unsupported local-process builtin at deployment validation.

This fixes the release build failure caused by the workspace dead-code deny lint on Windows.

Verified:
- cargo fmt --check
- cargo check --locked --package appa-runtime
- cargo test --locked --package appa-runtime (293 passed)
- native release build: Windows ARM64 and Windows amd64 passed