### PR TITLE
fix: derive resolver attention vocabulary from policy

### DIFF
--- a/appa-engine/src/check.rs
+++ b/appa-engine/src/check.rs
@@ -515,7 +515,10 @@ pub(crate) fn validate_tool_resolutions(
         if pinned
             .every_trust()
             .any(|trust| !registry.trust_chain().contains_rank(trust))
-            || pinned.every_mark().iter().any(|mark| !registry.attends(mark))
+            || pinned
+                .every_mark()
+                .iter()
+                .any(|mark| !registry.knows_attention_mark(mark))
         {
             return Err(ToolResolutionRefusal::OutsidePolicy(uses.resolver.as_str().to_string()));
         }
@@ -601,12 +604,11 @@ fn unresolved_recipient(key: &str) -> Audience {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::authority::{Authority, Mandate, Scope};
     use crate::candidate::CallStage;
     use crate::contract::{PinnedToolResolution, RequiredAudience, ResolverReturn, ToolResolverUse};
     use crate::fact::EffectSet;
     use crate::label::{Dim, Label};
-    use crate::names::{AuthorityName, DynamicResolverName, MarkName};
+    use crate::names::{DynamicResolverName, MarkName};
     use crate::params::ToolParameters;
     use crate::registry::{Registry, RegistryConfig, TrustChain};
     use crate::value::ToolName;
@@ -781,22 +783,28 @@ mod tests {
         };
         let registry = Registry::build_covered(RegistryConfig {
             trust_chain: TrustChain::new(vec!["suspicious".into(), "trusted".into()]),
-            tools: vec![contract],
-            authorities: vec![Authority {
-                name: AuthorityName::new("operator"),
-                mandate: Mandate {
-                    trust_ceiling: Some(Trust::new(1)),
-                    attends: vec![MarkName::new("operator-signoff")],
-                    ..Mandate::default()
+            tools: vec![
+                contract,
+                ToolContract {
+                    name: ToolName::new("blocked"),
+                    tags: vec![],
+                    parameters: ToolParameters::open(),
+                    description: Some("A statically blocked tool.".to_string()),
+                    uses: vec![],
+                    delta: Some(crate::contract::Delta::NONE),
+                    emits: EffectSet::default(),
+                    requires: crate::contract::Requires {
+                        attention: vec![MarkName::new("operator-signoff")],
+                        ..Default::default()
+                    },
                 },
-                scope: Scope::default(),
-                hint: None,
-            }],
+            ],
+            authorities: vec![],
             sanitizers: vec![],
             casts: vec![],
             membership: None,
         })
-        .expect("the policy loads");
+        .expect("a policy mark does not require an authority");
         let contract = registry.tool(&ToolName::new("lookup")).expect("the tool is registered");
         let arguments = serde_json::json!({});
         let args = contract.resolver_args_digest(&binding, &arguments);

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -508,6 +508,9 @@ fn worst_case_plan_alternatives(
         );
     }
     if tool.resolver_owns(crate::contract::ResolverReturn::Attention) {
+        // Only dynamic marks with an authority remedy multiply the plan menu. Marks declared
+        // solely by static requirements remain valid resolver outputs, but produce a terminal
+        // gap rather than alternative executable plans.
         let dynamic_marks: BTreeSet<_> = authorities
             .iter()
             .flat_map(|authority| authority.mandate.attends.iter())
@@ -895,10 +898,22 @@ impl Registry {
             }
         }
 
-        let attention_marks = config
-            .authorities
-            .iter()
-            .flat_map(|authority| authority.mandate.attends.iter().cloned())
+        // Attention names are a policy vocabulary, not an authority vocabulary. A policy may
+        // deliberately use a mark as an unremediable denial (for example `blocked`) while
+        // registering no authority at all. Dynamic resolvers must be able to return those marks,
+        // but still remain confined to names the policy declares somewhere.
+        let attention_marks = tools
+            .values()
+            .flatten()
+            .map(|(_, tool)| tool)
+            .chain(provider_run.values())
+            .flat_map(|tool| tool.requires.attention.iter().cloned())
+            .chain(
+                config
+                    .authorities
+                    .iter()
+                    .flat_map(|authority| authority.mandate.attends.iter().cloned()),
+            )
             .collect();
 
         Ok(Registry {
@@ -1019,14 +1034,14 @@ impl Registry {
         &self.authorities
     }
 
-    /// Every attention mark at least one registered authority attends, in stable name order.
-    /// Attention ignores scope, so this policy-wide set is also the complete set a dynamic
-    /// resolver may demand while retaining an in-place authority remedy.
+    /// Every attention mark declared by a static tool requirement or an authority permit, in
+    /// stable name order. This is the closed policy vocabulary a dynamic resolver may return;
+    /// a mark need not have an authority remedy and may deliberately make a call unexecutable.
     pub fn attention_marks(&self) -> impl Iterator<Item = &MarkName> {
         self.attention_marks.iter()
     }
 
-    pub(crate) fn attends(&self, mark: &MarkName) -> bool {
+    pub(crate) fn knows_attention_mark(&self, mark: &MarkName) -> bool {
         self.attention_marks.contains(mark)
     }
 
@@ -1296,6 +1311,21 @@ mod tests {
             scope: Scope::default(),
             hint: None,
         }
+    }
+
+    #[test]
+    fn static_requirements_declare_attention_vocabulary_without_an_authority() {
+        let mut blocked = tool("blocked");
+        blocked.requires.attention = vec![MarkName::new("blocked")];
+        let mut cfg = base();
+        cfg.tools = vec![blocked];
+
+        let registry = Registry::build_covered(cfg).expect("an unremediable attention mark is valid policy");
+
+        assert_eq!(
+            registry.attention_marks().map(MarkName::as_str).collect::<Vec<_>>(),
+            ["blocked"]
+        );
     }
 
     fn audience_sites(reader: &str) -> Vec<(&'static str, RegistryConfig)> {

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -2913,6 +2913,39 @@ mod tests {
         engine.validated(opening, trajectory, 1).expect("the opening validates")
     }
 
+    #[test]
+    fn a_static_policy_mark_reaches_dynamic_consults_without_an_authority() {
+        let policy = appa_policy::Config::from_toml_str(
+            r#"
+                version = 1
+                [[dynamic_resolver]]
+                name = "classifier"
+                returns = ["requires.attention"]
+                [[tool]]
+                name = "classify"
+                description = "Classifies a proposed operation."
+                uses = [{ resolver = "classifier" }]
+                delta = {}
+                [[tool]]
+                name = "blocked"
+                description = "A statically blocked operation."
+                delta = {}
+                requires = { attention = ["blocked"] }
+            "#,
+        )
+        .expect("a closed attention vocabulary does not require an authority");
+        let engine = RuntimeEngine::new(policy.engine().clone());
+        let contract = policy
+            .registry()
+            .variants(&ToolName::new("classify"))
+            .next()
+            .expect("the classifier-backed tool is registered");
+
+        let declaration = engine.dynamic_declaration(&contract.uses[0]);
+
+        assert_eq!(declaration.attention_marks, ["blocked"]);
+    }
+
     fn classifier_policy() -> appa_policy::Config {
         classifier_policy_permitting("privacy-review")
     }
@@ -3098,10 +3131,10 @@ mod tests {
                             "arguments": {"nested": {"id": 7}, "deep": true},
                         })
                     );
-                    // The declaration carries the policy's vocabulary and nothing of the
-                    // trajectory: no current label, no static attention.
+                    // The declaration carries the policy's complete vocabulary and nothing of
+                    // the trajectory: no current label and no call-specific requirements.
                     assert_eq!(declaration.trust_ranks, ["suspicious", "trusted"]);
-                    assert_eq!(declaration.attention_marks, ["privacy-review"]);
+                    assert_eq!(declaration.attention_marks, ["privacy-review", "static-review"]);
                     assert_eq!(
                         declaration.returns,
                         ["delta.trust", "delta.audience", "requires.trust", "requires.audience"]


### PR DESCRIPTION
## Summary

- derive the closed resolver attention vocabulary from static tool requirements as well as authority permits
- allow policy-declared, intentionally unremediable attention marks when no authority is configured
- keep resolver answers confined to declared policy marks and retain authority-only remedy planning
- add engine and runtime regression coverage

## Validation

- cargo test -p appa-engine: 507 passed
- cargo test -p appa-runtime --lib: 209 passed
- cargo test -p appa-policy: 41 passed across unit and integration tests
- cargo clippy for appa-engine and appa-runtime with warnings denied
- cargo fmt check
