### PR TITLE
engine: replayed-acceptance evidence rule, two proptest gaps, and four simplifications

### DIFF
--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -733,19 +733,13 @@ impl ToolContract {
         )
     }
 
-    /// The output label with a proposed call's pinned resolver answers applied.
-    /// Only a successful answer enters the engine, and every binding a contract spells carries one
-    /// by the time a call is checked — [`crate::check::validate_tool_resolutions`] refuses the
-    /// proposal otherwise, before any fact, and replay holds a persisted call to the same rule.
-    pub(crate) fn output_label_for_call(&self, call: &crate::value::ResolvedCall, expansions: &Expansions) -> Label {
-        let mut label = self.output_label(expansions);
-        apply_tool_resolutions(&mut label, call.tool_resolutions());
-        label
-    }
-
-    /// The output label recovered from the resolver answers persisted on a dispatch. Admission —
-    /// and the runtime composing a whole-source pending-cast answer against it — uses
-    /// this form, never the caller's in-memory resolution.
+    /// The output label with a set of pinned resolver answers applied. Admission — and the runtime
+    /// composing a whole-source pending-cast answer against it — passes the answers persisted on
+    /// the dispatch, never the caller's in-memory resolution. Plan construction passes the proposed
+    /// call's own: only a successful answer enters the engine, and every binding a contract spells
+    /// carries one by the time a call is checked — [`crate::check::validate_tool_resolutions`]
+    /// refuses the proposal otherwise, before any fact, and replay holds a persisted call to the
+    /// same rule.
     pub fn output_label_for_resolutions(
         &self,
         tool_resolutions: &[PinnedToolResolution],

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -3181,18 +3181,26 @@ impl Engine {
         use crate::projection::OfferEnd;
         if let crate::basis::SubjectKey::ConfinedResult(dispatch) = &recorded.subject {
             return match (end, &execution.outcome, recorded.plan.hop()) {
-                (OfferEnd::Accepted, OfferOutcome::Derived(Evidence::Sanitizer { .. }), Some(_))
-                | (OfferEnd::Accepted, OfferOutcome::Approved(_), None) => Ok(EngineDecision {
-                    append: None,
-                    follow_up: FollowUp::Offer(self.confined_repeat(views, dispatch)),
-                }),
+                (OfferEnd::Accepted, OfferOutcome::Derived(Evidence::Sanitizer { .. }), Some(_)) => {
+                    Ok(EngineDecision {
+                        append: None,
+                        follow_up: FollowUp::Offer(self.confined_repeat(views, dispatch)),
+                    })
+                }
+                (OfferEnd::Accepted, OfferOutcome::Approved(evidence), None) if evidence.is_empty() => {
+                    Ok(EngineDecision {
+                        append: None,
+                        follow_up: FollowUp::Offer(self.confined_repeat(views, dispatch)),
+                    })
+                }
                 (OfferEnd::Invalidated, _, _) => Ok(EngineDecision {
                     append: None,
                     follow_up: FollowUp::Offer(OfferFollowUp::Invalidated),
                 }),
                 (OfferEnd::Accepted, OfferOutcome::Derived(_), Some(_))
                 | (_, OfferOutcome::Derived(_), None)
-                | (_, OfferOutcome::Approved(_), Some(_)) => Err(TransitionError::PlanOutcomeMismatch),
+                | (_, OfferOutcome::Approved(_), Some(_))
+                | (OfferEnd::Accepted, OfferOutcome::Approved(_), None) => Err(TransitionError::PlanOutcomeMismatch),
                 _ => Err(TransitionError::TerminalOffer),
             };
         }
@@ -3214,18 +3222,20 @@ impl Engine {
                         follow_up: FollowUp::Offer(self.return_repeat(views, id)),
                     })
                 }
-                (OfferEnd::Accepted, OfferOutcome::Approved(_), None) => Ok(EngineDecision {
-                    append: None,
-                    follow_up: FollowUp::Offer(self.return_repeat(views, id)),
-                }),
+                (OfferEnd::Accepted, OfferOutcome::Approved(evidence), None) if evidence.is_empty() => {
+                    Ok(EngineDecision {
+                        append: None,
+                        follow_up: FollowUp::Offer(self.return_repeat(views, id)),
+                    })
+                }
                 (OfferEnd::Invalidated, _, _) => Ok(EngineDecision {
                     append: None,
                     follow_up: FollowUp::Offer(OfferFollowUp::Invalidated),
                 }),
                 (OfferEnd::Accepted, OfferOutcome::Derived(_), Some(_)) => Err(TransitionError::PlanOutcomeMismatch),
-                (_, OfferOutcome::Derived(_), None) | (_, OfferOutcome::Approved(_), Some(_)) => {
-                    Err(TransitionError::PlanOutcomeMismatch)
-                }
+                (_, OfferOutcome::Derived(_), None)
+                | (_, OfferOutcome::Approved(_), Some(_))
+                | (OfferEnd::Accepted, OfferOutcome::Approved(_), None) => Err(TransitionError::PlanOutcomeMismatch),
                 _ => Err(TransitionError::TerminalOffer),
             };
         }
@@ -5972,6 +5982,17 @@ mod tests {
             )
             .map(|_| ()),
             Err(TransitionError::PlanOutcomeMismatch)
+        );
+        assert_eq!(
+            execute_offer(
+                &e,
+                &settled,
+                accept,
+                OfferOutcome::Approved(vec![stray_evidence(accept)])
+            )
+            .map(|_| ()),
+            Err(TransitionError::PlanOutcomeMismatch),
+            "an acceptance carrying evidence is refused after the offer ends, as it is before"
         );
     }
 
@@ -14265,6 +14286,20 @@ mod tests {
             .expect("the fork opened")
     }
 
+    /// Authority evidence an `Approved` outcome may not carry: a plan that assigns no
+    /// authority is accepted only with an empty vector, so any entry is a mismatch.
+    fn stray_evidence(offer: crate::value::OfferId) -> crate::execute::AuthorityEvidence {
+        crate::execute::AuthorityEvidence {
+            offer,
+            authority: crate::names::AuthorityName::new("officer"),
+            covers: Vec::new(),
+            reviewed: crate::execute::AuthorityReview {
+                tool: ToolName::new("anything"),
+                trajectory_label: PartialLabel::established(established(Trust::new(0), Audience::Public)),
+            },
+        }
+    }
+
     fn return_offer(log: &[Fact], hop: bool) -> crate::value::OfferId {
         log.iter()
             .rev()
@@ -14438,6 +14473,17 @@ mod tests {
             offer_answer(&repeat),
             OfferFollowUp::Admitted { value } if value == &body
         ));
+        assert_eq!(
+            execute_offer(
+                &e,
+                &merged,
+                accept,
+                OfferOutcome::Approved(vec![stray_evidence(accept)])
+            )
+            .map(|_| ()),
+            Err(TransitionError::PlanOutcomeMismatch),
+            "an acceptance carrying evidence is refused after the offer ends, as it is before"
+        );
         let again = e
             .handle(
                 &viewing(&e, &merged),

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -3596,14 +3596,6 @@ impl Engine {
         branch::submit_child_return(&self.registry, parent, child, &body, &Expansions::default())
     }
 
-    /// Record a child's void return: the child-attributed terminal that ends the branch and
-    /// crosses no value — no merge, no label contribution. A branch ends at most once.
-    /// See [`crate::branch`].
-    #[cfg(test)]
-    pub(crate) fn submit_void_return(&self, parent: &Views, child: &TrajectoryId) -> Result<Vec<Fact>, BranchError> {
-        branch::submit_void_return(parent, child)
-    }
-
     fn dispatch_contract(&self, views: &Views, dispatch: &DispatchId) -> Result<&ToolContract, TransitionError> {
         let call = views.dispatch_call(dispatch).ok_or(TransitionError::UnknownDispatch)?;
         self.validated_contract(call).map_err(TransitionError::Call)
@@ -9165,8 +9157,7 @@ mod tests {
         let e = engine_at(vec![crm_tool()], known(TRUSTED, internal));
         let mut log = vec![opened(&e)];
         log.extend(forked_child(&e, &log.clone(), &child));
-        let ended = e
-            .submit_void_return(&Projection::build(&log, log.len() as u64).view(&traj()), &child)
+        let ended = branch::submit_void_return(&Projection::build(&log, log.len() as u64).view(&traj()), &child)
             .expect("the child ends with no value");
         log.extend(ended);
         let view = e.view(&traj(), log.clone(), log.len() as u64).unwrap();

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -487,7 +487,20 @@ mod tests {
         fn fully_established_start_decides_every_test(start in established_strategy()) {
             let partial = PartialLabel::established(start.clone());
             prop_assert!(partial.is_fully_established());
+            // The rank above the start is out of reach; `Adequacy::Unresolved` is what a
+            // consumed dimension would answer, so both arms below prove the start decides.
             prop_assert_eq!(partial.meets_floor(start.trust), Adequacy::Holds);
+            prop_assert_eq!(partial.meets_floor(Trust::new(start.trust.rank() + 1)), Adequacy::Fails);
+            // A cap naming only a reader the alphabet never generates admits exactly the
+            // empty restricted audience, so the expectation is decided by the start alone.
+            let outside = Audience::restricted([ReaderId::new("z".to_string())]);
+            let admitted = match &start.audience {
+                Audience::Restricted(readers) if readers.is_empty() => Adequacy::Holds,
+                Audience::Public | Audience::Restricted(_) => Adequacy::Fails,
+            };
+            prop_assert_eq!(partial.within_cap(&outside), admitted);
+            // Every established audience is within a Public cap, the empty restricted one
+            // and Public itself included; only a generated bound reaches those two.
             prop_assert_eq!(partial.within_cap(&Audience::Public), Adequacy::Holds);
         }
     }

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -314,18 +314,6 @@ impl PartialLabel {
         self.bound = self.bound.combine(by);
     }
 
-    pub fn combine(&self, other: &PartialLabel) -> PartialLabel {
-        PartialLabel {
-            bound: self.bound.combine(&other.bound),
-            unresolved_trust: self.unresolved_trust.union(&other.unresolved_trust).copied().collect(),
-            unresolved_audience: self
-                .unresolved_audience
-                .union(&other.unresolved_audience)
-                .copied()
-                .collect(),
-        }
-    }
-
     /// The established bound: every known restriction, readable even while sources
     /// stay unresolved. The narrowing check and sanitizer residual comparisons read
     /// exactly this.
@@ -424,34 +412,38 @@ mod tests {
 
     proptest! {
         #[test]
-        fn combine_is_commutative(a in partial_strategy(), b in partial_strategy()) {
+        fn combine_is_commutative(a in established_strategy(), b in established_strategy()) {
             prop_assert_eq!(a.combine(&b), b.combine(&a));
         }
 
         #[test]
-        fn combine_is_associative(a in partial_strategy(), b in partial_strategy(), c in partial_strategy()) {
+        fn combine_is_associative(
+            a in established_strategy(),
+            b in established_strategy(),
+            c in established_strategy(),
+        ) {
             prop_assert_eq!(a.combine(&b).combine(&c), a.combine(&b.combine(&c)));
         }
 
         #[test]
-        fn combine_is_idempotent(a in partial_strategy()) {
+        fn combine_is_idempotent(a in established_strategy()) {
             prop_assert_eq!(a.combine(&a), a.clone());
         }
 
         #[test]
-        fn established_top_is_identity(a in partial_strategy()) {
-            let identity = PartialLabel::established(EstablishedLabel::top());
+        fn established_top_is_identity(a in established_strategy()) {
+            let identity = EstablishedLabel::top();
             prop_assert_eq!(identity.combine(&a), a.clone());
             prop_assert_eq!(a.combine(&identity), a.clone());
         }
 
         #[test]
-        fn combine_never_widens(a in partial_strategy(), b in partial_strategy()) {
+        fn combine_never_widens(a in established_strategy(), b in established_strategy()) {
             let folded = a.combine(&b);
-            prop_assert!(folded.bound().trust <= a.bound().trust);
-            prop_assert!(folded.bound().trust <= b.bound().trust);
-            prop_assert!(folded.bound().audience.within(&a.bound().audience));
-            prop_assert!(folded.bound().audience.within(&b.bound().audience));
+            prop_assert!(folded.trust <= a.trust);
+            prop_assert!(folded.trust <= b.trust);
+            prop_assert!(folded.audience.within(&a.audience));
+            prop_assert!(folded.audience.within(&b.audience));
         }
 
         #[test]

--- a/appa-engine/src/params.rs
+++ b/appa-engine/src/params.rs
@@ -21,7 +21,6 @@ pub const MAX_ARGUMENT_BYTES: usize = 256 * 1024;
 const MAX_ARGUMENT_DEPTH: usize = 32;
 const MAX_ARGUMENT_NODES: usize = 4096;
 const MAX_ARRAY_ELEMENTS: usize = 4096;
-const MAX_STRING_BYTES: usize = 256 * 1024;
 const MAX_NUMBER_TOKEN_BYTES: usize = 64;
 const MAX_SAFE_INTEGER: i64 = (1 << 53) - 1;
 
@@ -98,8 +97,6 @@ pub enum ArgumentError {
     TooManyNodes,
     #[error("array exceeds {MAX_ARRAY_ELEMENTS} elements")]
     TooManyArrayElements,
-    #[error("string exceeds {MAX_STRING_BYTES} decoded UTF-8 bytes")]
-    StringTooLong,
     #[error("number token exceeds {MAX_NUMBER_TOKEN_BYTES} source bytes")]
     NumberTokenTooLong,
     #[error("integer is outside the exact safe range")]
@@ -1089,9 +1086,6 @@ impl Scanner<'_> {
                 }
                 c if (c as u32) < 0x20 => return Err(self.syntax("unescaped control character")),
                 c => decoded.push(c),
-            }
-            if decoded.len() > MAX_STRING_BYTES {
-                return Err(ArgumentError::StringTooLong);
             }
         }
         Ok(decoded)

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -646,7 +646,7 @@ pub(crate) fn narrowing_remedies(
     if !registry.profile().confines_result(&contract.name) {
         return settlements;
     }
-    let output = contract.output_label_for_call(call, expansions);
+    let output = contract.output_label_for_resolutions(call.tool_resolutions(), expansions);
     for sanitizer in applicable_output_sanitizers(registry, contract, &output, expansions) {
         if sanitized_commit(current, &output, sanitizer, expansions).is_none() {
             continue;
@@ -961,7 +961,7 @@ pub(crate) fn bound_contribution(
     expansions: &Expansions,
 ) -> Option<EstablishedLabel> {
     let derived = registry.sanitizer(sanitizer)?.derive_output(
-        &contract.output_label_for_call(call, expansions),
+        &contract.output_label_for_resolutions(call.tool_resolutions(), expansions),
         &contract.tags,
         expansions,
     )?;

--- a/appa-engine/src/projection.rs
+++ b/appa-engine/src/projection.rs
@@ -1978,7 +1978,7 @@ mod tests {
     }
 
     #[test]
-    fn cold_replay_is_deterministic() {
+    fn a_cold_replay_reports_the_ended_trajectory_and_the_unresolved_crossing_source() {
         let log = vec![
             opened("a"),
             admit("a", labeled(2, Audience::Public)),
@@ -1987,7 +1987,6 @@ mod tests {
                 kind: BoundaryKind::VoidReturn,
             },
         ];
-        assert_eq!(build(&log), build(&log));
         assert!(build(&log).view(&traj("a")).has_ended(&traj("a")));
 
         let crossing = [
@@ -2033,7 +2032,6 @@ mod tests {
             ],
         ]
         .concat();
-        assert_eq!(build(&crossing), build(&crossing));
         let unresolved = |log: &[Fact]| {
             build(log)
                 .view(&traj("root"))
@@ -2139,7 +2137,6 @@ mod tests {
                 kind: BoundaryKind::Merge { child_return: id },
             },
         ];
-        assert_eq!(build(&log), build(&log));
         assert_eq!(
             build(&log).view(&traj("root")).current_label().bound(),
             &EstablishedLabel::new(Trust::new(0), Audience::Public)
@@ -2263,7 +2260,6 @@ mod tests {
                 kind: BoundaryKind::Merge { child_return: id },
             },
         ];
-        assert_eq!(build(&log), build(&log));
         assert_eq!(
             build(&log).view(&traj("root")).current_label().bound(),
             &EstablishedLabel::new(Trust::new(2), Audience::Public)

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -1782,7 +1782,7 @@ mod tests {
     }
 
     #[test]
-    fn the_search_is_the_same_for_the_same_block_and_total_within_the_bound() {
+    fn the_search_is_total_within_the_bound() {
         let registry = Deployment::of(vec![
             emitting("b1", &["backup"]),
             emitting("b2", &["backup"]),
@@ -1795,8 +1795,6 @@ mod tests {
         let wipe = call("wipe", json!({}));
 
         let first = routes(&registry, &log, &wipe, depth(4));
-        let again = routes(&registry, &log, &wipe, depth(4));
-        assert_eq!(first, again);
         let complete: Vec<Vec<String>> = first
             .iter()
             .filter(|route| route.outcome == RouteOutcome::Complete)

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -980,7 +980,7 @@ fn required<'a>(
 fn settled(menu: Option<MenuDebt>) -> Result<(), TransitionRefusal> {
     match menu {
         Some(debt) if debt.offered.len() != debt.menu.len() => Err(TransitionRefusal::IncompleteMenu),
-        Some(_) | None => Ok(()),
+        _ => Ok(()),
     }
 }
 
@@ -2910,13 +2910,12 @@ impl<'a> Sequence<'a> {
         match kind {
             BoundaryKind::Merge { child_return } => {
                 let views = self.projection.view(trajectory);
-                let crossed = views
+                views
                     .child_return(child_return)
                     .ok_or(TransitionRefusal::UnknownReturn)?;
                 if views.parent_of(child_return.child()) != Some(trajectory) {
                     return Err(TransitionRefusal::ForeignTrajectory);
                 }
-                let _ = crossed;
                 let crossing = self
                     .crossed
                     .get_mut(child_return)
@@ -3502,7 +3501,7 @@ impl<'a> Sequence<'a> {
         if self.admitted.contains(dispatch) || self.derived.contains_key(dispatch) {
             return Err(TransitionRefusal::RepeatAdmission);
         }
-        let confined = views.is_open(dispatch) && views.is_succeeded(dispatch);
+        let confined = views.is_succeeded(dispatch);
         let admissible = match settles {
             true => confined || views.closed_successfully(dispatch),
             false => confined,


### PR DESCRIPTION
Small fixes and simplifications in `appa-engine`, one cluster per commit.

**Fixes**

- `ended_offer` accepted a replayed `Approved(_)` outcome carrying authority evidence on a plan that assigns no authority, where the live paths and the attest-schema replay arm in the same match all require the evidence to be empty. Both `PlanOutcomeMismatch` groups now cover it, so the same event gets the same verdict live and on replay.

**Tests that could not fail**

- Four `assert_eq!(build(&log), build(&log))` self-comparisons in `projection`, and one duplicated `routes()` pair in `route`. Two test names described the deleted half and were renamed to what remains.
- The fully-established proptest asserted `meets_floor` against the label's own trust, which is true by construction. It now also asserts a floor one rank above the start and a cap naming a reader outside the generated alphabet, alongside the public-cap law it already covered.

**Simplifications**

- `PartialLabel::combine` had no production caller. Its five laws now run against `EstablishedLabel::combine`, the operator the engine folds with, which no proptest covered.
- `ToolContract::output_label_for_call` was `output_label_for_resolutions` with the slice taken from the call; `Engine::submit_void_return` was a `#[cfg(test)]` forwarder to the `branch` function production already calls directly.
- The decoded-string cap in `params` was checked after a bound the same function already enforces, so it could never fire.
- Three dead conditions in `transition`: an `is_open` conjunct implied by `is_succeeded`, a binding kept only to be discarded, and `Some(_) | None` where `_` says the same.
