### PR TITLE
fix: archestra-style Slack board for the canary verdict

### DIFF
--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -110,6 +110,36 @@ def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -
     return "\n".join(lines) + "\n"
 
 
+def _board(runs: list[ModelSummaries]) -> str:
+    """One monospace row per model × arm; the provider prefix carries no
+    information at a glance, so rows show the bare model name."""
+    rows = [("model", "arm", "utility", "ASR", "err")]
+    for run in runs:
+        for arm_name, label in ((DEFENDED_ARM, "defended"), (EMPTY_ARM, "empty")):
+            summary = run.arm(arm_name)
+            model = run.model.split("/", 1)[-1]
+            if summary is None:
+                rows.append((model, label, "—", "—", "—"))
+            else:
+                rows.append(
+                    (
+                        model,
+                        label,
+                        f"{summary.utility_passed}/{summary.utility_total}",
+                        f"{summary.attacks_succeeded}/{summary.attacks_total}",
+                        str(summary.errors),
+                    )
+                )
+    widths = [max(len(row[column]) for row in rows) for column in range(5)]
+    out = [
+        "  ".join(
+            f"{row[i]:<{widths[i]}}" if i < 2 else f"{row[i]:>{widths[i]}}" for i in range(5)
+        ).rstrip()
+        for row in rows
+    ]
+    return "```\n" + "\n".join(out) + "\n```"
+
+
 def slack_payload(
     runs: list[ModelSummaries], verdict: Verdict, run_id: str, run_url: str | None
 ) -> dict:
@@ -117,13 +147,12 @@ def slack_payload(
         "✅ APPA canary: defended arm clean" if verdict.healthy else "🔥 APPA canary tripped"
     )
     lines = [f"{headline} — run {run_id}"]
-    for run in runs:
-        lines.append(
-            f"{run.model}: defended {_arm_cell(run.arm(DEFENDED_ARM))}"
-            f" | empty {_arm_cell(run.arm(EMPTY_ARM))}"
-        )
-    lines += [f"🔥 {failure}" for failure in verdict.failures]
-    lines += [f"⚠️ {warning}" for warning in verdict.warnings]
+    if verdict.failures:
+        lines.append("failures: " + " · ".join(verdict.failures))
+    if verdict.warnings:
+        lines.append("warnings: " + " · ".join(verdict.warnings))
+    if runs:
+        lines.append(_board(runs))
     if run_url:
-        lines.append(run_url)
+        lines.append(f"<{run_url}|run>")
     return {"text": "\n".join(lines)}

--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -90,7 +90,7 @@ def _arm_cell(summary: AgentSummary | None) -> str:
 
 
 def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -> str:
-    status = "✅ clean" if verdict.healthy else "😞 tripped"
+    status = "✅ passed" if verdict.healthy else "😞 failed"
     lines = [
         f"## APPA nightly canary — {status}",
         "",
@@ -143,9 +143,7 @@ def _board(runs: list[ModelSummaries]) -> str:
 def slack_payload(
     runs: list[ModelSummaries], verdict: Verdict, run_id: str, run_url: str | None
 ) -> dict:
-    headline = (
-        "✅ APPA canary: defended arm clean" if verdict.healthy else "😞 APPA canary tripped"
-    )
+    headline = "✅ APPA canary passed" if verdict.healthy else "😞 APPA canary failed"
     lines = [f"{headline} — run {run_id}"]
     if verdict.failures:
         lines.append("failures: " + " · ".join(verdict.failures))

--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -90,7 +90,7 @@ def _arm_cell(summary: AgentSummary | None) -> str:
 
 
 def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -> str:
-    status = "✅ clean" if verdict.healthy else "🔥 tripped"
+    status = "✅ clean" if verdict.healthy else "😞 tripped"
     lines = [
         f"## APPA nightly canary — {status}",
         "",
@@ -144,7 +144,7 @@ def slack_payload(
     runs: list[ModelSummaries], verdict: Verdict, run_id: str, run_url: str | None
 ) -> dict:
     headline = (
-        "✅ APPA canary: defended arm clean" if verdict.healthy else "🔥 APPA canary tripped"
+        "✅ APPA canary: defended arm clean" if verdict.healthy else "😞 APPA canary tripped"
     )
     lines = [f"{headline} — run {run_id}"]
     if verdict.failures:

--- a/bench/corp/src/bench_corp/cli.py
+++ b/bench/corp/src/bench_corp/cli.py
@@ -218,7 +218,7 @@ def _run_canary(args: argparse.Namespace) -> int:
         print(f"canary warning: {warning}", file=sys.stderr)
     if not verdict.healthy:
         for failure in verdict.failures:
-            print(f"canary tripped: {failure}", file=sys.stderr)
+            print(f"canary failure: {failure}", file=sys.stderr)
         return 1
     return 0
 


### PR DESCRIPTION
Reshapes the canary's Slack message to the compact archestra bench format: emoji headline with run id (✅ passed / 😞 failed), a single `failures:` / `warnings:` line, a monospace model × arm board (utility, ASR, errors) in a code block, and a `run` link. The `err` column counts episodes that did not run to a clean end (provider faults, runtime refusals, timeouts) — task outcomes stay in `utility`/`ASR`. Rendered against the 20260831-115710 run:

```
😞 APPA canary failed — run 20260831-115710
failures: openai/gpt-5.6-luna/appa: 1 episode error(s) · deepseek/deepseek-v4-flash-0731/appa: 3 episode error(s)
model                   arm       utility   ASR  err
gpt-5.6-luna            defended    16/20  0/20    1
gpt-5.6-luna            empty       19/20  6/20    0
deepseek-v4-flash-0731  defended    15/20  0/20    3
deepseek-v4-flash-0731  empty       19/20  8/20    0
run
```