### PR TITLE
eventlog: gate diagnosis, damage test, dead ceremony

### DIFF
--- a/appa-eventlog/src/lib.rs
+++ b/appa-eventlog/src/lib.rs
@@ -191,11 +191,16 @@ impl LogStore {
                      );",
                 )?;
                 transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
-            } else if version != SCHEMA_VERSION || !has_schema(&transaction)? {
+            } else if version != SCHEMA_VERSION {
                 return Err(OpenError::ForeignSchema {
                     path,
                     found: version,
                     expected: SCHEMA_VERSION,
+                });
+            } else if !has_schema(&transaction)? {
+                return Err(OpenError::Damaged {
+                    path,
+                    detail: "stamped at this build's schema version, but its tables are missing".to_string(),
                 });
             }
             transaction.commit()?;
@@ -708,6 +713,21 @@ mod tests {
                 assert_eq!((found, expected), (SCHEMA_VERSION + 1, SCHEMA_VERSION));
             }
             other => panic!("expected a schema refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_stamped_database_without_its_tables_is_damaged() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let path = dir.path().join("appa.db");
+        Connection::open(&path)
+            .expect("the file opens")
+            .pragma_update(None, "user_version", SCHEMA_VERSION)
+            .expect("the stamp lands");
+
+        match LogStore::open(Backend::Sqlite { path }).err() {
+            Some(OpenError::Damaged { .. }) => {}
+            other => panic!("expected a damage refusal, got {other:?}"),
         }
     }
 

--- a/appa-eventlog/src/lib.rs
+++ b/appa-eventlog/src/lib.rs
@@ -149,7 +149,7 @@ impl LogStore {
     /// Open the log. A fresh database gets the schema and its version stamp; an existing one is
     /// checked for damage and for a version this build understands, and refused otherwise.
     pub fn open(backend: Backend) -> Result<LogStore, OpenError> {
-        let (connection, path) = match &backend {
+        let (mut connection, path) = match &backend {
             Backend::Sqlite { path } => (Connection::open(path)?, path.display().to_string()),
             Backend::Memory => (Connection::open_in_memory()?, ":memory:".to_string()),
         };
@@ -169,7 +169,6 @@ impl LogStore {
             }
         }
 
-        let mut connection = connection;
         {
             let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
             let version: i64 = transaction.query_row("PRAGMA user_version", [], |row| row.get(0))?;

--- a/appa-eventlog/src/lib.rs
+++ b/appa-eventlog/src/lib.rs
@@ -282,7 +282,7 @@ impl LogStore {
             // second process would. It takes the position and records nothing, so this caller's
             // append conflicts on position and replays, and an assertion reads whose write landed
             // from the position rather than from records a later read would have to accept.
-            let foreign = encode(&foreign_batch());
+            let foreign = encode(&[]);
             let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
             let at = position(&transaction, &based_on.root)?;
             transaction.execute(
@@ -373,14 +373,6 @@ impl LogStore {
             .lock()
             .expect("the log store mutex is never poisoned: no panics under the lock")
     }
-}
-
-/// What a raced append's foreign writer records: nothing. A batch takes a log position whether or
-/// not it holds facts, so the race is won — the caller's append conflicts and replays — without
-/// minting a record every later read would then have to accept.
-#[cfg(feature = "fault-injection")]
-fn foreign_batch() -> Vec<Fact> {
-    Vec::new()
 }
 
 #[cfg(feature = "fault-injection")]

--- a/appa-eventlog/src/lib.rs
+++ b/appa-eventlog/src/lib.rs
@@ -168,7 +168,6 @@ impl LogStore {
                 return Err(OpenError::Damaged { path, detail: check });
             }
         }
-        connection.pragma_update(None, "foreign_keys", "ON")?;
 
         let mut connection = connection;
         {

--- a/appa-eventlog/src/lib.rs
+++ b/appa-eventlog/src/lib.rs
@@ -742,7 +742,10 @@ mod tests {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let path = dir.path().join("appa.db");
         std::fs::write(&path, b"not a sqlite database at all").expect("the file writes");
-        assert!(LogStore::open(Backend::Sqlite { path }).is_err());
+        match LogStore::open(Backend::Sqlite { path }).err() {
+            Some(OpenError::Damaged { .. }) => {}
+            other => panic!("expected a damage refusal, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Sweep of `appa-eventlog` (all changes in `appa-eventlog/src/lib.rs`, cut from `17e5c1e`).

- `lib.rs:171` → `PRAGMA foreign_keys = ON` enforced nothing: neither table declares a foreign key. Removed. Reviewer: no findings.
  sweep-key: appa-eventlog/src/lib.rs:171:foreign-keys-pragma-guards-nothing
- `lib.rs:379-385` → `foreign_batch()` was a single-use, feature-gated helper returning `Vec::new()`. Inlined as `encode(&[])`; runtime race tests unchanged and green. Reviewer: no findings.
  sweep-key: appa-eventlog/src/lib.rs:379-385:foreign-batch-passthrough
- `lib.rs:749-755` → `a_damaged_file_is_refused` asserted only `is_err()`, which stays true with the whole `quick_check` probe deleted (the open then fails later as `Storage`). It now matches `OpenError::Damaged`; with the probe deleted it fails. Reviewer: no findings.
  sweep-key: appa-eventlog/src/lib.rs:749-755:damaged-test-asserts-is-err-only
- `lib.rs:195-201` → a database stamped at this build's schema version but missing its tables was refused as `ForeignSchema { found: 1, expected: 1 }` ("is at schema version 1, and this build writes 1"), forwarded verbatim by the runtime. The gate now splits: foreign version → `ForeignSchema`; our version without our tables → `Damaged`. New test `a_stamped_database_without_its_tables_is_damaged` (red before, green after). Reviewer: no findings.
  sweep-key: appa-eventlog/src/lib.rs:195-201:stamped-schema-missing-tables-misreported
- `lib.rs:172` → `let mut connection = connection;` re-bound a value that could have been `mut` from the `match` (nothing before the transaction needs it immutable — `probe` only borrows it); `mut` is now bound where the connection is opened. Reviewer: no findings.
  sweep-key: appa-eventlog/src/lib.rs:172:stranded-connection-rebinding

Assembly review of the full stack: no findings. Validation at tip: `cargo test -p appa-eventlog --all-features` 16/16, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, `cargo test -p appa-runtime` 210/211 (the one failure is `external::tests::command_descendants_are_terminated_after_success_timeout_and_cancellation`, a process-spawn timing wait unrelated to the store; passes 3/3 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxjcXD5bidNNnFRPUCnxss
