### PR TITLE
fix(engine,runtime): keep a loopback token off the proxy, bound two maps, and tighten load checks

### DIFF
--- a/appa-agent-python/tests/test_spawn_lifecycle.py
+++ b/appa-agent-python/tests/test_spawn_lifecycle.py
@@ -122,8 +122,8 @@ def test_a_session_naming_no_spawn_tool_opens_no_children():
 
 
 def test_a_quarantine_exit_needs_a_host_that_opens_children():
-    """The host declares its coverage by naming a spawn tool. Without one this
-    policy's return sanitizer would have no application point, and the loader
-    says so rather than loading a sanitizer that could never run."""
-    with pytest.raises(AppaError, match="confines no application point"):
+    """A host that names no spawn tool controls no child context, so this policy's
+    return binding has nothing to bind to. The loader refuses rather than loading a
+    return sanitizer that could never run."""
+    with pytest.raises(AppaError, match="does not control child context"):
         Session(POLICY, json.dumps(TOOLS), "decide the ticket")

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1294,6 +1294,9 @@ impl Engine {
         if !views.is_open(dispatch) {
             match (views.closed_successfully(dispatch), &observed) {
                 (true, None) => return Err(TransitionError::ContradictedSuccess),
+                (false, Some(_)) if views.closed_unobserved(dispatch) => {
+                    return Err(TransitionError::ClosedUnobserved);
+                }
                 (false, Some(_)) => return Err(TransitionError::ObservationMismatch),
                 _ => {}
             }
@@ -5217,6 +5220,72 @@ mod tests {
         assert_eq!(
             forge(crossing_at + 1, known(TRUSTED, Audience::Public)),
             Err(TransitionRefusal::ForgedLabel)
+        );
+    }
+
+    /// An indeterminate close records no observation and leaves the reservation
+    /// standing, because the call may have executed. A report that arrives afterwards is
+    /// refused on that ground, not on a contradiction with an observation there is none of.
+    #[test]
+    fn a_report_after_an_indeterminate_close_is_refused_on_its_own_ground() {
+        let internal = Audience::restricted([ReaderId::new("internal")]);
+        let e = engine_at(vec![crm_tool()], known(TRUSTED, internal));
+        let call = call("get_ticket", json!({}));
+        let records = vec![opened(&e)];
+        let view = e.view(&traj(), records.clone(), 1).unwrap();
+        let decision = e
+            .handle(
+                &view,
+                EngineEvent::Proposals(ProposalBatch {
+                    id: crate::transition::ProposalBatchId::new("b1"),
+                    trajectory: traj(),
+                    provider_results: Vec::new(),
+                    proposals: vec![raw(&call)],
+                    spawn: None,
+                    offer_nonce: nonce(),
+                    evidence: Vec::new(),
+                    expansions: vec![],
+                }),
+            )
+            .unwrap();
+        let FollowUp::Proposals { released, .. } = decision.follow_up else {
+            panic!("a proposal batch answers with proposals")
+        };
+        let dispatch = released[0].dispatch.clone();
+        let log = [records, decision.append.unwrap().facts().to_vec()].concat();
+        let released_view = e.view(&traj(), log.clone(), 2).unwrap();
+
+        let report = |outcome: ToolOutcome| ToolReport {
+            dispatch: dispatch.clone(),
+            outcome,
+            evidence: Vec::new(),
+            offer_nonce: nonce(),
+            expansions: vec![],
+        };
+        let closed = e
+            .handle(&released_view, EngineEvent::Outcome(report(ToolOutcome::Indeterminate)))
+            .expect("an indeterminate outcome closes the dispatch");
+        let facts = closed.append.expect("the close appends").facts().to_vec();
+        assert!(
+            matches!(
+                facts.as_slice(),
+                [Fact::DispatchClosed {
+                    outcome: crate::fact::CloseOutcome::Indeterminate,
+                    ..
+                }]
+            ),
+            "the close records the indeterminate outcome and no observation: {facts:?}"
+        );
+
+        let after = e.view(&traj(), [log, facts].concat(), 3).unwrap();
+        assert_eq!(
+            e.handle(
+                &after,
+                EngineEvent::Outcome(report(ToolOutcome::Success {
+                    body: OutcomeBody::Available(ValueBody::new("the ticket")),
+                }))
+            ),
+            Err(crate::transition::TransitionError::ClosedUnobserved)
         );
     }
 

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -16961,7 +16961,7 @@ mod tests {
             let identity = |cfg: &RegistryConfig| {
                 let profile = crate::profile::DeploymentProfile::declare(crate::profile::covering_declaration(cfg))
                     .expect("the covering declaration declares");
-                crate::profile::PolicyIdentityV1::of(cfg, &ReturnPolicy::Raw, &profile)
+                crate::profile::identity_of(cfg, &ReturnPolicy::Raw, &profile)
             };
             let forward = config(vec![capped_send(), team_delta("read")], vec![]);
             let backward = config(vec![team_delta("read"), capped_send()], vec![]);

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -13,7 +13,7 @@ use crate::groups::{Expansions, GroupExpansion, GroupResolution};
 use crate::label::{EstablishedLabel, Label, PartialLabel};
 use crate::names::{AuthorityName, SanitizerName};
 use crate::params::{ArgumentError, CanonicalArguments};
-use crate::plan::{self, PlannedBlock};
+use crate::plan::{self, BlockedCall, PlannedBlock};
 use crate::profile::{self, DeploymentPolicy, DeploymentProfile, OpenVector, PolicyDialectVersion, PolicyIdentityV1};
 use crate::projection::Projection;
 use crate::projection::Views;
@@ -77,13 +77,6 @@ struct Opening<'a> {
 
 /// A refused call and the block the check produced for it — what a remedy menu is planned over.
 #[derive(Clone, Copy)]
-struct BlockedCall<'a> {
-    call: &'a ResolvedCall,
-    raw: &'a crate::check::RawBlock,
-    stage: &'a CallStage,
-    role: plan::CallRole,
-}
-
 /// What a staged return's remedy menu is computed over: the crossing the child owes, at the
 /// label and body the stage stands on, and the sanitizer lineage that reached it.
 struct ReturnStageInput<'a> {
@@ -2054,7 +2047,7 @@ impl Engine {
         // moves nothing, so the two agree by construction.
         let advance = Sequence::advance_of(self, view, &facts);
         let final_views = working.view(&batch.trajectory);
-        let mut refused: Vec<(usize, &ResolvedCall, RawBlock, plan::CallRole)> = Vec::new();
+        let mut refused: Vec<(usize, &ResolvedCall, &ToolContract, RawBlock, plan::CallRole)> = Vec::new();
         for (position, call) in composed
             .iter()
             .enumerate()
@@ -2071,21 +2064,15 @@ impl Engine {
                 true => plan::CallRole::MarkedSpawn,
                 false => plan::CallRole::Ordinary,
             };
-            refused.push((position, call, raw, role));
+            refused.push((position, call, contract, raw, role));
         }
         let block_stage: Vec<crate::names::GroupName> = refused
             .iter()
-            .flat_map(|(_, call, raw, role)| {
-                let contract = self
-                    .registry
-                    .contract(call)
-                    .expect("a refused sibling names a checkable tool");
-                plan::block_groups(&self.registry, contract, raw, *role)
-            })
+            .flat_map(|(_, _, contract, raw, role)| plan::block_groups(&self.registry, contract, raw, *role))
             .collect();
         expansions.require(&block_stage)?;
         let mut blocked = Vec::new();
-        for (position, call, raw, role) in refused {
+        for (position, call, contract, raw, role) in refused {
             let subject = crate::basis::SubjectKey::Call {
                 trajectory: batch.trajectory.clone(),
                 batch: batch.id.clone(),
@@ -2101,6 +2088,7 @@ impl Engine {
                 },
                 BlockedCall {
                     call,
+                    contract,
                     raw: &raw,
                     stage: &CallStage::default(),
                     role,
@@ -2212,8 +2200,8 @@ impl Engine {
         blocked: BlockedCall<'_>,
         expansions: &Expansions,
     ) -> (Blocked, Vec<Fact>) {
-        let BlockedCall { call, raw, stage, role } = blocked;
-        let planned = plan::plan(&self.registry, views, call, raw, stage, role, expansions);
+        let call = blocked.call;
+        let planned = plan::plan(&self.registry, views, blocked, expansions);
         let (block_id, offers, opened) = self.open_offers(
             views,
             opening,
@@ -2381,7 +2369,18 @@ impl Engine {
                                 (block_id, Vec::new())
                             });
                             blocked.push(Blocked {
-                                block: plan::plan(&self.registry, views, &candidate, &raw, &stage, role, expansions),
+                                block: plan::plan(
+                                    &self.registry,
+                                    views,
+                                    BlockedCall {
+                                        call: &candidate,
+                                        contract,
+                                        raw: &raw,
+                                        stage: &stage,
+                                        role,
+                                    },
+                                    expansions,
+                                ),
                                 call: candidate,
                                 block_id,
                                 offers,
@@ -2451,12 +2450,23 @@ impl Engine {
             CheckOutcome::Block(raw) => {
                 expansions.require(&plan::block_groups(&self.registry, contract, &raw, role))?;
                 expansions.require(&plan::plan_groups(&self.registry, contract, &recorded.plan))?;
-                plan::plan(&self.registry, &views, &call, &raw, &stage, role, expansions)
-                    .plans
-                    .iter()
-                    .filter_map(plan::RemedyPlan::executable)
-                    .any(|offered| offered == &recorded.plan)
-                    .then_some(raw)
+                plan::plan(
+                    &self.registry,
+                    &views,
+                    BlockedCall {
+                        call: &call,
+                        contract,
+                        raw: &raw,
+                        stage: &stage,
+                        role,
+                    },
+                    expansions,
+                )
+                .plans
+                .iter()
+                .filter_map(plan::RemedyPlan::executable)
+                .any(|offered| offered == &recorded.plan)
+                .then_some(raw)
             }
             // The block is gone: whatever the agent would have remedied, nothing needs it now.
             CheckOutcome::Allow => None,
@@ -2472,7 +2482,7 @@ impl Engine {
                 view, &views, execution, &recorded, contract, &raw, &call, evidence, expansions,
             ),
             (OfferOutcome::Denied { authority }, None) => self.deny_offer(
-                view, &views, execution, &recorded, &call, &raw, &stage, authority, expansions,
+                view, &views, execution, &recorded, contract, &call, &raw, &stage, authority, expansions,
             ),
             _ => Err(TransitionError::PlanOutcomeMismatch),
         }
@@ -3112,6 +3122,7 @@ impl Engine {
                     },
                     BlockedCall {
                         call: &substituted,
+                        contract,
                         raw: &raw,
                         stage: &next,
                         role,
@@ -3359,7 +3370,18 @@ impl Engine {
             .pending_block(&recorded.subject)
             .unwrap_or((offer_block(recorded, execution, &call), Vec::new()));
         Ok(Some(Blocked {
-            block: plan::plan(&self.registry, views, &call, &raw, &stage, role, expansions),
+            block: plan::plan(
+                &self.registry,
+                views,
+                BlockedCall {
+                    call: &call,
+                    contract,
+                    raw: &raw,
+                    stage: &stage,
+                    role,
+                },
+                expansions,
+            ),
             call,
             block_id,
             offers,
@@ -3467,6 +3489,7 @@ impl Engine {
         views: &Views,
         execution: &OfferExecution,
         recorded: &crate::projection::RecordedOffer,
+        contract: &ToolContract,
         call: &ResolvedCall,
         raw: &crate::check::RawBlock,
         stage: &CallStage,
@@ -3510,7 +3533,13 @@ impl Engine {
                 nonce: &execution.offer_nonce,
                 subject: &recorded.subject,
             },
-            BlockedCall { call, raw, stage, role },
+            BlockedCall {
+                call,
+                contract,
+                raw,
+                stage,
+                role,
+            },
             expansions,
         );
         facts.extend(opened);
@@ -3573,14 +3602,17 @@ impl Engine {
     /// implemented remedy subset — see [`crate::plan`].
     #[cfg(test)]
     pub(crate) fn plan(&self, views: &Views, call: &ResolvedCall, raw: &RawBlock) -> Result<PlannedBlock, EngineError> {
-        self.validated_contract(call)?;
+        let contract = self.validated_contract(call)?;
         Ok(plan::plan(
             &self.registry,
             views,
-            call,
-            raw,
-            &CallStage::default(),
-            plan::CallRole::Ordinary,
+            BlockedCall {
+                call,
+                contract,
+                raw,
+                stage: &CallStage::default(),
+                role: plan::CallRole::Ordinary,
+            },
             &Expansions::default(),
         ))
     }

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -14702,7 +14702,14 @@ mod tests {
         scoped.scope = crate::authority::Scope {
             tags: vec![crate::names::TagName::new("web")],
         };
-        let e = open_engine(returning_registry(vec![scoped], vec![classifier_cast()]));
+        let mut cfg = returning_registry(vec![scoped], vec![classifier_cast()]);
+        // A tool the sanitizer's scope reaches, so the sanitizer is one a result could
+        // meet. A child return originates from no tool, which is what leaves it unreached.
+        cfg.tools.push(ToolContract {
+            tags: vec![crate::names::TagName::new("web")],
+            ..open_tool("browse")
+        });
+        let e = open_engine(cfg);
         let child = TrajectoryId::new("child");
         let mut log = spawn_family(&e, None, &child);
         reads(&e, &mut log, &child, "read_suspicious_internal");

--- a/appa-engine/src/params.rs
+++ b/appa-engine/src/params.rs
@@ -432,7 +432,7 @@ fn compile_node(node: &Value, depth: usize, budget: &mut SchemaBudget) -> Result
             })
         }
         "number" => {
-            let constraint = compile_constraint(map, |v| v.is_number())?;
+            let constraint = compile_constraint(map, |v| matches!(v, Value::Number(n) if suppliable(n)))?;
             let bounds = compile_numeric_bounds(map)?;
             Ok(SchemaNode::Number {
                 description,
@@ -511,7 +511,7 @@ fn compile_numeric_bounds(map: &serde_json::Map<String, Value>) -> Result<Numeri
     let bound = |key: &str| -> Result<Option<serde_json::Number>, ParamsError> {
         match map.get(key) {
             None => Ok(None),
-            Some(Value::Number(n)) => Ok(Some(n.clone())),
+            Some(Value::Number(n)) if suppliable(n) => Ok(Some(n.clone())),
             Some(_) => Err(ParamsError::BadNumericBound),
         }
     };
@@ -536,6 +536,20 @@ fn compile_numeric_bounds(map: &serde_json::Map<String, Value>) -> Result<Numeri
         }
     }
     Ok(NumericBounds { lower, upper })
+}
+
+/// Could a legal argument carry this authored number? Argument scanning refuses an
+/// integer-formed token outside the safe-integer range, so a `const`, an `enum` member or a
+/// bound beyond it names a value no call can supply. Inside the range every value is exact
+/// in `f64`, which is what validation and scalar equality compare through; outside it, two
+/// distinct authored integers can compare equal. A number authored in a non-integer form
+/// carries no such bound, and the scanner applies none to it either.
+fn suppliable(number: &serde_json::Number) -> bool {
+    match (number.as_u64(), number.as_i64()) {
+        (Some(n), _) => n <= MAX_SAFE_INTEGER as u64,
+        (None, Some(n)) => n.unsigned_abs() <= MAX_SAFE_INTEGER as u64,
+        (None, None) => true,
+    }
 }
 
 fn is_schema_integer(value: &Value) -> bool {
@@ -1315,6 +1329,38 @@ mod tests {
             compile(json!({ "type": "object", "properties": { "x": { "type": "integer", "const": i64::MIN } } })),
             Err(ParamsError::BadConst)
         );
+    }
+
+    /// A `number` schema had no domain of its own, so it could name a constant no legal
+    /// argument can carry — argument scanning refuses an integer-formed token past the safe
+    /// range — and, compared through `f64`, that constant equals its supported neighbour.
+    #[test]
+    fn a_number_schema_names_only_values_an_argument_could_carry() {
+        let scalar = |keyword: &str, value: serde_json::Value| {
+            compile(json!({ "type": "object", "properties": {
+                "x": { "type": "number", keyword: value } } }))
+        };
+        assert_eq!(scalar("const", json!(9007199254740993u64)), Err(ParamsError::BadConst));
+        assert_eq!(scalar("const", json!(i64::MIN)), Err(ParamsError::BadConst));
+        assert_eq!(
+            scalar("enum", json!([1, 9007199254740993u64])),
+            Err(ParamsError::BadEnum)
+        );
+        assert_eq!(
+            scalar("minimum", json!(9007199254740993u64)),
+            Err(ParamsError::BadNumericBound)
+        );
+        assert_eq!(
+            scalar("exclusiveMaximum", json!(i64::MIN)),
+            Err(ParamsError::BadNumericBound)
+        );
+
+        // The edge of the range, and a non-integer form, both stay authorable: the scanner
+        // bounds an integer-formed token and nothing else.
+        assert!(scalar("const", json!(9007199254740991u64)).is_ok());
+        assert!(scalar("const", json!(-9007199254740991i64)).is_ok());
+        assert!(scalar("const", json!(1.5e300)).is_ok());
+        assert!(scalar("maximum", json!(1.5)).is_ok());
     }
 
     #[test]

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -220,15 +220,31 @@ pub(crate) enum CallRole {
 /// `unestablished` source lists nothing: no plan clears the missing fact, and the engine
 /// requests every applicable cast before it composes, so the block arises only where no cast
 /// applies. See the module docs for the direct-clearing model.
+/// One refused call as planning receives it: the call, the contract its check resolved,
+/// the block that check found, and the stage and role it was found at. The contract is
+/// carried rather than looked up again — an empty plan set is read as a proof that the
+/// block is unliftable, and a lookup that missed would have said the same thing.
+pub(crate) struct BlockedCall<'a> {
+    pub(crate) call: &'a ResolvedCall,
+    pub(crate) contract: &'a ToolContract,
+    pub(crate) raw: &'a RawBlock,
+    pub(crate) stage: &'a CallStage,
+    pub(crate) role: CallRole,
+}
+
 pub(crate) fn plan(
     registry: &Registry,
     views: &Views,
-    call: &ResolvedCall,
-    raw: &RawBlock,
-    stage: &CallStage,
-    role: CallRole,
+    blocked: BlockedCall<'_>,
     expansions: &Expansions,
 ) -> PlannedBlock {
+    let BlockedCall {
+        call,
+        contract,
+        raw,
+        stage,
+        role,
+    } = blocked;
     let current = views.current_label();
     let no_denials = BTreeSet::new();
     let denied = views.denied_authorities(&call.digest()).unwrap_or(&no_denials);
@@ -238,6 +254,7 @@ pub(crate) fn plan(
     let mut plans: Vec<RemedyPlan> = match raw.unestablished.is_empty() {
         true => enumerate_plans(
             registry,
+            contract,
             &current,
             &has_committed,
             &has_reserved,
@@ -285,6 +302,7 @@ pub(crate) fn plan(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn enumerate_plans(
     registry: &Registry,
+    contract: &ToolContract,
     current: &PartialLabel,
     has_committed: &impl Fn(&EffectKind) -> bool,
     has_reserved: &impl Fn(&EffectKind) -> bool,
@@ -293,9 +311,6 @@ pub(crate) fn enumerate_plans(
     role: CallRole,
     expansions: &Expansions,
 ) -> Vec<ExecutableRemedyPlan> {
-    let Some(contract) = registry.keyed_tool(call.tool(), call.contract_id()) else {
-        return Vec::new();
-    };
     let block = check::evaluate_state(
         contract,
         current,
@@ -1256,10 +1271,13 @@ mod tests {
         plan(
             registry,
             &views,
-            call,
-            &raw,
-            &CallStage::default(),
-            CallRole::Ordinary,
+            BlockedCall {
+                call,
+                contract,
+                raw: &raw,
+                stage: &CallStage::default(),
+                role: CallRole::Ordinary,
+            },
             &Expansions::default(),
         )
     }
@@ -3849,7 +3867,18 @@ mod tests {
             let projection = Projection::build(&log, log.len() as u64);
             let trajectory = traj();
             let views = projection.view(&trajectory);
-            let planned = plan(&registry, &views, &call, &raw, &CallStage::default(), CallRole::Ordinary, &Expansions::default());
+            let planned = plan(
+                &registry,
+                &views,
+                BlockedCall {
+                    call: &call,
+                    contract,
+                    raw: &raw,
+                    stage: &CallStage::default(),
+                    role: CallRole::Ordinary,
+                },
+                &Expansions::default(),
+            );
 
             let coverable = raw
                 .requirement_gaps
@@ -3938,7 +3967,18 @@ mod tests {
             let projection = Projection::build(&log, log.len() as u64);
             let trajectory = traj();
             let views = projection.view(&trajectory);
-            let planned = plan(&registry, &views, &call, &raw, &CallStage::default(), CallRole::Ordinary, &Expansions::default());
+            let planned = plan(
+                &registry,
+                &views,
+                BlockedCall {
+                    call: &call,
+                    contract,
+                    raw: &raw,
+                    stage: &CallStage::default(),
+                    role: CallRole::Ordinary,
+                },
+                &Expansions::default(),
+            );
 
             let authorities = registry.authorities();
             let mut bound: u128 = 1;
@@ -4079,7 +4119,18 @@ mod tests {
             let projection = Projection::build(&log, log.len() as u64);
             let trajectory = traj();
             let views = projection.view(&trajectory);
-            let planned = plan(&registry, &views, &call, &raw, &CallStage::default(), CallRole::Ordinary, &Expansions::default());
+            let planned = plan(
+                &registry,
+                &views,
+                BlockedCall {
+                    call: &call,
+                    contract,
+                    raw: &raw,
+                    stage: &CallStage::default(),
+                    role: CallRole::Ordinary,
+                },
+                &Expansions::default(),
+            );
 
             let competent = |authority: &Authority, gap: &Gap| -> bool {
                 let scoped = authority.scope.covers(&contract.tags);

--- a/appa-engine/src/profile.rs
+++ b/appa-engine/src/profile.rs
@@ -298,16 +298,6 @@ impl PolicyFileKey {
 pub struct PolicyIdentityV1(#[serde(with = "crate::hex32")] [u8; 32]);
 
 impl PolicyIdentityV1 {
-    pub fn of(registry: &RegistryConfig, child_return: &ReturnPolicy, profile: &DeploymentProfile) -> Self {
-        let document = identity_document(registry, child_return, profile);
-        let canonical = serde_json_canonicalizer::to_vec(&document).expect("an identity document canonicalizes");
-        let mut hasher = Sha256::new();
-        hasher.update(b"appa:policy-identity:v1");
-        hasher.update([0u8]);
-        hasher.update(&canonical);
-        PolicyIdentityV1(hasher.finalize().into())
-    }
-
     pub(crate) fn of_registry(registry: &Registry, child_return: &ReturnPolicy) -> Self {
         let document = identity_document_from_registry(registry, child_return);
         let canonical = serde_json_canonicalizer::to_vec(&document).expect("an identity document canonicalizes");
@@ -370,6 +360,24 @@ fn identity_document_from_registry(registry: &Registry, child_return: &ReturnPol
         .expect("identity document is an object")
         .insert("tools".into(), tools.into());
     document
+}
+
+/// The digest of a configuration as the engine that serves it would stamp it. Test-only:
+/// production reads [`crate::engine::Engine::identity`], which is this same digest taken
+/// from the registry the engine actually holds.
+#[cfg(test)]
+pub(crate) fn identity_of(
+    registry: &RegistryConfig,
+    child_return: &ReturnPolicy,
+    profile: &DeploymentProfile,
+) -> PolicyIdentityV1 {
+    let built = crate::registry::Registry::build(
+        registry.clone(),
+        crate::registry::PlannerCap::default(),
+        profile.clone(),
+    )
+    .expect("a fixture configuration builds");
+    PolicyIdentityV1::of_registry(&built, child_return)
 }
 
 fn canonical_value(value: &impl Serialize) -> serde_json::Value {
@@ -637,7 +645,7 @@ pub(crate) fn opening_at(trajectory: crate::value::TrajectoryId, starting_label:
     crate::fact::Fact::TrajectoryOpened {
         trajectory,
         dialect: PolicyDialectVersion::new(1),
-        policy_digest: PolicyIdentityV1::of(&config, &ReturnPolicy::Raw, &profile),
+        policy_digest: identity_of(&config, &ReturnPolicy::Raw, &profile),
         profile,
         policy_file_key: PolicyFileKey::of(b"fixture"),
         open_vectors: Vec::new(),
@@ -1261,7 +1269,7 @@ mod tests {
     }
 
     fn identity(cfg: &RegistryConfig, child: &ReturnPolicy, profile: &DeploymentProfile) -> PolicyIdentityV1 {
-        PolicyIdentityV1::of(cfg, child, profile)
+        super::identity_of(cfg, child, profile)
     }
 
     #[test]
@@ -1308,7 +1316,12 @@ mod tests {
 
     #[test]
     fn rescoping_a_cast_moves_the_identity() {
-        let mut cfg = config(vec![tool("fetch")]);
+        // The origin carries the tag the cast is rescoped to, so both configurations are
+        // ones the engine would load: the identity is only meaningful for those.
+        let mut origin = tool("fetch");
+        origin.tags = vec![TagName::new("inbound")];
+        origin.delta = None;
+        let mut cfg = config(vec![origin]);
         cfg.casts = vec![crate::authority::Cast {
             name: crate::names::CastName::new("vouch"),
             resolution: crate::authority::CastResolution::Constant(DeclaredLabel::literal(

--- a/appa-engine/src/profile.rs
+++ b/appa-engine/src/profile.rs
@@ -548,15 +548,6 @@ pub(crate) fn validate_coverage(
         }
     }
 
-    if profile.confined_results.is_empty()
-        && !profile.confined_child_return
-        && let Some(sanitizer) = registry.sanitizers().find(|sanitizer| sanitizer.on.output)
-    {
-        return Err(LoadError::OutputSanitizerUncovered {
-            sanitizer: sanitizer.name.as_str().to_string(),
-        });
-    }
-
     if let ReturnPolicy::Sanitized(name) = child_return {
         if !profile.context_control {
             return Err(LoadError::ChildWithoutContextControl);
@@ -572,6 +563,24 @@ pub(crate) fn validate_coverage(
             None => {
                 return Err(LoadError::ChildReturnSanitizerUnknown(name.as_str().to_string()));
             }
+        }
+    }
+
+    // An output sanitizer runs on a confined result its scope reaches, or on a confined
+    // child return, which originates from no tool and so is reached only by an unscoped
+    // one. A sanitizer no confined source can reach never runs, and the deployment that
+    // declares it believes a derivation is available that is not.
+    for sanitizer in registry.sanitizers().filter(|sanitizer| sanitizer.on.output) {
+        let reaches_a_result = profile.confined_results.iter().any(|tool| {
+            registry
+                .variants(tool)
+                .any(|contract| sanitizer.scope.covers(&contract.tags))
+        });
+        let reaches_the_child_return = profile.confined_child_return && sanitizer.scope.is_unscoped();
+        if !reaches_a_result && !reaches_the_child_return {
+            return Err(LoadError::OutputSanitizerUncovered {
+                sanitizer: sanitizer.name.as_str().to_string(),
+            });
         }
     }
 
@@ -771,6 +780,44 @@ mod tests {
         let mut result_only = uncovered(&cfg);
         result_only.confined_results.insert(ToolName::new("fetch"));
         assert!(open(cfg, result_only, ReturnPolicy::Raw).is_ok());
+    }
+
+    /// Coverage is per sanitizer and per scope: some other tool being confined does not
+    /// give a scoped sanitizer an application point. A child return originates from no
+    /// tool, so only an unscoped sanitizer reaches it.
+    #[test]
+    fn a_scoped_output_sanitizer_needs_a_confined_result_its_scope_reaches() {
+        let mut cfg = config(vec![tool("fetch"), tool("post")]);
+        cfg.tools[1].tags = vec![TagName::new("outbound")];
+        let mut scoped = output_sanitizer("redactor");
+        scoped.scope = Scope {
+            tags: vec![TagName::new("outbound")],
+        };
+        cfg.sanitizers = vec![scoped];
+
+        let confining = |cfg: &RegistryConfig, tools: &[&str], child: bool| {
+            let mut declaration = covering_declaration(cfg);
+            declaration.confined_results = tools.iter().map(|name| ToolName::new(*name)).collect();
+            declaration.confined_child_return = child;
+            declaration
+        };
+
+        assert!(
+            matches!(
+                open(cfg.clone(), confining(&cfg, &["fetch"], false), ReturnPolicy::Raw),
+                Err(LoadError::OutputSanitizerUncovered { sanitizer }) if sanitizer == "redactor"
+            ),
+            "a confined tool outside the scope is not an application point"
+        );
+        assert!(
+            matches!(
+                open(cfg.clone(), confining(&cfg, &["fetch"], true), ReturnPolicy::Raw),
+                Err(LoadError::OutputSanitizerUncovered { sanitizer }) if sanitizer == "redactor"
+            ),
+            "a scoped sanitizer never reaches a child return"
+        );
+        let covered = confining(&cfg, &["post"], false);
+        assert!(open(cfg, covered, ReturnPolicy::Raw).is_ok());
     }
 
     #[test]

--- a/appa-engine/src/projection.rs
+++ b/appa-engine/src/projection.rs
@@ -1335,6 +1335,14 @@ impl Views<'_> {
         matches!(self.projection.closed.get(dispatch), Some(CloseKind::Failure))
     }
 
+    /// Did this dispatch close as indeterminate with nothing observed? The reservation
+    /// stands, because the call may have executed, and the log holds no observation that
+    /// a later report could agree or disagree with.
+    pub(crate) fn closed_unobserved(&self, dispatch: &DispatchId) -> bool {
+        matches!(self.projection.closed.get(dispatch), Some(CloseKind::Indeterminate))
+            && !self.projection.observations.contains_key(dispatch)
+    }
+
     /// Has this still-open dispatch's success checkpoint already committed its effects? Gates the
     /// close (success-family only, no duplicate effects) and the runtime's once-only checkpoint.
     /// Derived: a checkpoint is exactly a recorded observation on a dispatch that is still open.

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -426,7 +426,7 @@ fn worst_case_plan_alternatives(
     literal: &Expansions,
 ) -> u128 {
     use crate::check::Gap;
-    use crate::contract::{AudienceRequirement, HistoryRequirement, ResolverReturn};
+    use crate::contract::{AudienceRequirement, HistoryRequirement, RecipientSpec, ResolverReturn};
     use crate::fact::EffectKind;
     use crate::plan::covers_gap;
 
@@ -444,6 +444,32 @@ fn worst_case_plan_alternatives(
         authorities
             .iter()
             .filter(|authority| authority.scope.covers(&tool.tags) && authority.mandate.reader_ceiling.is_some())
+            .count()
+    };
+    // A static `includes` is decidable at load whenever neither side names a group, so the
+    // count is the authorities that can actually cover it rather than every one carrying a
+    // reader ceiling — planning admits only the former. A group on either side is a
+    // directory answer this lint cannot have, and ruling such an authority out would
+    // UNDERCOUNT: the cap is the only bound on how many plans one block surfaces, so an
+    // undecidable authority stays counted.
+    let includes_competent = |recipients: &crate::groups::DeclaredAudience| {
+        authorities
+            .iter()
+            .filter(|authority| {
+                let Some(ceiling) = &authority.mandate.reader_ceiling else {
+                    return false;
+                };
+                if !authority.scope.covers(&tool.tags) {
+                    return false;
+                }
+                if recipients.groups().next().is_some() || ceiling.groups().next().is_some() {
+                    return true;
+                }
+                let gap = Gap::Includes {
+                    recipients: recipients.resolve(literal),
+                };
+                covers_gap(authority, &gap, &tool.tags, literal)
+            })
             .count()
     };
 
@@ -470,9 +496,14 @@ fn worst_case_plan_alternatives(
     let mut seen_includes: Vec<&AudienceRequirement> = Vec::new();
     for requirement in &tool.requires.label.audience {
         match requirement {
-            AudienceRequirement::Includes(_) if !seen_includes.contains(&requirement) => {
+            AudienceRequirement::Includes(spec) if !seen_includes.contains(&requirement) => {
                 seen_includes.push(requirement);
-                multiply(reader_cap_competent());
+                match spec {
+                    RecipientSpec::Static(recipients) => multiply(includes_competent(recipients)),
+                    // A placeholder's recipients come from the call, so nothing about the
+                    // gap is known here.
+                    RecipientSpec::Placeholder(_) => multiply(reader_cap_competent()),
+                }
             }
             AudienceRequirement::Includes(_) | AudienceRequirement::Cap(_) => {}
         }
@@ -2569,6 +2600,69 @@ mod tests {
         assert!(matches!(
             Registry::build_covered_with_cap(cfg, cap),
             Err(LoadError::TooManyPlanAlternatives { count: 17, max: 16, .. })
+        ));
+    }
+
+    /// The cap bounds the plans a block can surface, so it must count the authorities
+    /// planning would admit. For a wholly literal `contains`, that is decidable here:
+    /// an authority capped at readers that exclude the recipient covers nothing.
+    #[test]
+    fn the_cap_counts_only_the_authorities_a_literal_contains_can_reach() {
+        let recipient = ReaderId::new("auditor");
+        let mut cfg = base();
+        let mut emit = tool("emit");
+        emit.requires.label.audience = vec![AudienceRequirement::Includes(RecipientSpec::Static(
+            DeclaredAudience::restricted([recipient.clone()]),
+        ))];
+        cfg.tools = vec![emit];
+        let capped_at = |name: &str, ceiling: DeclaredAudience| Authority {
+            name: AuthorityName::new(name),
+            mandate: Mandate {
+                reader_ceiling: Some(ceiling),
+                ..Mandate::default()
+            },
+            scope: Scope::default(),
+            hint: None,
+        };
+        // None of these reaches `auditor`, so none of them can cover the gap.
+        cfg.authorities = (0..80)
+            .map(|index| {
+                capped_at(
+                    &format!("a{index}"),
+                    DeclaredAudience::restricted([ReaderId::new(format!("other-{index}"))]),
+                )
+            })
+            .collect();
+        assert!(
+            Registry::build_covered(cfg.clone()).is_ok(),
+            "authorities that cannot cover the recipient are not alternatives"
+        );
+
+        // Authorities that do reach it are still counted, beside the ones that cannot.
+        let mut reaching = cfg.clone();
+        reaching.authorities.extend(
+            (0..65).map(|index| capped_at(&format!("r{index}"), DeclaredAudience::restricted([recipient.clone()]))),
+        );
+        assert!(matches!(
+            Registry::build_covered(reaching),
+            Err(LoadError::TooManyPlanAlternatives { count: 65, max: 64, .. })
+        ));
+
+        // A group on the authority's ceiling is a directory answer the lint cannot have,
+        // so those authorities stay counted rather than being ruled out.
+        let mut grouped = cfg.clone();
+        grouped.authorities = (0..80)
+            .map(|index| {
+                capped_at(
+                    &format!("g{index}"),
+                    DeclaredAudience::declared([], [GroupName::new("desk")]).expect("a group declaration"),
+                )
+            })
+            .collect();
+        grouped.membership = Some(crate::names::MembershipResolverName::new("directory"));
+        assert!(matches!(
+            Registry::build_covered(grouped),
+            Err(LoadError::TooManyPlanAlternatives { count: 80, max: 64, .. })
         ));
     }
 

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -498,6 +498,7 @@ impl Search<'_> {
         } else {
             for plan in plan::enumerate_plans(
                 self.registry,
+                context.contract,
                 &state.label,
                 &self.has_committed(state),
                 &self.has_reserved(),
@@ -1842,10 +1843,13 @@ mod tests {
             let planned = plan::plan(
                 &registry,
                 &views,
-                &proposal,
-                &raw_block(&registry, &views, &proposal),
-                &CallStage::default(),
-                CallRole::Ordinary,
+                plan::BlockedCall {
+                    call: &proposal,
+                    contract: registry.tool(proposal.tool()).expect("the fixture registers the tool"),
+                    raw: &raw_block(&registry, &views, &proposal),
+                    stage: &CallStage::default(),
+                    role: CallRole::Ordinary,
+                },
                 &Expansions::default(),
             );
             let expected: Vec<RecoveryRoute> = planned

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -487,6 +487,10 @@ pub enum TransitionError {
     UnknownDispatch,
     #[error("the report contradicts the observation this dispatch already checkpointed")]
     ObservationMismatch,
+    #[error(
+        "this dispatch closed as indeterminate and observed nothing, so a later report has no observation to check against"
+    )]
+    ClosedUnobserved,
     #[error("the dispatch recorded success: a failure or indeterminate outcome contradicts it")]
     ContradictedSuccess,
     #[error("the cast resolution is not admissible for this confined result")]

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -1608,10 +1608,13 @@ impl<'a> Sequence<'a> {
                 Ok(crate::plan::plan(
                     self.engine.registry(),
                     views,
-                    candidate,
-                    &block,
-                    &stage,
-                    role,
+                    crate::plan::BlockedCall {
+                        call: candidate,
+                        contract,
+                        raw: &block,
+                        stage: &stage,
+                        role,
+                    },
                     expansions,
                 )
                 .plans

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -3878,7 +3878,7 @@ mod tests {
         let other_policy = ValidatedFactBatch::seal(
             vec![],
             1,
-            PolicyIdentityV1::of(
+            crate::profile::identity_of(
                 &crate::registry::RegistryConfig {
                     trust_chain: crate::registry::TrustChain::new(vec!["suspicious".into()]),
                     tools: vec![],

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -353,6 +353,10 @@ impl Inner {
         Ok(policy)
     }
 
+    /// The engine for a policy this deployment no longer serves, compiled once. The
+    /// compile stays outside the lock — it is the expensive step, and the mutex's
+    /// "no panic runs while it is held" reading must keep holding — so a race can
+    /// still compile twice, but only one result is ever cached and handed out.
     fn retired_engine(&self, key: &str, bytes: &[u8]) -> Result<Arc<RuntimeEngine>, EventError> {
         if let Some(engine) = self
             .retired
@@ -364,11 +368,13 @@ impl Inner {
         }
         let compiled = compile_stored_policy(bytes).map_err(EventError::PolicyUnavailable)?;
         let engine = Arc::new(RuntimeEngine::new(compiled.engine().clone()));
-        self.retired
-            .lock()
-            .expect("the retired-engine mutex is never poisoned: no panic runs while it is held")
-            .insert(key.to_string(), Arc::clone(&engine));
-        Ok(engine)
+        Ok(Arc::clone(
+            self.retired
+                .lock()
+                .expect("the retired-engine mutex is never poisoned: no panic runs while it is held")
+                .entry(key.to_string())
+                .or_insert(engine),
+        ))
     }
 
     pub(super) fn log(&self, root: &TrajectoryId) -> Result<Log, EventError> {
@@ -436,6 +442,18 @@ impl Runtime {
             self.inner.gates.serve_llm(deployment.config.externals.llm_bound());
             std::mem::replace(&mut *serving, Arc::clone(&deployment))
         };
+        // Every reload retires at most one more policy, so clearing here bounds the
+        // cache by the reloads since the last one instead of by the life of the
+        // process. A trajectory still replaying under a dropped entry recompiles it.
+        self.inner
+            .retired
+            .lock()
+            .expect("the retired-engine mutex is never poisoned: no panic runs while it is held")
+            .clear();
+        // Every reload retires at most one more policy, so clearing here bounds the
+        // cache by the reloads since the last one instead of by the life of the
+        // process. A trajectory still replaying under a dropped entry recompiles it.
+
         let key = crate::engine::policy_file_key(deployment.config.policy_file().bytes());
         let changed = crate::engine::policy_file_key(previous.config.policy_file().bytes()) != key;
         tracing::info!(
@@ -646,6 +664,19 @@ impl Runtime {
         let mut permits = self.inner.permits.lock().expect("the permit mutex is never poisoned");
         let mut holders = permits.remove(&quoted.0)?;
         (holders.len() == 1).then(|| holders.remove(0))
+    }
+
+    /// Drop every vouch this actor still holds. A vouch is recorded when the actor
+    /// quotes an offer at the control tool's hook and taken when the tool itself
+    /// runs, both inside one turn. One still standing at the turn's end was never
+    /// spent — the harness declined the call, or the tool never ran — and nothing
+    /// later can spend it.
+    pub(crate) fn release_vouches(&self, acting: &Actor) {
+        let mut permits = self.inner.permits.lock().expect("the permit mutex is never poisoned");
+        permits.retain(|_, holders| {
+            holders.retain(|holder| holder != acting);
+            !holders.is_empty()
+        });
     }
 
     fn spend_vouch(&self, quoted: &OfferId, acting: &Actor) {
@@ -1284,5 +1315,101 @@ delta = { audience = { resolver = "directory", argument = "customer" } }
             .externals
             .llm_bound();
         assert_eq!(runtime.inner.gates.llm_permits(), serving);
+    }
+
+    /// Two policies that differ only in a tool's description, so a root opened
+    /// under one replays against the other through the retired branch.
+    fn versioned_policy(description: &str) -> Config {
+        claude_config(&format!(
+            r#"
+            version = 1
+            [[tool]]
+            name = "fetch"
+            description = "{description}"
+            "#
+        ))
+    }
+
+    #[tokio::test]
+    async fn a_reload_drops_the_retired_engines_compiled_before_it() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = std::sync::Arc::new(
+            Runtime::open(versioned_policy("first"), dir.path().join("appa.db"), None).expect("the deployment opens"),
+        );
+        let root = TrajectoryId("retired-cache".to_string());
+        assert_eq!(
+            crate::hooks::handle(
+                &runtime,
+                appa_runtime_api::HookEvent::SessionStart { root: root.clone() }
+            )
+            .await,
+            appa_runtime_api::HookDecision::Ack
+        );
+
+        // The root's policy is no longer the serving one, so reading it compiles the
+        // retired engine and caches it.
+        runtime
+            .reload(versioned_policy("second"))
+            .expect("the second deployment loads");
+        assert!(
+            runtime.audit(&root).is_some(),
+            "the root still reads under its own policy"
+        );
+        assert_eq!(retired_len(&runtime), 1);
+
+        runtime
+            .reload(versioned_policy("third"))
+            .expect("the third deployment loads");
+        assert_eq!(
+            retired_len(&runtime),
+            0,
+            "the cache does not carry compiled engines across a reload"
+        );
+    }
+
+    fn retired_len(runtime: &Runtime) -> usize {
+        runtime
+            .inner
+            .retired
+            .lock()
+            .expect("the retired-engine mutex is never poisoned")
+            .len()
+    }
+
+    #[tokio::test]
+    async fn a_vouch_the_turn_never_spent_does_not_outlive_it() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = std::sync::Arc::new(
+            Runtime::open(versioned_policy("first"), dir.path().join("appa.db"), None).expect("the deployment opens"),
+        );
+        let root = TrajectoryId("vouch-release".to_string());
+        assert_eq!(
+            crate::hooks::handle(
+                &runtime,
+                appa_runtime_api::HookEvent::SessionStart { root: root.clone() }
+            )
+            .await,
+            appa_runtime_api::HookDecision::Ack
+        );
+        let actor = Actor {
+            root: root.clone(),
+            child: None,
+        };
+        let quoted = OfferId("offer-1".to_string());
+
+        runtime.vouch(&quoted, &actor);
+        assert_eq!(
+            runtime.take_vouched(&quoted),
+            Some(actor.clone()),
+            "a standing vouch is what the tool takes"
+        );
+
+        runtime.vouch(&quoted, &actor);
+        crate::hooks::handle(&runtime, appa_runtime_api::HookEvent::TurnEnd { actor: actor.clone() }).await;
+        assert_eq!(
+            runtime.take_vouched(&quoted),
+            None,
+            "the turn ended without spending it, so nothing later can"
+        );
     }
 }

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -56,7 +56,6 @@ pub(crate) enum ToolCallDecision {
         feedback: String,
         unestablished: Vec<UnestablishedValue>,
     },
-    Control,
 }
 
 /// What the adapter gives the harness as the tool output. `Keep`: use

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -513,20 +513,10 @@ impl Runtime {
     /// carry the refusal: the session-start hook, and the start-after-lazy-open
     /// race. Every other path refuses inside the event it is already deciding.
     pub(crate) fn live(&self, root: &TrajectoryId, trajectory: &TrajectoryId) -> Result<(), EventError> {
-        let log = match self.inner.log(root) {
-            Ok(log) => log,
-            Err(EventError::UnknownTrajectory) => return Err(EventError::UnknownTrajectory),
-            Err(error) => return Err(EventError::Storage(error.to_string())),
-        };
+        let log = self.inner.log(root)?;
         let deployment = self.inner.deployment();
-        let policy = self
-            .inner
-            .resolve_policy(&deployment, &log)
-            .map_err(|error| EventError::Storage(error.to_string()))?;
-        let view = policy
-            .engine()
-            .rebuild_view(&log)
-            .map_err(|refusal| EventError::Storage(refusal.to_string()))?;
+        let policy = self.inner.resolve_policy(&deployment, &log)?;
+        let view = policy.engine().rebuild_view(&log).map_err(EventError::from)?;
         match policy.engine().liveness(&view, trajectory) {
             Liveness::Unopened => Err(EventError::UnknownTrajectory),
             Liveness::Ended => Err(EventError::TrajectoryEnded),
@@ -997,8 +987,13 @@ fn compile_stored_policy(bytes: &[u8]) -> Result<appa_policy::Config, String> {
 #[cfg(test)]
 pub(crate) mod testing {
     fn engine_dispatch(label: &str) -> appa_engine::value::DispatchId {
-        let policy = appa_policy::Config::from_toml_str("version = 1\n[[tool]]\nname = \"Bash\"\n")
-            .expect("the fixture policy compiles");
+        let policy = appa_policy::Config::from_toml_str(
+            "version = 1
+[[tool]]
+name = \"Bash\"
+",
+        )
+        .expect("the fixture policy compiles");
         let engine = policy.engine().clone();
         let call = engine
             .resolve_call(appa_engine::value::ToolName::new("Bash"), br#"{"command":"ls"}"#)
@@ -1410,6 +1405,33 @@ delta = { audience = { resolver = "directory", argument = "customer" } }
             runtime.take_vouched(&quoted),
             None,
             "the turn ended without spending it, so nothing later can"
+        );
+    }
+
+    /// The session-start check refuses on any fault, so the variant it refuses with is
+    /// what an operator reads. A missing policy file is not a storage failure, and
+    /// flattening it to one named the wrong incident.
+    #[tokio::test]
+    async fn a_liveness_check_refuses_with_the_fault_it_met() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = std::sync::Arc::new(
+            Runtime::open(versioned_policy("first"), dir.path().join("appa.db"), None).expect("the deployment opens"),
+        );
+        let root = TrajectoryId("liveness-fault".to_string());
+        assert_eq!(
+            crate::hooks::handle(
+                &runtime,
+                appa_runtime_api::HookEvent::SessionStart { root: root.clone() }
+            )
+            .await,
+            appa_runtime_api::HookDecision::Ack
+        );
+        assert!(runtime.live(&root, &root).is_ok());
+
+        runtime.inner.store.forget_policy_files();
+        assert!(
+            matches!(runtime.live(&root, &root), Err(EventError::PolicyUnavailable(_))),
+            "the root's policy file is gone, which is not a storage failure"
         );
     }
 }

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -1000,10 +1000,7 @@ mod deployment_tests {
     }
 
     fn endpoint() -> DynamicImplementation {
-        DynamicImplementation::Resolver(Endpoint {
-            url: "https://resolver.example".to_string(),
-            token: None,
-        })
+        DynamicImplementation::Resolver(Endpoint::new("https://resolver.example".to_string(), None))
     }
 
     fn load(config: Config) -> Result<Deployment, OpenError> {
@@ -1126,10 +1123,7 @@ delta = { audience = { resolver = "directory", argument = "customer" } }
         let mut extra = claude_config(policy);
         extra.externals.authorities.insert(
             "auditor".to_string(),
-            crate::config::Implementation::Resolver(Endpoint {
-                url: "https://auditor.example".to_string(),
-                token: None,
-            }),
+            crate::config::Implementation::Resolver(Endpoint::new("https://auditor.example".to_string(), None)),
         );
         assert!(matches!(
             load(extra),

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -245,10 +245,6 @@ impl Session {
     }
 
     pub async fn on_tool_call(&self, call: ProposedCall, spawn: bool) -> Result<ToolCallDecision, EventError> {
-        if is_control_tool(&call.tool) {
-            tracing::debug!(trajectory = %self.trajectory.0, "control tool passes unchecked");
-            return Ok(ToolCallDecision::Control);
-        }
         if let Some(open) = self.substituted_release(&call)? {
             return self.claim_or_abandon(call, open).await;
         }
@@ -368,10 +364,6 @@ impl Session {
     }
 
     pub async fn on_tool_result(&self, call: ProposedCall, o: ToolOutcome) -> Result<ToolResultDecision, EventError> {
-        if is_control_tool(&call.tool) {
-            tracing::debug!(trajectory = %self.trajectory.0, "control tool outcome absorbed");
-            return Ok(ToolResultDecision::Keep);
-        }
         let o = self.cap_outcome(o);
         outcome_decision(self.report_outcome(&call, &o).await?)
     }
@@ -4473,35 +4465,6 @@ context_control = true
             tool: name.to_string(),
             arguments: raw(serde_json::json!({"offer_id": "o1:cc:root:ff"})),
         }
-    }
-
-    #[tokio::test]
-    async fn the_control_tool_passes_unchecked_under_every_shipped_name() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_runtime(&dir);
-        let session = runtime.create_session(root()).expect("a fresh id opens");
-        for name in [
-            "execute_remedy_plan",
-            "mcp__appa__execute_remedy_plan",
-            "mcp__plugin_appa-runtime_appa__execute_remedy_plan",
-        ] {
-            assert_eq!(
-                session
-                    .on_tool_call(control_call(name), false)
-                    .await
-                    .expect("it passes"),
-                ToolCallDecision::Control,
-                "{name} is a control call",
-            );
-            assert_eq!(
-                session
-                    .on_tool_result(control_call(name), ToolOutcome::Indeterminate)
-                    .await
-                    .expect("its outcome is absorbed"),
-                ToolResultDecision::Keep,
-            );
-        }
-        assert!(only_the_opening(&runtime), "no control call reached the log");
     }
 
     #[tokio::test]

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -240,6 +240,35 @@ pub const LLM_BUILTIN: &str = "llm";
 pub struct Endpoint {
     pub url: String,
     pub token: Option<Token>,
+    host: EndpointHost,
+}
+
+/// Where an endpoint's host is. A request to `Loopback` must not leave this
+/// machine, so it never goes through a proxy: cleartext is permitted only
+/// there, and the bearer token it carries stays on the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointHost {
+    Loopback,
+    Remote,
+}
+
+impl Endpoint {
+    /// The endpoint at `url`. The host is derived here rather than taken from the
+    /// caller, so no endpoint can name a reach that disagrees with its own URL.
+    pub fn new(url: String, token: Option<Token>) -> Endpoint {
+        // An unparsable URL never reaches this far — `validated_url` refuses it — and a
+        // request to one fails anyway. Withholding the proxy is the safe reading of it.
+        let remote = reqwest::Url::parse(&url).is_ok_and(|parsed| !is_loopback(&parsed));
+        let host = match remote {
+            true => EndpointHost::Remote,
+            false => EndpointHost::Loopback,
+        };
+        Endpoint { url, token, host }
+    }
+
+    pub(crate) fn host(&self) -> EndpointHost {
+        self.host
+    }
 }
 
 /// A bearer token resolved from an `APPA_*` environment variable.
@@ -1069,7 +1098,7 @@ fn resolve_binding(
         (Some(url), None, None) => {
             let url = validated_url(section.name(), name, url)?;
             let token = resolve_token(section.name(), name, token_env, lookup)?;
-            Ok(Implementation::Resolver(Endpoint { url, token }))
+            Ok(Implementation::Resolver(Endpoint::new(url, token)))
         }
         (None, Some(builtin), None) if token_env.is_none() => {
             section.check_builtin(name, &builtin)?;

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1089,6 +1089,7 @@ impl RuntimeEngine {
                 let chain = self.engine.registry().trust_chain();
                 let acting = engine_id(trajectory);
                 let mut consults = Vec::new();
+                let mut settled = false;
                 for request in requests {
                     let EvidenceRequest::Cast { casts, value, body } = request else {
                         return Err(EngineRefusal::Invariant {
@@ -1101,12 +1102,16 @@ impl RuntimeEngine {
                             ask: self.cast_ask(value_source(view, &acting, value), casts, body),
                         }),
                         CastAnswerState::Unreadable(continued) => consults.push(*continued),
-                        CastAnswerState::NoAnswer | CastAnswerState::Resolved => {
-                            return Ok(deny_next(NO_CAST_ANSWERED.to_string()));
-                        }
+                        // This source will not be asked again: it answered, or it was
+                        // asked and answered nothing. The rest of the batch still goes
+                        // out, so one settled source does not cost the others a redrive.
+                        CastAnswerState::NoAnswer | CastAnswerState::Resolved => settled = true,
                     }
                 }
-                Ok(Next::ResolveExternal(consults))
+                match (settled, consults.is_empty()) {
+                    (true, true) => Ok(deny_next(NO_CAST_ANSWERED.to_string())),
+                    _ => Ok(Next::ResolveExternal(consults)),
+                }
             }
             FollowUp::Proposals {
                 released: releases,

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -15,8 +15,8 @@ use serde::Deserialize;
 
 use crate::builtins::{ClaudeCodeBackend, LoadedModule, MODULE_OUTPUT_CEILING, ModuleRegistry, ModulesError, Stock};
 use crate::config::{
-    CLAUDE_CODE_BUILTIN, DynamicImplementation, Endpoint, Externals, Implementation, LLM_BUILTIN, ResolverCommand,
-    Section,
+    CLAUDE_CODE_BUILTIN, DynamicImplementation, Endpoint, EndpointHost, Externals, Implementation, LLM_BUILTIN,
+    ResolverCommand, Section,
 };
 use crate::consult::{Consult, ConsultBody, ConsultKind, ModelPrompt, dynamic_answer_reads_readers_from};
 use crate::elicit::Elicitation;
@@ -110,6 +110,10 @@ fn kind_of(section: Section) -> ConsultKind {
 /// here.
 pub struct ExternalServices {
     http: reqwest::Client,
+    /// The client for every loopback endpoint. It refuses proxies, so a request
+    /// meant for this machine — and the bearer token cleartext is permitted to
+    /// carry there — is never relayed to whatever `HTTP_PROXY` names.
+    http_loopback: reqwest::Client,
     timeout: Duration,
     max_body_bytes: usize,
     backends: BTreeMap<ConsultKind, BTreeMap<String, Backend>>,
@@ -182,9 +186,16 @@ impl ExternalServices {
         gates: ConsultGates,
     ) -> Result<ExternalServices, ModulesError> {
         crate::tls::install_crypto_provider();
-        let http = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .timeout(config.timeout)
+        let client = || {
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .timeout(config.timeout)
+        };
+        let http = client()
+            .build()
+            .expect("the reqwest client builds: the crypto provider is installed above");
+        let http_loopback = client()
+            .no_proxy()
             .build()
             .expect("the reqwest client builds: the crypto provider is installed above");
         let claude = ClaudeCodeBackend {
@@ -248,6 +259,7 @@ impl ExternalServices {
         backends.insert(ConsultKind::Dynamic, dynamic);
         Ok(ExternalServices {
             http,
+            http_loopback,
             timeout: config.timeout,
             max_body_bytes: config.max_body_bytes,
             backends,
@@ -398,7 +410,11 @@ impl ExternalServices {
     }
 
     async fn post(&self, endpoint: &Endpoint, consult: &Consult) -> Result<Vec<u8>, NoAnswerReason> {
-        let mut builder = self.http.post(&endpoint.url).json(consult);
+        let http = match endpoint.host() {
+            EndpointHost::Loopback => &self.http_loopback,
+            EndpointHost::Remote => &self.http,
+        };
+        let mut builder = http.post(&endpoint.url).json(consult);
         if let Some(token) = &endpoint.token {
             builder = builder.bearer_auth(token.reveal());
         }
@@ -813,10 +829,7 @@ mod tests {
     }
 
     fn endpoint(url: &str) -> Implementation {
-        Implementation::Resolver(Endpoint {
-            url: url.to_string(),
-            token: None,
-        })
+        Implementation::Resolver(Endpoint::new(url.to_string(), None))
     }
 
     /// Bindings with `classifier` and `review` dynamic resolvers and the `directory`
@@ -826,10 +839,7 @@ mod tests {
             .iter()
             .flat_map(|url| {
                 ["classifier", "review"].into_iter().map(move |name| {
-                    let endpoint = DynamicImplementation::Resolver(Endpoint {
-                        url: url.to_string(),
-                        token: None,
-                    });
+                    let endpoint = DynamicImplementation::Resolver(Endpoint::new(url.to_string(), None));
                     (name.to_string(), endpoint)
                 })
             })
@@ -1780,10 +1790,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         let mut config = externals(None, 2000, 65536);
         config.authorities.insert(
             "security".to_string(),
-            Implementation::Resolver(Endpoint {
-                url,
-                token: Some(Token::new("sekret".to_string())),
-            }),
+            Implementation::Resolver(Endpoint::new(url, Some(Token::new("sekret".to_string())))),
         );
         let services = services_over(config);
         let outcome = services

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -675,7 +675,11 @@ pub(crate) async fn exchange_with_child(
         biased;
         bytes = &mut output => {
             let bytes = bytes?;
-            wait_for_child_exit(process_group).await?;
+            // The answer is already complete here, so an unobservable exit must not
+            // discard it: `waitid` reports `ECHILD` for a child something else reaped,
+            // and that says nothing about the answer. Whether the child exited well is
+            // still decided by the status `terminate_and_reap` returns to the caller.
+            let _ = wait_for_child_exit(process_group).await;
             Ok(bytes)
         }
         exited = wait_for_child_exit(process_group) => {

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -59,6 +59,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             if let Err(error) = on_actor(runtime, &actor, |session| async move { session.on_turn_end().await }).await {
                 tracing::warn!(root = %actor.root.0, %error, "the turn end closed no abandoned call");
             }
+            runtime.release_vouches(&actor);
             HookDecision::Ack
         }
         HookEvent::ToolCall { actor, call, spawn } => {

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -73,7 +73,6 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             .await
             {
                 Ok(ToolCallDecision::Allow { spawn }) => HookDecision::AllowCall { spawn },
-                Ok(ToolCallDecision::Control) => HookDecision::PassControl,
                 Ok(ToolCallDecision::Deny {
                     feedback,
                     unestablished,

--- a/appa-runtime/tests/cast.rs
+++ b/appa-runtime/tests/cast.rs
@@ -729,3 +729,32 @@ async fn a_silent_classifier_leaves_the_source_unresolved() {
         "the unanswered ask left nothing decided, so the retry resolves it"
     );
 }
+
+/// Two unresolved sources block one call, and their cascades are not the same length: the
+/// web ask has nothing behind its classifier, the files ask has a constant behind its own.
+/// The exhausted ask leaves the other's cascade alone.
+#[tokio::test]
+async fn a_source_with_nothing_left_to_ask_does_not_cancel_the_rest_of_its_batch() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, classifier) = serve_classifier().await;
+    // Silent, and no cast behind it: this ask ends here.
+    classifier.answering("web-classifier", Answer::Down);
+    // Over its ceiling, so the engine refuses it and the ask continues to the constant.
+    classifier.answering("files-classifier", labelled("trusted", serde_json::json!("public")));
+    let runtime = opened(&dir, &url).await;
+
+    for tool in ["read_page", "list_files"] {
+        assert_eq!(propose(&runtime, tool).await, HookDecision::AllowCall { spawn: None });
+        assert_eq!(returned(&runtime, tool, PAGE).await, HookDecision::Ack);
+    }
+
+    assert!(
+        matches!(propose(&runtime, "notify").await, HookDecision::DenyCall { .. }),
+        "the web source stays unresolved, so the sink stays blocked"
+    );
+    assert_eq!(
+        established(&runtime),
+        vec![("files-fallback".to_string(), "suspicious".to_string())],
+        "the files ask reached the constant behind it, though the web ask had nothing left"
+    );
+}

--- a/appa-runtime/tests/loopback_proxy.rs
+++ b/appa-runtime/tests/loopback_proxy.rs
@@ -1,0 +1,148 @@
+//! A loopback endpoint's request must not leave this machine. `HTTP_PROXY` and its
+//! siblings are process-wide and read when a client is built, so this suite owns a
+//! test binary of its own: setting them here cannot disturb any other suite.
+
+mod common;
+use common::{raw, serve};
+
+use std::sync::{Arc, Mutex};
+
+use appa_runtime::api::Runtime;
+use appa_runtime::{config::Config, hooks};
+use appa_runtime_api::{Actor, HookDecision, HookEvent, ProposedCall, TrajectoryId};
+use axum::Router;
+use axum::extract::State;
+use axum::routing::post;
+
+const TOKEN_VAR: &str = "APPA_LOOPBACK_PROXY_TEST_TOKEN";
+const TOKEN: &str = "must-not-be-relayed";
+
+/// The bearer tokens the loopback resolver was presented with.
+#[derive(Clone, Default)]
+struct Seen(Arc<Mutex<Vec<String>>>);
+
+/// A resolver that answers only a request carrying the expected bearer token, and
+/// records every token it is shown.
+async fn serve_resolver() -> (String, Seen) {
+    let seen = Seen::default();
+    let router = Router::new()
+        .route(
+            "/resolve",
+            post(|State(seen): State<Seen>, headers: axum::http::HeaderMap| async move {
+                let bearer = headers
+                    .get(axum::http::header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.strip_prefix("Bearer "))
+                    .unwrap_or_default()
+                    .to_string();
+                seen.0.lock().unwrap().push(bearer.clone());
+                match bearer == TOKEN {
+                    true => (
+                        axum::http::StatusCode::OK,
+                        serde_json::json!({ "version": 1, "answer": { "delta.trust": "trusted" } }).to_string(),
+                    ),
+                    false => (axum::http::StatusCode::FORBIDDEN, "no token".to_string()),
+                }
+            }),
+        )
+        .with_state(seen.clone());
+    (format!("{}/resolve", serve(router).await), seen)
+}
+
+/// A proxy that accepts a connection and drops it. Anything relayed here fails; the
+/// listener stays bound for the test, so no other process can take the port back.
+async fn serve_hostile_proxy() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("an ephemeral loopback port binds");
+    let addr = listener.local_addr().expect("the bound address is readable");
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            drop(stream);
+        }
+    });
+    format!("http://{addr}")
+}
+
+fn policy(url: &str) -> String {
+    format!(
+        r#"
+[policy]
+version = 1
+
+[[policy.dynamic_resolver]]
+name = "classifier"
+returns = ["delta.trust"]
+
+[[policy.tool]]
+name = "fetch"
+description = "Fetches one URL and returns its body."
+parameters = {{ type = "object", properties = {{ url = {{ type = "string" }} }}, required = ["url"] }}
+uses = [{{ resolver = "classifier" }}]
+
+[externals]
+timeout_ms = 2000
+max_body_bytes = 65536
+
+[externals.dynamic.classifier]
+url = "{url}"
+token_env = "{TOKEN_VAR}"
+"#
+    )
+}
+
+#[tokio::test]
+async fn a_token_bearing_loopback_resolver_is_reached_directly_when_a_proxy_is_configured() {
+    let (url, seen) = serve_resolver().await;
+    let proxy = serve_hostile_proxy().await;
+    // Set before the runtime opens: reqwest reads the proxy environment once, when it
+    // builds a client. `ALL_PROXY` covers the cleartext scheme a loopback endpoint uses.
+    unsafe {
+        std::env::set_var("ALL_PROXY", &proxy);
+        std::env::set_var(TOKEN_VAR, TOKEN);
+    }
+
+    let dir = tempfile::tempdir().expect("the fixture directory is created");
+    let path = dir.path().join("appa.toml");
+    std::fs::write(&path, policy(&url)).expect("the fixture writes");
+    let config = Config::load(&path).expect("the fixture validates");
+    let runtime = Arc::new(Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens"));
+    let root = TrajectoryId("loopback-proxy-test".to_string());
+    let actor = Actor {
+        root: root.clone(),
+        child: None,
+    };
+    assert_eq!(
+        hooks::handle(&runtime, HookEvent::SessionStart { root }).await,
+        HookDecision::Ack
+    );
+
+    let decision = hooks::handle(
+        &runtime,
+        HookEvent::ToolCall {
+            actor,
+            call: ProposedCall {
+                tool: "fetch".to_string(),
+                arguments: raw(serde_json::json!({ "url": "https://a.example" })),
+            },
+            spawn: false,
+        },
+    )
+    .await;
+
+    unsafe {
+        std::env::remove_var("ALL_PROXY");
+        std::env::remove_var(TOKEN_VAR);
+    }
+
+    assert_eq!(
+        decision,
+        HookDecision::AllowCall { spawn: None },
+        "the resolver answered, so its consult was not relayed through the proxy"
+    );
+    assert_eq!(
+        seen.0.lock().unwrap().as_slice(),
+        [TOKEN.to_string()],
+        "the resolver itself received the token, and received it exactly once"
+    );
+}

--- a/bench/corp-agent/src/bin/appa_corp_agent.rs
+++ b/bench/corp-agent/src/bin/appa_corp_agent.rs
@@ -292,10 +292,7 @@ fn bind_hosted_externals(config: &mut Config, origin: &str) -> usize {
         if !shim::serves(path) {
             continue;
         }
-        *endpoint = Endpoint {
-            url: format!("{origin}{path}"),
-            token: endpoint.token.clone(),
-        };
+        *endpoint = Endpoint::new(format!("{origin}{path}"), endpoint.token.clone());
         bound += 1;
     }
     bound


### PR DESCRIPTION
Follow-ups from the sweep of `appa-engine` and `appa-runtime`, one cluster per commit.

## Runtime

- A loopback endpoint's request went through whatever `HTTP_PROXY`/`ALL_PROXY` named, carrying the bearer token cleartext is permitted to attach there. reqwest applies an environment proxy to loopback destinations too, which the regression test demonstrates. `Endpoint` derives its host from its own URL, and loopback endpoints take a client built with `.no_proxy()`.
- Two unbounded maps. `permits` took an entry on every control-tool hook and nothing evicted it when the harness declined the call; the turn's end releases what it did not spend. `retired` kept one compiled engine per distinct retired policy for the life of the process; a reload clears it. `retired_engine` also checked and inserted under two separate acquisitions and now inserts through `entry`.
- A complete consult answer was discarded when `waitid` failed for a reason unrelated to it, `ECHILD` included. Whether the child exited well is still decided by the exit status the caller checks.
- `Runtime::live` rewrote log tampering and an unloadable policy as "storage failure". Every variant reachable there is already operational and the caller refuses on any of them, so the mapping decided nothing and only cost the operator the real fault.
- A cast batch was dropped whole by its first already-settled source, against the rule stated three lines above it. See the commit for what this does and does not demonstrate.
- The in-session control-tool guards are deleted. The hook dispatcher short-circuits control tools before any session method runs, and it keeps its own coverage for all three shipped names.

## Engine

- A report arriving after an indeterminate close was refused as contradicting an observation the log does not hold. It gets its own refusal.
- Output-sanitizer coverage is checked per sanitizer and per scope, instead of accepting any sanitizer as long as something somewhere was confined.
- The planner cap counted every in-scope authority carrying a reader ceiling for a literal `contains`, while planning admits only those that can cover it. Authorities capped at readers excluding the recipient inflated the count and could refuse a policy for alternatives that do not exist. Group-bearing declarations stay counted: that answer is not available at load, and ruling them out would undercount.
- A `number` schema could name a constant no legal argument can carry, and past the safe-integer range two distinct authored constants compare equal through `f64`. Both follow from the same missing bound.
- `PolicyIdentityV1::of` and `of_registry` gave one policy two digests, and the whole identity suite went through the one nothing persists. `of` had no caller outside those tests and is deleted. Repointing them made one fail: it had been digesting a configuration the loader refuses.
- An empty plan set is documented as a proof that a block is unliftable, but a contract-lookup miss produced the same empty set. Every caller has the contract already, so it is passed in and the miss is unrepresentable.

## Not included

Four items were investigated and dropped rather than shipped; the reasons are in the review notes on this PR.
