### PR TITLE
perf: post hooks from the runtime binary, pin the replay crates, move to toml 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,11 +2168,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2477,44 +2477,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3040,12 +3038,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ publish = false
 dead_code = "deny"
 
 # Sized for a binary people install and ship, not for a numeric hot loop. Most of
-# this binary is monomorphized generic code, so `s` cuts build time and size
-# together; the gating path is bounded by inference and tool latency, not codegen.
+# this binary is monomorphized generic code waiting on a socket, so `s` cuts build
+# time and size together at no cost to it. The exception is the two crates pinned
+# below, which are the one stretch of the gating path that spends real CPU.
 # `panic` stays at the default unwind: a module crate built in this workspace
 # needs it to contain a panic at its `extern "C"` boundary (see appa-builtin).
 [profile.release]
@@ -35,23 +36,34 @@ lto = "thin"
 codegen-units = 16
 strip = "symbols"
 
+# The engine replays the whole trajectory before every decision, and sha2 digests
+# every value it admits, so these two run once per fact per hook while the rest of
+# the binary runs once per process. `3` here is free: it leaves build time where it
+# was and the binary very slightly smaller, and cuts the replay by about a fifth.
+[profile.release.package.appa-engine]
+opt-level = 3
+
+[profile.release.package.sha2]
+opt-level = 3
+
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_json_canonicalizer = "0.3"
 sha2 = "0.10"
 thiserror = "2"
-toml = "0.8"
+toml = "1"
 tracing = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "time", "macros", "sync", "process"] }
 # 0.13 is the version rig-core speaks: one reqwest in the graph rather than two
 # whole HTTP stacks. `rustls-no-provider` leaves the crypto provider to `rustls`
 # below and keeps the platform verifier, so roots still come from the OS store.
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"] }
-# The one crypto provider behind every rustls client here. Naming exactly one
-# provider feature is what lets rustls install it as the process default, so no
-# caller installs it by hand. aws-lc-rs is deliberately absent: it is a second C
-# and assembly toolchain on the install path for no capability ring lacks.
+# The one crypto provider behind every rustls client here. reqwest refuses to
+# build a client until a provider is installed, so an entry point installs this one
+# process-wide (appa-runtime/src/tls.rs) rather than each client naming it. aws-lc-rs
+# is deliberately absent: it is a second C and assembly toolchain on the install
+# path for no capability ring lacks.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 axum = { version = "0.8", default-features = false, features = ["json", "tokio", "http1"] }
 tokio-util = { version = "0.7", default-features = false }

--- a/appa-runtime/src/hook_client.rs
+++ b/appa-runtime/src/hook_client.rs
@@ -1,0 +1,246 @@
+//! The hook client: this same binary, invoked as `appa-runtime hook`, posting one
+//! hook event read on stdin to the running runtime and printing its answer.
+//!
+//! The harness spawns a process per hook, so the cost of reaching the runtime is
+//! paid on every tool call. Doing it here rather than through `curl` spends one
+//! process where a shell and a curl spent two, and spends it on the binary the
+//! install already puts on disk, so the install path grows nothing.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+/// Where the runtime answers hooks: an authority to connect to and the prefix the
+/// runtime's routes hang under. Only `http` is spoken: the runtime refuses to
+/// listen anywhere but loopback, so there is no transport to secure.
+struct Endpoint {
+    authority: String,
+    prefix: String,
+}
+
+impl Endpoint {
+    fn parse(url: &str) -> Result<Self, String> {
+        let rest = url
+            .strip_prefix("http://")
+            .ok_or_else(|| format!("{url} is not an http:// URL; the runtime serves plain HTTP on loopback"))?;
+        let (authority, prefix) = match rest.find('/') {
+            Some(slash) => (&rest[..slash], rest[slash..].trim_end_matches('/')),
+            None => (rest, ""),
+        };
+        if authority.is_empty() {
+            return Err(format!("{url} names no host to post to"));
+        }
+        Ok(Self {
+            authority: authority.to_owned(),
+            prefix: prefix.to_owned(),
+        })
+    }
+
+    fn address(&self) -> Result<SocketAddr, String> {
+        self.authority
+            .to_socket_addrs()
+            .map_err(|error| format!("{} does not resolve: {error}", self.authority))?
+            .next()
+            .ok_or_else(|| format!("{} resolves to no address", self.authority))
+    }
+
+    fn request_head(&self, length: usize) -> String {
+        format!(
+            "POST {}/hook HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\n\
+             Content-Length: {length}\r\nConnection: close\r\n\r\n",
+            self.prefix, self.authority
+        )
+    }
+}
+
+/// What the answer to this hook decides. A turn end reports a turn the actor has
+/// already finished, so it decides nothing: it discards the answer and never
+/// blocks, because every blocking outcome there would hold the actor in that turn.
+/// Every other hook authorizes something, so a runtime that does not answer blocks
+/// rather than letting the action through.
+///
+/// The caller says which, rather than this client reading the event name: the hook
+/// map already registers each hook for one event and is where that choice is
+/// reviewed, and nothing in the posted event can move a hook off it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Decides {
+    Authorization,
+    Nothing,
+}
+
+impl Decides {
+    pub(crate) fn of_a_turn_end(turn_end: bool) -> Self {
+        match turn_end {
+            true => Self::Nothing,
+            false => Self::Authorization,
+        }
+    }
+
+    /// The budget for the whole round trip. Authorization outlasts the runtime's
+    /// own evidence round trips; a turn end waits on none, so it takes the shorter
+    /// one and costs a runtime that is down a call left open, never a stuck turn.
+    /// Both stay under the timeout the harness declares, which is the deadline that
+    /// matters: a hook the harness kills has its exit code ignored and fails open.
+    fn budget(self) -> Duration {
+        match self {
+            Self::Authorization => Duration::from_secs(120),
+            Self::Nothing => Duration::from_secs(30),
+        }
+    }
+}
+
+/// The wall clock the whole round trip runs against. Every socket operation takes
+/// what is left of it, so a trickle of bytes cannot outlast the budget the way a
+/// per-operation timeout allows.
+struct Deadline(Instant);
+
+impl Deadline {
+    fn spanning(budget: Duration) -> Self {
+        Self(Instant::now() + budget)
+    }
+
+    /// A socket reads a zero timeout as "no timeout", so a spent budget must fail
+    /// here rather than reach one.
+    fn left(&self) -> Result<Duration, String> {
+        self.0
+            .checked_duration_since(Instant::now())
+            .filter(|left| !left.is_zero())
+            .ok_or_else(|| "the runtime did not answer in time".to_owned())
+    }
+}
+
+struct Answer {
+    status: u16,
+    body: Vec<u8>,
+}
+
+fn post(endpoint: &Endpoint, event: &[u8], deadline: &Deadline) -> Result<Answer, String> {
+    let address = endpoint.address()?;
+    let mut socket = TcpStream::connect_timeout(&address, deadline.left()?)
+        .map_err(|error| format!("cannot reach {address}: {error}"))?;
+    socket.set_nodelay(true).ok();
+
+    for part in [endpoint.request_head(event.len()).as_bytes(), event] {
+        socket
+            .set_write_timeout(Some(deadline.left()?))
+            .map_err(|error| format!("cannot bound the write to {address}: {error}"))?;
+        socket
+            .write_all(part)
+            .map_err(|error| format!("cannot post to {address}: {error}"))?;
+    }
+
+    let mut answer = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        socket
+            .set_read_timeout(Some(deadline.left()?))
+            .map_err(|error| format!("cannot bound the read from {address}: {error}"))?;
+        match socket.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => answer.extend_from_slice(&chunk[..read]),
+            Err(error) => return Err(format!("cannot read the answer from {address}: {error}")),
+        }
+    }
+    parse(&answer)
+}
+
+fn parse(answer: &[u8]) -> Result<Answer, String> {
+    let end_of_head = answer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| "the answer ended before its headers did".to_owned())?;
+    let head =
+        std::str::from_utf8(&answer[..end_of_head]).map_err(|_| "the answer's headers are not text".to_owned())?;
+    let status = head
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .ok_or_else(|| format!("the answer carries no status code: {head}"))?;
+    Ok(Answer {
+        status,
+        body: answer[end_of_head + 4..].to_vec(),
+    })
+}
+
+/// The blocking hook outcome. Claude Code reads stderr as the reason it blocked.
+fn block(failure: &str) -> ExitCode {
+    eprintln!("OpenAPPA runtime did not approve the hook: {failure}");
+    ExitCode::from(2)
+}
+
+pub(crate) fn run(url: &str, decides: Decides) -> ExitCode {
+    let mut event = Vec::new();
+    if let Err(error) = std::io::stdin().read_to_end(&mut event) {
+        return block(&format!("the hook event could not be read: {error}"));
+    }
+    let answered =
+        Endpoint::parse(url).and_then(|endpoint| post(&endpoint, &event, &Deadline::spanning(decides.budget())));
+    if decides == Decides::Nothing {
+        if let Err(failure) = answered {
+            eprintln!("OpenAPPA runtime did not answer the turn end: {failure}");
+        }
+        return ExitCode::SUCCESS;
+    }
+    match answered {
+        Ok(answer) => {
+            std::io::stdout().write_all(&answer.body).ok();
+            std::io::stdout().flush().ok();
+            match answer.status {
+                200..=299 => ExitCode::SUCCESS,
+                status => block(&format!("it answered {status}")),
+            }
+        }
+        Err(failure) => block(&failure),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_endpoint_is_an_authority_and_the_prefix_its_routes_hang_under() {
+        let plain = Endpoint::parse("http://127.0.0.1:8787").expect("a bare authority parses");
+        assert_eq!(plain.authority, "127.0.0.1:8787");
+        assert_eq!(
+            plain.request_head(3),
+            "POST /hook HTTP/1.1\r\nHost: 127.0.0.1:8787\r\nContent-Type: application/json\r\n\
+             Content-Length: 3\r\nConnection: close\r\n\r\n"
+        );
+
+        let nested = Endpoint::parse("http://127.0.0.1:8787/appa/").expect("a prefix parses");
+        assert!(nested.request_head(0).starts_with("POST /appa/hook HTTP/1.1\r\n"));
+
+        assert!(Endpoint::parse("https://127.0.0.1:8787").is_err());
+        assert!(Endpoint::parse("127.0.0.1:8787").is_err());
+        assert!(Endpoint::parse("http:///hook").is_err());
+    }
+
+    #[test]
+    fn a_turn_end_waits_on_less_than_an_authorization_does() {
+        assert!(Decides::of_a_turn_end(true) == Decides::Nothing);
+        assert!(Decides::of_a_turn_end(false) == Decides::Authorization);
+        assert!(Decides::Nothing.budget() < Decides::Authorization.budget());
+    }
+
+    #[test]
+    fn an_answer_is_its_status_and_the_body_after_the_headers() {
+        let answered = parse(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\n{}").expect("a well formed answer parses");
+        assert_eq!(answered.status, 200);
+        assert_eq!(answered.body, b"{}");
+
+        let refused = parse(b"HTTP/1.1 422 Unprocessable Entity\r\n\r\nwhy").expect("a refusal parses");
+        assert_eq!(refused.status, 422);
+        assert_eq!(refused.body, b"why");
+
+        assert!(parse(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n").is_err());
+        assert!(parse(b"garbage\r\n\r\n").is_err());
+    }
+
+    #[test]
+    fn a_spent_deadline_refuses_rather_than_bounding_a_socket_by_zero() {
+        assert!(Deadline::spanning(Duration::from_secs(5)).left().expect("time is left") > Duration::ZERO);
+        assert!(Deadline::spanning(Duration::ZERO).left().is_err());
+    }
+}

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -1,6 +1,9 @@
-//! Process entry: an HTTP listener for hooks. Policy decisions live behind the runtime API; this file
+//! Process entry. Policy decisions live behind the runtime API; this file
 //! parses flags, initializes a missing deployment config, opens the
-//! runtime, picks the adapter codec, and serves.
+//! runtime, picks the adapter codec, and serves. Invoked as `appa-runtime hook`
+//! it is instead the client the harness runs once per hook (see `hook_client`).
+
+mod hook_client;
 
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
@@ -40,7 +43,12 @@ fn ensure_default_config(path: &Path) -> io::Result<bool> {
     name = "appa-runtime",
     version = include_str!("../../version.txt").trim()
 )]
+/// Gate a harness's flows. With no subcommand it serves the runtime; `hook` posts
+/// one hook event to a runtime already serving.
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     #[arg(long, env = "APPA_CONFIG", default_value = "appa.toml")]
     config: PathBuf,
 
@@ -58,6 +66,23 @@ struct Args {
 
     #[arg(short, action = clap::ArgAction::Count)]
     verbose: u8,
+}
+
+/// The one thing this binary does besides serve. The harness spawns it once per
+/// hook, so it runs before anything the server needs is built.
+#[derive(clap::Subcommand)]
+enum Command {
+    /// Post the hook event on stdin to the running runtime and print its answer.
+    Hook {
+        #[arg(long, env = "APPA_RUNTIME_URL", default_value = "http://127.0.0.1:8787")]
+        url: String,
+
+        /// Post a hook that reports a finished turn. It decides nothing, so it
+        /// discards the answer and never blocks, and waits on no evidence round
+        /// trip, so it takes the shorter deadline.
+        #[arg(long)]
+        turn_end: bool,
+    },
 }
 
 fn require_loopback(addr: &SocketAddr) -> Result<(), String> {
@@ -228,9 +253,21 @@ async fn status(
     }
 }
 
-#[tokio::main]
-async fn main() -> ExitCode {
+fn main() -> ExitCode {
     let args = Args::parse();
+    if let Some(Command::Hook { url, turn_end }) = &args.command {
+        return hook_client::run(url, hook_client::Decides::of_a_turn_end(*turn_end));
+    }
+    match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
+        Ok(async_runtime) => async_runtime.block_on(serve(args)),
+        Err(error) => {
+            eprintln!("appa-runtime: cannot start the async runtime: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn serve(args: Args) -> ExitCode {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -12,8 +12,16 @@ use axum::routing::post;
 const TURN_ENDS: [&str; 3] = ["Stop", "StopFailure", "SubagentStop"];
 
 fn turn_end_command() -> &'static str {
-    "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" \
-     -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0"
+    "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; \
+     [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook --turn-end || exit 0"
+}
+
+/// Where the shipped commands look for the binary first. Without it they would
+/// find whatever appa-runtime this machine has installed, not the one built here.
+fn install_dir() -> &'static std::path::Path {
+    std::path::Path::new(env!("CARGO_BIN_EXE_appa-runtime"))
+        .parent()
+        .expect("the built binary sits in a directory")
 }
 
 fn shipped(file: &str) -> serde_json::Value {
@@ -86,8 +94,8 @@ fn shipped_command() -> String {
         Some(
             command
                 .replace(
-                    "; curl",
-                    "; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && curl",
+                    "; \"$b\" hook",
+                    "; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && \"$b\" hook",
                 )
                 .as_str()
         ),
@@ -105,6 +113,7 @@ fn run_gated(command: &str, url: &str, gated: bool) -> (i32, String) {
         .arg("-c")
         .arg(command)
         .env("APPA_RUNTIME_URL", url)
+        .env("APPA_INSTALL_DIR", install_dir())
         .env("APPA_GATE", if gated { "1" } else { "0" })
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -186,6 +195,22 @@ async fn an_ungated_session_posts_nothing_and_never_blocks() {
 #[tokio::test(flavor = "multi_thread")]
 async fn an_unreachable_runtime_never_blocks_a_turn_end() {
     let url = refused_url().await;
+    let (code, stdout) = tokio::task::spawn_blocking(move || run_hook(turn_end_command(), &url))
+        .await
+        .expect("the blocking task joins");
+    assert_eq!(code, 0, "a turn end must never block the harness");
+    assert_eq!(stdout, "", "a turn end prints no decision");
+}
+
+/// The same guarantee where the runtime answers and refuses: the answer decides
+/// nothing, so it never reaches the harness and never becomes a blocking outcome.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_refused_turn_end_still_prints_nothing_and_exits_0() {
+    let url = serve(Router::new().route(
+        "/hook",
+        post(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
+    ))
+    .await;
     let (code, stdout) = tokio::task::spawn_blocking(move || run_hook(turn_end_command(), &url))
         .await
         .expect("the blocking task joins");

--- a/integrations/claude-code/plugin/hooks/hooks.json
+++ b/integrations/claude-code/plugin/hooks/hooks.json
@@ -1,12 +1,12 @@
 {
-  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and the plugin prints nothing into the session; installing the runtime is the appa-setup skill's job, invoked only when the user asks. In a protected session every hook posts its event to the appa-runtime process and prints the runtime's answer. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health and replaces a running one that answers stale, because an install replaced its binary on disk; the install runs the same script as its last step, so a protected session normally finds the runtime already up. curl --fail-with-body exits non-zero on a non-2xx answer and on a connection failure; plain curl exits 0 on server errors and would fail open. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. Every hook declares a timeout above its own curl deadline, and SessionStart's also covers the starter's 20-second budget. Claude Code kills a hook that outruns the timeout and then lets the action proceed, because it never reads the killed hook's exit code, so an undeclared timeout is the one way these hooks fail open. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They discard the answer and always exit 0, and take the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
+  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and the plugin prints nothing into the session; installing the runtime is the appa-setup skill's job, invoked only when the user asks. In a protected session every hook posts its event to the appa-runtime process and prints the runtime's answer. The poster is `appa-runtime hook`: the installed runtime binary run as its own client, so a hook spends one process where a shell and a curl spent two, and the install path grows nothing. Each command resolves that binary where the install puts it and falls back to PATH. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health and replaces a running one that answers stale, because an install replaced its binary on disk; the install runs the same script as its last step, so a protected session normally finds the runtime already up. `appa-runtime hook` prints the answer and exits non-zero on a non-2xx one and on a connection failure. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. Every hook declares a timeout above its own client deadline, and SessionStart's also covers the starter's 20-second budget. Claude Code kills a hook that outruns the timeout and then lets the action proceed, because it never reads the killed hook's exit code, so an undeclared timeout is the one way these hooks fail open. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They pass --turn-end, which discards the answer, always exits 0, and takes the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The flag says so here rather than the client reading the event name, so a hook's blocking outcome is declared beside the event it is registered for and nothing in a posted event can move it. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && \"$b\" hook || exit 2",
             "timeout": 150
           },
           {
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook || exit 2",
             "timeout": 130
           }
         ]
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook || exit 2",
             "timeout": 130
           }
         ]
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook || exit 2",
             "timeout": 130
           }
         ]
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook --turn-end || exit 0",
             "timeout": 40
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook --turn-end || exit 0",
             "timeout": 40
           }
         ]
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook || exit 2",
             "timeout": 130
           }
         ]
@@ -89,7 +89,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl -s -m 30 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- -o /dev/null; exit 0",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook --turn-end || exit 0",
             "timeout": 40
           }
         ]
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; curl --fail-with-body -sS -m 120 -X POST \"${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/hook\" -H 'content-type: application/json' --data-binary @- || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa-runtime; [ -x \"$b\" ] || b=appa-runtime; \"$b\" hook || exit 2",
             "timeout": 130
           }
         ]

--- a/website-chat-playground/Cargo.toml
+++ b/website-chat-playground/Cargo.toml
@@ -17,7 +17,7 @@ tokio-stream = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = { workspace = true }
 anyhow = "1"
 thiserror = "2"
 # Unguessable session ids.


### PR DESCRIPTION
Items 2–4 of the gating-overhead teardown. Item 1 (caching the engine view) is not here.

## The hook transport

Every hook spawned a shell and a curl. `appa-runtime hook` is the same installed binary run as its own client: one process per hook, nothing new on the install path.

| | per hook | per tool call |
| --- | --- | --- |
| `sh` + `curl` | 9.65 ms | 19.31 ms |
| `sh` + `appa-runtime hook` | 7.82 ms | 15.64 ms |

Median of 4 alternating rounds of 60, macOS, loopback. The 16 MB binary starts faster than curl does here (3.7 ms vs 8.1 ms to `--version`), and `main` no longer builds a tokio runtime before parsing its flags.

Behaviour is unchanged: the answer goes to stdout, a non-2xx or a connection failure exits 2, and the deadline is a genuine total budget rather than per-operation, so a slow trickle cannot outrun the timeout the harness declares and fail open. A turn end passes `--turn-end`, so the blocking outcome stays declared in `hooks.json` beside the event it is registered for; nothing in a posted event can move a hook off it.

## The profile pins

`appa-engine` and `sha2` run once per fact per hook; the rest of the binary runs once per process.

| replay slope, ms per 1000 prior calls | r1 | r2 | r3 | median |
| --- | --- | --- | --- | --- |
| unpinned | 60.8 | 81.1 | 64.2 | 64.2 |
| `opt-level = 3` | 53.3 | 51.9 | 53.4 | 53.3 |

Clean build stays at 39 s and the binary is 0.06 MB smaller.

## toml 1

Drops `toml_edit`. `website-chat-playground` pinned its own `0.8`, which kept it in the lockfile; it now takes the workspace dependency. Same crate count, −0.12 MB.

Binary overall: 16.47 → 16.29 MB.

## Corrections

Two comments the measurements refuted: the gating path is CPU-bound, not bounded by inference and tool latency; and rustls does not install its own default provider — `appa-runtime/src/tls.rs` does.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --workspace -- -D warnings`, 50 test binaries. `tests/plugin_hooks.rs` runs the shipped commands against the built binary and covers the new refused-turn-end path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHu6LFjTdfPGv9i9zkBud6