### PR TITLE
fix(engine): serialize every digest as hex, not a 32-integer array

### DIFF
--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -177,7 +177,7 @@ impl From<ToolCallSource> for String {
 /// value itself: the arguments and the `uses` entry are both already on the record, so the value
 /// is re-derivable, and a tool with several resolvers would otherwise persist a copy per resolver.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct ResolverArgsDigest([u8; 32]);
+pub struct ResolverArgsDigest(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl ResolverArgsDigest {
     pub fn of(canonical: &[u8]) -> Self {

--- a/appa-engine/src/hex32.rs
+++ b/appa-engine/src/hex32.rs
@@ -1,0 +1,98 @@
+//! The lowercase-hex wire form of the engine's 32-byte digests.
+//!
+//! JSON has no bytes type, so serde renders a `[u8; 32]` as a sequence of 32 decimal
+//! integers. Every identity the engine derives is such a digest, the event log is JSON, and
+//! the runtime already surfaces offers to the model as 64 hex characters. These functions
+//! give every digest that one form: an order of magnitude smaller on the record, and a
+//! string an operator can match against a hash printed anywhere else.
+
+use serde::{Deserializer, Serializer, de};
+
+/// The character count of a digest's hex form.
+const HEX_LEN: usize = 64;
+
+pub(crate) fn encode(bytes: &[u8; 32]) -> String {
+    let mut hex = String::with_capacity(HEX_LEN);
+    for byte in bytes {
+        hex.push(hex_char(byte >> 4));
+        hex.push(hex_char(byte & 0x0f));
+    }
+    hex
+}
+
+/// Parse a digest's hex form. Untrusted input: a wrong length, a non-hex character, or an
+/// uppercase one is refused, never guessed.
+pub(crate) fn decode(text: &str) -> Option<[u8; 32]> {
+    let bytes = text.as_bytes();
+    if bytes.len() != HEX_LEN {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (index, [high, low]) in bytes.as_chunks::<2>().0.iter().enumerate() {
+        out[index] = (nibble(*high)? << 4) | nibble(*low)?;
+    }
+    Some(out)
+}
+
+fn hex_char(nibble: u8) -> char {
+    char::from_digit(u32::from(nibble), 16).expect("a nibble is one hex digit")
+}
+
+fn nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
+}
+
+pub(crate) fn serialize<S: Serializer>(bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&encode(bytes))
+}
+
+pub(crate) fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 32], D::Error> {
+    deserializer.deserialize_str(HexDigest)
+}
+
+struct HexDigest;
+
+impl de::Visitor<'_> for HexDigest {
+    type Value = [u8; 32];
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("64 lowercase-hex characters")
+    }
+
+    fn visit_str<E: de::Error>(self, text: &str) -> Result<[u8; 32], E> {
+        decode(text).ok_or_else(|| E::invalid_value(de::Unexpected::Str(text), &self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode, encode};
+
+    #[test]
+    fn a_digest_round_trips_through_its_hex_form() {
+        let mut bytes = [0u8; 32];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(7).wrapping_add(3);
+        }
+        assert_eq!(decode(&encode(&bytes)), Some(bytes));
+    }
+
+    #[test]
+    fn every_byte_renders_as_two_lowercase_digits() {
+        assert_eq!(encode(&[0u8; 32]), "0".repeat(64));
+        assert_eq!(encode(&[255u8; 32]), "ff".repeat(32));
+    }
+
+    #[test]
+    fn malformed_hex_is_refused() {
+        let valid = encode(&[0xabu8; 32]);
+        assert_eq!(decode(&valid[..63]), None);
+        assert_eq!(decode(&format!("{valid}0")), None);
+        assert_eq!(decode(&valid.to_uppercase()), None);
+        assert_eq!(decode(&format!("g{}", &valid[1..])), None);
+    }
+}

--- a/appa-engine/src/lib.rs
+++ b/appa-engine/src/lib.rs
@@ -26,6 +26,7 @@ pub mod engine;
 pub mod execute;
 pub mod fact;
 pub mod groups;
+mod hex32;
 pub mod label;
 pub mod names;
 pub mod params;

--- a/appa-engine/src/profile.rs
+++ b/appa-engine/src/profile.rs
@@ -295,7 +295,7 @@ impl PolicyFileKey {
 /// the semantic sequences (the trust chain's rank order, authority registration order), sorts
 /// true maps and sets, and excludes source syntax, runtime bindings, `[limits]`, and hints.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PolicyIdentityV1([u8; 32]);
+pub struct PolicyIdentityV1(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl PolicyIdentityV1 {
     pub fn of(registry: &RegistryConfig, child_return: &ReturnPolicy, profile: &DeploymentProfile) -> Self {

--- a/appa-engine/src/value.rs
+++ b/appa-engine/src/value.rs
@@ -51,7 +51,7 @@ impl ValueId {
 /// A collision-resistant digest of the canonical rendered call (tool + resolved arguments). Two
 /// calls with the same digest are the same call; a ruling is scoped to one digest.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct CanonicalDigest([u8; 32]);
+pub struct CanonicalDigest(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl CanonicalDigest {
     /// Digest the canonical rendered call: domain-separated over the tool name and the
@@ -108,7 +108,7 @@ fn canonical_json<T: Serialize>(pinned: &T) -> Vec<u8> {
 /// A digest of a raw tool result. Binds a cast resolution or a child-return derivation to the bytes it
 /// derived from, so a later differing result cannot silently reuse an old derivative.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct RawResultDigest([u8; 32]);
+pub struct RawResultDigest(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl RawResultDigest {
     pub fn of(bytes: &[u8]) -> Self {
@@ -164,7 +164,7 @@ impl OfferNonce {
 /// the block is about. Fresh per surfaced block: the same call blocked again under a new act gets
 /// a new one.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct BlockId([u8; 32]);
+pub struct BlockId(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl BlockId {
     /// The block one proposal's refusal surfaces. Bound to the deciding act and the exact position
@@ -234,7 +234,7 @@ impl BlockId {
 /// trajectory may execute an offer is the runtime's question, answered from the harness channel
 /// and never from this value.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct OfferId([u8; 32]);
+pub struct OfferId(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl OfferId {
     /// One plan of one block: its deterministic position in the derived order, and the canonical
@@ -257,26 +257,14 @@ impl OfferId {
     /// The offer's lowercase-hex wire form. Runtime surfaces this string to the model and routes
     /// `execute_remedy_plan` by it; the id itself stays engine-derived.
     pub fn to_hex(&self) -> String {
-        let mut hex = String::with_capacity(64);
-        for byte in &self.0 {
-            hex.push_str(&format!("{byte:02x}"));
-        }
-        hex
+        crate::hex32::encode(&self.0)
     }
 
     /// Parse an offer id the model named back into its 32 bytes. Untrusted input: a wrong length or
     /// a non-hex character is refused, never guessed. A well-formed id this family never
     /// opened is not this parser's concern — the engine refuses it as an unknown offer.
     pub fn from_hex(text: &str) -> Result<OfferId, OfferIdParseError> {
-        let bytes = text.as_bytes();
-        if bytes.len() != 64 {
-            return Err(OfferIdParseError);
-        }
-        let mut out = [0u8; 32];
-        for (index, [high, low]) in bytes.as_chunks::<2>().0.iter().enumerate() {
-            out[index] = (hex_nibble(*high)? << 4) | hex_nibble(*low)?;
-        }
-        Ok(OfferId(out))
+        crate::hex32::decode(text).map(OfferId).ok_or(OfferIdParseError)
     }
 }
 
@@ -285,14 +273,6 @@ impl OfferId {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 #[error("an offer id is 64 lowercase-hex characters")]
 pub struct OfferIdParseError;
-
-fn hex_nibble(byte: u8) -> Result<u8, OfferIdParseError> {
-    match byte {
-        b'0'..=b'9' => Ok(byte - b'0'),
-        b'a'..=b'f' => Ok(byte - b'a' + 10),
-        _ => Err(OfferIdParseError),
-    }
-}
 
 /// Identifies one dispatch of one call within a trajectory. The occurrence counter distinguishes a
 /// repeated identical call — a second `transfer(A, $1)` is a new dispatch, not a re-issue.
@@ -616,6 +596,28 @@ mod tests {
         assert_eq!(OfferId::from_hex("abc"), Err(OfferIdParseError));
         assert_eq!(OfferId::from_hex(&"g".repeat(64)), Err(OfferIdParseError));
         assert_eq!(OfferId::from_hex(&"AB".repeat(32)), Err(OfferIdParseError));
+    }
+
+    #[test]
+    fn every_identity_takes_its_hex_form_on_the_record() {
+        let block = BlockId([7u8; 32]);
+        let offer = OfferId::of_plan(&block, 3, b"plan-bytes");
+        let raw = RawResultDigest::of(b"result");
+        let canonical = call("transfer", json!({ "to": "alice" })).digest();
+
+        assert_eq!(json!(offer), json!(offer.to_hex()));
+        assert_eq!(json!(block), json!(crate::hex32::encode(block.bytes())));
+        assert_eq!(json!(raw), json!(crate::hex32::encode(raw.bytes())));
+        assert_eq!(json!(canonical), json!(crate::hex32::encode(canonical.bytes())));
+
+        assert_eq!(
+            serde_json::from_value::<OfferId>(json!(offer)).expect("an offer id reads back"),
+            offer
+        );
+        assert_eq!(
+            serde_json::from_value::<BlockId>(json!(block)).expect("a block id reads back"),
+            block
+        );
     }
 
     #[test]


### PR DESCRIPTION
JSON has no bytes type, so serde rendered every `[u8; 32]` digest as a sequence of 32 decimal integers: `OfferId`, `BlockId`, `CanonicalDigest`, `RawResultDigest`, `ResolverArgsDigest`, `PolicyIdentityV1`, and everything embedding them (`DispatchId`, `ForkId`, `Provenance`, the `Fact` enum the event log persists).

Each now serializes as the 64-character lowercase-hex string the runtime already surfaces for offers.

- New private `appa-engine/src/hex32.rs`: `encode`, `decode` (refuses wrong length, non-hex, uppercase), and serde `serialize`/`deserialize` via a `visit_str` visitor, so reads allocate nothing per digest.
- The six newtypes carry `#[serde(with = "crate::hex32")]` on their byte field.
- `OfferId::to_hex`/`from_hex` delegate to the same module instead of carrying their own hex loop, so the form on the record and the form the model is given are one implementation.

The event log is JSON in SQLite, so records shrink by about an order of magnitude per digest and a log is greppable by the same hex an offer id prints.

`PinnedToolResolution` embeds a `ResolverArgsDigest` and is canonicalized inside `CanonicalDigest::of_batch`, so batch digest values change with the encoding. Pre-existing logs are unreadable either way — their digests are arrays the new visitor refuses.
