### PR TITLE
perf(build): drop the duplicate crypto provider and size the release profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
  "appa-runtime",
  "appa-runtime-api",
  "pyo3",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -142,7 +142,7 @@ dependencies = [
  "appa-runtime",
  "appa-runtime-api",
  "axum",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -192,10 +192,11 @@ dependencies = [
  "libc",
  "libloading",
  "rand 0.10.2",
- "reqwest 0.12.28",
+ "reqwest",
  "rig-agent",
  "rig-core",
  "rmcp 3.1.2",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",
@@ -266,29 +267,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
 
 [[package]]
 name = "axum"
@@ -401,8 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -411,12 +387,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -480,15 +450,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -667,12 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,12 +647,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -779,12 +728,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -901,10 +844,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -926,11 +867,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1062,7 +1001,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1301,16 +1239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,12 +1299,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1647,63 +1569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,15 +1636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,44 +1683,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1887,7 +1705,6 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -1949,14 +1766,13 @@ dependencies = [
  "mime_guess",
  "ordered-float",
  "pin-project-lite",
- "reqwest 0.13.4",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
  "tracing",
  "tracing-futures",
  "url",
@@ -2015,7 +1831,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest",
  "rmcp-macros 3.1.2",
  "schemars",
  "serde",
@@ -2071,12 +1887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,7 +1914,6 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2131,7 +1940,6 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2168,7 +1976,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2378,17 +2185,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
 ]
 
 [[package]]
@@ -2618,21 +2414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,22 +2459,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2874,24 +2639,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.5",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror",
-]
 
 [[package]]
 name = "typenum"
@@ -3098,38 +2845,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,17 @@ publish = false
 [workspace.lints.rust]
 dead_code = "deny"
 
+# Sized for a binary people install and ship, not for a numeric hot loop. Most of
+# this binary is monomorphized generic code, so `s` cuts build time and size
+# together; the gating path is bounded by inference and tool latency, not codegen.
+# `panic` stays at the default unwind: a module crate built in this workspace
+# needs it to contain a panic at its `extern "C"` boundary (see appa-builtin).
+[profile.release]
+opt-level = "s"
+lto = "thin"
+codegen-units = 16
+strip = "symbols"
+
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -33,7 +44,15 @@ thiserror = "2"
 toml = "0.8"
 tracing = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "time", "macros", "sync", "process"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# 0.13 is the version rig-core speaks: one reqwest in the graph rather than two
+# whole HTTP stacks. `rustls-no-provider` leaves the crypto provider to `rustls`
+# below and keeps the platform verifier, so roots still come from the OS store.
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"] }
+# The one crypto provider behind every rustls client here. Naming exactly one
+# provider feature is what lets rustls install it as the process default, so no
+# caller installs it by hand. aws-lc-rs is deliberately absent: it is a second C
+# and assembly toolchain on the install path for no capability ring lacks.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 axum = { version = "0.8", default-features = false, features = ["json", "tokio", "http1"] }
 tokio-util = { version = "0.7", default-features = false }
 appa-engine = { path = "appa-engine" }

--- a/appa-agent-python/src/lib.rs
+++ b/appa-agent-python/src/lib.rs
@@ -760,6 +760,7 @@ fn encode(response: impl Serialize) -> Result<String, String> {
 }
 
 fn loopback_client() -> Result<reqwest::Client, String> {
+    appa_runtime::tls::install_crypto_provider();
     reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .no_proxy()

--- a/appa-example-agent/src/http.rs
+++ b/appa-example-agent/src/http.rs
@@ -10,6 +10,7 @@ pub struct HttpClient(reqwest::Client);
 
 impl HttpClient {
     pub fn new() -> Self {
+        appa_runtime::tls::install_crypto_provider();
         HttpClient(
             reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())
@@ -19,6 +20,7 @@ impl HttpClient {
     }
 
     pub fn loopback() -> Self {
+        appa_runtime::tls::install_crypto_provider();
         HttpClient(
             reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())

--- a/appa-runtime/Cargo.toml
+++ b/appa-runtime/Cargo.toml
@@ -43,8 +43,12 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
-rig-core = { version = "0.42", default-features = false, features = ["reqwest", "rustls"] }
+# Not rig-core's `rustls` feature: it pins reqwest to aws-lc-rs, which would put a
+# second crypto provider beside the workspace's ring. TLS still comes from reqwest.
+rig-core = { version = "0.42", default-features = false, features = ["reqwest"] }
 rig-agent = { version = "0.42", default-features = false }
+# Depended on only to name the crypto provider; see the workspace manifest.
+rustls = { workspace = true }
 
 [dev-dependencies]
 # The fail points the orchestration tests drive. A dev-dependency, so they are

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -181,11 +181,12 @@ impl ExternalServices {
         dynamic_builtins: BTreeMap<String, DynamicBuiltin>,
         gates: ConsultGates,
     ) -> Result<ExternalServices, ModulesError> {
+        crate::tls::install_crypto_provider();
         let http = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .timeout(config.timeout)
             .build()
-            .expect("the reqwest client builds: no TLS or resolver overrides are set");
+            .expect("the reqwest client builds: the crypto provider is installed above");
         let claude = ClaudeCodeBackend {
             #[cfg(unix)]
             command: config.claude_code.command.clone(),

--- a/appa-runtime/src/lib.rs
+++ b/appa-runtime/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api;
 pub mod config;
 pub mod hooks;
 pub mod mcp;
+pub mod tls;
 
 mod builtins;
 mod consult;

--- a/appa-runtime/src/llm.rs
+++ b/appa-runtime/src/llm.rs
@@ -174,6 +174,9 @@ impl LlmBackend {
         max_body_bytes: usize,
         gate: Arc<LlmGate>,
     ) -> Result<LlmBackend, LlmClientError> {
+        // Every provider client below builds a reqwest client of rig's own, so the
+        // provider must be in place before the first of them is constructed.
+        crate::tls::install_crypto_provider();
         let token = profile.token.as_ref().map(|token| token.reveal()).unwrap_or("");
         let failed = |error: rig_core::http_client::Error| LlmClientError {
             provider: profile.provider.as_str(),

--- a/appa-runtime/src/tls.rs
+++ b/appa-runtime/src/tls.rs
@@ -1,0 +1,19 @@
+//! The process-wide rustls crypto provider.
+
+/// Installs ring as the process default crypto provider, once.
+///
+/// `reqwest` is built with `rustls-no-provider` so that aws-lc-rs — a second C
+/// and assembly toolchain on the install path — stays out of the graph, and it
+/// refuses to build a client until a provider is installed. Every client in the
+/// process draws on this one, including the clients rig builds inside its own
+/// provider clients, which no caller here routes through a builder. So this is
+/// a process-level choke point rather than an argument threaded to each client.
+///
+/// Idempotent, and safe to call from any entry point: a second call, or a race
+/// lost to another installer, leaves the process with a provider either way.
+pub fn install_crypto_provider() {
+    static INSTALLED: std::sync::Once = std::sync::Once::new();
+    INSTALLED.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}


### PR DESCRIPTION
## What

`reqwest` 0.12 pulled `ring` while `rig-core`'s `reqwest` 0.13 pulled `aws-lc-rs`, so both crypto providers compiled into a single `rustls`. This unifies on `reqwest` 0.13 with `rustls-no-provider` and names `ring` as the one provider, then sizes `[profile.release]` for a binary people install rather than a numeric hot loop.

## Changes

- Workspace `reqwest` 0.12 → 0.13, matching `rig-core`; one HTTP stack in the graph instead of two.
- `rig-core` loses its `rustls` feature, which is what pinned `reqwest` to `aws-lc-rs`.
- New `appa-runtime/src/tls.rs` installs `ring` as the process default provider. `reqwest` 0.13 checks for a provider itself before `rustls` can fall back to one named by crate features, and `rig` builds `reqwest` clients inside its own provider clients where no caller can pass a builder — so this is a process-level choke point, called from each client-construction site.
- `[profile.release]`: `opt-level = "s"`, `lto = "thin"`, `codegen-units = 16`, `strip = "symbols"`. `panic` stays `unwind` — a module crate built in this workspace needs it to contain a panic at its `extern "C"` boundary (`appa-builtin`).

## Effect

Clean release build of `appa-runtime`:

| | wall | binary |
|---|---|---|
| before | 87s | 30.4 MB |
| after | 35s | 16.5 MB |

23 crates leave the lockfile, none enter — including `aws-lc-sys`, `cmake`, and `jobserver`. Dropping that C and assembly toolchain off the build path is a prerequisite for `cargo install`, where the compile happens on a machine we do not control.

## Behavior change

Root certificates now come from the OS trust store (`rustls-platform-verifier`) rather than bundled `webpki-roots`. Corporate internal CAs work without a rebuild.

## Verification

`cargo clippy --all-targets -- -D warnings` clean; 50 test binaries pass. TLS verified end-to-end against a real HTTPS endpoint through a throwaway example (not committed).