### PR TITLE
runtime: MCP version drift, three tests that could not fail, and four simplifications

### DIFF
--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -149,18 +149,6 @@ pub enum OpenError {
     Storage(String),
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum SessionError {
-    #[error("a trajectory with this id already exists")]
-    AlreadyExists,
-    #[error("no trajectory with this id exists")]
-    Unknown,
-    #[error("the trajectory has ended")]
-    Ended,
-    #[error("storage failure: {0}")]
-    Storage(String),
-}
-
 /// Every lifecycle misuse is one typed error; the adapter renders it
 /// as a deny.
 #[derive(Debug, thiserror::Error)]
@@ -238,17 +226,6 @@ impl EventError {
             | EventError::SpawnNotTaken
             | EventError::SpawnAmbiguous
             | EventError::BindingMismatch => false,
-        }
-    }
-}
-
-impl From<SessionError> for EventError {
-    fn from(error: SessionError) -> EventError {
-        match error {
-            SessionError::AlreadyExists => EventError::TrajectoryExists,
-            SessionError::Unknown => EventError::UnknownTrajectory,
-            SessionError::Ended => EventError::TrajectoryEnded,
-            SessionError::Storage(detail) => EventError::Storage(detail),
         }
     }
 }
@@ -479,7 +456,7 @@ impl Runtime {
     /// One transaction writes the opening
     /// record and stores the policy file it names, so the root is bound
     /// to that file durably or is not opened at all.
-    pub(crate) fn create_session(&self, id: TrajectoryId) -> Result<Session, SessionError> {
+    pub(crate) fn create_session(&self, id: TrajectoryId) -> Result<Session, EventError> {
         let deployment = self.inner.deployment();
         let opening = deployment.root_opening(&id);
         let root = self
@@ -487,8 +464,8 @@ impl Runtime {
             .store
             .create_root(opening, deployment.config.policy_file().bytes())
             .map_err(|error| match error {
-                appa_eventlog::CreateError::AlreadyExists { .. } => SessionError::AlreadyExists,
-                error => SessionError::Storage(error.to_string()),
+                appa_eventlog::CreateError::AlreadyExists { .. } => EventError::TrajectoryExists,
+                error => EventError::Storage(error.to_string()),
             })?;
         let root = TrajectoryId(root.as_str().to_string());
         Ok(Session::attach(Arc::clone(&self.inner), deployment, root.clone(), root))
@@ -496,14 +473,14 @@ impl Runtime {
 
     /// Reopens a persisted trajectory. There is no stored view: the next
     /// event rebuilds the engine's picture from the log.
-    pub(crate) fn session(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Result<Session, SessionError> {
+    pub(crate) fn session(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Result<Session, EventError> {
         let known = self
             .inner
             .store
             .has_root(&crate::engine::engine_id(root))
-            .map_err(|error| SessionError::Storage(error.to_string()))?;
+            .map_err(|error| EventError::Storage(error.to_string()))?;
         if !known {
-            return Err(SessionError::Unknown);
+            return Err(EventError::UnknownTrajectory);
         }
         Ok(Session::attach(
             Arc::clone(&self.inner),
@@ -517,24 +494,24 @@ impl Runtime {
     /// rebuild, for the two callers that have no following engine event to
     /// carry the refusal: the session-start hook, and the start-after-lazy-open
     /// race. Every other path refuses inside the event it is already deciding.
-    pub(crate) fn live(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Result<(), SessionError> {
+    pub(crate) fn live(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Result<(), EventError> {
         let log = match self.inner.log(root) {
             Ok(log) => log,
-            Err(EventError::UnknownTrajectory) => return Err(SessionError::Unknown),
-            Err(error) => return Err(SessionError::Storage(error.to_string())),
+            Err(EventError::UnknownTrajectory) => return Err(EventError::UnknownTrajectory),
+            Err(error) => return Err(EventError::Storage(error.to_string())),
         };
         let deployment = self.inner.deployment();
         let policy = self
             .inner
             .resolve_policy(&deployment, &log)
-            .map_err(|error| SessionError::Storage(error.to_string()))?;
+            .map_err(|error| EventError::Storage(error.to_string()))?;
         let view = policy
             .engine()
             .rebuild_view(&log)
-            .map_err(|refusal| SessionError::Storage(refusal.to_string()))?;
+            .map_err(|refusal| EventError::Storage(refusal.to_string()))?;
         match policy.engine().liveness(&view, trajectory) {
-            Liveness::Unopened => Err(SessionError::Unknown),
-            Liveness::Ended => Err(SessionError::Ended),
+            Liveness::Unopened => Err(EventError::UnknownTrajectory),
+            Liveness::Ended => Err(EventError::TrajectoryEnded),
             Liveness::Live => Ok(()),
         }
     }

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -188,9 +188,8 @@ impl Session {
     /// judgment — a stale offer declines at execution by live re-plan.
     /// The runtime keeps no transcript, so there is nothing
     /// left for this event to do.
-    pub fn on_prompt(&self, _text: String) -> Result<(), EventError> {
+    pub fn on_prompt(&self) {
         tracing::debug!(trajectory = %self.trajectory.0, "prompt acknowledged");
-        Ok(())
     }
 
     /// The actor finished a turn. A call still open here got no outcome
@@ -4403,9 +4402,7 @@ context_control = true
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
         let session = runtime.create_session(root()).expect("a fresh id opens");
-        session
-            .on_prompt("read the report".to_string())
-            .expect("the prompt acks");
+        session.on_prompt();
         assert!(only_the_opening(&runtime));
     }
 

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -1006,7 +1006,7 @@ pub(crate) fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> 
 }
 #[cfg(test)]
 mod real_engine_tests {
-    use super::super::{OpenError, OutcomeBody, Runtime, SessionError};
+    use super::super::{OpenError, OutcomeBody, Runtime};
     use super::*;
     use crate::api::{
         LabelDimension, RemedyDecision, SpawnBinding, ToolCallDecision, ToolOutcome, ToolResultDecision,
@@ -1215,7 +1215,7 @@ starting_label = { trust = "suspicious" }
         assert!(runtime.live(&root(), &root()).is_ok());
         assert!(matches!(
             runtime.live(&root(), &TrajectoryId("cc:never-bound".to_string())),
-            Err(SessionError::Unknown),
+            Err(EventError::UnknownTrajectory),
         ));
     }
 
@@ -2028,7 +2028,7 @@ context_control = false
         );
         assert!(matches!(
             runtime.live(&root(), &TrajectoryId("cc:child".to_string())),
-            Err(SessionError::Ended),
+            Err(EventError::TrajectoryEnded),
         ));
     }
 
@@ -2070,7 +2070,7 @@ context_control = false
         );
         assert!(matches!(
             runtime.live(&root(), &TrajectoryId("cc:child".to_string())),
-            Err(SessionError::Ended),
+            Err(EventError::TrajectoryEnded),
         ));
 
         session
@@ -2902,7 +2902,7 @@ confined_child_return = true
         };
         assert!(matches!(
             runtime.live(&root(), &TrajectoryId("cc:child".to_string())),
-            Err(SessionError::Ended),
+            Err(EventError::TrajectoryEnded),
         ));
     }
 
@@ -3797,7 +3797,7 @@ context_control = true
             }),
         );
         assert!(
-            matches!(runtime.live(&root(), &child("c1")), Err(SessionError::Ended)),
+            matches!(runtime.live(&root(), &child("c1")), Err(EventError::TrajectoryEnded)),
             "the child ended at its return",
         );
         assert!(!dispatch_open(&runtime, &root()), "the spawn dispatch closed");
@@ -4089,7 +4089,10 @@ context_control = true
             .on_child_end(Some("done".to_string()))
             .await
             .expect("with nothing in flight the same end crosses");
-        assert!(matches!(runtime.live(&root(), &child("c1")), Err(SessionError::Ended)));
+        assert!(matches!(
+            runtime.live(&root(), &child("c1")),
+            Err(EventError::TrajectoryEnded)
+        ));
     }
 
     /// The harness refused the released call at its permission prompt,
@@ -4374,7 +4377,7 @@ context_control = true
         runtime.create_session(root()).expect("a fresh id opens");
         assert!(matches!(
             runtime.create_session(root()),
-            Err(SessionError::AlreadyExists),
+            Err(EventError::TrajectoryExists),
         ));
         assert!(runtime.session(&root(), &root()).is_ok());
         assert!(matches!(
@@ -4382,7 +4385,7 @@ context_control = true
                 &TrajectoryId("cc:ghost".to_string()),
                 &TrajectoryId("cc:ghost".to_string())
             ),
-            Err(SessionError::Unknown),
+            Err(EventError::UnknownTrajectory),
         ));
     }
 

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -2005,17 +2005,8 @@ impl RuntimeEngine {
         resolved: &ResolvedCall,
         evidence: &[ExternalEvidence],
     ) -> Result<Vec<PinnedMembership>, Resolution> {
-        // Same fast path as the dynamic pass: no placeholder, nothing to read.
-        if !contract.requires.label.audience.iter().any(|requirement| {
-            matches!(
-                requirement,
-                appa_engine::contract::AudienceRequirement::Includes(
-                    appa_engine::contract::RecipientSpec::Placeholder(_)
-                )
-            )
-        }) {
-            return Ok(Vec::new());
-        }
+        // No placeholder resolving to a group, nothing to read: `group_reads` already
+        // answers empty for that, and for strictly more.
         let reads = appa_engine::check::group_reads(contract, resolved);
         if reads.is_empty() {
             return Ok(Vec::new());

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -3238,9 +3238,9 @@ mod tests {
             "x\u{FFFD}rlo\u{FFFD}z\u{FFFD}"
         );
         assert_eq!(terminal_safe("tru\u{200B}sted"), "tru\u{FFFD}sted");
-        assert_ne!(
+        assert_eq!(
             terminal_safe("tru\u{206A}sted"),
-            "trusted",
+            "tru\u{FFFD}sted",
             "the full Cf range replaces"
         );
     }

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -39,10 +39,10 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             },
             Err(error) => refuse(error.to_string()),
         },
-        HookEvent::Prompt { actor, text } => {
-            match on_actor(runtime, &actor, |session| {
-                let text = text.clone();
-                async move { session.on_prompt(text) }
+        HookEvent::Prompt { actor, .. } => {
+            match on_actor(runtime, &actor, |session| async move {
+                session.on_prompt();
+                Ok(())
             })
             .await
             {

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -4,8 +4,8 @@
 use appa_runtime_api::{Actor, Codec, HookDecision, HookEvent, ParseRefusal, ProposedCall, TrajectoryId};
 
 use crate::api::{
-    ChildReturnDecision, EventError, LateOpen, OfferId, Runtime, Session, SessionError, SpawnResultDecision,
-    ToolCallDecision, ToolResultDecision, is_control_tool,
+    ChildReturnDecision, EventError, LateOpen, OfferId, Runtime, Session, SpawnResultDecision, ToolCallDecision,
+    ToolResultDecision, is_control_tool,
 };
 
 /// One hook call, wire to wire: parse through the codec, dispatch,
@@ -159,12 +159,12 @@ fn return_decision(said: Option<String>, decision: ChildReturnDecision) -> HookD
     }
 }
 
-fn open_or_reopen(runtime: &Runtime, root: &appa_runtime_api::TrajectoryId) -> Result<Session, SessionError> {
+fn open_or_reopen(runtime: &Runtime, root: &appa_runtime_api::TrajectoryId) -> Result<Session, EventError> {
     match runtime.session(root, root) {
         Ok(session) => Ok(session),
-        Err(SessionError::Unknown) => match runtime.create_session(root.clone()) {
+        Err(EventError::UnknownTrajectory) => match runtime.create_session(root.clone()) {
             Ok(session) => Ok(session),
-            Err(SessionError::AlreadyExists) => runtime.session(root, root),
+            Err(EventError::TrajectoryExists) => runtime.session(root, root),
             Err(error) => Err(error),
         },
         Err(error) => Err(error),

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -105,7 +105,10 @@ fn refuse_unobservable_returns(adapter: Adapter, policy: &toml::Value) -> Result
                 };
                 if (name == "Agent" || name == "Task") && !pins_foreground(tool) {
                     return Err(format!(
-                        "this deployment controls the subagent's context, and its `{name}` tool does not pin                          `run_in_background` to `false` (`parameters.properties.run_in_background.const = false`):                          a background subagent returns where no hook can check it. Pin the argument, as the                          shipped examples do."
+                        "this deployment controls the subagent's context, and its `{name}` tool does not pin \
+                        `run_in_background` to `false` (`parameters.properties.run_in_background.const = false`): a \
+                        background subagent returns where no hook can check it. Pin the argument, as the shipped \
+                        examples do."
                     ));
                 }
             }

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -83,7 +83,7 @@ impl ServerHandler for RemedyService {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
         info.server_info.name = "appa-runtime".to_string();
-        info.server_info.version = env!("CARGO_PKG_VERSION").to_string();
+        info.server_info.version = RUNTIME_VERSION.to_string();
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
         info.instructions = Some(
             "When blocking feedback names an offer id, call execute_remedy_plan \
@@ -93,6 +93,9 @@ impl ServerHandler for RemedyService {
         info
     }
 }
+
+/// The release version the CLI advertises, so an MCP client and `--version` agree.
+const RUNTIME_VERSION: &str = include_str!("../../version.txt").trim_ascii();
 
 const SESSION_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 
@@ -115,6 +118,25 @@ mod tests {
     use crate::api::{ProposedCall, Runtime, ToolCallDecision};
     use crate::config::Config;
     use appa_runtime_api::HookDecision;
+
+    #[test]
+    fn the_mcp_server_advertises_the_release_version_the_cli_advertises() {
+        let service = RemedyService::new(std::sync::Arc::new(
+            Runtime::open(
+                config(),
+                tempfile::tempdir()
+                    .expect("a temp dir is creatable")
+                    .path()
+                    .join("appa.db"),
+                None,
+            )
+            .expect("the deployment opens"),
+        ));
+        assert_eq!(
+            service.get_info().server_info.version,
+            include_str!("../../version.txt").trim()
+        );
+    }
 
     fn config() -> Config {
         let text = r#"

--- a/appa-runtime/tests/audit_read.rs
+++ b/appa-runtime/tests/audit_read.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::raw;
+use common::{offers, raw};
 
 use std::sync::Arc;
 
@@ -149,18 +149,14 @@ async fn open_child(runtime: &Arc<Runtime>, spawn: ProposedCall) -> HookDecision
 }
 
 fn first_offer(feedback: &str) -> OfferId {
-    OfferId(opaque_offer_id(feedback).unwrap_or_else(|| panic!("no offer id in feedback: {feedback}")))
+    offers(feedback)
+        .first()
+        .cloned()
+        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 
 fn all_offers(feedback: &str) -> Vec<OfferId> {
-    feedback.lines().filter_map(opaque_offer_id).map(OfferId).collect()
-}
-
-fn opaque_offer_id(text: &str) -> Option<String> {
-    let after = text.split("offer_id:").nth(1)?;
-    let rest = after.trim_start().strip_prefix('"')?;
-    let end = rest.find('"')?;
-    Some(rest[..end].to_string())
+    offers(feedback)
 }
 
 fn feedback_of(decision: &HookDecision) -> String {

--- a/appa-runtime/tests/cast.rs
+++ b/appa-runtime/tests/cast.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{raw, serve};
+use common::{offers, raw, serve};
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
@@ -318,14 +318,9 @@ async fn returned(runtime: &Arc<Runtime>, tool: &str, body: &str) -> HookDecisio
 }
 
 fn last_offer(feedback: &str) -> OfferId {
-    feedback
-        .lines()
-        .filter_map(|line| {
-            let after = line.split("offer_id:").nth(1)?;
-            let rest = after.trim_start().strip_prefix('"')?;
-            Some(OfferId(rest[..rest.find('"')?].to_string()))
-        })
-        .next_back()
+    offers(feedback)
+        .last()
+        .cloned()
         .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -22,6 +22,20 @@ pub fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
+/// Every offer a feedback body names, in the order the feedback lists
+/// them. Which end a suite takes is its own assertion: a remedy plan
+/// that stages several offers surfaces one line each.
+pub fn offers(feedback: &str) -> Vec<appa_runtime::api::OfferId> {
+    feedback
+        .lines()
+        .filter_map(|line| {
+            let after = line.split("offer_id:").nth(1)?;
+            let rest = after.trim_start().strip_prefix('"')?;
+            Some(appa_runtime::api::OfferId(rest[..rest.find('"')?].to_string()))
+        })
+        .collect()
+}
+
 /// Serve one router on an ephemeral loopback port for the rest of the
 /// test, and answer with its base URL.
 pub async fn serve(router: axum::Router) -> String {

--- a/appa-runtime/tests/config_reload.rs
+++ b/appa-runtime/tests/config_reload.rs
@@ -251,7 +251,7 @@ async fn a_declared_builtin_the_deployment_cannot_serve_refuses_open_and_reload(
 }
 
 #[tokio::test]
-async fn reload_rereads_includes_and_a_broken_include_keeps_the_previous_deployment() {
+async fn reload_rereads_includes_and_a_broken_include_refuses() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let root_path = dir.path().join("appa.toml");
     let battery_path = dir.path().join("battery.toml");
@@ -276,12 +276,6 @@ async fn reload_rereads_includes_and_a_broken_include_keeps_the_previous_deploym
 
     std::fs::write(&battery_path, "[policy]\nversion = 1\nlimits = {}\n").expect("the broken battery writes");
     assert!(Config::load(&root_path).is_err(), "a broken include must refuse");
-    let still_active = TrajectoryId("reload:included-refusal".to_string());
-    start(&runtime, &still_active).await;
-    assert!(
-        allowed(&propose_notes(&runtime, &still_active).await),
-        "a failed composition leaves the previous deployment active"
-    );
 
     std::fs::write(&battery_path, "[policy]\nversion = 1\n").expect("the edited battery writes");
     let reloaded = runtime

--- a/appa-runtime/tests/hitl_elicitation.rs
+++ b/appa-runtime/tests/hitl_elicitation.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::raw;
+use common::{offers, raw};
 
 use std::sync::Arc;
 
@@ -295,13 +295,11 @@ builtin = "hitl"
 }
 
 fn offer_id(feedback: &str) -> String {
-    let after = feedback
-        .split("offer_id:")
-        .nth(1)
-        .unwrap_or_else(|| panic!("the feedback surfaces an offer id: {feedback}"));
-    let rest = after.trim_start().strip_prefix('"').expect("the offer id is quoted");
-    let end = rest.find('"').expect("the offer id closes its quote");
-    rest[..end].to_string()
+    offers(feedback)
+        .first()
+        .unwrap_or_else(|| panic!("the feedback surfaces an offer id: {feedback}"))
+        .0
+        .clone()
 }
 
 async fn execute<H: ClientHandler>(deployment: &Deployment, reviewer: H) -> String {

--- a/appa-runtime/tests/input_substitution.rs
+++ b/appa-runtime/tests/input_substitution.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::raw;
+use common::{offers, raw};
 
 use std::sync::Arc;
 
@@ -97,14 +97,9 @@ fn feedback_of(decision: &HookDecision) -> String {
 }
 
 fn last_offer(feedback: &str) -> OfferId {
-    feedback
-        .lines()
-        .filter_map(|line| {
-            let after = line.split("offer_id:").nth(1)?;
-            let rest = after.trim_start().strip_prefix('"')?;
-            Some(OfferId(rest[..rest.find('"')?].to_string()))
-        })
-        .next_back()
+    offers(feedback)
+        .last()
+        .cloned()
         .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 

--- a/appa-runtime/tests/membership.rs
+++ b/appa-runtime/tests/membership.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{raw, serve};
+use common::{offers, raw, serve};
 
 use std::sync::{Arc, Mutex};
 
@@ -143,14 +143,9 @@ async fn ran(runtime: &Arc<Runtime>, call: ProposedCall) {
 }
 
 fn last_offer(feedback: &str) -> appa_runtime::api::OfferId {
-    feedback
-        .lines()
-        .filter_map(|line| {
-            let after = line.split("offer_id:").nth(1)?;
-            let rest = after.trim_start().strip_prefix('"')?;
-            Some(appa_runtime::api::OfferId(rest[..rest.find('"')?].to_string()))
-        })
-        .next_back()
+    offers(feedback)
+        .last()
+        .cloned()
         .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 

--- a/appa-runtime/tests/rewrite_selects_contract.rs
+++ b/appa-runtime/tests/rewrite_selects_contract.rs
@@ -2,7 +2,7 @@
 //! real boundaries: a loopback HTTP resolver and sanitizer, a real store, the real hook path.
 
 mod common;
-use common::{raw, serve};
+use common::{offers, raw, serve};
 
 use std::sync::{Arc, Mutex};
 
@@ -161,14 +161,9 @@ fn last_offer(decision: &HookDecision) -> OfferId {
     let HookDecision::DenyCall { feedback, .. } = decision else {
         panic!("expected a deny carrying feedback, got {decision:?}")
     };
-    feedback
-        .lines()
-        .filter_map(|line| {
-            let after = line.split("offer_id:").nth(1)?;
-            let rest = after.trim_start().strip_prefix('"')?;
-            Some(OfferId(rest[..rest.find('"')?].to_string()))
-        })
-        .next_back()
+    offers(feedback)
+        .last()
+        .cloned()
         .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 

--- a/appa-runtime/tests/tool_resolvers.rs
+++ b/appa-runtime/tests/tool_resolvers.rs
@@ -1,6 +1,9 @@
 //! Tool-level dynamic resolvers over real boundaries: a loopback HTTP classifier, a fake
 //! `claude` executable behind the command override, a real store, the real hook path.
 
+mod common;
+use common::{raw, serve};
+
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -65,18 +68,7 @@ async fn serve_classifier() -> (String, Classifier) {
             }),
         )
         .with_state(classifier.clone());
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("an ephemeral loopback port binds");
-    let addr = listener.local_addr().expect("the bound address is readable");
-    tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("the stub serves");
-    });
-    (format!("http://{addr}/resolve"), classifier)
-}
-
-fn raw(value: serde_json::Value) -> Box<serde_json::value::RawValue> {
-    serde_json::value::to_raw_value(&value).expect("the fixture serializes")
+    (format!("{}/resolve", serve(router).await), classifier)
 }
 
 fn root() -> TrajectoryId {
@@ -773,14 +765,7 @@ async fn serve_ollama(content: &'static str) -> (String, Arc<Mutex<Vec<serde_jso
             }
         }),
     );
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("an ephemeral loopback port binds");
-    let addr = listener.local_addr().expect("the bound address is readable");
-    tokio::spawn(async move {
-        axum::serve(listener, router).await.expect("the stub serves");
-    });
-    (format!("http://{addr}"), requests)
+    (serve(router).await, requests)
 }
 
 /// A resolver that names `builtin = "llm"` on its declaration is served by the

--- a/appa-runtime/tests/unbound_authority.rs
+++ b/appa-runtime/tests/unbound_authority.rs
@@ -2,7 +2,7 @@
 //! remedy that names the authority leaves its offer standing.
 
 mod common;
-use common::raw;
+use common::{offers, raw};
 
 use std::sync::Arc;
 
@@ -64,14 +64,9 @@ fn offer_of(decision: &HookDecision) -> OfferId {
     let HookDecision::DenyCall { feedback, .. } = decision else {
         panic!("expected a deny carrying feedback, got {decision:?}")
     };
-    feedback
-        .lines()
-        .filter_map(|line| {
-            let after = line.split("offer_id:").nth(1)?;
-            let rest = after.trim_start().strip_prefix('"')?;
-            Some(OfferId(rest[..rest.find('"')?].to_string()))
-        })
-        .next_back()
+    offers(feedback)
+        .last()
+        .cloned()
         .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 


### PR DESCRIPTION
Small fixes and simplifications in `appa-runtime`, one cluster per commit.

**Fixes**

- The MCP server advertised a hardcoded version string that had drifted from `version.txt`, which the CLI reads through `include_str!`. Both now read the same file, with a test that fails if they diverge.

**Tests that could not fail**

- `terminal_safe` was pinned with `assert_ne!` against the input it was never going to return, so deleting the whole format-character range left the test green. It now asserts the exact replacement output.
- A config-reload assertion compared a value with itself; the test name described a property it did not check.

**Simplifications**

- `SessionError` existed only to be converted into `EventError` one line later at every call site. `create_session`, `session` and `live` return `EventError` directly. The non-lifecycle failures inside `live` stay flattened to `Storage`, which keeps today's operator-facing text and lets the callers fold them without matching on which fault it was.
- `Session::on_prompt` took the prompt text, ignored it, and returned an always-`Ok` result; the dispatcher cloned the text on every prompt to feed it.
- A hand-rolled placeholder pre-check in `memberships_for` restated what `group_reads` already answers.
- Three ~26-space runs inside an operator-facing config-validation message.
- `tool_resolvers` re-implemented `common::raw` and inlined `common::serve` in both its stubs; seven suites hand-rolled the same `offer_id:` scraper under three names. They share `common::offers` now, with `.first()` or `.last()` stated at each call site.
