### PR TITLE
fix(website): label FIDES baseline as FIDES (Microsoft) in benchmark banner

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1299,7 +1299,7 @@ samp {
   display: grid;
   /* The name column fits the longest arm label ("FIDES (Microsoft)", ~95px)
      without wrapping; the track takes whatever is left. */
-  grid-template-columns: 6.5rem minmax(0, 1fr) 3rem;
+  grid-template-columns: 7.25rem minmax(0, 1fr) 3rem;
   align-items: center;
   gap: 10px;
   padding: 3px 0;

--- a/website/components/BenchmarkHighlight.tsx
+++ b/website/components/BenchmarkHighlight.tsx
@@ -30,7 +30,7 @@ export function BenchmarkHighlight() {
             Task completion <span className="bench-chart-hint">tasks completed</span>
           </figcaption>
           <BenchRow name="OpenAPPA" pct={89} isSubject />
-          <BenchRow name="Defended FIDES" pct={41} />
+          <BenchRow name="FIDES (Microsoft)" pct={41} />
         </figure>
 
         <figure className="bench-chart">
@@ -38,7 +38,7 @@ export function BenchmarkHighlight() {
             Attacks that succeeded <span className="bench-chart-hint">lower is better</span>
           </figcaption>
           <BenchRow name="OpenAPPA" pct={0} isSubject />
-          <BenchRow name="Defended FIDES" pct={31} />
+          <BenchRow name="FIDES (Microsoft)" pct={31} />
         </figure>
       </div>
 


### PR DESCRIPTION
Updates the benchmark highlight banner to use `FIDES (Microsoft)` instead of `Defended FIDES` and expands the name column width in `globals.css` so the label fits cleanly without wrapping.