### PR TITLE
fix(init): install the plugin and binary as one coherent bundle

### DIFF
--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: ""
         type: string
+      plugin_sha256:
+        description: SHA-256 of the plugin artifact these binaries must accept
+        required: false
+        default: ""
+        type: string
   workflow_dispatch:
     inputs:
       source_ref:
@@ -90,8 +95,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
+      # The binary accepts only the plugin artifact whose digest it is built
+      # with. Baking it in at compile time is what makes a shipped binary
+      # unable to install any other release's plugin.
       - name: Build binary
         env:
+          APPA_PLUGIN_SHA256: ${{ inputs.plugin_sha256 }}
           RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=+crt-static' || '' }}
           TARGET: ${{ matrix.target }}
         run: cargo build --release --locked --package appa --target "$TARGET"
@@ -130,15 +139,13 @@ jobs:
           EXECUTABLE: ${{ matrix.executable }}
           TARGET: ${{ matrix.target }}
         run: |
+          # Binary only. The plugin ships once, platform-independently, as
+          # appa-plugin-<version>.tar.gz, and init fetches exactly the artifact
+          # whose digest this binary was built with.
           mkdir -p "dist/${ASSET}"
           cp "target/${TARGET}/release/${EXECUTABLE}" "dist/${ASSET}/${EXECUTABLE}"
-          cp -R integrations/claude-code "dist/${ASSET}/claude-code"
-          cp -R batteries "dist/${ASSET}/claude-code/batteries"
-          mkdir -p "dist/${ASSET}/claude-code/website/content/docs"
-          cp website/content/docs/contracts.md "dist/${ASSET}/claude-code/website/content/docs/contracts.md"
           if [[ "$RUNNER_OS" != "Windows" ]]; then
             chmod 755 "dist/${ASSET}/${EXECUTABLE}"
-            chmod 755 "dist/${ASSET}/claude-code/plugin/statusline.sh"
           fi
 
       - name: Package Unix archive
@@ -167,6 +174,19 @@ jobs:
           cd verify
           test -x appa
           ./appa init claude-code --help >/dev/null
+          # [profile.release] pins debug-assertions = false, so neither
+          # debug-only seam is readable here. A release binary that honoured
+          # them could be pointed at another release's plugin.
+          hostile=$(APPA_PLUGIN_SHA256=$(printf 'a%.0s' {1..64}) \
+            APPA_RELEASE_BASE_URL=http://127.0.0.1:9 \
+            APPA_ENDPOINT=http://127.0.0.1:9999 \
+            ./appa init claude-code 2>&1 || true)
+          case "$hostile" in
+            *"development build"*|*"127.0.0.1:9"*)
+              echo "::error::the released binary honoured a debug-only seam: $hostile"
+              exit 1
+              ;;
+          esac
           "./${EXECUTABLE}" runtime >runtime.stdout.log 2>runtime.stderr.log &
           runtime_pid=$!
           cleanup() {
@@ -178,15 +198,6 @@ jobs:
             if health="$(curl --fail --silent --max-time 1 http://127.0.0.1:8787/health 2>/dev/null)"; then
               test "$health" = "ok"
               test -s appa.toml
-              test -f claude-code/.claude-plugin/marketplace.json
-              test -f claude-code/plugin/.claude-plugin/plugin.json
-              test -f claude-code/plugin/.mcp.json
-              test -f claude-code/plugin/hooks/hooks.json
-              test -f claude-code/plugin/hooks/session-context.md
-              test -f claude-code/plugin/skills/appa-guide/SKILL.md
-              test -d claude-code/batteries
-              test -f claude-code/website/content/docs/contracts.md
-              test -x claude-code/plugin/statusline.sh
               exit 0
             fi
             kill -0 "$runtime_pid" 2>/dev/null || break
@@ -246,38 +257,18 @@ jobs:
             if ($LASTEXITCODE -ne 0) {
               throw "Extracted appa.exe does not expose init claude-code"
             }
-            if (-not (Test-Path (Join-Path $package "claude-code/.claude-plugin/marketplace.json"))) {
-              throw "Extracted package does not contain the Claude Code marketplace"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/hooks/hooks.json"))) {
-              throw "Extracted package does not contain the Claude Code plugin"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/.claude-plugin/plugin.json"))) {
-              throw "Extracted package does not contain the Claude Code plugin manifest"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/.mcp.json"))) {
-              throw "Extracted package does not contain the Claude Code MCP configuration"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/hooks/session-context.md"))) {
-              throw "Extracted package does not contain the Claude Code session context"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/hooks/hooks.windows.json"))) {
-              throw "Extracted package does not contain the Windows Claude Code hooks"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/hooks/hook.ps1"))) {
-              throw "Extracted package does not contain the Windows Claude Code hook adapter"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/statusline.ps1"))) {
-              throw "Extracted package does not contain the Windows Claude Code statusline"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/plugin/skills/appa-guide/SKILL.md"))) {
-              throw "Extracted package does not contain the Claude Code appa-guide skill"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/batteries"))) {
-              throw "Extracted package does not contain batteries for appa-guide"
-            }
-            if (-not (Test-Path (Join-Path $package "claude-code/website/content/docs/contracts.md"))) {
-              throw "Extracted package does not contain the contract guide for appa-guide"
+            # A released binary must ignore both debug-only seams: the digest
+            # it accepts is compiled in, so a hostile environment cannot point
+            # it at another release's plugin.
+            $env:APPA_PLUGIN_SHA256 = "a" * 64
+            $env:APPA_RELEASE_BASE_URL = "http://127.0.0.1:9"
+            $env:APPA_ENDPOINT = "http://127.0.0.1:9999"
+            $hostile = (& $cli init claude-code 2>&1 | Out-String)
+            $env:APPA_PLUGIN_SHA256 = $null
+            $env:APPA_RELEASE_BASE_URL = $null
+            $env:APPA_ENDPOINT = $null
+            if ($hostile -match "development build" -or $hostile -match "127\.0\.0\.1:9") {
+              throw "the released binary honoured a debug-only seam: $hostile"
             }
           } finally {
             $process.Refresh()
@@ -287,6 +278,7 @@ jobs:
       - name: Upload package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: ${{ matrix.asset }}
           path: dist/${{ matrix.archive }}
           archive: false
           if-no-files-found: error

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -14,8 +14,7 @@ on:
         type: string
       plugin_sha256:
         description: SHA-256 of the plugin artifact these binaries must accept
-        required: false
-        default: ""
+        required: true
         type: string
   workflow_dispatch:
     inputs:
@@ -26,11 +25,11 @@ on:
         type: string
       plugin_sha256:
         description: >-
-          SHA-256 of the plugin artifact these binaries must accept. Leave empty
-          to build binaries that can only initialize from an explicit
-          --plugin-source; the release workflow always supplies it.
-        required: false
-        default: ""
+          SHA-256 of the plugin artifact these binaries must accept, as the
+          release workflow's plugin-artifact job computes it. Required: a binary
+          built here without one refuses every init that does not pass an
+          explicit --plugin-source, and the package smoke test rejects it.
+        required: true
         type: string
 
 permissions: {}

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -24,6 +24,14 @@ on:
         required: true
         default: main
         type: string
+      plugin_sha256:
+        description: >-
+          SHA-256 of the plugin artifact these binaries must accept. Leave empty
+          to build binaries that can only initialize from an explicit
+          --plugin-source; the release workflow always supplies it.
+        required: false
+        default: ""
+        type: string
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,17 @@ jobs:
       - name: Check plugin shell syntax
         run: |
           sh -n integrations/claude-code/plugin/hooks/ensure-runtime.sh \
-            integrations/claude-code/plugin/statusline.sh
+            integrations/claude-code/plugin/hooks/hook.sh \
+            integrations/claude-code/plugin/hooks/appa-paths.sh \
+            integrations/claude-code/plugin/statusline.sh \
+            scripts/appa-stage-plugin-bundle.sh
 
       - name: Lint plugin shell scripts
-        run: shellcheck -s sh integrations/claude-code/plugin/hooks/ensure-runtime.sh
+        run: |
+          shellcheck -x -s sh integrations/claude-code/plugin/hooks/ensure-runtime.sh \
+            integrations/claude-code/plugin/hooks/hook.sh \
+            integrations/claude-code/plugin/hooks/appa-paths.sh \
+            scripts/appa-stage-plugin-bundle.sh
 
       - name: Validate plugin JSON
         run: |
@@ -77,6 +84,32 @@ jobs:
 
       - name: Rust tests
         run: cargo test --workspace --locked
+
+  macos-deployment-checks:
+    name: macOS Deployment Checks
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Setup Rust
+        run: rustup show
+
+      # Only what is platform-specific here: the config and data directory
+      # rules, the proc_pidpath process discovery the stop set verifies with,
+      # and the hooks a materialized deployment renders. Not a second full
+      # workspace check, clippy and test run.
+      - name: Deployment tests
+        run: |
+          cargo test --locked --package appa --lib init:: -- --include-ignored --skip real_claude
+          cargo test --locked --package appa --lib plugin_bundle::
+          cargo test --locked --package appa --test init_cli
+          cargo test --locked --package appa --test plugin_hooks
+          cargo test --locked --package appa --test rendered_hooks
 
   python-binding-checks:
     name: Python Binding Checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,27 @@ jobs:
             integrations/claude-code/plugin/hooks/appa-paths.sh \
             scripts/appa-stage-plugin-bundle.sh
 
+      # The Windows hook implementation had no check of any kind until a
+      # review found a fail-open bug in it. `pwsh` is preinstalled on the
+      # runner, and its own parser is the authority on what it will run.
+      - name: Lint plugin PowerShell scripts
+        shell: pwsh
+        run: |
+          $failed = $false
+          foreach ($script in @(
+            "integrations/claude-code/plugin/hooks/hook.ps1",
+            "integrations/claude-code/plugin/hooks/appa-paths.ps1",
+            "integrations/claude-code/plugin/statusline.ps1"
+          )) {
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($script, [ref]$null, [ref]$errors) | Out-Null
+            foreach ($error in $errors) {
+              Write-Output "::error file=$script,line=$($error.Extent.StartLineNumber)::$($error.Message)"
+              $failed = $true
+            }
+          }
+          if ($failed) { exit 1 }
+
       - name: Validate plugin JSON
         run: |
           jq -e .hooks integrations/claude-code/plugin/hooks/hooks.json >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,22 +148,67 @@ jobs:
             -c 'credential.helper=!f() { test "$1" = get && printf "%s\n" "username=x-access-token" "password=$RELEASE_PUSH_TOKEN"; }; f' \
             push origin "HEAD:${RELEASE_BRANCH}"
 
+  plugin-artifact:
+    name: Build the plugin artifact
+    if: ${{ needs.release-please.outputs.should_publish == 'true' }}
+    needs: release-please
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      sha256: ${{ steps.package.outputs.sha256 }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The same ref the binaries are built from. `github.sha` would be the
+          # commit that triggered this run, which is not the release tag when
+          # publishing an existing release.
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Package the plugin
+        id: package
+        env:
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          mkdir -p dist
+          sh scripts/appa-stage-plugin-bundle.sh staged
+          tar -C staged -czf "dist/appa-plugin-${VERSION}.tar.gz" .
+          digest=$(sha256sum "dist/appa-plugin-${VERSION}.tar.gz" | cut -d' ' -f1)
+          echo "sha256=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the plugin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: appa-plugin
+          path: dist/appa-plugin-${{ needs.release-please.outputs.version }}.tar.gz
+          archive: false
+          if-no-files-found: error
+          retention-days: 7
+
   build-binaries:
     name: Build release binaries
     if: ${{ needs.release-please.outputs.should_publish == 'true' }}
-    needs: release-please
+    needs:
+      - release-please
+      - plugin-artifact
     permissions:
       contents: read # Required by the reusable workflow to check out the release tag.
     uses: ./.github/workflows/build-appa-runtime-binaries.yml
     with:
       source_ref: ${{ needs.release-please.outputs.tag_name }}
       expected_version: ${{ needs.release-please.outputs.version }}
+      plugin_sha256: ${{ needs.plugin-artifact.outputs.sha256 }}
 
   publish-release:
     name: Publish GitHub release
     if: ${{ needs.release-please.outputs.should_publish == 'true' }}
     needs:
       - release-please
+      - plugin-artifact
       - build-binaries
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -183,9 +228,12 @@ jobs:
         working-directory: dist
         env:
           EXPECTED_VERSION: ${{ needs.release-please.outputs.version }}
+          PLUGIN_SHA256: ${{ needs.plugin-artifact.outputs.sha256 }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           test "$TAG_NAME" = "v${EXPECTED_VERSION}"
+          # Six binary-only platform archives plus the one platform-independent
+          # plugin artifact every binary of this release is built to accept.
           expected_archives=(
             appa-x86_64-unknown-linux-gnu.tar.gz
             appa-aarch64-unknown-linux-gnu.tar.gz
@@ -193,6 +241,7 @@ jobs:
             appa-aarch64-apple-darwin.tar.gz
             appa-x86_64-pc-windows-msvc.zip
             appa-aarch64-pc-windows-msvc.zip
+            "appa-plugin-${EXPECTED_VERSION}.tar.gz"
           )
           for archive in "${expected_archives[@]}"; do
             test -f "$archive" || {
@@ -203,7 +252,14 @@ jobs:
           shopt -s nullglob
           actual_archives=(appa-*.tar.gz appa-*.zip)
           if [ "${#actual_archives[@]}" -ne "${#expected_archives[@]}" ]; then
-            echo "::error::expected exactly 6 release archives, found ${#actual_archives[@]}"
+            echo "::error::expected exactly ${#expected_archives[@]} release archives, found ${#actual_archives[@]}"
+            exit 1
+          fi
+          # The binaries were built with this digest compiled in; a mismatch
+          # here would ship a release whose binaries refuse their own plugin.
+          published=$(sha256sum "appa-plugin-${EXPECTED_VERSION}.tar.gz" | cut -d' ' -f1)
+          if [ "$published" != "$PLUGIN_SHA256" ]; then
+            echo "::error::the published plugin artifact is not the one the binaries accept"
             exit 1
           fi
           sha256sum "${expected_archives[@]}" > SHA256SUMS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,7 @@ dependencies = [
  "appa-runtime-api",
  "axum",
  "clap",
+ "flate2",
  "futures-util",
  "libc",
  "libloading",
@@ -101,6 +108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",
@@ -551,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,10 +727,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1343,6 +1380,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2225,6 +2272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2407,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3054,6 +3118,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ dead_code = "deny"
 # `panic` stays at the default unwind: a module crate built in this workspace
 # needs it to contain a panic at its `extern "C"` boundary (see appa-builtin).
 [profile.release]
+debug-assertions = false
 opt-level = "s"
 lto = "thin"
 codegen-units = 16

--- a/README.md
+++ b/README.md
@@ -65,15 +65,19 @@ fastest way to watch a policy make a decision on real work:
 
 ```sh
 cargo install --path appa-runtime --force
-appa init claude-code
+plugin=$(mktemp -d)/bundle
+sh scripts/appa-stage-plugin-bundle.sh "$plugin"
+appa init claude-code --plugin-source "$plugin"
 ```
 
-Initialization installs the `clappa` launcher beside `appa`.
+A release binary carries the digest of its own release's plugin and needs no
+`--plugin-source`; a build from a checkout has no such digest, so it is given
+the bundle staged from that same checkout.
 
-The native `appa` command installs this checkout's Claude Code plugin, the
-runtime deployment, statusline, and `clappa` launcher. It replaces an existing
-APPA plugin instead of stacking a second copy and preserves an existing policy
-or custom statusline. Start `clappa`, then run `/appa-guide init` to bring the
+The native `appa` command installs the plugin, the runtime deployment,
+statusline, and `clappa` launcher. It replaces an existing APPA plugin instead
+of stacking a second copy and preserves an existing policy or custom
+statusline. Start `clappa`, then run `/appa-guide init` to bring the
 session's MCP servers into the policy. Plain `claude` sessions stay untouched.
 
 ![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](website/public/images/claude-code-blocked-flow.png)

--- a/appa-runtime/Cargo.toml
+++ b/appa-runtime/Cargo.toml
@@ -28,6 +28,7 @@ clap = { version = "4", features = ["derive", "env"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 libloading = "0.9"
 libc = "0.2"
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 rand = "0.10"
 reqwest = { workspace = true }
 # `server` carries the tool macros' schema derive; `transport-streamable-http-server`
@@ -39,6 +40,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
+tar = "0.4"
 tempfile = "3"
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/appa-runtime/README.md
+++ b/appa-runtime/README.md
@@ -13,30 +13,25 @@ re-validates its persisted log before it is trusted.
 
 ## Install
 
-The Claude Code adapter requires the `claude` command and `curl`.
+The Claude Code adapter requires the `claude` command, `curl`, and Cargo when building from a checkout.
 
-From a source checkout, install `appa`, then initialize the harness adapter:
-
-```sh
-cargo install --path appa-runtime --force
-appa init claude-code
-```
-
-From an extracted release archive on POSIX:
+Every `appa` build knows the SHA-256 of the plugin artifact belonging to its own
+release and accepts no other bytes. From an extracted release archive on POSIX,
+init downloads that artifact, verifies it, and caches it:
 
 ```sh
 install -m 755 appa ~/.local/bin/
 appa init claude-code
 ```
 
-Every `appa` build knows the SHA-256 of the plugin artifact belonging to its own
-release and accepts no other bytes. Release builds download that artifact once,
-verify it, and cache it; a build from a checkout has no such digest, refuses to
-download, and asks for `--plugin-source`:
+A build from a checkout has no such digest, refuses to download, and requires an
+explicit source:
 
 ```sh
-sh scripts/appa-stage-plugin-bundle.sh /tmp/appa-plugin
-appa init claude-code --plugin-source /tmp/appa-plugin
+cargo install --path appa-runtime --force
+plugin=$(mktemp -d)/bundle
+sh scripts/appa-stage-plugin-bundle.sh "$plugin"
+appa init claude-code --plugin-source "$plugin"
 ```
 
 The result does not depend on the working directory. It replaces an existing APPA plugin instead of stacking

--- a/appa-runtime/README.md
+++ b/appa-runtime/README.md
@@ -26,12 +26,20 @@ From an extracted release archive on POSIX:
 
 ```sh
 install -m 755 appa ~/.local/bin/
-appa init claude-code --source ./claude-code
+appa init claude-code
 ```
 
-From a checkout, `init` installs that checkout's marketplace. From an extracted
-release it uses the marketplace shipped beside the binaries. Otherwise it uses
-`archestra-ai/OpenAPPA`. It replaces an existing APPA plugin instead of stacking
+Every `appa` build knows the SHA-256 of the plugin artifact belonging to its own
+release and accepts no other bytes. Release builds download that artifact once,
+verify it, and cache it; a build from a checkout has no such digest, refuses to
+download, and asks for `--plugin-source`:
+
+```sh
+sh scripts/appa-stage-plugin-bundle.sh /tmp/appa-plugin
+appa init claude-code --plugin-source /tmp/appa-plugin
+```
+
+The result does not depend on the working directory. It replaces an existing APPA plugin instead of stacking
 another copy, deploys the same `appa` build for its internal `runtime` command, creates `clappa`, installs the
 statusline unless Claude already has a custom one, preserves an existing policy,
 and starts the runtime. The [Claude Code integration guide](../integrations/claude-code/README.md)

--- a/appa-runtime/src/bin/appa.rs
+++ b/appa-runtime/src/bin/appa.rs
@@ -57,9 +57,11 @@ impl Adapter {
 enum Harness {
     /// Install this build's Claude Code plugin and initialize its local deployment.
     ClaudeCode {
-        /// Marketplace source. Defaults to this checkout/package, then the OpenAPPA repository.
+        /// Development override: a marketplace root to deploy instead of this
+        /// build's own release plugin. Without it, init installs only the
+        /// plugin artifact whose digest this binary was built with.
         #[arg(long)]
-        source: Option<String>,
+        plugin_source: Option<String>,
     },
 }
 
@@ -77,8 +79,8 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Command::Init {
-            harness: Harness::ClaudeCode { source },
-        } => match appa_runtime::init::claude_code(source.as_deref()) {
+            harness: Harness::ClaudeCode { plugin_source },
+        } => match appa_runtime::init::claude_code(plugin_source.as_deref()) {
             Ok(description) => {
                 print!("{description}");
                 ExitCode::SUCCESS

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -11,9 +11,12 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+use crate::plugin_bundle::{
+    self, Deployment, Endpoint, Population, PluginBundleError, PluginSource,
+};
+
 const MARKETPLACE: &str = "appa";
 const PLUGIN: &str = "appa-runtime@appa";
-const REMOTE_MARKETPLACE: &str = "archestra-ai/OpenAPPA";
 const RECOVERY_PREFIX: &str = ".appa-init-recovery-";
 const DEFAULT_CONFIG: &str = include_str!("../../integrations/claude-code/examples/claude-code.appa.toml");
 
@@ -27,8 +30,6 @@ pub enum InitError {
     ClaudeUnavailable(std::io::Error),
     #[error("`claude {command}` failed: {message}")]
     ClaudeCommand { command: String, message: String },
-    #[error("the local Claude Code marketplace at {0} is incomplete")]
-    InvalidMarketplace(PathBuf),
     #[error("cannot install the runtime at {path}: {source}")]
     InstallRuntime { path: PathBuf, source: std::io::Error },
     #[error("cannot initialize {path}: {source}")]
@@ -47,38 +48,19 @@ pub enum InitError {
     MissingPluginFile(PathBuf),
     #[error("the installed Claude plugin could not start `appa runtime`: {0}")]
     Starter(String),
-    #[error("the runtime at 127.0.0.1:8787 is not this installed build: {0}")]
-    RuntimeIdentity(String),
+    #[error("the runtime at {endpoint} is not this installed build: {message}")]
+    RuntimeIdentity { endpoint: String, message: String },
+    #[error(
+        "a previous appa runtime (pid {pid}) is still executing {path}; stop it and rerun init"
+    )]
+    RuntimeSurvived { pid: i32, path: PathBuf },
+    #[error(transparent)]
+    PluginBundle(#[from] PluginBundleError),
     #[error("{operation}; restoring the previous Claude Code plugin also failed: {recovery}")]
     PluginRecovery {
         operation: Box<InitError>,
         recovery: Box<InitError>,
     },
-}
-
-#[derive(Clone)]
-enum MarketplaceSource {
-    Local(PathBuf),
-    Remote(String),
-}
-
-impl MarketplaceSource {
-    fn command_argument(&self) -> &OsStr {
-        match self {
-            Self::Local(path) => path.as_os_str(),
-            Self::Remote(source) => source.as_ref(),
-        }
-    }
-
-    fn label(&self) -> String {
-        match self {
-            Self::Local(path) if env::current_dir().is_ok_and(|current| current.starts_with(path)) => {
-                "current checkout".to_owned()
-            }
-            Self::Local(path) => friendly_path(path),
-            Self::Remote(source) => source.clone(),
-        }
-    }
 }
 
 struct DeploymentPaths {
@@ -93,39 +75,80 @@ pub fn installed_config_path() -> PathBuf {
     installed_config_dir().map_or_else(|| PathBuf::from("appa.toml"), |dir| dir.join("appa.toml"))
 }
 
-/// Install this build and this checkout's adapter into Claude Code.
+/// Install the plugin belonging to this binary's own release into Claude Code,
+/// together with this binary, as one bundle.
+///
+/// The sequence is ordered so that nothing outside a temporary file changes
+/// until the plugin source has been resolved and verified, and so that the
+/// endpoint is cleared before any mutation rather than after Claude has been
+/// switched over.
 pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     let appa = env::current_exe().map_err(InitError::CurrentExecutable)?;
-    let source = resolve_marketplace_source(explicit_source, &appa)?;
+    let endpoint = Endpoint::resolve()?;
+
+    // 1. Resolve and verify the source. Nothing outside a temp file has changed.
+    let source = PluginSource::resolve(explicit_source)?;
     let paths = deployment_paths()?;
     let installations = installed_plugin_installations(&paths.claude_dir)?;
     let marketplaces = run_claude(["plugin", "marketplace", "list"])?;
 
-    fs::create_dir_all(&paths.install_dir).map_err(|source| InitError::InstallRuntime {
-        path: paths.install_dir.clone(),
-        source,
-    })?;
-    let deployed_appa = paths.install_dir.join(appa_filename());
-
-    fs::create_dir_all(&paths.config_dir).map_err(|source| InitError::WriteFile {
-        path: paths.config_dir.clone(),
-        source,
-    })?;
-    fs::create_dir_all(&paths.data_dir).map_err(|source| InitError::WriteFile {
-        path: paths.data_dir.clone(),
-        source,
-    })?;
+    // 2. Directories, and the config that survives every upgrade.
+    for directory in [&paths.install_dir, &paths.config_dir, &paths.data_dir] {
+        fs::create_dir_all(directory).map_err(|source| InitError::WriteFile {
+            path: directory.clone(),
+            source,
+        })?;
+    }
+    let deployed_appa = paths.data_dir.join("bin").join(appa_filename());
+    fs::create_dir_all(deployed_appa.parent().expect("the deployed binary has a parent"))
+        .map_err(|source| InitError::InstallRuntime {
+            path: deployed_appa.clone(),
+            source,
+        })?;
     let config = paths.config_dir.join("appa.toml");
     let config_created = create_default_config(&config)?;
+
+    // 3. Materialize the deployment, or validate and reuse an existing one.
+    let cache_dir = paths.data_dir.join("cache").join("plugin");
+    let archive = match &source {
+        PluginSource::Explicit(_) => None,
+        PluginSource::Release(digest) => Some(plugin_bundle::ensure_archive(
+            *digest,
+            env!("CARGO_PKG_VERSION"),
+            &cache_dir,
+            &plugin_bundle::release_base_url(),
+        )?),
+    };
+    let population = match (&source, &archive) {
+        (PluginSource::Explicit(path), _) => Population::Tree(path),
+        (_, Some(archive)) => Population::Archive(archive),
+        (PluginSource::Release(_), None) => unreachable!("a release source always resolves an archive"),
+    };
+    let deployment = plugin_bundle::materialize(
+        population,
+        &paths.data_dir.join("deployments"),
+        &deployed_appa,
+        &config,
+        &paths.data_dir,
+        &endpoint,
+    )?;
+
+    // 4. Clear the endpoint before anything is mutated. A verified runtime at a
+    //    retired install path that will not stop aborts init here, rather than
+    //    leaving a new plugin registered against an old runtime that a rerun
+    //    cannot dislodge.
+    clear_retired_runtime(&paths)?;
+
+    // 5. Snapshot for recovery and disarm the launcher.
     let launcher_dir = appa.parent().unwrap_or(&paths.install_dir);
     let recovery = prepare_plugin_recovery(&installations, &paths.data_dir)?;
-
     if recovery.is_some() {
         install_disabled_clappa(launcher_dir)?;
     }
 
-    let replacement =
-        replace_plugin(&source, &marketplaces, &installations).and_then(|()| install_runtime(&appa, &deployed_appa));
+    // 6. The Claude switch and the binary, with the existing rollback.
+    let replacement = replace_plugin(&deployment.root, &marketplaces, &installations)
+        .and_then(|()| install_runtime(&appa, &deployed_appa));
     if let Err(operation) = replacement {
         if let Some(recovery) = recovery.as_ref()
             && let Err(recovery_error) = restore_plugin(recovery).and_then(|()| install_clappa(launcher_dir).map(drop))
@@ -140,22 +163,48 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
 
     remove_legacy_runtime(&appa, &paths)?;
 
+    // 7. Launcher, statusline, runtime, and the fingerprint backstop.
     let plugin_root = installed_plugin_root(&paths.claude_dir)?;
-    activate_platform_hooks(&plugin_root)?;
     install_clappa(launcher_dir)?;
-    install_statusline(&plugin_root, &paths)?;
-    start_runtime(&plugin_root, &paths, &deployed_appa)?;
+    install_statusline(&plugin_root, &paths, &endpoint)?;
+    start_runtime(&plugin_root, &deployed_appa, &endpoint)?;
     cleanup_plugin_recoveries(&paths.data_dir);
 
+    // 8. Anything left on PATH that this init did not deploy is named, never
+    //    removed: it is the user's file to keep or drop.
+    let stale_path_copy = stale_path_copy(&paths, &deployed_appa);
+
     Ok(render_receipt(
-        &source.label(),
+        &source_label(&source, &deployment),
         &config,
         config_created,
+        stale_path_copy.as_deref(),
         std::io::stdout().is_terminal() && env::var_os("NO_COLOR").is_none(),
     ))
 }
 
-fn render_receipt(adapter: &str, config: &Path, config_created: bool, color: bool) -> String {
+fn source_label(source: &PluginSource, deployment: &Deployment) -> String {
+    let origin = match source {
+        PluginSource::Explicit(path) => format!("{} (development source)", friendly_path(path)),
+        PluginSource::Release(_) => format!("appa {} release plugin", env!("CARGO_PKG_VERSION")),
+    };
+    format!("{origin} -> {}", friendly_path(&deployment.root))
+}
+
+/// A copy of `appa` at the retired install path, which earlier versions
+/// deployed to and which may still shadow this build on PATH.
+fn stale_path_copy(paths: &DeploymentPaths, deployed: &Path) -> Option<PathBuf> {
+    let retired = paths.install_dir.join(appa_filename());
+    (retired.is_file() && !same_file(&retired, deployed)).then_some(retired)
+}
+
+fn render_receipt(
+    adapter: &str,
+    config: &Path,
+    config_created: bool,
+    stale_path_copy: Option<&Path>,
+    color: bool,
+) -> String {
     let title = if color {
         "\u{1b}[1;32m✓ OpenAPPA initialized\u{1b}[0m \u{1b}[2mfor Claude Code\u{1b}[0m"
     } else {
@@ -168,8 +217,8 @@ fn render_receipt(adapter: &str, config: &Path, config_created: bool, color: boo
             format!("{name:<9}")
         }
     };
-    format!(
-        "{title}\n\n  {} {adapter}\n  {} {PLUGIN}\n  {} healthy\n  {} {} ({})\n  {} clappa\n\nNext: run `clappa`, then `/appa-guide init`.\n",
+    let mut receipt = format!(
+        "{title}\n\n  {} {adapter}\n  {} {PLUGIN}\n  {} healthy\n  {} {} ({})\n  {} clappa\n",
         label("Adapter"),
         label("Plugin"),
         label("Runtime"),
@@ -177,7 +226,19 @@ fn render_receipt(adapter: &str, config: &Path, config_created: bool, color: boo
         friendly_path(config),
         if config_created { "created" } else { "kept" },
         label("Launcher"),
-    )
+    );
+    // A session loads its hooks at session start, and the hook wire carries no
+    // version, so a session running across an upgrade keeps talking to the
+    // runtime it started with.
+    receipt.push_str("\nRestart any running `clappa` session to pick this up.\n");
+    if let Some(stale) = stale_path_copy {
+        receipt.push_str(&format!(
+            "\nA previous appa remains at {}. It is not used any more and may shadow\nthis build on PATH; remove it when you are ready.\n",
+            friendly_path(stale),
+        ));
+    }
+    receipt.push_str("\nNext: run `clappa`, then `/appa-guide init`.\n");
+    receipt
 }
 
 fn friendly_path(path: &Path) -> String {
@@ -191,77 +252,6 @@ fn friendly_path(path: &Path) -> String {
             }
         },
     )
-}
-
-fn resolve_marketplace_source(explicit: Option<&str>, appa: &Path) -> Result<MarketplaceSource, InitError> {
-    if let Some(source) = explicit {
-        let path = PathBuf::from(source);
-        if path.exists() {
-            return local_marketplace(path);
-        }
-        return Ok(MarketplaceSource::Remote(source.to_owned()));
-    }
-
-    if let Ok(current) = env::current_dir() {
-        let mut fallback = None;
-        for ancestor in current.ancestors() {
-            for candidate in [ancestor.to_path_buf(), ancestor.join("integrations/claude-code")] {
-                if marketplace_manifest(&candidate).is_file() {
-                    if candidate.join("batteries").is_dir()
-                        && candidate.join("website/content/docs/contracts.md").is_file()
-                    {
-                        return local_marketplace(candidate);
-                    }
-                    fallback.get_or_insert(candidate);
-                }
-            }
-        }
-        if let Some(candidate) = fallback {
-            return local_marketplace(candidate);
-        }
-    }
-
-    if let Some(parent) = appa.parent() {
-        let packaged = parent.join("claude-code");
-        if marketplace_manifest(&packaged).is_file() {
-            return local_marketplace(packaged);
-        }
-    }
-
-    Ok(MarketplaceSource::Remote(REMOTE_MARKETPLACE.to_owned()))
-}
-
-fn local_marketplace(path: PathBuf) -> Result<MarketplaceSource, InitError> {
-    #[cfg(not(windows))]
-    let path = path.canonicalize().unwrap_or(path);
-    // Windows canonicalization adds a `\\?\` prefix that Claude Code rejects as
-    // an invalid marketplace source. The discovered paths are already absolute,
-    // and an explicit relative path must remain relative to this process.
-    #[cfg(windows)]
-    let path = path;
-    let manifest = marketplace_manifest(&path);
-    let marketplace = fs::read(&manifest)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok());
-    let plugin_source = marketplace
-        .filter(|value| value.get("name").and_then(Value::as_str) == Some(MARKETPLACE))
-        .and_then(|value| {
-            value.get("plugins")?.as_array()?.iter().find_map(|plugin| {
-                (plugin.get("name").and_then(Value::as_str) == Some("appa-runtime"))
-                    .then(|| plugin.get("source").and_then(Value::as_str))
-                    .flatten()
-                    .map(str::to_owned)
-            })
-        })
-        .map(|source| path.join(source.trim_start_matches("./")));
-    let Some(plugin_source) = plugin_source else {
-        return Err(InitError::InvalidMarketplace(path));
-    };
-    if !plugin_source.join(".claude-plugin/plugin.json").is_file() || !plugin_source.join("hooks/hooks.json").is_file()
-    {
-        return Err(InitError::InvalidMarketplace(path));
-    }
-    Ok(MarketplaceSource::Local(path))
 }
 
 fn marketplace_manifest(path: &Path) -> PathBuf {
@@ -442,6 +432,160 @@ fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
 #[cfg(windows)]
 fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
     stop_windows_process_at(target, "appa-runtime")
+}
+
+/// Stop any runtime executing the retired install path before anything is
+/// mutated.
+///
+/// The stop set is exact: `<install_dir>/appa`, the path an init with the
+/// environment resolving as it does now would have deployed to. Managed
+/// stopping and default-endpoint ownership are bounded to that. A runtime left
+/// by an init run under a different `APPA_INSTALL_DIR` or `APPA_DATA_DIR`
+/// executes a path this init never computes, so it is not in the stop set;
+/// `verify_runtime_binary` reports it as a foreign responder and leaves it
+/// running.
+///
+/// A verified target that survives termination aborts init, because the
+/// fingerprint backstop runs after the Claude switch: proceeding would register
+/// the new plugin against an old runtime, and a rerun would find the same
+/// surviving process and do the same thing again.
+fn clear_retired_runtime(paths: &DeploymentPaths) -> Result<(), InitError> {
+    let retired = paths.install_dir.join(appa_filename());
+    match stop_processes_executing(&retired)?.first() {
+        Some(&pid) => Err(InitError::RuntimeSurvived { pid, path: retired }),
+        None => Ok(()),
+    }
+}
+
+/// Terminate every process whose executable *is* `target`, and return those
+/// still alive afterwards.
+///
+/// Discovery starts from `ps`, whose `command` column is argv and therefore
+/// spoofable, so every candidate is verified against the operating system's own
+/// answer for that pid before it is signalled. A pid whose executable cannot be
+/// read is skipped and reported, never killed on argv alone.
+#[cfg(unix)]
+fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
+    let Ok(output) = Command::new("ps").args(["-axo", "pid=,command="]).output() else {
+        return Ok(Vec::new());
+    };
+    if !output.status.success() {
+        // Restricted environments may deny ps. Continue, and let the fingerprint
+        // check report whatever is answering.
+        return Ok(Vec::new());
+    }
+    let Some(identity) = file_identity(target) else {
+        return Ok(Vec::new());
+    };
+
+    // init itself commonly runs from the retired path -- that is what a user
+    // typing `~/.local/bin/appa init claude-code` does -- and it is in the stop
+    // set by every other measure, so it is excluded by pid.
+    let own = std::process::id() as i32;
+    let mut signalled = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Some((pid, _)) = line.trim_start().split_once(char::is_whitespace) else {
+            continue;
+        };
+        let Ok(pid) = pid.parse::<i32>() else {
+            continue;
+        };
+        if pid == own {
+            continue;
+        }
+        match executable_of(pid) {
+            Some(executable) if file_identity(&executable) == Some(identity) => {}
+            // Not this executable, or unreadable: report and skip.
+            _ => continue,
+        }
+        if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return Err(InitError::InstallRuntime {
+                    path: target.to_path_buf(),
+                    source: error,
+                });
+            }
+            continue;
+        }
+        signalled.push(pid);
+    }
+
+    if signalled.is_empty() {
+        return Ok(Vec::new());
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        signalled.retain(|pid| unsafe { libc::kill(*pid, 0) == 0 });
+        if signalled.is_empty() {
+            return Ok(Vec::new());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    signalled.retain(|pid| unsafe { libc::kill(*pid, 0) == 0 });
+    Ok(signalled)
+}
+
+/// OS file identity, so a runtime launched through a symlinked install path is
+/// not wrongly excluded. On Unix `(dev, ino)` is exact, and it identifies hard
+/// links to one file as that file.
+#[cfg(unix)]
+fn file_identity(path: &Path) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = fs::metadata(path).ok()?;
+    Some((metadata.dev(), metadata.ino()))
+}
+
+/// The executable a pid is actually running, from the operating system rather
+/// than from its own argv.
+#[cfg(target_os = "linux")]
+fn executable_of(pid: i32) -> Option<PathBuf> {
+    fs::read_link(format!("/proc/{pid}/exe")).ok()
+}
+
+#[cfg(target_os = "macos")]
+fn executable_of(pid: i32) -> Option<PathBuf> {
+    // PROC_PIDPATHINFO_MAXSIZE
+    const MAX: usize = 4 * libc::PATH_MAX as usize;
+
+    let mut buffer = vec![0u8; MAX];
+    let written =
+        unsafe { libc::proc_pidpath(pid, buffer.as_mut_ptr().cast(), buffer.len() as u32) };
+    if written <= 0 {
+        return None;
+    }
+    buffer.truncate(written as usize);
+    Some(PathBuf::from(String::from_utf8(buffer).ok()?))
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn executable_of(_pid: i32) -> Option<PathBuf> {
+    // No portable primitive here: report and skip rather than kill on argv.
+    None
+}
+
+#[cfg(windows)]
+fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
+    stop_windows_process_at(target, "appa")
+}
+
+/// Whether two paths name the same file, resolving symlinks.
+fn same_file(left: &Path, right: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        match (file_identity(left), file_identity(right)) {
+            (Some(left), Some(right)) => left == right,
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        match (fs::canonicalize(left), fs::canonicalize(right)) {
+            (Ok(left), Ok(right)) => left == right,
+            _ => false,
+        }
+    }
 }
 
 fn install_runtime(source: &Path, target: &Path) -> Result<(), InitError> {
@@ -664,7 +808,7 @@ struct PluginRecovery {
 }
 
 fn replace_plugin(
-    source: &MarketplaceSource,
+    deployment: &Path,
     marketplaces: &Output,
     installations: &[PluginInstallation],
 ) -> Result<(), InitError> {
@@ -681,7 +825,7 @@ fn replace_plugin(
         OsStr::new("plugin"),
         OsStr::new("marketplace"),
         OsStr::new("add"),
-        source.command_argument(),
+        deployment.as_os_str(),
     ])?;
     run_claude(["plugin", "install", PLUGIN, "--scope", "user"])?;
     Ok(())
@@ -840,23 +984,11 @@ fn install_disabled_clappa(install_dir: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
-#[cfg(not(windows))]
-fn activate_platform_hooks(_plugin_root: &Path) -> Result<(), InitError> {
-    Ok(())
-}
-
-#[cfg(windows)]
-fn activate_platform_hooks(plugin_root: &Path) -> Result<(), InitError> {
-    let source = plugin_root.join("hooks/hooks.windows.json");
-    let target = plugin_root.join("hooks/hooks.json");
-    if !source.is_file() {
-        return Err(InitError::MissingPluginFile(source));
-    }
-    fs::copy(&source, &target).map_err(|source| InitError::WriteFile { path: target, source })?;
-    Ok(())
-}
-
-fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(), InitError> {
+fn install_statusline(
+    plugin_root: &Path,
+    paths: &DeploymentPaths,
+    endpoint: &Endpoint,
+) -> Result<(), InitError> {
     #[cfg(windows)]
     let (source, target) = (
         plugin_root.join("statusline.ps1"),
@@ -871,6 +1003,8 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(),
         return Err(InitError::MissingPluginFile(source));
     }
 
+    // The copy lives outside the deployment tree, so the endpoint is rendered
+    // into it here rather than during materialization.
     let settings_path = paths.claude_dir.join("settings.json");
     let mut settings = if settings_path.exists() {
         let bytes = fs::read(&settings_path).map_err(|source| InitError::WriteFile {
@@ -896,6 +1030,9 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(),
         path: target.clone(),
         source,
     })?;
+    // The copy lands outside the deployment tree, so materialization never sees
+    // it and the endpoint is rendered into it here.
+    plugin_bundle::render_endpoint_in_file(&target, endpoint)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -932,7 +1069,7 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(),
     Ok(())
 }
 
-fn start_runtime(plugin_root: &Path, paths: &DeploymentPaths, runtime: &Path) -> Result<(), InitError> {
+fn start_runtime(plugin_root: &Path, runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     #[cfg(windows)]
     let mut command = {
         let starter = plugin_root.join("hooks/hook.ps1");
@@ -955,15 +1092,16 @@ fn start_runtime(plugin_root: &Path, paths: &DeploymentPaths, runtime: &Path) ->
         command.arg(starter);
         command
     };
+    // Every path and the endpoint reach the starter through the appa-paths file
+    // rendered into the deployment beside it. APPA_RUNTIME_URL is removed rather
+    // than set: to a starter it means "the user runs their own runtime here",
+    // and setting it would suppress managed replacement permanently.
     let output = command
-        .env("APPA_INSTALL_DIR", &paths.install_dir)
-        .env("APPA_CONFIG_DIR", &paths.config_dir)
-        .env("APPA_DATA_DIR", &paths.data_dir)
         .env_remove("APPA_RUNTIME_URL")
         .output()
         .map_err(|error| InitError::Starter(error.to_string()))?;
     if output.status.success() {
-        return verify_runtime_binary(runtime);
+        return verify_runtime_binary(runtime, endpoint);
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
     Err(InitError::Starter(if stderr.is_empty() {
@@ -973,34 +1111,37 @@ fn start_runtime(plugin_root: &Path, paths: &DeploymentPaths, runtime: &Path) ->
     }))
 }
 
-fn verify_runtime_binary(runtime: &Path) -> Result<(), InitError> {
+fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     let expected = Sha256::digest(fs::read(runtime).map_err(|source| InitError::InstallRuntime {
         path: runtime.to_path_buf(),
         source,
     })?);
     let expected: String = expected.iter().map(|byte| format!("{byte:02x}")).collect();
     let output = Command::new("curl")
-        .args([
-            "--fail",
-            "--silent",
-            "--max-time",
-            "2",
-            "http://127.0.0.1:8787/binary-fingerprint",
-        ])
+        .args(["--fail", "--silent", "--max-time", "2"])
+        .arg(endpoint.join("/binary-fingerprint"))
         .output()
-        .map_err(|error| InitError::RuntimeIdentity(error.to_string()))?;
+        .map_err(|error| InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: error.to_string(),
+        })?;
     if !output.status.success() {
-        return Err(InitError::RuntimeIdentity(
-            "the answering process exposes no binary fingerprint; stop it and rerun init".to_owned(),
-        ));
+        return Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: "the answering process exposes no binary fingerprint; stop it and rerun init".to_owned(),
+        });
     }
     let actual = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     if actual == expected {
         return Ok(());
     }
-    Err(InitError::RuntimeIdentity(
-        "a different appa build is answering; stop it and rerun init".to_owned(),
-    ))
+    // Managed stopping covers only the paths this environment resolves to. A
+    // runtime left by an init run under a different APPA_INSTALL_DIR or
+    // APPA_DATA_DIR is a foreign responder: named, never killed.
+    Err(InitError::RuntimeIdentity {
+        endpoint: endpoint.url().to_owned(),
+        message: "a different appa build is answering; stop that process and rerun init".to_owned(),
+    })
 }
 
 #[cfg(test)]
@@ -1044,7 +1185,7 @@ mod tests {
         let config = user_home()
             .unwrap_or_else(|| PathBuf::from("/home/user"))
             .join("config/appa.toml");
-        let receipt = render_receipt("current checkout", &config, false, false);
+        let receipt = render_receipt("current checkout", &config, false, None, false);
 
         assert!(receipt.starts_with("OpenAPPA initialized for Claude Code\n\n"));
         assert!(receipt.contains("Adapter   current checkout"));
@@ -1055,7 +1196,7 @@ mod tests {
         assert!(!receipt.contains("appa-runtime (healthy)"));
         assert!(!receipt.contains("\u{1b}["));
 
-        let colored = render_receipt("current checkout", &config, false, true);
+        let colored = render_receipt("current checkout", &config, false, None, true);
         assert!(colored.starts_with("\u{1b}[1;32m✓ OpenAPPA initialized\u{1b}[0m"));
     }
 }

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -469,13 +469,27 @@ fn clear_retired_runtime(paths: &DeploymentPaths) -> Result<(), InitError> {
     }
 }
 
-/// Terminate every process whose executable *is* `target`, and return those
-/// still alive afterwards.
+/// The subcommand a managed runtime is started with, by every starter and by
+/// init itself. It is what distinguishes a runtime from any other invocation of
+/// the same binary.
+#[cfg(unix)]
+const RUNTIME_SUBCOMMAND: &str = "runtime";
+
+/// Terminate every managed runtime whose executable *is* `target`, and return
+/// those still alive afterwards.
 ///
-/// Discovery starts from `ps`, whose `command` column is argv and therefore
-/// spoofable, so every candidate is verified against the operating system's own
-/// answer for that pid before it is signalled. A pid whose executable cannot be
-/// read is skipped and reported, never killed on argv alone.
+/// Two conditions, and a candidate needs both. The executable must be the
+/// retired path, verified against the operating system's own answer for that
+/// pid, because `ps` reports argv and argv is spoofable. And argv must name the
+/// `runtime` subcommand, because the retired binary is also what a concurrent
+/// `appa init` or an in-flight `appa hook` is executing, and terminating those
+/// would interrupt work that has nothing to do with the runtime being replaced.
+/// Argv is only ever narrowing here: it can excuse a process from the stop set,
+/// never admit one the executable check rejected.
+///
+/// Windows applies the executable condition alone. Reading another process's
+/// command line there needs a CIM query rather than `Get-Process`, and the same
+/// helper serves legacy cleanup, whose binary had no subcommand at all.
 #[cfg(unix)]
 fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
     let Ok(output) = Command::new("ps").args(["-axo", "pid=,command="]).output() else {
@@ -496,13 +510,19 @@ fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
     let own = std::process::id() as i32;
     let mut signalled = Vec::new();
     for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let Some((pid, _)) = line.trim_start().split_once(char::is_whitespace) else {
+        let Some((pid, arguments)) = line.trim_start().split_once(char::is_whitespace) else {
             continue;
         };
         let Ok(pid) = pid.parse::<i32>() else {
             continue;
         };
         if pid == own {
+            continue;
+        }
+        // A whole token, so a path that merely contains the word does not match.
+        // The starter runs `<binary> runtime --listen <addr>`, and a binary path
+        // carrying spaces splits into tokens that are all still not `runtime`.
+        if !arguments.split_whitespace().any(|token| token == RUNTIME_SUBCOMMAND) {
             continue;
         }
         match executable_of(pid) {
@@ -1247,15 +1267,20 @@ mod tests {
     #[cfg(unix)]
     const STAND_IN: &str = "/usr/bin/perl";
 
-    /// A process whose executable really *is* `at`, so verification finds it
-    /// there rather than taking a spoofable argv on trust.
+    /// What every starter runs: the subcommand plus the endpoint it binds.
+    #[cfg(unix)]
+    const RUNTIME_ARGUMENTS: &[&str] = &["runtime", "--listen", "127.0.0.1:8787"];
+
+    /// A process whose executable really *is* `at`, started with `arguments`, so
+    /// verification finds it there rather than taking a spoofable argv on trust
+    /// and the stop set sees the argv it decides on.
     ///
     /// The stand-in is reaped on its own thread. A dead child that nobody has
     /// waited for is a zombie, and `kill(pid, 0)` still succeeds on one, so
     /// without the reaper these tests could not tell a stopped process from a
     /// running one. In production the retired runtime is never init's child.
     #[cfg(unix)]
-    fn process_executing(at: &Path, ignores_sigterm: bool) -> Option<i32> {
+    fn process_executing(at: &Path, ignores_sigterm: bool, arguments: &[&str]) -> Option<i32> {
         use std::os::unix::fs::PermissionsExt;
 
         if !Path::new(STAND_IN).is_file() {
@@ -1276,6 +1301,7 @@ mod tests {
         let mut child = Command::new(at)
             .args(["-e", &script])
             .arg(&ready)
+            .args(arguments)
             .spawn()
             .expect("the stand-in process starts");
         let pid = child.id() as i32;
@@ -1306,7 +1332,7 @@ mod tests {
     fn a_runtime_at_the_retired_path_is_stopped() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let retired = directory.path().join("bin/appa");
-        let Some(pid) = process_executing(&retired, false) else {
+        let Some(pid) = process_executing(&retired, false, RUNTIME_ARGUMENTS) else {
             return;
         };
 
@@ -1323,7 +1349,7 @@ mod tests {
         // What an init run under a different APPA_INSTALL_DIR or APPA_DATA_DIR
         // leaves behind: a path this environment never computes.
         let elsewhere = directory.path().join("other-install/appa");
-        let Some(pid) = process_executing(&elsewhere, false) else {
+        let Some(pid) = process_executing(&elsewhere, false, RUNTIME_ARGUMENTS) else {
             return;
         };
         let retired = directory.path().join("bin/appa");
@@ -1340,6 +1366,31 @@ mod tests {
         unsafe { libc::kill(pid, libc::SIGKILL) };
     }
 
+    /// What a second `appa init`, or an `appa hook` in flight, looks like: the
+    /// retired executable, doing something that is not serving the endpoint.
+    /// Terminating it would interrupt work unrelated to the runtime being
+    /// replaced -- and killing a concurrent init mid-switch is the worst of
+    /// them, because the Claude plugin replacement it is performing is not
+    /// atomic.
+    #[cfg(unix)]
+    #[test]
+    fn another_invocation_of_the_retired_binary_is_left_alone() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let retired = directory.path().join("bin/appa");
+        let Some(pid) = process_executing(&retired, false, &["init", "claude-code"]) else {
+            return;
+        };
+
+        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
+
+        assert!(survivors.is_empty());
+        assert!(
+            still_running(pid),
+            "the stop set signalled a process that is not a runtime",
+        );
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+
     #[cfg(unix)]
     #[test]
     fn a_verified_runtime_that_refuses_to_die_is_reported() {
@@ -1347,7 +1398,7 @@ mod tests {
         let retired = directory.path().join("bin/appa");
         // Ignores SIGTERM, which is exactly the case that must abort init
         // rather than let a new plugin bind to an old runtime.
-        let Some(pid) = process_executing(&retired, true) else {
+        let Some(pid) = process_executing(&retired, true, RUNTIME_ARGUMENTS) else {
             return;
         };
 
@@ -1365,8 +1416,10 @@ mod tests {
     #[test]
     fn cleanup_stops_an_unlinked_legacy_runtime() {
         let directory = tempfile::tempdir().expect("temporary directory");
+        // The retired daemon was its own binary and took no subcommand; legacy
+        // cleanup matches on the executable path alone.
         let target = directory.path().join("appa-runtime");
-        let Some(pid) = process_executing(&target, false) else {
+        let Some(pid) = process_executing(&target, false, &[]) else {
             return;
         };
         fs::remove_file(target.with_extension("ready")).expect("the readiness marker is removed");

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -431,7 +431,9 @@ fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
 
 #[cfg(windows)]
 fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
-    stop_windows_process_at(target, "appa-runtime")
+    // Legacy cleanup removes the file next, and a surviving process surfaces
+    // there as a failed removal.
+    stop_windows_processes_at(target, "appa-runtime").map(drop)
 }
 
 /// Stop any runtime executing the retired install path before anything is
@@ -567,7 +569,23 @@ fn executable_of(_pid: i32) -> Option<PathBuf> {
 
 #[cfg(windows)]
 fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
-    stop_windows_process_at(target, "appa")
+    stop_windows_processes_at(target, "appa")
+}
+
+/// The comparison operand on Windows: the fully resolved path, folded for the
+/// case-insensitive filesystem.
+///
+/// Both sides are canonicalized, rather than trusting `Get-Process.Path` to
+/// return one particular form. `fs::canonicalize` yields the Win32 final path,
+/// whose extended-length prefix is stripped so the two sides can be compared as
+/// written. This is equality of resolved final paths, not file-ID identity, so
+/// two hard links to one file at different paths compare unequal -- a gap named
+/// in the deployment documentation rather than papered over.
+#[cfg(windows)]
+fn windows_identity(path: &Path) -> Option<String> {
+    let canonical = fs::canonicalize(path).ok()?;
+    let text = canonical.to_str()?;
+    Some(text.strip_prefix(r"\\?\").unwrap_or(text).to_lowercase())
 }
 
 /// Whether two paths name the same file, resolving symlinks.
@@ -594,7 +612,7 @@ fn install_runtime(source: &Path, target: &Path) -> Result<(), InitError> {
     }
     #[cfg(windows)]
     if target.exists() {
-        stop_windows_process_at(target, "appa")?;
+        stop_windows_processes_at(target, "appa")?;
         fs::remove_file(target).map_err(|source| InitError::InstallRuntime {
             path: target.to_path_buf(),
             source,
@@ -628,30 +646,100 @@ fn install_runtime(source: &Path, target: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
+/// Terminate every `process_name` process whose resolved executable is
+/// `target`, and answer with those still alive afterwards.
+///
+/// PowerShell only enumerates and stops. The comparison happens here, so
+/// Windows and Unix apply the same rule and neither swallows a discovery or
+/// termination failure the way `-ErrorAction SilentlyContinue` did.
 #[cfg(windows)]
-fn stop_windows_process_at(target: &Path, process_name: &str) -> Result<(), InitError> {
-    let output = Command::new("powershell.exe")
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-Command",
-            "$target = $env:APPA_RUNTIME_REPLACE_TARGET; $name = $env:APPA_RUNTIME_REPLACE_NAME; Get-Process -Name $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -eq $target } | Stop-Process -Force -ErrorAction SilentlyContinue; exit 0",
-        ])
-        .env("APPA_RUNTIME_REPLACE_TARGET", target)
-        .env("APPA_RUNTIME_REPLACE_NAME", process_name)
-        .output()
-        .map_err(|source| InitError::InstallRuntime {
-            path: target.to_path_buf(),
-            source,
-        })?;
-    if output.status.success() {
-        return Ok(());
+fn stop_windows_processes_at(target: &Path, process_name: &str) -> Result<Vec<i32>, InitError> {
+    let Some(identity) = windows_identity(target) else {
+        // A path that will not resolve is reported and skipped, never killed.
+        return Ok(Vec::new());
+    };
+
+    let listed = powershell(
+        "Get-Process -Name $env:APPA_STOP_NAME -ErrorAction SilentlyContinue | \
+         ForEach-Object { \"$($_.Id)`t$($_.Path)\" }",
+        [("APPA_STOP_NAME", process_name.to_owned())],
+    )?;
+
+    let own = std::process::id() as i32;
+    let mut targets = Vec::new();
+    for line in listed.lines() {
+        let Some((pid, path)) = line.trim_end().split_once('\t') else {
+            continue;
+        };
+        let Ok(pid) = pid.trim().parse::<i32>() else {
+            continue;
+        };
+        // init commonly runs from the retired path itself.
+        if pid == own {
+            continue;
+        }
+        // An empty or access-denied path is reported and skipped.
+        if path.is_empty() {
+            tracing::debug!(pid, "skipping a process whose executable path is unreadable");
+            continue;
+        }
+        if windows_identity(Path::new(path)).as_deref() == Some(identity.as_str()) {
+            targets.push(pid);
+        }
     }
-    // Process discovery is a migration convenience. Continue the install and let
-    // runtime identity verification reject a surviving daemon.
-    Ok(())
+    if targets.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let ids = targets
+        .iter()
+        .map(i32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let survivors = powershell(
+        "$ids = $env:APPA_STOP_IDS -split ',' | ForEach-Object { [int]$_ }; \
+         foreach ($id in $ids) { Stop-Process -Id $id -Force -ErrorAction Stop }; \
+         $deadline = (Get-Date).AddSeconds(10); \
+         while ((Get-Date) -lt $deadline) { \
+           $alive = @($ids | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }); \
+           if ($alive.Count -eq 0) { break }; \
+           Start-Sleep -Milliseconds 200 \
+         }; \
+         $ids | Where-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue }",
+        [("APPA_STOP_IDS", ids)],
+    )?;
+
+    Ok(survivors
+        .lines()
+        .filter_map(|line| line.trim().parse::<i32>().ok())
+        .collect())
+}
+
+/// Run one PowerShell command, surfacing its failure rather than exiting 0.
+#[cfg(windows)]
+fn powershell<const N: usize>(
+    command: &str,
+    environment: [(&str, String); N],
+) -> Result<String, InitError> {
+    let mut process = Command::new("powershell.exe");
+    process.args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        command,
+    ]);
+    for (name, value) in environment {
+        process.env(name, value);
+    }
+    let output = process.output().map_err(|error| InitError::Starter(error.to_string()))?;
+    if !output.status.success() {
+        return Err(InitError::Starter(
+            String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn create_default_config(path: &Path) -> Result<bool, InitError> {

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -147,6 +147,10 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     //    leaving a new plugin registered against an old runtime that a rerun
     //    cannot dislodge.
     clear_retired_runtime(&paths)?;
+    //    Whatever still answers must be the build this init installs. A foreign
+    //    responder cannot be stopped from here, so it is refused now, while
+    //    Claude and the launcher are still untouched.
+    refuse_foreign_endpoint(&appa, &endpoint)?;
 
     // 5. Snapshot for recovery and disarm the launcher.
     let launcher_dir = appa.parent().unwrap_or(&paths.install_dir);
@@ -155,13 +159,20 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         install_disabled_clappa(launcher_dir)?;
     }
 
-    // 6. The Claude switch and the binary, with the existing rollback.
-    let replacement = replace_plugin(&deployment.root, &marketplaces, &installations)
-        .and_then(|()| install_runtime(&appa, &deployed_appa));
-    if let Err(operation) = replacement {
-        if let Some(recovery) = recovery.as_ref()
-            && let Err(recovery_error) = restore_plugin(recovery).and_then(|()| install_clappa(launcher_dir).map(drop))
-        {
+    // 6. The Claude switch, the binary, and the runtime this plugin is being
+    //    bound to: one transaction. Verification is inside it, because a plugin
+    //    left registered against a runtime that failed verification is exactly
+    //    the skew this bundle exists to prevent.
+    let switch = replace_plugin(&deployment.root, &marketplaces, &installations)
+        .and_then(|()| install_runtime(&appa, &deployed_appa))
+        .and_then(|()| remove_legacy_runtime(&appa, &paths))
+        .and_then(|()| installed_plugin_root(&paths.claude_dir))
+        .and_then(|plugin_root| {
+            install_statusline(&plugin_root, &paths)?;
+            start_runtime(&plugin_root, &deployed_appa, &endpoint)
+        });
+    if let Err(operation) = switch {
+        if let Err(recovery_error) = undo_plugin_switch(recovery.as_ref(), launcher_dir) {
             return Err(InitError::PluginRecovery {
                 operation: Box::new(operation),
                 recovery: Box::new(recovery_error),
@@ -170,13 +181,10 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         return Err(operation);
     }
 
-    remove_legacy_runtime(&appa, &paths)?;
-
-    // 7. Launcher, statusline, runtime, and the fingerprint backstop.
-    let plugin_root = installed_plugin_root(&paths.claude_dir)?;
+    // 7. Only now is the launcher armed. Every earlier return leaves `clappa`
+    //    absent on a first install and disabled on an upgrade, so a session
+    //    started against a half-installed bundle cannot be a protected one.
     install_clappa(launcher_dir)?;
-    install_statusline(&plugin_root, &paths)?;
-    start_runtime(&plugin_root, &deployed_appa, &endpoint)?;
     cleanup_plugin_recoveries(&paths.data_dir);
 
     // 8. Anything left on PATH that this init did not deploy is named, never
@@ -1012,6 +1020,24 @@ fn copy_directory(source_path: &Path, target: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
+/// Undo a switch that has already reached Claude.
+///
+/// With a snapshot the previous plugin is restored and its launcher re-armed.
+/// Without one there was no APPA plugin before this init, so the new one is
+/// removed outright rather than left pointing Claude at a runtime this init
+/// could not verify. Both errors reach the caller, which reports them beside
+/// the failure that caused the undo.
+fn undo_plugin_switch(recovery: Option<&PluginRecovery>, launcher_dir: &Path) -> Result<(), InitError> {
+    match recovery {
+        Some(recovery) => restore_plugin(recovery).and_then(|()| install_clappa(launcher_dir).map(drop)),
+        None => {
+            run_claude(["plugin", "uninstall", PLUGIN, "--scope", "user", "--yes"])?;
+            run_claude(["plugin", "marketplace", "remove", MARKETPLACE])?;
+            Ok(())
+        }
+    }
+}
+
 fn restore_plugin(recovery: &PluginRecovery) -> Result<(), InitError> {
     for installation in &recovery.installations {
         let _ = run_claude_in(
@@ -1214,9 +1240,24 @@ fn start_runtime(plugin_root: &Path, runtime: &Path, endpoint: &Endpoint) -> Res
     }))
 }
 
-fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
-    let expected = Sha256::digest(fs::read(runtime).map_err(|source| InitError::InstallRuntime {
-        path: runtime.to_path_buf(),
+/// Who is answering the endpoint, as far as one probe can establish.
+///
+/// Managed stopping covers only the paths this environment resolves to, so a
+/// runtime left by an init run under a different `APPA_INSTALL_DIR` or
+/// `APPA_DATA_DIR` is foreign: named, never killed.
+enum EndpointOwner {
+    /// Nothing answered, or what answered serves no fingerprint. Before the
+    /// start this is the ordinary case; after it, it is a failure.
+    Unidentified,
+    /// The binary whose bytes were offered for comparison.
+    Deployment,
+    /// A different build.
+    Foreign,
+}
+
+fn endpoint_owner(binary: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {
+    let expected = Sha256::digest(fs::read(binary).map_err(|source| InitError::InstallRuntime {
+        path: binary.to_path_buf(),
         source,
     })?);
     let expected: String = expected.iter().map(|byte| format!("{byte:02x}")).collect();
@@ -1229,22 +1270,42 @@ fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), Init
             message: error.to_string(),
         })?;
     if !output.status.success() {
-        return Err(InitError::RuntimeIdentity {
-            endpoint: endpoint.url().to_owned(),
-            message: "the answering process exposes no binary fingerprint; stop it and rerun init".to_owned(),
-        });
+        return Ok(EndpointOwner::Unidentified);
     }
     let actual = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    if actual == expected {
-        return Ok(());
-    }
-    // Managed stopping covers only the paths this environment resolves to. A
-    // runtime left by an init run under a different APPA_INSTALL_DIR or
-    // APPA_DATA_DIR is a foreign responder: named, never killed.
-    Err(InitError::RuntimeIdentity {
-        endpoint: endpoint.url().to_owned(),
-        message: "a different appa build is answering; stop that process and rerun init".to_owned(),
+    Ok(if actual == expected {
+        EndpointOwner::Deployment
+    } else {
+        EndpointOwner::Foreign
     })
+}
+
+/// Refuse a foreign owner while Claude and the launcher are still untouched.
+///
+/// Silence is not refused here: nothing answering is what a first install looks
+/// like, and the backstop after the start is what proves the runtime is ours.
+fn refuse_foreign_endpoint(binary: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+    match endpoint_owner(binary, endpoint)? {
+        EndpointOwner::Deployment | EndpointOwner::Unidentified => Ok(()),
+        EndpointOwner::Foreign => Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: "a different appa build already owns this endpoint; stop that process and rerun init".to_owned(),
+        }),
+    }
+}
+
+fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+    match endpoint_owner(runtime, endpoint)? {
+        EndpointOwner::Deployment => Ok(()),
+        EndpointOwner::Unidentified => Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: "the answering process exposes no binary fingerprint; stop it and rerun init".to_owned(),
+        }),
+        EndpointOwner::Foreign => Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: "a different appa build is answering; stop that process and rerun init".to_owned(),
+        }),
+    }
 }
 
 #[cfg(test)]

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -175,7 +175,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     // 7. Launcher, statusline, runtime, and the fingerprint backstop.
     let plugin_root = installed_plugin_root(&paths.claude_dir)?;
     install_clappa(launcher_dir)?;
-    install_statusline(&plugin_root, &paths, &endpoint)?;
+    install_statusline(&plugin_root, &paths)?;
     start_runtime(&plugin_root, &deployed_appa, &endpoint)?;
     cleanup_plugin_recoveries(&paths.data_dir);
 
@@ -1096,7 +1096,7 @@ fn install_disabled_clappa(install_dir: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
-fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths, endpoint: &Endpoint) -> Result<(), InitError> {
+fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(), InitError> {
     #[cfg(windows)]
     let (source, target) = (
         plugin_root.join("statusline.ps1"),
@@ -1111,8 +1111,6 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths, endpoint: &En
         return Err(InitError::MissingPluginFile(source));
     }
 
-    // The copy lives outside the deployment tree, so the endpoint is rendered
-    // into it here rather than during materialization.
     let settings_path = paths.claude_dir.join("settings.json");
     let mut settings = if settings_path.exists() {
         let bytes = fs::read(&settings_path).map_err(|source| InitError::WriteFile {
@@ -1138,9 +1136,6 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths, endpoint: &En
         path: target.clone(),
         source,
     })?;
-    // The copy lands outside the deployment tree, so materialization never sees
-    // it and the endpoint is rendered into it here.
-    plugin_bundle::render_endpoint_in_file(&target, endpoint)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1148,29 +1148,154 @@ fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), Init
 mod tests {
     use super::*;
 
+    /// A stand-in the stop set can actually find and signal.
+    ///
+    /// macOS kills a copied platform binary outright -- a copy of `/bin/sh` or
+    /// `/bin/sleep` dies with SIGKILL before it runs a single instruction -- so
+    /// a test built on one would pass without ever exercising the stop set,
+    /// because a killed process is also a stopped one. `perl` copies and runs,
+    /// and can be told to ignore SIGTERM, which is the case that must abort
+    /// init rather than be assumed gone.
+    #[cfg(unix)]
+    const STAND_IN: &str = "/usr/bin/perl";
+
+    /// A process whose executable really *is* `at`, so verification finds it
+    /// there rather than taking a spoofable argv on trust.
+    ///
+    /// The stand-in is reaped on its own thread. A dead child that nobody has
+    /// waited for is a zombie, and `kill(pid, 0)` still succeeds on one, so
+    /// without the reaper these tests could not tell a stopped process from a
+    /// running one. In production the retired runtime is never init's child.
+    #[cfg(unix)]
+    fn process_executing(at: &Path, ignores_sigterm: bool) -> Option<i32> {
+        use std::os::unix::fs::PermissionsExt;
+
+        if !Path::new(STAND_IN).is_file() {
+            return None;
+        }
+        fs::create_dir_all(at.parent().expect("a parent")).expect("the directory exists");
+        fs::copy(STAND_IN, at).expect("the stand-in executable is copied");
+        fs::set_permissions(at, fs::Permissions::from_mode(0o755)).expect("the stand-in is executable");
+
+        // The stand-in announces itself by creating a file. Waiting on a signal
+        // it sends is the only reliable liveness proof here: a copied binary the
+        // platform refuses to run leaves a zombie that `kill(pid, 0)` still
+        // reports as alive, so checking the pid would accept a process that
+        // never ran.
+        let ready = at.with_extension("ready");
+        let disposition = if ignores_sigterm {
+            "$SIG{TERM} = 'IGNORE'; "
+        } else {
+            ""
+        };
+        let script = format!(
+            "{disposition}open(my $f, '>', $ARGV[0]) or die; close $f; sleep 30"
+        );
+        let mut child = Command::new(at)
+            .args(["-e", &script])
+            .arg(&ready)
+            .spawn()
+            .expect("the stand-in process starts");
+        let pid = child.id() as i32;
+        std::thread::spawn(move || child.wait());
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            if ready.is_file() {
+                return Some(pid);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        // This platform will not run the stand-in at all. Skip rather than
+        // report a pass that exercised nothing.
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        None
+    }
+
+    /// Whether a pid is still running, once its reaper has had a moment.
+    #[cfg(unix)]
+    fn still_running(pid: i32) -> bool {
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        unsafe { libc::kill(pid, 0) == 0 }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_runtime_at_the_retired_path_is_stopped() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let retired = directory.path().join("bin/appa");
+        let Some(pid) = process_executing(&retired, false) else {
+            return;
+        };
+
+        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
+
+        assert!(survivors.is_empty(), "a stoppable runtime was reported as surviving");
+        assert!(
+            !still_running(pid),
+            "the runtime at the retired path is still running",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_runtime_at_another_path_is_left_alone() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        // What an init run under a different APPA_INSTALL_DIR or APPA_DATA_DIR
+        // leaves behind: a path this environment never computes.
+        let elsewhere = directory.path().join("other-install/appa");
+        let Some(pid) = process_executing(&elsewhere, false) else {
+            return;
+        };
+        let retired = directory.path().join("bin/appa");
+        fs::create_dir_all(retired.parent().expect("a parent")).expect("the retired directory");
+        fs::copy(STAND_IN, &retired).expect("the retired binary exists but runs nothing");
+
+        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
+
+        assert!(survivors.is_empty());
+        assert!(
+            still_running(pid),
+            "a runtime outside the stop set must be left running, not killed",
+        );
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_verified_runtime_that_refuses_to_die_is_reported() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let retired = directory.path().join("bin/appa");
+        // Ignores SIGTERM, which is exactly the case that must abort init
+        // rather than let a new plugin bind to an old runtime.
+        let Some(pid) = process_executing(&retired, true) else {
+            return;
+        };
+
+        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
+
+        assert_eq!(
+            survivors,
+            vec![pid],
+            "a verified target that outlived SIGTERM must be reported, not assumed gone",
+        );
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+
     #[cfg(unix)]
     #[test]
     fn cleanup_stops_an_unlinked_legacy_runtime() {
-        use std::os::unix::fs::PermissionsExt;
-
         let directory = tempfile::tempdir().expect("temporary directory");
         let target = directory.path().join("appa-runtime");
-        fs::copy("/bin/sleep", &target).expect("the legacy executable is copied");
-        fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).expect("the legacy executable is executable");
-        let mut child = Command::new(&target)
-            .arg("5")
-            .spawn()
-            .expect("the legacy process starts");
+        let Some(pid) = process_executing(&target, false) else {
+            return;
+        };
+        fs::remove_file(target.with_extension("ready")).expect("the readiness marker is removed");
         fs::remove_file(&target).expect("Cargo unlinks the installed legacy executable");
-        let reaper = std::thread::spawn(move || child.wait().expect("the legacy process is reaped"));
 
         stop_legacy_runtime_at(&target).expect("legacy cleanup succeeds");
 
-        let status = reaper.join().expect("the reaper joins");
-        assert!(
-            !status.success(),
-            "cleanup must stop the unlinked process before sleep completes"
-        );
+        assert!(!still_running(pid), "cleanup must stop the unlinked process");
     }
 
     #[test]

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -11,9 +11,7 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use crate::plugin_bundle::{
-    self, Deployment, Endpoint, Population, PluginBundleError, PluginSource,
-};
+use crate::plugin_bundle::{self, Deployment, Endpoint, PluginBundleError, PluginSource, Population};
 
 const MARKETPLACE: &str = "appa";
 const PLUGIN: &str = "appa-runtime@appa";
@@ -50,9 +48,7 @@ pub enum InitError {
     Starter(String),
     #[error("the runtime at {endpoint} is not this installed build: {message}")]
     RuntimeIdentity { endpoint: String, message: String },
-    #[error(
-        "a previous appa runtime (pid {pid}) is still executing {path}; stop it and rerun init"
-    )]
+    #[error("a previous appa runtime (pid {pid}) is still executing {path}; stop it and rerun init")]
     RuntimeSurvived { pid: i32, path: PathBuf },
     #[error(transparent)]
     PluginBundle(#[from] PluginBundleError),
@@ -68,6 +64,18 @@ struct DeploymentPaths {
     config_dir: PathBuf,
     data_dir: PathBuf,
     claude_dir: PathBuf,
+}
+
+/// A directory override made absolute, without touching the filesystem.
+///
+/// Overrides are rendered into a deployment's hooks and hashed into its
+/// identity, and a hook runs from whatever working directory Claude was
+/// launched in. A relative override would therefore resolve somewhere else
+/// entirely at hook time, so it is made absolute here, once, before any of that.
+/// This is lexical: no `canonicalize`, no case folding, consistent with
+/// refusing rather than normalizing elsewhere.
+fn absolute_directory(path: PathBuf) -> PathBuf {
+    std::path::absolute(&path).unwrap_or(path)
 }
 
 /// The platform config file used by installed deployments and `appa describe`.
@@ -100,38 +108,39 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         })?;
     }
     let deployed_appa = paths.data_dir.join("bin").join(appa_filename());
-    fs::create_dir_all(deployed_appa.parent().expect("the deployed binary has a parent"))
-        .map_err(|source| InitError::InstallRuntime {
+    fs::create_dir_all(deployed_appa.parent().expect("the deployed binary has a parent")).map_err(|source| {
+        InitError::InstallRuntime {
             path: deployed_appa.clone(),
             source,
-        })?;
+        }
+    })?;
     let config = paths.config_dir.join("appa.toml");
     let config_created = create_default_config(&config)?;
 
     // 3. Materialize the deployment, or validate and reuse an existing one.
-    let cache_dir = paths.data_dir.join("cache").join("plugin");
-    let archive = match &source {
-        PluginSource::Explicit(_) => None,
-        PluginSource::Release(digest) => Some(plugin_bundle::ensure_archive(
-            *digest,
-            env!("CARGO_PKG_VERSION"),
-            &cache_dir,
-            &plugin_bundle::release_base_url(),
-        )?),
+    let deployments = paths.data_dir.join("deployments");
+    let deploy = |population| {
+        plugin_bundle::materialize(
+            population,
+            &deployments,
+            &deployed_appa,
+            &config,
+            &paths.data_dir,
+            &endpoint,
+        )
     };
-    let population = match (&source, &archive) {
-        (PluginSource::Explicit(path), _) => Population::Tree(path),
-        (_, Some(archive)) => Population::Archive(archive),
-        (PluginSource::Release(_), None) => unreachable!("a release source always resolves an archive"),
+    let deployment = match &source {
+        PluginSource::Explicit(path) => deploy(Population::Tree(path))?,
+        PluginSource::Release(digest) => {
+            let archive = plugin_bundle::ensure_archive(
+                *digest,
+                env!("CARGO_PKG_VERSION"),
+                &paths.data_dir.join("cache").join("plugin"),
+                &plugin_bundle::release_base_url(),
+            )?;
+            deploy(Population::Archive(&archive))?
+        }
     };
-    let deployment = plugin_bundle::materialize(
-        population,
-        &paths.data_dir.join("deployments"),
-        &deployed_appa,
-        &config,
-        &paths.data_dir,
-        &endpoint,
-    )?;
 
     // 4. Clear the endpoint before anything is mutated. A verified runtime at a
     //    retired install path that will not stop aborts init here, rather than
@@ -263,7 +272,7 @@ fn deployment_paths() -> Result<DeploymentPaths, InitError> {
     let config_dir = installed_config_dir().ok_or(InitError::MissingHome)?;
     let data_dir = installed_data_dir().ok_or(InitError::MissingHome)?;
     let install_dir = if let Some(path) = env::var_os("APPA_INSTALL_DIR") {
-        PathBuf::from(path)
+        absolute_directory(PathBuf::from(path))
     } else if cfg!(windows) {
         data_dir.join("bin")
     } else {
@@ -271,6 +280,7 @@ fn deployment_paths() -> Result<DeploymentPaths, InitError> {
     };
     let claude_dir = env::var_os("CLAUDE_CONFIG_DIR")
         .map(PathBuf::from)
+        .map(absolute_directory)
         .or_else(|| home.map(|path| path.join(".claude")))
         .ok_or(InitError::MissingHome)?;
     Ok(DeploymentPaths {
@@ -296,7 +306,7 @@ fn user_home() -> Option<PathBuf> {
 
 fn installed_config_dir() -> Option<PathBuf> {
     if let Some(path) = env::var_os("APPA_CONFIG_DIR") {
-        return Some(PathBuf::from(path));
+        return Some(absolute_directory(PathBuf::from(path)));
     }
     #[cfg(target_os = "macos")]
     return env::var_os("HOME")
@@ -317,7 +327,7 @@ fn installed_config_dir() -> Option<PathBuf> {
 
 fn installed_data_dir() -> Option<PathBuf> {
     if let Some(path) = env::var_os("APPA_DATA_DIR") {
-        return Some(PathBuf::from(path));
+        return Some(absolute_directory(PathBuf::from(path)));
     }
     #[cfg(target_os = "macos")]
     return env::var_os("HOME")
@@ -552,8 +562,7 @@ fn executable_of(pid: i32) -> Option<PathBuf> {
     const MAX: usize = 4 * libc::PATH_MAX as usize;
 
     let mut buffer = vec![0u8; MAX];
-    let written =
-        unsafe { libc::proc_pidpath(pid, buffer.as_mut_ptr().cast(), buffer.len() as u32) };
+    let written = unsafe { libc::proc_pidpath(pid, buffer.as_mut_ptr().cast(), buffer.len() as u32) };
     if written <= 0 {
         return None;
     }
@@ -691,11 +700,7 @@ fn stop_windows_processes_at(target: &Path, process_name: &str) -> Result<Vec<i3
         return Ok(Vec::new());
     }
 
-    let ids = targets
-        .iter()
-        .map(i32::to_string)
-        .collect::<Vec<_>>()
-        .join(",");
+    let ids = targets.iter().map(i32::to_string).collect::<Vec<_>>().join(",");
     let survivors = powershell(
         "$ids = $env:APPA_STOP_IDS -split ',' | ForEach-Object { [int]$_ }; \
          foreach ($id in $ids) { Stop-Process -Id $id -Force -ErrorAction Stop }; \
@@ -717,10 +722,7 @@ fn stop_windows_processes_at(target: &Path, process_name: &str) -> Result<Vec<i3
 
 /// Run one PowerShell command, surfacing its failure rather than exiting 0.
 #[cfg(windows)]
-fn powershell<const N: usize>(
-    command: &str,
-    environment: [(&str, String); N],
-) -> Result<String, InitError> {
+fn powershell<const N: usize>(command: &str, environment: [(&str, String); N]) -> Result<String, InitError> {
     let mut process = Command::new("powershell.exe");
     process.args([
         "-NoProfile",
@@ -733,7 +735,9 @@ fn powershell<const N: usize>(
     for (name, value) in environment {
         process.env(name, value);
     }
-    let output = process.output().map_err(|error| InitError::Starter(error.to_string()))?;
+    let output = process
+        .output()
+        .map_err(|error| InitError::Starter(error.to_string()))?;
     if !output.status.success() {
         return Err(InitError::Starter(
             String::from_utf8_lossy(&output.stderr).trim().to_owned(),
@@ -1072,11 +1076,7 @@ fn install_disabled_clappa(install_dir: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
-fn install_statusline(
-    plugin_root: &Path,
-    paths: &DeploymentPaths,
-    endpoint: &Endpoint,
-) -> Result<(), InitError> {
+fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths, endpoint: &Endpoint) -> Result<(), InitError> {
     #[cfg(windows)]
     let (source, target) = (
         plugin_root.join("statusline.ps1"),
@@ -1271,14 +1271,8 @@ mod tests {
         // reports as alive, so checking the pid would accept a process that
         // never ran.
         let ready = at.with_extension("ready");
-        let disposition = if ignores_sigterm {
-            "$SIG{TERM} = 'IGNORE'; "
-        } else {
-            ""
-        };
-        let script = format!(
-            "{disposition}open(my $f, '>', $ARGV[0]) or die; close $f; sleep 30"
-        );
+        let disposition = if ignores_sigterm { "$SIG{TERM} = 'IGNORE'; " } else { "" };
+        let script = format!("{disposition}open(my $f, '>', $ARGV[0]) or die; close $f; sleep 30");
         let mut child = Command::new(at)
             .args(["-e", &script])
             .arg(&ready)
@@ -1319,10 +1313,7 @@ mod tests {
         let survivors = stop_processes_executing(&retired).expect("the stop set runs");
 
         assert!(survivors.is_empty(), "a stoppable runtime was reported as surviving");
-        assert!(
-            !still_running(pid),
-            "the runtime at the retired path is still running",
-        );
+        assert!(!still_running(pid), "the runtime at the retired path is still running",);
     }
 
     #[cfg(unix)]

--- a/appa-runtime/src/lib.rs
+++ b/appa-runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod hook_client;
 pub mod hooks;
 pub mod init;
 pub mod mcp;
+pub mod plugin_bundle;
 #[path = "main.rs"]
 pub mod runtime_cli;
 pub mod tls;

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -65,6 +66,16 @@ pub enum PluginBundleError {
     MalformedArchive { path: PathBuf, reason: String },
     #[error("cannot reserve a working directory under {path}")]
     NoReservation { path: PathBuf },
+    #[error("cannot fetch the plugin artifact from {url}: {reason}")]
+    Fetch { url: String, reason: String },
+    #[error(
+        "the plugin artifact at {url} is not the one this build accepts: expected {expected}, got {actual}"
+    )]
+    DigestMismatch {
+        url: String,
+        expected: PluginDigest,
+        actual: PluginDigest,
+    },
 }
 
 /// The SHA-256 of a plugin artifact: what a binary was built with, and what a
@@ -141,9 +152,18 @@ impl PluginSource {
     /// `--plugin-source` when given, otherwise this build's release artifact.
     /// A development build with neither refuses rather than guessing.
     pub fn resolve(explicit: Option<&str>) -> Result<Self, PluginBundleError> {
+        Self::decide(explicit, expected_plugin_digest())
+    }
+
+    /// The decision itself, with this build's digest supplied rather than read,
+    /// so it is testable without touching the process environment.
+    pub fn decide(
+        explicit: Option<&str>,
+        baked: Option<PluginDigest>,
+    ) -> Result<Self, PluginBundleError> {
         match explicit {
             Some(path) => Ok(Self::Explicit(canonical_source(Path::new(path))?)),
-            None => expected_plugin_digest()
+            None => baked
                 .map(Self::Release)
                 .ok_or(PluginBundleError::NoBakedDigest {
                     version: env!("CARGO_PKG_VERSION"),
@@ -691,9 +711,17 @@ fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundl
             .path()
             .map_err(|error| malformed(format!("unreadable entry path: {error}")))?
             .into_owned();
-        let relative = safe_relative(&path).ok_or_else(|| {
-            malformed(format!("{} escapes the archive root", path.display()))
-        })?;
+        let relative = match safe_relative(&path) {
+            EntryPath::Relative(relative) => relative,
+            // A `./` root entry carries no content of its own.
+            EntryPath::ArchiveRoot => continue,
+            EntryPath::Escaping => {
+                return Err(malformed(format!(
+                    "{} escapes the archive root",
+                    path.display()
+                )));
+            }
+        };
         let target = destination.join(&relative);
         let write = |source: std::io::Error| PluginBundleError::WriteDeployment {
             path: target.clone(),
@@ -730,17 +758,30 @@ fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundl
     Ok(())
 }
 
-/// A relative, traversal-free path, or nothing.
-fn safe_relative(path: &Path) -> Option<PathBuf> {
+/// What an archive entry's path denotes.
+#[derive(Debug, PartialEq, Eq)]
+enum EntryPath {
+    Relative(PathBuf),
+    /// `.` or `./`: the archive root itself, which carries no content.
+    ArchiveRoot,
+    /// Absolute, or climbing out with `..`.
+    Escaping,
+}
+
+fn safe_relative(path: &Path) -> EntryPath {
     let mut relative = PathBuf::new();
     for component in path.components() {
         match component {
             std::path::Component::Normal(part) => relative.push(part),
             std::path::Component::CurDir => {}
-            _ => return None,
+            _ => return EntryPath::Escaping,
         }
     }
-    (!relative.as_os_str().is_empty()).then_some(relative)
+    if relative.as_os_str().is_empty() {
+        EntryPath::ArchiveRoot
+    } else {
+        EntryPath::Relative(relative)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -910,6 +951,191 @@ fn sh_literal(value: &str) -> String {
 /// Total for any UTF-8 path: single-quoted, with embedded `'` doubled.
 fn ps_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
+}
+
+// ---------------------------------------------------------------------------
+// Release artifact fetch and cache
+// ---------------------------------------------------------------------------
+
+const RELEASE_BASE_URL: &str = "https://github.com/archestra-ai/OpenAPPA/releases/download";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const MAX_REDIRECTS: usize = 5;
+/// The archive is a few hundred KB; this bounds a hostile or wrong response.
+const MAX_ARCHIVE_BYTES: u64 = 32 * 1024 * 1024;
+
+fn artifact_name(version: &str) -> String {
+    format!("appa-plugin-{version}.tar.gz")
+}
+
+/// The cache is content-addressed by name, so an entry can never be the wrong
+/// bytes under the right name without the re-hash catching it.
+fn cached_archive_path(cache_dir: &Path, version: &str, digest: PluginDigest) -> PathBuf {
+    cache_dir.join(format!("appa-plugin-{version}-{digest}.tar.gz"))
+}
+
+/// The release download base. `APPA_RELEASE_BASE_URL` overrides it in debug
+/// builds only, and init reads it once at the boundary rather than leaving the
+/// fetch to consult the environment underneath its caller.
+pub fn release_base_url() -> String {
+    let configured = if cfg!(debug_assertions) {
+        env::var("APPA_RELEASE_BASE_URL").ok()
+    } else {
+        None
+    };
+    configured.unwrap_or_else(|| RELEASE_BASE_URL.to_owned())
+}
+
+/// The verified archive for this build's release, from the cache when it is
+/// already there and from the release otherwise.
+///
+/// Every path ends in the same check against the digest this binary was built
+/// with, so the cache cannot be used to bypass a refusal.
+pub fn ensure_archive(
+    digest: PluginDigest,
+    version: &str,
+    cache_dir: &Path,
+    base_url: &str,
+) -> Result<PathBuf, PluginBundleError> {
+    let cached = cached_archive_path(cache_dir, version, digest);
+    if cached.is_file() {
+        match digest_of_file(&cached) {
+            Ok(actual) if actual == digest => return Ok(cached),
+            // A corrupt or truncated cache entry is replaced by a fresh
+            // download rather than trusted or reported as fatal.
+            Ok(_) | Err(_) => {
+                tracing::debug!(path = %cached.display(), "re-fetching a cache entry that no longer matches its digest");
+            }
+        }
+    }
+
+    fs::create_dir_all(cache_dir).map_err(|source| PluginBundleError::WriteDeployment {
+        path: cache_dir.to_path_buf(),
+        source,
+    })?;
+
+    let url = format!("{base_url}/v{version}/{}", artifact_name(version));
+    let incoming = tempfile::NamedTempFile::new_in(cache_dir).map_err(|source| {
+        PluginBundleError::WriteDeployment {
+            path: cache_dir.to_path_buf(),
+            source,
+        }
+    })?;
+    download(&url, incoming.path())?;
+
+    // The check runs against the temp file. Nothing enters the cache before it
+    // passes, so a failed check leaves the cache empty.
+    let actual = digest_of_file(incoming.path())?;
+    if actual != digest {
+        return Err(PluginBundleError::DigestMismatch {
+            url,
+            expected: digest,
+            actual,
+        });
+    }
+
+    incoming
+        .persist(&cached)
+        .map_err(|error| PluginBundleError::WriteDeployment {
+            path: cached.clone(),
+            source: error.error,
+        })?;
+    Ok(cached)
+}
+
+fn digest_of_file(path: &Path) -> Result<PluginDigest, PluginBundleError> {
+    let mut file = fs::File::open(path).map_err(|source| PluginBundleError::ReadSource {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = std::io::Read::read(&mut file, &mut buffer).map_err(|source| {
+            PluginBundleError::ReadSource {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(PluginDigest::from_hasher(hasher))
+}
+
+/// Stream the artifact to `destination`, enforcing the size cap as it goes.
+///
+/// Init is the synchronous CLI path and never runs under an existing reactor, so
+/// this owns a current-thread runtime for the duration of the fetch.
+fn download(url: &str, destination: &Path) -> Result<(), PluginBundleError> {
+    crate::tls::install_crypto_provider();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|source| PluginBundleError::Fetch {
+            url: url.to_owned(),
+            reason: format!("cannot start a runtime for the download: {source}"),
+        })?;
+
+    runtime.block_on(async {
+        let failed = |reason: String| PluginBundleError::Fetch {
+            url: url.to_owned(),
+            reason,
+        };
+        let client = reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::limited(MAX_REDIRECTS))
+            .build()
+            .map_err(|error| failed(error.to_string()))?;
+
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|error| failed(error.to_string()))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(failed(format!("the release responded {status}")));
+        }
+        if let Some(length) = response.content_length()
+            && length > MAX_ARCHIVE_BYTES
+        {
+            return Err(failed(format!(
+                "it declares {length} bytes, more than the {MAX_ARCHIVE_BYTES} accepted"
+            )));
+        }
+
+        let mut file = fs::File::create(destination).map_err(|source| {
+            PluginBundleError::WriteDeployment {
+                path: destination.to_path_buf(),
+                source,
+            }
+        })?;
+        let mut written = 0u64;
+        let mut stream = response;
+        while let Some(chunk) = stream
+            .chunk()
+            .await
+            .map_err(|error| failed(error.to_string()))?
+        {
+            written = written.saturating_add(chunk.len() as u64);
+            if written > MAX_ARCHIVE_BYTES {
+                return Err(failed(format!(
+                    "it exceeds the {MAX_ARCHIVE_BYTES} bytes accepted"
+                )));
+            }
+            std::io::Write::write_all(&mut file, &chunk).map_err(|source| {
+                PluginBundleError::WriteDeployment {
+                    path: destination.to_path_buf(),
+                    source,
+                }
+            })?;
+        }
+        Ok(())
+    })
 }
 
 #[cfg(test)]
@@ -1136,14 +1362,148 @@ mod tests {
         assert_eq!(ps_literal("it's"), "'it''s'");
     }
 
+    /// A one-shot artifact server on an ephemeral loopback port. Serves `body`
+    /// to every request until dropped.
+    fn serve(body: Vec<u8>) -> (String, std::sync::mpsc::Sender<()>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let (stop, stopped) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            for connection in listener.incoming() {
+                if stopped.try_recv().is_ok() {
+                    return;
+                }
+                let Ok(mut connection) = connection else {
+                    return;
+                };
+                let mut scratch = [0u8; 2048];
+                let _ = connection.read(&mut scratch);
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = connection.write_all(header.as_bytes());
+                let _ = connection.write_all(&body);
+                let _ = connection.flush();
+            }
+        });
+        (base, stop)
+    }
+
+    #[test]
+    fn a_verified_download_lands_in_the_cache() {
+        let cache = tempfile::tempdir().unwrap();
+        let body = b"an archive".to_vec();
+        let digest = PluginDigest::of(&body);
+        let (base, _stop) = serve(body);
+
+        let archive = ensure_archive(digest, "9.9.9", cache.path(), &base).unwrap();
+
+        assert_eq!(digest_of_file(&archive).unwrap(), digest);
+        assert!(
+            archive.file_name().unwrap().to_string_lossy().contains(&digest.to_string()),
+            "the cache is content-addressed by name"
+        );
+    }
+
+    #[test]
+    fn a_wrong_artifact_is_refused_and_leaves_the_cache_empty() {
+        let cache = tempfile::tempdir().unwrap();
+        let (base, _stop) = serve(b"someone else's bytes".to_vec());
+        let expected = PluginDigest::of(b"what this build accepts");
+
+        let refused = ensure_archive(expected, "9.9.9", cache.path(), &base);
+
+        assert!(matches!(
+            refused,
+            Err(PluginBundleError::DigestMismatch { .. })
+        ));
+        let leftovers: Vec<_> = fs::read_dir(cache.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(leftovers.is_empty(), "a failed check left {leftovers:?}");
+    }
+
+    #[test]
+    fn a_cached_artifact_is_used_without_a_release_to_reach() {
+        let cache = tempfile::tempdir().unwrap();
+        let body = b"an archive".to_vec();
+        let digest = PluginDigest::of(&body);
+        fs::write(cached_archive_path(cache.path(), "9.9.9", digest), &body).unwrap();
+
+        // Nothing is listening here, so any request would fail.
+        let archive =
+            ensure_archive(digest, "9.9.9", cache.path(), "http://127.0.0.1:1").unwrap();
+
+        assert_eq!(fs::read(archive).unwrap(), body);
+    }
+
+    #[test]
+    fn a_corrupt_cache_entry_is_replaced_rather_than_trusted() {
+        let cache = tempfile::tempdir().unwrap();
+        let body = b"an archive".to_vec();
+        let digest = PluginDigest::of(&body);
+        let path = cached_archive_path(cache.path(), "9.9.9", digest);
+        fs::write(&path, b"corrupted").unwrap();
+
+        let (base, _stop) = serve(body.clone());
+        let archive = ensure_archive(digest, "9.9.9", cache.path(), &base).unwrap();
+
+        assert_eq!(fs::read(archive).unwrap(), body);
+    }
+
+    #[test]
+    fn a_development_build_refuses_to_download() {
+        assert!(matches!(
+            PluginSource::decide(None, None),
+            Err(PluginBundleError::NoBakedDigest { .. })
+        ));
+    }
+
+    #[test]
+    fn an_extracted_archive_materializes() {
+        let source = tempfile::tempdir().unwrap();
+        let deployments = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+
+        let archive = source.path().parent().unwrap().join("bundle.tar.gz");
+        let packed = fs::File::create(&archive).unwrap();
+        let mut builder =
+            tar::Builder::new(flate2::write::GzEncoder::new(packed, flate2::Compression::fast()));
+        builder.append_dir_all(".", source.path()).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let deployment = materialize(
+            Population::Archive(&archive),
+            deployments.path(),
+            Path::new("/data/bin/appa"),
+            Path::new("/config/appa.toml"),
+            Path::new("/data"),
+            &Endpoint::parse(DEFAULT_ENDPOINT_URL).unwrap(),
+        )
+        .unwrap();
+
+        assert!(deployment.root.join("plugin/hooks/hooks.json").is_file());
+        assert!(deployment.root.join(PATHS_SH).is_file());
+        // The platform selection removes the map this platform does not use.
+        assert!(!deployment.root.join(WINDOWS_HOOKS).is_file());
+        fs::remove_file(&archive).unwrap();
+    }
+
     #[test]
     fn extraction_refuses_traversal_and_specials() {
-        assert!(safe_relative(Path::new("../escape")).is_none());
-        assert!(safe_relative(Path::new("/absolute")).is_none());
-        assert!(safe_relative(Path::new("plugin/../../escape")).is_none());
+        for escaping in ["../escape", "/absolute", "plugin/../../escape"] {
+            assert_eq!(safe_relative(Path::new(escaping)), EntryPath::Escaping);
+        }
+        assert_eq!(safe_relative(Path::new(".")), EntryPath::ArchiveRoot);
         assert_eq!(
-            safe_relative(Path::new("./plugin/hooks.json")).unwrap(),
-            PathBuf::from("plugin/hooks.json")
+            safe_relative(Path::new("./plugin/hooks.json")),
+            EntryPath::Relative(PathBuf::from("plugin/hooks.json"))
         );
     }
 }

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 /// Files and directories every plugin source must carry, in the marketplace-root
 /// shape `scripts/appa-stage-plugin-bundle.sh` produces. One validator serves
 /// both source resolution and the reuse check on an existing deployment.
-const REQUIRED_FILES: [&str; 6] = [
+const REQUIRED_FILES: [&str; 8] = [
     ".claude-plugin/marketplace.json",
     "plugin/.claude-plugin/plugin.json",
     "plugin/hooks/hooks.json",
@@ -28,6 +28,12 @@ const REQUIRED_FILES: [&str; 6] = [
     // Materialization keeps both scripts; only the inactive map is removed.
     "plugin/hooks/hook.sh",
     "plugin/hooks/hook.ps1",
+    // Both statuslines, for the same reason and one more: init copies the one
+    // for its platform after the plugin has already been replaced, and Windows
+    // reaches that step without having touched the file at all. Missing here is
+    // a refusal before anything is mutated; missing there is a half-upgrade.
+    "plugin/statusline.sh",
+    "plugin/statusline.ps1",
     "website/content/docs/contracts.md",
 ];
 const REQUIRED_DIRS: [&str; 2] = ["plugin", "batteries"];
@@ -880,25 +886,6 @@ fn render_endpoint(root: &Path, endpoint_url: &str) -> Result<(), PluginBundleEr
     Ok(())
 }
 
-/// Substitute the endpoint into one file outside the deployment tree, such as an
-/// installed statusline copy.
-pub fn render_endpoint_in_file(path: &Path, endpoint: &Endpoint) -> Result<(), PluginBundleError> {
-    if endpoint.url() == DEFAULT_ENDPOINT_URL {
-        return Ok(());
-    }
-    let bytes = fs::read(path).map_err(|source| PluginBundleError::ReadSource {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let Ok(text) = String::from_utf8(bytes) else {
-        return Ok(());
-    };
-    if !text.contains(DEFAULT_ENDPOINT_URL) {
-        return Ok(());
-    }
-    write_file(path, text.replace(DEFAULT_ENDPOINT_URL, endpoint.url()).as_bytes())
-}
-
 fn write_file(path: &Path, bytes: &[u8]) -> Result<(), PluginBundleError> {
     fs::write(path, bytes).map_err(|source| PluginBundleError::WriteDeployment {
         path: path.to_path_buf(),
@@ -1503,6 +1490,28 @@ mod tests {
         // The platform selection removes the map this platform does not use.
         assert!(!deployment.root.join(WINDOWS_HOOKS).is_file());
         fs::remove_file(&archive).unwrap();
+    }
+
+    /// Every required file, refused at validation rather than partway through an
+    /// install. The ones init reaches only after the Claude plugin has already
+    /// been replaced -- the platform statuslines -- are the reason this covers
+    /// the whole list instead of the file some earlier failure happens to reach
+    /// first: on Windows nothing touches `statusline.ps1` until that point, and
+    /// a refusal there would leave a half-upgraded installation.
+    #[test]
+    fn a_source_missing_any_required_file_is_refused() {
+        for missing in REQUIRED_FILES {
+            let source = tempfile::tempdir().unwrap();
+            sample_tree(source.path());
+            fs::remove_file(source.path().join(missing)).unwrap();
+
+            let refused = validate_tree(source.path(), TreeShape::Source);
+
+            assert!(
+                matches!(refused, Err(PluginBundleError::InvalidSource { .. })),
+                "a source without {missing} was accepted",
+            );
+        }
     }
 
     #[test]

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -626,16 +626,20 @@ pub fn materialize(
 
 /// Whether an existing deployment can be reused as-is.
 ///
-/// Structural validation plus a byte comparison of the one generated file. This
-/// is deliberately not a content hash of every file: a tree whose `batteries/`
+/// Structural validation plus a byte comparison of both generated files. Both
+/// are checked on every platform, not just the one whose hooks are active here:
+/// a deployment is a single artifact, and a stale PowerShell paths file would
+/// otherwise survive every rerun performed from a POSIX host. This is
+/// deliberately not a content hash of every file: a tree whose `batteries/`
 /// contents were edited in place is not detected, and init's convergence claim
 /// is scoped to match.
 fn reusable(published: &Path, plan: &DeploymentPlan) -> Result<(), String> {
     validate_tree(published, TreeShape::Deployment).map_err(|error| error.to_string())?;
-    let rendered = published.join(PATHS_SH);
-    let current = fs::read(&rendered).map_err(|error| format!("{PATHS_SH} is unreadable: {error}"))?;
-    if current != paths_sh(plan).into_bytes() {
-        return Err(format!("{PATHS_SH} is stale"));
+    for (name, expected) in [(PATHS_SH, paths_sh(plan)), (PATHS_PS1, paths_ps1(plan))] {
+        let current = fs::read(published.join(name)).map_err(|error| format!("{name} is unreadable: {error}"))?;
+        if current != expected.into_bytes() {
+            return Err(format!("{name} is stale"));
+        }
     }
     Ok(())
 }
@@ -1320,22 +1324,29 @@ mod tests {
         assert!(quarantined[0].path().join("tree").is_dir());
     }
 
+    /// Either generated paths file, whichever platform's hooks are active on the
+    /// host running init. A deployment is one artifact: a PowerShell paths file
+    /// left stale would otherwise survive every rerun performed from POSIX.
     #[test]
     fn a_stale_paths_file_is_repaired_on_rerun() {
-        let source = tempfile::tempdir().unwrap();
-        let deployments = tempfile::tempdir().unwrap();
-        sample_tree(source.path());
+        for (name, damaged, restored) in [
+            (PATHS_SH, "APPA_BIN='/tmp/hostile'\n", "APPA_BIN='/data/bin/appa'"),
+            (PATHS_PS1, "$AppaBin = '/tmp/hostile'\n", "$AppaBin = '/data/bin/appa'"),
+        ] {
+            let source = tempfile::tempdir().unwrap();
+            let deployments = tempfile::tempdir().unwrap();
+            sample_tree(source.path());
 
-        let first = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
-        fs::write(first.root.join(PATHS_SH), "APPA_BIN='/tmp/hostile'\n").unwrap();
+            let first = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+            fs::write(first.root.join(name), damaged).unwrap();
 
-        let repaired = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
-        assert!(!repaired.reused);
-        assert!(
-            fs::read_to_string(repaired.root.join(PATHS_SH))
-                .unwrap()
-                .contains("APPA_BIN='/data/bin/appa'")
-        );
+            let repaired = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+            assert!(!repaired.reused, "{name} was reused while stale");
+            assert!(
+                fs::read_to_string(repaired.root.join(name)).unwrap().contains(restored),
+                "{name} was not restored",
+            );
+        }
     }
 
     #[test]

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -96,7 +96,9 @@ impl PluginDigest {
             return Err(malformed());
         }
         let mut bytes = [0u8; 32];
-        for (slot, pair) in bytes.iter_mut().zip(trimmed.as_bytes().chunks_exact(2)) {
+        // The length is already 64, so the remainder is empty by construction.
+        let (pairs, _) = trimmed.as_bytes().as_chunks::<2>();
+        for (slot, pair) in bytes.iter_mut().zip(pairs) {
             let hex = std::str::from_utf8(pair).map_err(|_| malformed())?;
             *slot = u8::from_str_radix(hex, 16).map_err(|_| malformed())?;
         }

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -19,10 +19,15 @@ use thiserror::Error;
 /// Files and directories every plugin source must carry, in the marketplace-root
 /// shape `scripts/appa-stage-plugin-bundle.sh` produces. One validator serves
 /// both source resolution and the reuse check on an existing deployment.
-const REQUIRED_FILES: [&str; 4] = [
+const REQUIRED_FILES: [&str; 6] = [
     ".claude-plugin/marketplace.json",
     "plugin/.claude-plugin/plugin.json",
     "plugin/hooks/hooks.json",
+    // Both hook maps register a wrapper script rather than a command line, so a
+    // tree carrying the map without its script registers hooks that cannot run.
+    // Materialization keeps both scripts; only the inactive map is removed.
+    "plugin/hooks/hook.sh",
+    "plugin/hooks/hook.ps1",
     "website/content/docs/contracts.md",
 ];
 const REQUIRED_DIRS: [&str; 2] = ["plugin", "batteries"];

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -1,0 +1,1149 @@
+//! The Claude plugin bundle belonging to this binary's own release.
+//!
+//! A binary is built knowing the SHA-256 of its release's plugin artifact and
+//! accepts no other bytes. That digest is the whole compatibility rule: there is
+//! no version field inside the artifact and no commit to compare, because the
+//! digest already pins the exact bytes. A development build has no digest, so it
+//! refuses to download and requires `--plugin-source`.
+
+use std::env;
+use std::fmt;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Files and directories every plugin source must carry, in the marketplace-root
+/// shape `scripts/appa-stage-plugin-bundle.sh` produces. One validator serves
+/// both source resolution and the reuse check on an existing deployment.
+const REQUIRED_FILES: [&str; 4] = [
+    ".claude-plugin/marketplace.json",
+    "plugin/.claude-plugin/plugin.json",
+    "plugin/hooks/hooks.json",
+    "website/content/docs/contracts.md",
+];
+const REQUIRED_DIRS: [&str; 2] = ["plugin", "batteries"];
+
+/// A source carries both hook maps; materialization keeps the one for this
+/// platform and removes the other, so a deployment carries exactly one. The same
+/// validator serves both, and this is the only thing it varies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TreeShape {
+    Source,
+    Deployment,
+}
+
+#[derive(Debug, Error)]
+pub enum PluginBundleError {
+    #[error(
+        "appa {version} is a development build with no plugin artifact digest; pass --plugin-source <checkout>"
+    )]
+    NoBakedDigest { version: &'static str },
+    #[error("{value} is not a SHA-256 digest")]
+    MalformedDigest { value: String },
+    #[error("the plugin source at {path} is not a marketplace root: {reason}")]
+    InvalidSource { path: PathBuf, reason: String },
+    #[error("cannot read the plugin source at {path}: {source}")]
+    ReadSource {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("{path} is not valid UTF-8 with `/` separators; rename it and retry")]
+    UnportablePath { path: PathBuf },
+    #[error("{path} is neither a regular file nor a directory")]
+    UnsupportedEntry { path: PathBuf },
+    #[error("{value} is not a usable runtime endpoint: {reason}")]
+    MalformedEndpoint { value: String, reason: String },
+    #[error("cannot write the deployment at {path}: {source}")]
+    WriteDeployment {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("the plugin archive at {path} is unusable: {reason}")]
+    MalformedArchive { path: PathBuf, reason: String },
+    #[error("cannot reserve a working directory under {path}")]
+    NoReservation { path: PathBuf },
+}
+
+/// The SHA-256 of a plugin artifact: what a binary was built with, and what a
+/// fetched or cached archive must hash to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PluginDigest([u8; 32]);
+
+impl PluginDigest {
+    pub fn parse(value: &str) -> Result<Self, PluginBundleError> {
+        let trimmed = value.trim();
+        let malformed = || PluginBundleError::MalformedDigest {
+            value: trimmed.to_owned(),
+        };
+        if trimmed.len() != 64 {
+            return Err(malformed());
+        }
+        let mut bytes = [0u8; 32];
+        for (slot, pair) in bytes.iter_mut().zip(trimmed.as_bytes().chunks_exact(2)) {
+            let hex = std::str::from_utf8(pair).map_err(|_| malformed())?;
+            *slot = u8::from_str_radix(hex, 16).map_err(|_| malformed())?;
+        }
+        Ok(Self(bytes))
+    }
+
+    pub fn of(bytes: &[u8]) -> Self {
+        let mut digest = Sha256::new();
+        digest.update(bytes);
+        Self(digest.finalize().into())
+    }
+
+    pub fn from_hasher(hasher: Sha256) -> Self {
+        Self(hasher.finalize().into())
+    }
+}
+
+impl fmt::Display for PluginDigest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for PluginDigest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "PluginDigest({self})")
+    }
+}
+
+/// The digest of the plugin artifact this build belongs to.
+///
+/// Release builds carry it as a compile-time constant, so a shipped binary
+/// cannot be pointed at other bytes by its environment. `[profile.release]` pins
+/// `debug-assertions = false`, which is what closes the debug branch there.
+pub fn expected_plugin_digest() -> Option<PluginDigest> {
+    let raw = if cfg!(debug_assertions) {
+        env::var("APPA_PLUGIN_SHA256").ok()
+    } else {
+        option_env!("APPA_PLUGIN_SHA256").map(str::to_owned)
+    };
+    raw.as_deref().and_then(|value| PluginDigest::parse(value).ok())
+}
+
+/// Where a deployment's bytes come from. `Explicit` is the development override;
+/// everything else resolves to this binary's own release artifact.
+#[derive(Debug, Clone)]
+pub enum PluginSource {
+    Explicit(PathBuf),
+    Release(PluginDigest),
+}
+
+impl PluginSource {
+    /// `--plugin-source` when given, otherwise this build's release artifact.
+    /// A development build with neither refuses rather than guessing.
+    pub fn resolve(explicit: Option<&str>) -> Result<Self, PluginBundleError> {
+        match explicit {
+            Some(path) => Ok(Self::Explicit(canonical_source(Path::new(path))?)),
+            None => expected_plugin_digest()
+                .map(Self::Release)
+                .ok_or(PluginBundleError::NoBakedDigest {
+                    version: env!("CARGO_PKG_VERSION"),
+                }),
+        }
+    }
+}
+
+/// Resolve the user's `--plugin-source` argument like any other path argument.
+///
+/// Windows keeps the existing carve-out: Claude rejects a `\\?\` marketplace
+/// path, so the extended-length prefix is stripped after canonicalization.
+fn canonical_source(path: &Path) -> Result<PathBuf, PluginBundleError> {
+    let canonical = fs::canonicalize(path).map_err(|source| PluginBundleError::ReadSource {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let canonical = if cfg!(windows) {
+        strip_extended_prefix(&canonical)
+    } else {
+        canonical
+    };
+    validate_tree(&canonical, TreeShape::Source)?;
+    Ok(canonical)
+}
+
+fn strip_extended_prefix(path: &Path) -> PathBuf {
+    match path.to_str().and_then(|text| text.strip_prefix(r"\\?\")) {
+        Some(stripped) => PathBuf::from(stripped),
+        None => path.to_path_buf(),
+    }
+}
+
+/// Structural validation, applied identically to a `--plugin-source` checkout, a
+/// freshly extracted archive, and an existing deployment considered for reuse.
+///
+/// This checks shape, not content: a tree whose `batteries/` files were edited in
+/// place passes. Reuse pairs it with a byte comparison of the one generated file.
+pub fn validate_tree(root: &Path, shape: TreeShape) -> Result<(), PluginBundleError> {
+    let invalid = |reason: String| PluginBundleError::InvalidSource {
+        path: root.to_path_buf(),
+        reason,
+    };
+    if !root.is_dir() {
+        return Err(invalid("it is not a directory".to_owned()));
+    }
+    for relative in REQUIRED_DIRS {
+        if !root.join(relative).is_dir() {
+            return Err(invalid(format!("{relative}/ is missing")));
+        }
+    }
+    for relative in REQUIRED_FILES {
+        if !root.join(relative).is_file() {
+            return Err(invalid(format!("{relative} is missing")));
+        }
+    }
+    if shape == TreeShape::Source && !root.join(WINDOWS_HOOKS).is_file() {
+        return Err(invalid(format!("{WINDOWS_HOOKS} is missing")));
+    }
+    Ok(())
+}
+
+/// A staged relative path as the canonical digest encodes it: UTF-8 with `/`
+/// separators on every platform. The bundle is ASCII filenames, so a path that
+/// cannot be spelled this way is refused rather than normalized.
+pub fn portable_relative_path(relative: &Path) -> Result<String, PluginBundleError> {
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            std::path::Component::Normal(part) => match part.to_str() {
+                Some(text) => parts.push(text),
+                None => {
+                    return Err(PluginBundleError::UnportablePath {
+                        path: relative.to_path_buf(),
+                    });
+                }
+            },
+            _ => {
+                return Err(PluginBundleError::UnportablePath {
+                    path: relative.to_path_buf(),
+                });
+            }
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint
+// ---------------------------------------------------------------------------
+
+/// The address the deployment's runtime listens on and every consumer talks to.
+///
+/// One value, validated once before any mutation, delivered explicitly to each
+/// consumer rather than left to per-file default constants. The production
+/// address is fixed; `APPA_ENDPOINT` overrides it in debug builds only, which is
+/// the seam the endpoint tests need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Endpoint {
+    url: String,
+    listen: SocketAddr,
+}
+
+/// The spelling every consumer carries today, and the one the regression scan
+/// looks for in a materialized tree.
+pub const DEFAULT_ENDPOINT_URL: &str = "http://127.0.0.1:8787";
+
+impl Endpoint {
+    pub fn resolve() -> Result<Self, PluginBundleError> {
+        let configured = if cfg!(debug_assertions) {
+            env::var("APPA_ENDPOINT").ok()
+        } else {
+            None
+        };
+        Self::parse(configured.as_deref().unwrap_or(DEFAULT_ENDPOINT_URL))
+    }
+
+    /// `http://` plus a loopback literal and a port. No path, no trailing slash,
+    /// no hostname: anything else is refused up front rather than half-applied.
+    pub fn parse(text: &str) -> Result<Self, PluginBundleError> {
+        let malformed = |reason: &str| PluginBundleError::MalformedEndpoint {
+            value: text.to_owned(),
+            reason: reason.to_owned(),
+        };
+        let authority = text
+            .strip_prefix("http://")
+            .ok_or_else(|| malformed("it must begin with http://"))?;
+        if authority.contains('/') {
+            return Err(malformed("it must carry no path and no trailing slash"));
+        }
+        let listen: SocketAddr = authority.parse().map_err(|_| {
+            malformed("it must be a literal address and port, such as 127.0.0.1:8787")
+        })?;
+        if !listen.ip().is_loopback() {
+            return Err(malformed("it must be a loopback address"));
+        }
+        if listen.port() == 0 {
+            return Err(malformed("it must name a fixed port"));
+        }
+        Ok(Self {
+            url: format!("http://{authority}"),
+            listen,
+        })
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn listen(&self) -> SocketAddr {
+        self.listen
+    }
+
+    /// The URL of one runtime path, for probes such as `/binary-fingerprint`.
+    pub fn join(&self, path: &str) -> String {
+        format!("{}{path}", self.url)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical digests
+// ---------------------------------------------------------------------------
+
+/// Every length prefix in both digests is an unsigned 64-bit big-endian integer
+/// followed immediately by exactly that many bytes. Naive concatenation would be
+/// ambiguous, and both digests name deployment directories, so the encoding is
+/// observable identity and is pinned rather than left to the implementation.
+fn absorb_field(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+const KIND_FILE: u8 = b'f';
+const KIND_DIRECTORY: u8 = b'd';
+
+type StagedEntry = (String, u8, PathBuf);
+
+/// The identity of a plugin source that has no release digest of its own.
+///
+/// Computed over the staged tree after staging and **before** rendering, so it
+/// never depends on the paths being rendered into it. Without this, editing a
+/// file in a `--plugin-source` checkout and re-running init would reuse the
+/// existing deployment and never reach Claude.
+pub fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundleError> {
+    let mut entries = Vec::new();
+    collect_entries(root, root, &mut entries)?;
+    // Bytewise on the UTF-8 path bytes, never locale collation.
+    entries.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+
+    let mut hasher = Sha256::new();
+    for (relative, kind, absolute) in entries {
+        absorb_field(&mut hasher, relative.as_bytes());
+        hasher.update([kind]);
+        if kind == KIND_DIRECTORY {
+            absorb_field(&mut hasher, &[]);
+        } else {
+            let contents = fs::read(&absolute).map_err(|source| PluginBundleError::ReadSource {
+                path: absolute.clone(),
+                source,
+            })?;
+            absorb_field(&mut hasher, &contents);
+        }
+    }
+    Ok(PluginDigest::from_hasher(hasher))
+}
+
+fn collect_entries(
+    root: &Path,
+    directory: &Path,
+    entries: &mut Vec<StagedEntry>,
+) -> Result<(), PluginBundleError> {
+    let read = fs::read_dir(directory).map_err(|source| PluginBundleError::ReadSource {
+        path: directory.to_path_buf(),
+        source,
+    })?;
+    for entry in read {
+        let entry = entry.map_err(|source| PluginBundleError::ReadSource {
+            path: directory.to_path_buf(),
+            source,
+        })?;
+        let absolute = entry.path();
+        let relative =
+            absolute
+                .strip_prefix(root)
+                .map_err(|_| PluginBundleError::UnportablePath {
+                    path: absolute.clone(),
+                })?;
+        let portable = portable_relative_path(relative)?;
+        // Symlinks and special files are refused here exactly as in extraction:
+        // the bundle is regular files and directories.
+        let kind = entry
+            .file_type()
+            .map_err(|source| PluginBundleError::ReadSource {
+                path: absolute.clone(),
+                source,
+            })?;
+        if kind.is_dir() {
+            entries.push((portable, KIND_DIRECTORY, absolute.clone()));
+            collect_entries(root, &absolute, entries)?;
+        } else if kind.is_file() {
+            entries.push((portable, KIND_FILE, absolute));
+        } else {
+            return Err(PluginBundleError::UnsupportedEntry { path: absolute });
+        }
+    }
+    Ok(())
+}
+
+/// Everything a deployment's identity depends on beyond the source bytes.
+#[derive(Debug, Clone)]
+pub struct DeploymentPlan {
+    pub source_digest: PluginDigest,
+    pub binary_path: PathBuf,
+    pub config_path: PathBuf,
+    pub data_dir: PathBuf,
+    pub endpoint: Endpoint,
+}
+
+/// The name of the deployment directory: the source identity plus every path and
+/// platform detail rendered into it, so a deployment can never be reused for a
+/// different binary, config, data directory, endpoint or platform.
+pub fn deployment_digest(plan: &DeploymentPlan) -> Result<PluginDigest, PluginBundleError> {
+    let mut hasher = Sha256::new();
+    absorb_field(&mut hasher, plan.source_digest.to_string().as_bytes());
+    absorb_field(&mut hasher, path_identity(&plan.binary_path)?.as_bytes());
+    absorb_field(&mut hasher, path_identity(&plan.config_path)?.as_bytes());
+    absorb_field(&mut hasher, path_identity(&plan.data_dir)?.as_bytes());
+    absorb_field(&mut hasher, plan.endpoint.url().as_bytes());
+    absorb_field(&mut hasher, platform_token().as_bytes());
+    Ok(PluginDigest::from_hasher(hasher))
+}
+
+fn platform_token() -> &'static str {
+    if cfg!(windows) { "windows" } else { "unix" }
+}
+
+/// The lexical absolute path init constructed: no `canonicalize`, no case
+/// folding, consistent with refusing rather than normalizing elsewhere.
+fn path_identity(path: &Path) -> Result<&str, PluginBundleError> {
+    path.to_str()
+        .ok_or_else(|| PluginBundleError::UnportablePath {
+            path: path.to_path_buf(),
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Materialization
+// ---------------------------------------------------------------------------
+
+/// Caps on what an archive may unpack to. The bundle is a few hundred small
+/// text files; these bound a hostile or corrupt archive without being tight
+/// enough to constrain the real one.
+const MAX_ENTRIES: usize = 4096;
+const MAX_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The generated file every deployed shell surface sources.
+const PATHS_SH: &str = "plugin/hooks/appa-paths.sh";
+const WINDOWS_HOOKS: &str = "plugin/hooks/hooks.windows.json";
+const PATHS_PS1: &str = "plugin/hooks/appa-paths.ps1";
+
+/// Where a deployment's bytes come from at materialization time.
+pub enum Population<'a> {
+    /// A `--plugin-source` checkout, copied.
+    Tree(&'a Path),
+    /// A verified release archive, extracted.
+    Archive(&'a Path),
+}
+
+/// A published, immutable deployment directory: what Claude registers.
+#[derive(Debug, Clone)]
+pub struct Deployment {
+    pub root: PathBuf,
+    pub digest: PluginDigest,
+    pub source_digest: PluginDigest,
+    pub reused: bool,
+}
+
+/// Materialize the deployment for this source and these paths, or reuse the
+/// existing one after validating it.
+///
+/// Publication is a rename, so two inits racing on the same source converge on
+/// one immutable directory rather than interleaving writes into it.
+pub fn materialize(
+    population: Population<'_>,
+    deployments_dir: &Path,
+    binary_path: &Path,
+    config_path: &Path,
+    data_dir: &Path,
+    endpoint: &Endpoint,
+) -> Result<Deployment, PluginBundleError> {
+    fs::create_dir_all(deployments_dir).map_err(|source| PluginBundleError::WriteDeployment {
+        path: deployments_dir.to_path_buf(),
+        source,
+    })?;
+
+    let incoming = reserve_directory(deployments_dir, ".incoming-")?;
+    let staged = || -> Result<(PluginDigest, DeploymentPlan), PluginBundleError> {
+        match population {
+            Population::Tree(source) => copy_tree(source, &incoming)?,
+            Population::Archive(archive) => extract_archive(archive, &incoming)?,
+        }
+        validate_tree(&incoming, TreeShape::Source)?;
+        // After staging, before rendering: the source identity must not depend
+        // on the paths about to be rendered into it.
+        let source_digest = canonical_source_digest(&incoming)?;
+        let plan = DeploymentPlan {
+            source_digest,
+            binary_path: binary_path.to_path_buf(),
+            config_path: config_path.to_path_buf(),
+            data_dir: data_dir.to_path_buf(),
+            endpoint: endpoint.clone(),
+        };
+        let digest = deployment_digest(&plan)?;
+        Ok((digest, plan))
+    }();
+
+    let (digest, plan) = match staged {
+        Ok(staged) => staged,
+        Err(error) => {
+            // Our own unpublished reservation: removing it deletes no
+            // registered state.
+            let _ = fs::remove_dir_all(&incoming);
+            return Err(error);
+        }
+    };
+
+    let published = deployments_dir.join(digest.to_string());
+    if published.is_dir() {
+        match reusable(&published, &plan) {
+            Ok(()) => {
+                let _ = fs::remove_dir_all(&incoming);
+                return Ok(Deployment {
+                    root: published,
+                    digest,
+                    source_digest: plan.source_digest,
+                    reused: true,
+                });
+            }
+            Err(reason) => {
+                tracing::debug!(path = %published.display(), %reason, "quarantining a damaged deployment");
+                quarantine(deployments_dir, &published)?;
+            }
+        }
+    }
+
+    if let Err(error) = render(&incoming, &plan) {
+        let _ = fs::remove_dir_all(&incoming);
+        return Err(error);
+    }
+
+    match fs::rename(&incoming, &published) {
+        Ok(()) => {}
+        // Another init published the same immutable bytes first. Both are
+        // correct and identical, so the race is benign.
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::DirectoryNotEmpty
+            ) =>
+        {
+            let _ = fs::remove_dir_all(&incoming);
+        }
+        Err(source) => {
+            let _ = fs::remove_dir_all(&incoming);
+            return Err(PluginBundleError::WriteDeployment {
+                path: published,
+                source,
+            });
+        }
+    }
+
+    Ok(Deployment {
+        root: deployments_dir.join(digest.to_string()),
+        digest,
+        source_digest: plan.source_digest,
+        reused: false,
+    })
+}
+
+/// Whether an existing deployment can be reused as-is.
+///
+/// Structural validation plus a byte comparison of the one generated file. This
+/// is deliberately not a content hash of every file: a tree whose `batteries/`
+/// contents were edited in place is not detected, and init's convergence claim
+/// is scoped to match.
+fn reusable(published: &Path, plan: &DeploymentPlan) -> Result<(), String> {
+    validate_tree(published, TreeShape::Deployment).map_err(|error| error.to_string())?;
+    let rendered = published.join(PATHS_SH);
+    let current = fs::read(&rendered).map_err(|error| format!("{PATHS_SH} is unreadable: {error}"))?;
+    if current != paths_sh(plan).into_bytes() {
+        return Err(format!("{PATHS_SH} is stale"));
+    }
+    Ok(())
+}
+
+/// Move a damaged deployment aside. Nothing is ever deleted, and the
+/// destination never pre-exists, so `rename` cannot silently replace a
+/// directory. The namespace is deliberately distinct from the
+/// `.appa-init-recovery-` prefix that init sweeps globally.
+fn quarantine(deployments_dir: &Path, published: &Path) -> Result<(), PluginBundleError> {
+    let name = published
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("deployment");
+    let container = reserve_directory(deployments_dir, &format!("{name}.quarantine-"))?;
+    fs::rename(published, container.join("tree")).map_err(|source| {
+        PluginBundleError::WriteDeployment {
+            path: container.join("tree"),
+            source,
+        }
+    })
+}
+
+/// Reserve a fresh directory by creation, incrementing until it succeeds.
+///
+/// A PID suffix would collide after PID reuse by a crashed init, so the
+/// reservation is the creation itself. One helper serves both the incoming
+/// directory and the quarantine container.
+fn reserve_directory(parent: &Path, prefix: &str) -> Result<PathBuf, PluginBundleError> {
+    for attempt in 0..1024 {
+        let candidate = parent.join(format!("{prefix}{attempt}"));
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(source) => {
+                return Err(PluginBundleError::WriteDeployment {
+                    path: candidate,
+                    source,
+                });
+            }
+        }
+    }
+    Err(PluginBundleError::NoReservation {
+        path: parent.join(prefix),
+    })
+}
+
+fn copy_tree(source: &Path, destination: &Path) -> Result<(), PluginBundleError> {
+    let write = |path: &Path, source: std::io::Error| PluginBundleError::WriteDeployment {
+        path: path.to_path_buf(),
+        source,
+    };
+    fs::create_dir_all(destination).map_err(|error| write(destination, error))?;
+    let entries = fs::read_dir(source).map_err(|error| PluginBundleError::ReadSource {
+        path: source.to_path_buf(),
+        source: error,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| PluginBundleError::ReadSource {
+            path: source.to_path_buf(),
+            source: error,
+        })?;
+        let from = entry.path();
+        let to = destination.join(entry.file_name());
+        let kind = entry
+            .file_type()
+            .map_err(|error| PluginBundleError::ReadSource {
+                path: from.clone(),
+                source: error,
+            })?;
+        if kind.is_dir() {
+            copy_tree(&from, &to)?;
+        } else if kind.is_file() {
+            fs::copy(&from, &to).map_err(|error| write(&to, error))?;
+        } else {
+            return Err(PluginBundleError::UnsupportedEntry { path: from });
+        }
+    }
+    Ok(())
+}
+
+/// Unpack a verified archive. Absolute paths, `..` components and anything that
+/// is not a regular file or directory are refused; entry count and total
+/// uncompressed bytes are capped. Modes come from init, not from the archive.
+fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundleError> {
+    let file = fs::File::open(archive).map_err(|source| PluginBundleError::ReadSource {
+        path: archive.to_path_buf(),
+        source,
+    })?;
+    let mut tar = tar::Archive::new(flate2::read::GzDecoder::new(file));
+    let malformed = |reason: String| PluginBundleError::MalformedArchive {
+        path: archive.to_path_buf(),
+        reason,
+    };
+    let entries = tar
+        .entries()
+        .map_err(|error| malformed(format!("it is not a tar archive: {error}")))?;
+
+    let mut count = 0usize;
+    let mut total = 0u64;
+    for entry in entries {
+        let mut entry = entry.map_err(|error| malformed(format!("unreadable entry: {error}")))?;
+        count += 1;
+        if count > MAX_ENTRIES {
+            return Err(malformed(format!("it holds more than {MAX_ENTRIES} entries")));
+        }
+        total = total.saturating_add(entry.size());
+        if total > MAX_UNCOMPRESSED_BYTES {
+            return Err(malformed(format!(
+                "it unpacks to more than {MAX_UNCOMPRESSED_BYTES} bytes"
+            )));
+        }
+
+        let path = entry
+            .path()
+            .map_err(|error| malformed(format!("unreadable entry path: {error}")))?
+            .into_owned();
+        let relative = safe_relative(&path).ok_or_else(|| {
+            malformed(format!("{} escapes the archive root", path.display()))
+        })?;
+        let target = destination.join(&relative);
+        let write = |source: std::io::Error| PluginBundleError::WriteDeployment {
+            path: target.clone(),
+            source,
+        };
+
+        match entry.header().entry_type() {
+            tar::EntryType::Directory => fs::create_dir_all(&target).map_err(write)?,
+            tar::EntryType::Regular => {
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent).map_err(|source| {
+                        PluginBundleError::WriteDeployment {
+                            path: parent.to_path_buf(),
+                            source,
+                        }
+                    })?;
+                }
+                let mut out = fs::File::create(&target).map_err(write)?;
+                std::io::copy(&mut entry, &mut out).map_err(|source| {
+                    PluginBundleError::WriteDeployment {
+                        path: target.clone(),
+                        source,
+                    }
+                })?;
+            }
+            other => {
+                return Err(malformed(format!(
+                    "{} is a {other:?} entry; only regular files and directories are accepted",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A relative, traversal-free path, or nothing.
+fn safe_relative(path: &Path) -> Option<PathBuf> {
+    let mut relative = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => relative.push(part),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    (!relative.as_os_str().is_empty()).then_some(relative)
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/// Turn the staged tree into a deployment for these exact paths: select the
+/// platform hook map, write the generated paths files, and replace the legacy
+/// endpoint literal everywhere it appears.
+fn render(root: &Path, plan: &DeploymentPlan) -> Result<(), PluginBundleError> {
+    select_platform_hooks(root)?;
+    write_file(&root.join(PATHS_SH), paths_sh(plan).as_bytes())?;
+    write_file(&root.join(PATHS_PS1), paths_ps1(plan).as_bytes())?;
+    render_endpoint(root, plan.endpoint.url())?;
+    set_executable_modes(root)
+}
+
+/// One hook map ships per platform. The other is removed rather than left for a
+/// reader to wonder about.
+fn select_platform_hooks(root: &Path) -> Result<(), PluginBundleError> {
+    let hooks = root.join("plugin/hooks/hooks.json");
+    let windows = root.join(WINDOWS_HOOKS);
+    if cfg!(windows) {
+        fs::rename(&windows, &hooks).map_err(|source| PluginBundleError::WriteDeployment {
+            path: hooks,
+            source,
+        })
+    } else {
+        fs::remove_file(&windows).map_err(|source| PluginBundleError::WriteDeployment {
+            path: windows,
+            source,
+        })
+    }
+}
+
+/// Replace the legacy endpoint literal in every text file of the deployment.
+///
+/// Three successive drafts of this change each missed a consumer, so the
+/// substitution is total over the tree rather than driven by a hand-written list
+/// of files. A file that does not contain the literal is left untouched, and
+/// binary files cannot contain it.
+fn render_endpoint(root: &Path, endpoint_url: &str) -> Result<(), PluginBundleError> {
+    if endpoint_url == DEFAULT_ENDPOINT_URL {
+        return Ok(());
+    }
+    let mut entries = Vec::new();
+    collect_entries(root, root, &mut entries)?;
+    for (_, kind, absolute) in entries {
+        if kind != KIND_FILE {
+            continue;
+        }
+        let bytes = fs::read(&absolute).map_err(|source| PluginBundleError::ReadSource {
+            path: absolute.clone(),
+            source,
+        })?;
+        let Ok(text) = String::from_utf8(bytes) else {
+            continue;
+        };
+        if !text.contains(DEFAULT_ENDPOINT_URL) {
+            continue;
+        }
+        let rendered = text.replace(DEFAULT_ENDPOINT_URL, endpoint_url);
+        write_file(&absolute, rendered.as_bytes())?;
+    }
+    Ok(())
+}
+
+/// Substitute the endpoint into one file outside the deployment tree, such as an
+/// installed statusline copy.
+pub fn render_endpoint_in_file(path: &Path, endpoint: &Endpoint) -> Result<(), PluginBundleError> {
+    if endpoint.url() == DEFAULT_ENDPOINT_URL {
+        return Ok(());
+    }
+    let bytes = fs::read(path).map_err(|source| PluginBundleError::ReadSource {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let Ok(text) = String::from_utf8(bytes) else {
+        return Ok(());
+    };
+    if !text.contains(DEFAULT_ENDPOINT_URL) {
+        return Ok(());
+    }
+    write_file(path, text.replace(DEFAULT_ENDPOINT_URL, endpoint.url()).as_bytes())
+}
+
+fn write_file(path: &Path, bytes: &[u8]) -> Result<(), PluginBundleError> {
+    fs::write(path, bytes).map_err(|source| PluginBundleError::WriteDeployment {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(unix)]
+fn set_executable_modes(root: &Path) -> Result<(), PluginBundleError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    for relative in ["plugin/statusline.sh", "plugin/hooks/ensure-runtime.sh"] {
+        let path = root.join(relative);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).map_err(|source| {
+            PluginBundleError::WriteDeployment { path, source }
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable_modes(_root: &Path) -> Result<(), PluginBundleError> {
+    Ok(())
+}
+
+/// The rendered paths file assigns unconditionally from what init resolved: a
+/// deployed tree performs no PATH resolution and honours no pre-existing
+/// `APPA_BIN`. Only the checkout's committed development copy falls back to the
+/// environment, so `claude --plugin-dir <checkout>` keeps working.
+fn paths_sh(plan: &DeploymentPlan) -> String {
+    let mut rendered = String::from("# Generated by appa init claude-code. Do not edit.\n");
+    for (name, value) in [
+        ("APPA_BIN", plan.binary_path.as_path()),
+        ("APPA_CONFIG", plan.config_path.as_path()),
+        ("APPA_DATA_DIR", plan.data_dir.as_path()),
+    ] {
+        rendered.push_str(&format!("{name}={}\n", sh_literal(&value.to_string_lossy())));
+    }
+    rendered.push_str(&format!(
+        "APPA_ENDPOINT={}\n",
+        sh_literal(plan.endpoint.url())
+    ));
+    rendered.push_str(&format!(
+        "APPA_LISTEN={}\n",
+        sh_literal(&plan.endpoint.listen().to_string())
+    ));
+    rendered.push_str("export APPA_BIN APPA_CONFIG APPA_DATA_DIR APPA_ENDPOINT APPA_LISTEN\n");
+    rendered
+}
+
+fn paths_ps1(plan: &DeploymentPlan) -> String {
+    let mut rendered = String::from("# Generated by appa init claude-code. Do not edit.\n");
+    for (name, value) in [
+        ("AppaBin", plan.binary_path.as_path()),
+        ("AppaConfig", plan.config_path.as_path()),
+        ("AppaDataDir", plan.data_dir.as_path()),
+    ] {
+        rendered.push_str(&format!(
+            "${name} = {}\n",
+            ps_literal(&value.to_string_lossy())
+        ));
+    }
+    rendered.push_str(&format!(
+        "$AppaEndpoint = {}\n",
+        ps_literal(plan.endpoint.url())
+    ));
+    rendered.push_str(&format!(
+        "$AppaListen = {}\n",
+        ps_literal(&plan.endpoint.listen().to_string())
+    ));
+    rendered
+}
+
+/// Total for any UTF-8 path: single-quoted, with embedded `'` closed, escaped
+/// and reopened. Spaces, `$`, backticks, quotes and newlines are all
+/// representable, so rendering never refuses a path that got this far.
+fn sh_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// Total for any UTF-8 path: single-quoted, with embedded `'` doubled.
+fn ps_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_round_trips_through_hex() {
+        let digest = PluginDigest::of(b"appa");
+        let text = digest.to_string();
+        assert_eq!(text.len(), 64);
+        assert_eq!(PluginDigest::parse(&text).unwrap(), digest);
+    }
+
+    #[test]
+    fn digest_rejects_malformed_hex() {
+        for value in ["", "abc", &"z".repeat(64), &"a".repeat(63), &"a".repeat(65)] {
+            assert!(PluginDigest::parse(value).is_err(), "accepted {value:?}");
+        }
+    }
+
+    #[test]
+    fn portable_path_uses_forward_slashes() {
+        let relative: PathBuf = ["plugin", "hooks", "hooks.json"].iter().collect();
+        assert_eq!(
+            portable_relative_path(&relative).unwrap(),
+            "plugin/hooks/hooks.json"
+        );
+    }
+
+    #[test]
+    fn portable_path_refuses_traversal_components() {
+        assert!(portable_relative_path(Path::new("../escape")).is_err());
+    }
+
+    fn sample_tree(root: &Path) {
+        for relative in REQUIRED_FILES {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, format!("{relative}\n")).unwrap();
+        }
+        fs::create_dir_all(root.join("batteries")).unwrap();
+        fs::write(root.join("batteries/README.md"), "batteries\n").unwrap();
+        fs::create_dir_all(root.join("plugin/hooks")).unwrap();
+        fs::write(root.join(WINDOWS_HOOKS), "{}\n").unwrap();
+        fs::write(
+            root.join("plugin/statusline.sh"),
+            format!("curl \"${{APPA_RUNTIME_URL:-{DEFAULT_ENDPOINT_URL}}}/status\"\n"),
+        )
+        .unwrap();
+        fs::write(
+            root.join("plugin/hooks/ensure-runtime.sh"),
+            format!("probe {DEFAULT_ENDPOINT_URL}/health\n"),
+        )
+        .unwrap();
+    }
+
+    fn sample_plan(root: &Path, endpoint: &str) -> DeploymentPlan {
+        DeploymentPlan {
+            source_digest: canonical_source_digest(root).unwrap(),
+            binary_path: PathBuf::from("/data/bin/appa"),
+            config_path: PathBuf::from("/config/appa.toml"),
+            data_dir: PathBuf::from("/data"),
+            endpoint: Endpoint::parse(endpoint).unwrap(),
+        }
+    }
+
+    fn deploy(source: &Path, deployments: &Path, endpoint: &str) -> Deployment {
+        materialize(
+            Population::Tree(source),
+            deployments,
+            Path::new("/data/bin/appa"),
+            Path::new("/config/appa.toml"),
+            Path::new("/data"),
+            &Endpoint::parse(endpoint).unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn endpoint_accepts_loopback_and_refuses_everything_else() {
+        assert_eq!(
+            Endpoint::parse("http://127.0.0.1:8787").unwrap().url(),
+            "http://127.0.0.1:8787"
+        );
+        assert!(Endpoint::parse("http://[::1]:9000").is_ok());
+        for rejected in [
+            "https://127.0.0.1:8787",
+            "http://127.0.0.1:8787/",
+            "http://127.0.0.1:8787/mcp",
+            "http://localhost:8787",
+            "http://10.0.0.1:8787",
+            "http://127.0.0.1:0",
+            "127.0.0.1:8787",
+        ] {
+            assert!(Endpoint::parse(rejected).is_err(), "accepted {rejected}");
+        }
+    }
+
+    #[test]
+    fn source_digest_changes_when_a_file_is_edited() {
+        let source = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+        let before = canonical_source_digest(source.path()).unwrap();
+        fs::write(source.path().join("batteries/README.md"), "edited\n").unwrap();
+        let after = canonical_source_digest(source.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn deployment_digest_separates_paths_and_endpoints() {
+        let source = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+        let base = sample_plan(source.path(), DEFAULT_ENDPOINT_URL);
+        let baseline = deployment_digest(&base).unwrap();
+
+        let mut other_binary = base.clone();
+        other_binary.binary_path = PathBuf::from("/elsewhere/bin/appa");
+        assert_ne!(deployment_digest(&other_binary).unwrap(), baseline);
+
+        let mut other_endpoint = base.clone();
+        other_endpoint.endpoint = Endpoint::parse("http://127.0.0.1:9999").unwrap();
+        assert_ne!(deployment_digest(&other_endpoint).unwrap(), baseline);
+    }
+
+    #[test]
+    fn materialize_renders_paths_and_endpoint_then_reuses() {
+        let source = tempfile::tempdir().unwrap();
+        let deployments = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+
+        let first = deploy(source.path(), deployments.path(), "http://127.0.0.1:9999");
+        assert!(!first.reused);
+
+        let paths = fs::read_to_string(first.root.join(PATHS_SH)).unwrap();
+        assert!(paths.contains("APPA_BIN='/data/bin/appa'"));
+        assert!(paths.contains("APPA_ENDPOINT='http://127.0.0.1:9999'"));
+
+        // Every consumer carrying the legacy literal is rendered, without a
+        // hand-written list of files.
+        let statusline = fs::read_to_string(first.root.join("plugin/statusline.sh")).unwrap();
+        assert!(statusline.contains("http://127.0.0.1:9999"));
+        assert!(!statusline.contains(DEFAULT_ENDPOINT_URL));
+
+        let second = deploy(source.path(), deployments.path(), "http://127.0.0.1:9999");
+        assert!(second.reused);
+        assert_eq!(second.root, first.root);
+    }
+
+    #[test]
+    fn editing_the_source_reaches_a_new_deployment() {
+        let source = tempfile::tempdir().unwrap();
+        let deployments = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+
+        let first = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+        fs::write(source.path().join("batteries/README.md"), "edited\n").unwrap();
+        let second = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+
+        assert_ne!(second.root, first.root);
+        assert_eq!(
+            fs::read_to_string(second.root.join("batteries/README.md")).unwrap(),
+            "edited\n"
+        );
+    }
+
+    #[test]
+    fn a_damaged_deployment_is_quarantined_and_rebuilt() {
+        let source = tempfile::tempdir().unwrap();
+        let deployments = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+
+        let first = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+        fs::remove_file(first.root.join("plugin/.claude-plugin/plugin.json")).unwrap();
+
+        let repaired = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+        assert_eq!(repaired.root, first.root);
+        assert!(repaired.root.join("plugin/.claude-plugin/plugin.json").is_file());
+
+        // Nothing was deleted: the damaged tree is still on disk beside it.
+        let quarantined: Vec<_> = fs::read_dir(deployments.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".quarantine-"))
+            .collect();
+        assert_eq!(quarantined.len(), 1);
+        assert!(quarantined[0].path().join("tree").is_dir());
+    }
+
+    #[test]
+    fn a_stale_paths_file_is_repaired_on_rerun() {
+        let source = tempfile::tempdir().unwrap();
+        let deployments = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+
+        let first = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+        fs::write(first.root.join(PATHS_SH), "APPA_BIN='/tmp/hostile'\n").unwrap();
+
+        let repaired = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
+        assert!(!repaired.reused);
+        assert!(
+            fs::read_to_string(repaired.root.join(PATHS_SH))
+                .unwrap()
+                .contains("APPA_BIN='/data/bin/appa'")
+        );
+    }
+
+    #[test]
+    fn paths_carrying_hostile_characters_render_as_literals() {
+        let awkward = "/tmp/a b/it's \"quoted\"/$(touch pwned)/`x`/tab\tnewline\n/appa";
+        let quoted = sh_literal(awkward);
+        assert!(quoted.starts_with('\'') && quoted.ends_with('\''));
+
+        // The shell must read back exactly the bytes init rendered.
+        let script = format!("printf '%s' {quoted}");
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), awkward);
+
+        assert_eq!(ps_literal("it's"), "'it''s'");
+    }
+
+    #[test]
+    fn extraction_refuses_traversal_and_specials() {
+        assert!(safe_relative(Path::new("../escape")).is_none());
+        assert!(safe_relative(Path::new("/absolute")).is_none());
+        assert!(safe_relative(Path::new("plugin/../../escape")).is_none());
+        assert_eq!(
+            safe_relative(Path::new("./plugin/hooks.json")).unwrap(),
+            PathBuf::from("plugin/hooks.json")
+        );
+    }
+}

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -38,39 +38,31 @@ pub enum TreeShape {
 
 #[derive(Debug, Error)]
 pub enum PluginBundleError {
-    #[error(
-        "appa {version} is a development build with no plugin artifact digest; pass --plugin-source <checkout>"
-    )]
+    #[error("appa {version} is a development build with no plugin artifact digest; pass --plugin-source <checkout>")]
     NoBakedDigest { version: &'static str },
     #[error("{value} is not a SHA-256 digest")]
     MalformedDigest { value: String },
     #[error("the plugin source at {path} is not a marketplace root: {reason}")]
     InvalidSource { path: PathBuf, reason: String },
     #[error("cannot read the plugin source at {path}: {source}")]
-    ReadSource {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    ReadSource { path: PathBuf, source: std::io::Error },
     #[error("{path} is not valid UTF-8 with `/` separators; rename it and retry")]
     UnportablePath { path: PathBuf },
     #[error("{path} is neither a regular file nor a directory")]
     UnsupportedEntry { path: PathBuf },
+    #[error("the plugin source at {path} is too large to deploy: {reason}")]
+    OversizedSource { path: PathBuf, reason: String },
     #[error("{value} is not a usable runtime endpoint: {reason}")]
     MalformedEndpoint { value: String, reason: String },
     #[error("cannot write the deployment at {path}: {source}")]
-    WriteDeployment {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    WriteDeployment { path: PathBuf, source: std::io::Error },
     #[error("the plugin archive at {path} is unusable: {reason}")]
     MalformedArchive { path: PathBuf, reason: String },
     #[error("cannot reserve a working directory under {path}")]
     NoReservation { path: PathBuf },
     #[error("cannot fetch the plugin artifact from {url}: {reason}")]
     Fetch { url: String, reason: String },
-    #[error(
-        "the plugin artifact at {url} is not the one this build accepts: expected {expected}, got {actual}"
-    )]
+    #[error("the plugin artifact at {url} is not the one this build accepts: expected {expected}, got {actual}")]
     DigestMismatch {
         url: String,
         expected: PluginDigest,
@@ -157,17 +149,12 @@ impl PluginSource {
 
     /// The decision itself, with this build's digest supplied rather than read,
     /// so it is testable without touching the process environment.
-    pub fn decide(
-        explicit: Option<&str>,
-        baked: Option<PluginDigest>,
-    ) -> Result<Self, PluginBundleError> {
+    pub fn decide(explicit: Option<&str>, baked: Option<PluginDigest>) -> Result<Self, PluginBundleError> {
         match explicit {
             Some(path) => Ok(Self::Explicit(canonical_source(Path::new(path))?)),
-            None => baked
-                .map(Self::Release)
-                .ok_or(PluginBundleError::NoBakedDigest {
-                    version: env!("CARGO_PKG_VERSION"),
-                }),
+            None => baked.map(Self::Release).ok_or(PluginBundleError::NoBakedDigest {
+                version: env!("CARGO_PKG_VERSION"),
+            }),
         }
     }
 }
@@ -294,9 +281,9 @@ impl Endpoint {
         if authority.contains('/') {
             return Err(malformed("it must carry no path and no trailing slash"));
         }
-        let listen: SocketAddr = authority.parse().map_err(|_| {
-            malformed("it must be a literal address and port, such as 127.0.0.1:8787")
-        })?;
+        let listen: SocketAddr = authority
+            .parse()
+            .map_err(|_| malformed("it must be a literal address and port, such as 127.0.0.1:8787"))?;
         if !listen.ip().is_loopback() {
             return Err(malformed("it must be a loopback address"));
         }
@@ -348,10 +335,7 @@ type StagedEntry = (String, u8, PathBuf);
 /// file in a `--plugin-source` checkout and re-running init would reuse the
 /// existing deployment and never reach Claude.
 pub fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundleError> {
-    let mut entries = Vec::new();
-    collect_entries(root, root, &mut entries)?;
-    // Bytewise on the UTF-8 path bytes, never locale collation.
-    entries.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+    let entries = walk(root)?;
 
     let mut hasher = Sha256::new();
     for (relative, kind, absolute) in entries {
@@ -360,21 +344,80 @@ pub fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundle
         if kind == KIND_DIRECTORY {
             absorb_field(&mut hasher, &[]);
         } else {
-            let contents = fs::read(&absolute).map_err(|source| PluginBundleError::ReadSource {
-                path: absolute.clone(),
-                source,
-            })?;
-            absorb_field(&mut hasher, &contents);
+            absorb_file(&mut hasher, &absolute)?;
         }
     }
     Ok(PluginDigest::from_hasher(hasher))
 }
 
-fn collect_entries(
-    root: &Path,
-    directory: &Path,
-    entries: &mut Vec<StagedEntry>,
-) -> Result<(), PluginBundleError> {
+/// The tree in canonical order, refused if it exceeds the source bounds.
+fn walk(root: &Path) -> Result<Vec<StagedEntry>, PluginBundleError> {
+    let mut entries = Vec::new();
+    collect_entries(root, root, &mut entries)?;
+    if entries.len() > MAX_ENTRIES {
+        return Err(PluginBundleError::OversizedSource {
+            path: root.to_path_buf(),
+            reason: format!("it holds more than {MAX_ENTRIES} entries"),
+        });
+    }
+    let mut total = 0u64;
+    for (_, kind, absolute) in &entries {
+        if *kind != KIND_FILE {
+            continue;
+        }
+        let length = fs::metadata(absolute)
+            .map_err(|source| PluginBundleError::ReadSource {
+                path: absolute.clone(),
+                source,
+            })?
+            .len();
+        total = total.saturating_add(length);
+        if total > MAX_UNCOMPRESSED_BYTES {
+            return Err(PluginBundleError::OversizedSource {
+                path: root.to_path_buf(),
+                reason: format!("it holds more than {MAX_UNCOMPRESSED_BYTES} bytes"),
+            });
+        }
+    }
+    // Bytewise on the UTF-8 path bytes, never locale collation.
+    entries.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+    Ok(entries)
+}
+
+/// A file's length prefix and then its bytes, streamed.
+///
+/// The length comes from the file's own metadata and exactly that many bytes are
+/// absorbed, so the encoding stays the length-prefixed one the digest is defined
+/// as, without holding a whole file in memory.
+fn absorb_file(hasher: &mut Sha256, path: &Path) -> Result<(), PluginBundleError> {
+    use std::io::Read;
+
+    let read = |source: std::io::Error| PluginBundleError::ReadSource {
+        path: path.to_path_buf(),
+        source,
+    };
+    let mut file = fs::File::open(path).map_err(read)?;
+    let length = file.metadata().map_err(read)?.len();
+    hasher.update(length.to_be_bytes());
+
+    let mut remaining = length;
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let wanted = remaining.min(buffer.len() as u64) as usize;
+        let filled = file.read(&mut buffer[..wanted]).map_err(read)?;
+        if filled == 0 {
+            return Err(PluginBundleError::OversizedSource {
+                path: path.to_path_buf(),
+                reason: "it changed size while being read".to_owned(),
+            });
+        }
+        hasher.update(&buffer[..filled]);
+        remaining -= filled as u64;
+    }
+    Ok(())
+}
+
+fn collect_entries(root: &Path, directory: &Path, entries: &mut Vec<StagedEntry>) -> Result<(), PluginBundleError> {
     let read = fs::read_dir(directory).map_err(|source| PluginBundleError::ReadSource {
         path: directory.to_path_buf(),
         source,
@@ -385,21 +428,16 @@ fn collect_entries(
             source,
         })?;
         let absolute = entry.path();
-        let relative =
-            absolute
-                .strip_prefix(root)
-                .map_err(|_| PluginBundleError::UnportablePath {
-                    path: absolute.clone(),
-                })?;
+        let relative = absolute
+            .strip_prefix(root)
+            .map_err(|_| PluginBundleError::UnportablePath { path: absolute.clone() })?;
         let portable = portable_relative_path(relative)?;
         // Symlinks and special files are refused here exactly as in extraction:
         // the bundle is regular files and directories.
-        let kind = entry
-            .file_type()
-            .map_err(|source| PluginBundleError::ReadSource {
-                path: absolute.clone(),
-                source,
-            })?;
+        let kind = entry.file_type().map_err(|source| PluginBundleError::ReadSource {
+            path: absolute.clone(),
+            source,
+        })?;
         if kind.is_dir() {
             entries.push((portable, KIND_DIRECTORY, absolute.clone()));
             collect_entries(root, &absolute, entries)?;
@@ -443,19 +481,19 @@ fn platform_token() -> &'static str {
 /// The lexical absolute path init constructed: no `canonicalize`, no case
 /// folding, consistent with refusing rather than normalizing elsewhere.
 fn path_identity(path: &Path) -> Result<&str, PluginBundleError> {
-    path.to_str()
-        .ok_or_else(|| PluginBundleError::UnportablePath {
-            path: path.to_path_buf(),
-        })
+    path.to_str().ok_or_else(|| PluginBundleError::UnportablePath {
+        path: path.to_path_buf(),
+    })
 }
 
 // ---------------------------------------------------------------------------
 // Materialization
 // ---------------------------------------------------------------------------
 
-/// Caps on what an archive may unpack to. The bundle is a few hundred small
-/// text files; these bound a hostile or corrupt archive without being tight
-/// enough to constrain the real one.
+/// Caps on what a plugin source may be, whichever way it arrives. The bundle is
+/// a few hundred small text files; these bound a hostile archive or a
+/// development checkout that has accumulated a large generated directory,
+/// without being tight enough to constrain the real one.
 const MAX_ENTRIES: usize = 4096;
 const MAX_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 
@@ -476,8 +514,9 @@ pub enum Population<'a> {
 #[derive(Debug, Clone)]
 pub struct Deployment {
     pub root: PathBuf,
-    pub digest: PluginDigest,
-    pub source_digest: PluginDigest,
+    /// Whether an existing deployment was validated and reused, rather than
+    /// materialized afresh. This is the convergence property: a rerun that
+    /// changes nothing reuses, and one that finds drift does not.
     pub reused: bool,
 }
 
@@ -502,7 +541,13 @@ pub fn materialize(
     let incoming = reserve_directory(deployments_dir, ".incoming-")?;
     let staged = || -> Result<(PluginDigest, DeploymentPlan), PluginBundleError> {
         match population {
-            Population::Tree(source) => copy_tree(source, &incoming)?,
+            Population::Tree(source) => {
+                // Bound the tree before copying it: a development source that
+                // accidentally holds a large generated directory should be
+                // refused, not duplicated into the deployment store.
+                walk(source)?;
+                copy_tree(source, &incoming)?
+            }
             Population::Archive(archive) => extract_archive(archive, &incoming)?,
         }
         validate_tree(&incoming, TreeShape::Source)?;
@@ -537,8 +582,6 @@ pub fn materialize(
                 let _ = fs::remove_dir_all(&incoming);
                 return Ok(Deployment {
                     root: published,
-                    digest,
-                    source_digest: plan.source_digest,
                     reused: true,
                 });
             }
@@ -577,8 +620,6 @@ pub fn materialize(
 
     Ok(Deployment {
         root: deployments_dir.join(digest.to_string()),
-        digest,
-        source_digest: plan.source_digest,
         reused: false,
     })
 }
@@ -609,11 +650,9 @@ fn quarantine(deployments_dir: &Path, published: &Path) -> Result<(), PluginBund
         .and_then(|name| name.to_str())
         .unwrap_or("deployment");
     let container = reserve_directory(deployments_dir, &format!("{name}.quarantine-"))?;
-    fs::rename(published, container.join("tree")).map_err(|source| {
-        PluginBundleError::WriteDeployment {
-            path: container.join("tree"),
-            source,
-        }
+    fs::rename(published, container.join("tree")).map_err(|source| PluginBundleError::WriteDeployment {
+        path: container.join("tree"),
+        source,
     })
 }
 
@@ -658,12 +697,10 @@ fn copy_tree(source: &Path, destination: &Path) -> Result<(), PluginBundleError>
         })?;
         let from = entry.path();
         let to = destination.join(entry.file_name());
-        let kind = entry
-            .file_type()
-            .map_err(|error| PluginBundleError::ReadSource {
-                path: from.clone(),
-                source: error,
-            })?;
+        let kind = entry.file_type().map_err(|error| PluginBundleError::ReadSource {
+            path: from.clone(),
+            source: error,
+        })?;
         if kind.is_dir() {
             copy_tree(&from, &to)?;
         } else if kind.is_file() {
@@ -716,10 +753,7 @@ fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundl
             // A `./` root entry carries no content of its own.
             EntryPath::ArchiveRoot => continue,
             EntryPath::Escaping => {
-                return Err(malformed(format!(
-                    "{} escapes the archive root",
-                    path.display()
-                )));
+                return Err(malformed(format!("{} escapes the archive root", path.display())));
             }
         };
         let target = destination.join(&relative);
@@ -732,19 +766,15 @@ fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundl
             tar::EntryType::Directory => fs::create_dir_all(&target).map_err(write)?,
             tar::EntryType::Regular => {
                 if let Some(parent) = target.parent() {
-                    fs::create_dir_all(parent).map_err(|source| {
-                        PluginBundleError::WriteDeployment {
-                            path: parent.to_path_buf(),
-                            source,
-                        }
+                    fs::create_dir_all(parent).map_err(|source| PluginBundleError::WriteDeployment {
+                        path: parent.to_path_buf(),
+                        source,
                     })?;
                 }
                 let mut out = fs::File::create(&target).map_err(write)?;
-                std::io::copy(&mut entry, &mut out).map_err(|source| {
-                    PluginBundleError::WriteDeployment {
-                        path: target.clone(),
-                        source,
-                    }
+                std::io::copy(&mut entry, &mut out).map_err(|source| PluginBundleError::WriteDeployment {
+                    path: target.clone(),
+                    source,
                 })?;
             }
             other => {
@@ -805,15 +835,9 @@ fn select_platform_hooks(root: &Path) -> Result<(), PluginBundleError> {
     let hooks = root.join("plugin/hooks/hooks.json");
     let windows = root.join(WINDOWS_HOOKS);
     if cfg!(windows) {
-        fs::rename(&windows, &hooks).map_err(|source| PluginBundleError::WriteDeployment {
-            path: hooks,
-            source,
-        })
+        fs::rename(&windows, &hooks).map_err(|source| PluginBundleError::WriteDeployment { path: hooks, source })
     } else {
-        fs::remove_file(&windows).map_err(|source| PluginBundleError::WriteDeployment {
-            path: windows,
-            source,
-        })
+        fs::remove_file(&windows).map_err(|source| PluginBundleError::WriteDeployment { path: windows, source })
     }
 }
 
@@ -827,9 +851,7 @@ fn render_endpoint(root: &Path, endpoint_url: &str) -> Result<(), PluginBundleEr
     if endpoint_url == DEFAULT_ENDPOINT_URL {
         return Ok(());
     }
-    let mut entries = Vec::new();
-    collect_entries(root, root, &mut entries)?;
-    for (_, kind, absolute) in entries {
+    for (_, kind, absolute) in walk(root)? {
         if kind != KIND_FILE {
             continue;
         }
@@ -881,9 +903,8 @@ fn set_executable_modes(root: &Path) -> Result<(), PluginBundleError> {
 
     for relative in ["plugin/statusline.sh", "plugin/hooks/ensure-runtime.sh"] {
         let path = root.join(relative);
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).map_err(|source| {
-            PluginBundleError::WriteDeployment { path, source }
-        })?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            .map_err(|source| PluginBundleError::WriteDeployment { path, source })?;
     }
     Ok(())
 }
@@ -906,10 +927,7 @@ fn paths_sh(plan: &DeploymentPlan) -> String {
     ] {
         rendered.push_str(&format!("{name}={}\n", sh_literal(&value.to_string_lossy())));
     }
-    rendered.push_str(&format!(
-        "APPA_ENDPOINT={}\n",
-        sh_literal(plan.endpoint.url())
-    ));
+    rendered.push_str(&format!("APPA_ENDPOINT={}\n", sh_literal(plan.endpoint.url())));
     rendered.push_str(&format!(
         "APPA_LISTEN={}\n",
         sh_literal(&plan.endpoint.listen().to_string())
@@ -925,15 +943,9 @@ fn paths_ps1(plan: &DeploymentPlan) -> String {
         ("AppaConfig", plan.config_path.as_path()),
         ("AppaDataDir", plan.data_dir.as_path()),
     ] {
-        rendered.push_str(&format!(
-            "${name} = {}\n",
-            ps_literal(&value.to_string_lossy())
-        ));
+        rendered.push_str(&format!("${name} = {}\n", ps_literal(&value.to_string_lossy())));
     }
-    rendered.push_str(&format!(
-        "$AppaEndpoint = {}\n",
-        ps_literal(plan.endpoint.url())
-    ));
+    rendered.push_str(&format!("$AppaEndpoint = {}\n", ps_literal(plan.endpoint.url())));
     rendered.push_str(&format!(
         "$AppaListen = {}\n",
         ps_literal(&plan.endpoint.listen().to_string())
@@ -1015,11 +1027,9 @@ pub fn ensure_archive(
     })?;
 
     let url = format!("{base_url}/v{version}/{}", artifact_name(version));
-    let incoming = tempfile::NamedTempFile::new_in(cache_dir).map_err(|source| {
-        PluginBundleError::WriteDeployment {
-            path: cache_dir.to_path_buf(),
-            source,
-        }
+    let incoming = tempfile::NamedTempFile::new_in(cache_dir).map_err(|source| PluginBundleError::WriteDeployment {
+        path: cache_dir.to_path_buf(),
+        source,
     })?;
     download(&url, incoming.path())?;
 
@@ -1051,11 +1061,9 @@ fn digest_of_file(path: &Path) -> Result<PluginDigest, PluginBundleError> {
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 64 * 1024];
     loop {
-        let read = std::io::Read::read(&mut file, &mut buffer).map_err(|source| {
-            PluginBundleError::ReadSource {
-                path: path.to_path_buf(),
-                source,
-            }
+        let read = std::io::Read::read(&mut file, &mut buffer).map_err(|source| PluginBundleError::ReadSource {
+            path: path.to_path_buf(),
+            source,
         })?;
         if read == 0 {
             break;
@@ -1108,30 +1116,20 @@ fn download(url: &str, destination: &Path) -> Result<(), PluginBundleError> {
             )));
         }
 
-        let mut file = fs::File::create(destination).map_err(|source| {
-            PluginBundleError::WriteDeployment {
-                path: destination.to_path_buf(),
-                source,
-            }
+        let mut file = fs::File::create(destination).map_err(|source| PluginBundleError::WriteDeployment {
+            path: destination.to_path_buf(),
+            source,
         })?;
         let mut written = 0u64;
         let mut stream = response;
-        while let Some(chunk) = stream
-            .chunk()
-            .await
-            .map_err(|error| failed(error.to_string()))?
-        {
+        while let Some(chunk) = stream.chunk().await.map_err(|error| failed(error.to_string()))? {
             written = written.saturating_add(chunk.len() as u64);
             if written > MAX_ARCHIVE_BYTES {
-                return Err(failed(format!(
-                    "it exceeds the {MAX_ARCHIVE_BYTES} bytes accepted"
-                )));
+                return Err(failed(format!("it exceeds the {MAX_ARCHIVE_BYTES} bytes accepted")));
             }
-            std::io::Write::write_all(&mut file, &chunk).map_err(|source| {
-                PluginBundleError::WriteDeployment {
-                    path: destination.to_path_buf(),
-                    source,
-                }
+            std::io::Write::write_all(&mut file, &chunk).map_err(|source| PluginBundleError::WriteDeployment {
+                path: destination.to_path_buf(),
+                source,
             })?;
         }
         Ok(())
@@ -1160,10 +1158,7 @@ mod tests {
     #[test]
     fn portable_path_uses_forward_slashes() {
         let relative: PathBuf = ["plugin", "hooks", "hooks.json"].iter().collect();
-        assert_eq!(
-            portable_relative_path(&relative).unwrap(),
-            "plugin/hooks/hooks.json"
-        );
+        assert_eq!(portable_relative_path(&relative).unwrap(), "plugin/hooks/hooks.json");
     }
 
     #[test]
@@ -1404,7 +1399,11 @@ mod tests {
 
         assert_eq!(digest_of_file(&archive).unwrap(), digest);
         assert!(
-            archive.file_name().unwrap().to_string_lossy().contains(&digest.to_string()),
+            archive
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .contains(&digest.to_string()),
             "the cache is content-addressed by name"
         );
     }
@@ -1417,10 +1416,7 @@ mod tests {
 
         let refused = ensure_archive(expected, "9.9.9", cache.path(), &base);
 
-        assert!(matches!(
-            refused,
-            Err(PluginBundleError::DigestMismatch { .. })
-        ));
+        assert!(matches!(refused, Err(PluginBundleError::DigestMismatch { .. })));
         let leftovers: Vec<_> = fs::read_dir(cache.path())
             .unwrap()
             .filter_map(Result::ok)
@@ -1437,8 +1433,7 @@ mod tests {
         fs::write(cached_archive_path(cache.path(), "9.9.9", digest), &body).unwrap();
 
         // Nothing is listening here, so any request would fail.
-        let archive =
-            ensure_archive(digest, "9.9.9", cache.path(), "http://127.0.0.1:1").unwrap();
+        let archive = ensure_archive(digest, "9.9.9", cache.path(), "http://127.0.0.1:1").unwrap();
 
         assert_eq!(fs::read(archive).unwrap(), body);
     }
@@ -1473,8 +1468,7 @@ mod tests {
 
         let archive = source.path().parent().unwrap().join("bundle.tar.gz");
         let packed = fs::File::create(&archive).unwrap();
-        let mut builder =
-            tar::Builder::new(flate2::write::GzEncoder::new(packed, flate2::Compression::fast()));
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(packed, flate2::Compression::fast()));
         builder.append_dir_all(".", source.path()).unwrap();
         builder.into_inner().unwrap().finish().unwrap();
 
@@ -1493,6 +1487,38 @@ mod tests {
         // The platform selection removes the map this platform does not use.
         assert!(!deployment.root.join(WINDOWS_HOOKS).is_file());
         fs::remove_file(&archive).unwrap();
+    }
+
+    #[test]
+    fn an_oversized_development_source_is_refused_before_it_is_copied() {
+        let source = tempfile::tempdir().unwrap();
+        let deployments = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+
+        // A generated directory that wandered into the checkout.
+        let generated = source.path().join("plugin/generated");
+        fs::create_dir_all(&generated).unwrap();
+        for index in 0..=MAX_ENTRIES {
+            fs::write(generated.join(format!("{index}")), b"x").unwrap();
+        }
+
+        let refused = materialize(
+            Population::Tree(source.path()),
+            deployments.path(),
+            Path::new("/data/bin/appa"),
+            Path::new("/config/appa.toml"),
+            Path::new("/data"),
+            &Endpoint::parse(DEFAULT_ENDPOINT_URL).unwrap(),
+        );
+
+        assert!(matches!(refused, Err(PluginBundleError::OversizedSource { .. })));
+        // Nothing was published, and no half-copied tree was left behind.
+        let published: Vec<_> = fs::read_dir(deployments.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(published.is_empty(), "a refused source left {published:?}");
     }
 
     #[test]

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -22,6 +22,19 @@ pub fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
+/// The marketplace root a developer passes to `--plugin-source`, staged into
+/// `into` by the same script the release runs.
+pub fn stage_bundle(into: &Path) -> PathBuf {
+    let staged = into.join("plugin-source");
+    let status = std::process::Command::new("sh")
+        .arg(repo_root().join("scripts/appa-stage-plugin-bundle.sh"))
+        .arg(&staged)
+        .status()
+        .expect("the staging script runs");
+    assert!(status.success(), "the staging script failed");
+    staged
+}
+
 /// Every offer a feedback body names, in the order the feedback lists
 /// them. Which end a suite takes is its own assertion: a remedy plan
 /// that stages several offers surfaces one line each.

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -1,3 +1,17 @@
 #!/bin/sh
+# The runtime's /binary-fingerprint answer. FAKE_RUNTIME_FINGERPRINT_LATER, when
+# set, is what every call after the first reports: init probes the endpoint once
+# before it mutates anything and once after the start, and the two answers
+# differing is how a foreign runtime arriving mid-install is reproduced.
 set -eu
+
+if [ -n "${FAKE_CURL_CALLS:-}" ]; then
+  count=$(( $(cat "$FAKE_CURL_CALLS" 2>/dev/null || echo 0) + 1 ))
+  printf '%s' "$count" >"$FAKE_CURL_CALLS"
+  if [ -n "${FAKE_RUNTIME_FINGERPRINT_LATER:-}" ] && [ "$count" -gt 1 ]; then
+    printf '%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER"
+    exit 0
+  fi
+fi
+
 printf '%s\n' "$FAKE_RUNTIME_FINGERPRINT"

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -271,3 +271,80 @@ fn init_keeps_a_custom_statusline() {
     assert!(settings.contains("my-status"));
     assert!(!bin.join("appa-statusline.sh").exists());
 }
+
+/// A relative directory override must not reach the rendered hooks as written.
+///
+/// Hooks run from whatever working directory Claude was launched in, so a
+/// relative `state/bin/appa` would resolve somewhere else entirely at hook time
+/// and find no binary, config or database.
+#[test]
+fn relative_directory_overrides_are_rendered_absolute() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let root = directory.path().canonicalize().expect("a resolved root");
+    let bin = root.join("bin");
+    let claude = root.join("claude");
+    let plugin = root.join("installed-plugin");
+    fs::create_dir_all(&bin).expect("bin directory");
+    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
+    let appa = install_test_binaries(&bin);
+    install_fake_curl(&bin);
+    let source = stage_bundle(&root);
+    let fingerprint = runtime_fingerprint(&appa);
+
+    let fake_claude = bin.join("claude");
+    fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
+        &fake_claude,
+    )
+    .expect("fake claude is copied");
+    executable(&fake_claude);
+    let starter = plugin.join("hooks/ensure-runtime.sh");
+    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
+    executable(&starter);
+    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
+
+    let output = Command::new(&appa)
+        .current_dir(&root)
+        .args(["init", "claude-code", "--plugin-source"])
+        .arg(&source)
+        .env(
+            "PATH",
+            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
+        )
+        .env("HOME", &root)
+        // Relative, resolved against this working directory and no other.
+        .env("APPA_INSTALL_DIR", "bin")
+        .env("APPA_CONFIG_DIR", "config")
+        .env("APPA_DATA_DIR", "state")
+        .env("CLAUDE_CONFIG_DIR", &claude)
+        .env("FAKE_CLAUDE_HOME", &claude)
+        .env("FAKE_CLAUDE_LOG", root.join("claude.log"))
+        .env("FAKE_PLUGIN_ROOT", &plugin)
+        .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
+        .output()
+        .expect("appa init runs");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+    let deployments = root.join("state/deployments");
+    let deployment = fs::read_dir(&deployments)
+        .expect("the deployment directory exists")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.join("plugin/hooks/appa-paths.sh").is_file())
+        .expect("one materialized deployment");
+
+    let rendered =
+        fs::read_to_string(deployment.join("plugin/hooks/appa-paths.sh")).expect("the rendered paths file is readable");
+    for name in ["APPA_BIN", "APPA_CONFIG", "APPA_DATA_DIR"] {
+        let value = rendered
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{name}='")))
+            .and_then(|rest| rest.strip_suffix('\''))
+            .unwrap_or_else(|| panic!("{name} is missing from {rendered}"));
+        assert!(Path::new(value).is_absolute(), "{name} was rendered relative: {value}",);
+        assert!(
+            Path::new(value).starts_with(&root),
+            "{name} does not resolve under the working directory it was given: {value}",
+        );
+    }
+}

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -30,9 +30,28 @@ fn install_fake_curl(bin: &Path) {
     executable(&curl);
 }
 
-fn runtime_fingerprint(bin: &Path) -> String {
-    let digest = Sha256::digest(fs::read(bin.join("appa")).expect("runtime bytes"));
+fn runtime_fingerprint(deployed: &Path) -> String {
+    let digest = Sha256::digest(fs::read(deployed).expect("runtime bytes"));
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// The marketplace root a developer passes to `--plugin-source`, staged by the
+/// same script the release runs.
+fn stage_bundle(into: &Path) -> std::path::PathBuf {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let staged = into.join("plugin-source");
+    let status = Command::new("sh")
+        .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
+        .arg(&staged)
+        .status()
+        .expect("the staging script runs");
+    assert!(status.success(), "the staging script failed");
+    staged
+}
+
+/// Where init deploys the harness binary: private to appa, never on PATH.
+fn deployed_binary(data: &Path) -> std::path::PathBuf {
+    data.join("bin/appa")
 }
 
 #[test]
@@ -49,7 +68,8 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     fs::copy(&appa, bin.join("appa-runtime")).expect("legacy runtime fixture is copied");
     executable(&bin.join("appa-runtime"));
     install_fake_curl(&bin);
-    let fingerprint = runtime_fingerprint(&bin);
+    let source = stage_bundle(directory.path());
+    let fingerprint = runtime_fingerprint(&appa);
 
     let fake_claude = bin.join("claude");
     fs::copy(
@@ -68,9 +88,13 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     let path = format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default());
     let run = |reported_fingerprint: &str, fail_once: Option<&str>| {
         let mut command = Command::new(&appa);
+        // Run from a directory that holds no marketplace: default resolution
+        // must not consult the working directory, and an explicit source is an
+        // ordinary path argument.
         command
-            .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join(".."))
-            .args(["init", "claude-code"])
+            .current_dir(directory.path())
+            .args(["init", "claude-code", "--plugin-source"])
+            .arg(&source)
             .env("PATH", &path)
             .env("HOME", directory.path())
             .env("APPA_INSTALL_DIR", &bin)
@@ -91,9 +115,13 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     assert!(first.status.success(), "{}", String::from_utf8_lossy(&first.stderr));
     let first_stdout = String::from_utf8(first.stdout).expect("UTF-8 output");
     assert!(first_stdout.starts_with("OpenAPPA initialized for Claude Code"));
-    assert!(first_stdout.contains("Adapter   current checkout"));
+    assert!(first_stdout.contains("development source"));
     assert!(first_stdout.contains("(created)"));
+    // The harness binary lands on an appa-private path, not on PATH, and the
+    // copy that is on PATH is named rather than removed.
+    assert!(deployed_binary(&data).is_file());
     assert!(bin.join("appa").is_file());
+    assert!(first_stdout.contains("A previous appa remains at"));
     assert!(!bin.join("appa-runtime").exists());
     assert!(bin.join("clappa").is_file());
     assert!(bin.join("appa-statusline.sh").is_file());
@@ -198,7 +226,8 @@ fn init_keeps_a_custom_statusline() {
     fs::create_dir_all(&claude).expect("Claude directory");
     let appa = install_test_binaries(&bin);
     install_fake_curl(&bin);
-    let fingerprint = runtime_fingerprint(&bin);
+    let source = stage_bundle(directory.path());
+    let fingerprint = runtime_fingerprint(&appa);
 
     let fake_claude = bin.join("claude");
     fs::copy(
@@ -218,8 +247,9 @@ fn init_keeps_a_custom_statusline() {
     .expect("custom settings");
 
     let output = Command::new(appa)
-        .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join(".."))
-        .args(["init", "claude-code"])
+        .current_dir(directory.path())
+        .args(["init", "claude-code", "--plugin-source"])
+        .arg(&source)
         .env(
             "PATH",
             format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -180,9 +180,30 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
         );
     }
 
+    // A foreign runtime already owning the endpoint is refused before Claude is
+    // touched at all, so the installation it would have replaced is still the
+    // one that is registered and running.
+    let before = fs::read_to_string(&log).expect("Claude invocation log");
     let wrong_runtime = run("not-this-build", None);
     assert!(!wrong_runtime.status.success());
     assert!(String::from_utf8_lossy(&wrong_runtime.stderr).contains("different appa build"));
+    let after = fs::read_to_string(&log).expect("Claude invocation log");
+    assert_eq!(
+        after.lines().count() - before.lines().count(),
+        after
+            .lines()
+            .skip(before.lines().count())
+            .filter(|line| line.starts_with("plugin marketplace list"))
+            .count(),
+        "a refused endpoint must not reach a single mutating claude call: {}",
+        &after[before.len()..],
+    );
+    assert!(
+        !fs::read_to_string(bin.join("clappa"))
+            .expect("launcher")
+            .contains("init did not complete"),
+        "a refused endpoint must leave the working launcher armed",
+    );
 
     let unrecoverable = run(&fingerprint, Some("plugin-install-always"));
     assert!(!unrecoverable.status.success());
@@ -336,4 +357,89 @@ fn relative_directory_overrides_are_rendered_absolute() {
             "{name} does not resolve under the working directory it was given: {value}",
         );
     }
+}
+
+/// A runtime that fails verification *after* the Claude switch must take the
+/// switch with it.
+///
+/// The preflight refuses a foreign owner that is already there, but one can
+/// arrive between the preflight and the start. Leaving the new plugin
+/// registered and the launcher armed against it would be the exact skew this
+/// bundle exists to prevent: Claude gated by a plugin talking to a runtime
+/// nobody verified. There was no plugin here before, so undoing means removing
+/// the one just installed rather than restoring a predecessor.
+#[test]
+fn a_runtime_that_fails_verification_after_the_switch_undoes_it() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let root = directory.path();
+    let bin = root.join("bin");
+    let claude = root.join("claude");
+    let plugin = root.join("installed-plugin");
+    fs::create_dir_all(&bin).expect("bin directory");
+    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
+    let appa = install_test_binaries(&bin);
+    install_fake_curl(&bin);
+    let source = stage_bundle(root);
+
+    let fake_claude = bin.join("claude");
+    fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
+        &fake_claude,
+    )
+    .expect("fake claude is copied");
+    executable(&fake_claude);
+    let starter = plugin.join("hooks/ensure-runtime.sh");
+    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
+    executable(&starter);
+    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
+
+    let output = Command::new(&appa)
+        .current_dir(root)
+        .args(["init", "claude-code", "--plugin-source"])
+        .arg(&source)
+        .env(
+            "PATH",
+            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
+        )
+        .env("HOME", root)
+        .env("APPA_INSTALL_DIR", &bin)
+        .env("APPA_CONFIG_DIR", root.join("config"))
+        .env("APPA_DATA_DIR", root.join("data"))
+        .env("CLAUDE_CONFIG_DIR", &claude)
+        .env("FAKE_CLAUDE_HOME", &claude)
+        .env("FAKE_CLAUDE_LOG", root.join("claude.log"))
+        .env("FAKE_PLUGIN_ROOT", &plugin)
+        // The preflight sees this build; everything after it sees a stranger.
+        .env("FAKE_CURL_CALLS", root.join("curl-calls"))
+        .env("FAKE_RUNTIME_FINGERPRINT", runtime_fingerprint(&appa))
+        .env("FAKE_RUNTIME_FINGERPRINT_LATER", "not-this-build")
+        .output()
+        .expect("appa init runs");
+
+    assert!(
+        !output.status.success(),
+        "verification against a foreign runtime must fail init",
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("different appa build"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let registry: serde_json::Value =
+        serde_json::from_slice(&fs::read(claude.join("plugins/installed_plugins.json")).expect("plugin registry"))
+            .expect("registry JSON");
+    assert_eq!(
+        registry["plugins"]["appa-runtime@appa"].as_array().map(Vec::len),
+        None,
+        "the plugin must not stay registered against a runtime that failed verification",
+    );
+    assert!(
+        !claude.join("marketplace-appa").is_file(),
+        "the marketplace must not stay registered either",
+    );
+    assert!(
+        !bin.join("clappa").exists(),
+        "the launcher must not be armed for a bundle whose runtime failed verification",
+    );
 }

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -7,6 +7,9 @@ use std::process::Command;
 
 use sha2::{Digest, Sha256};
 
+mod common;
+use common::stage_bundle;
+
 fn executable(path: &Path) {
     let mut permissions = fs::metadata(path).expect("fixture metadata").permissions();
     permissions.set_mode(0o755);
@@ -33,20 +36,6 @@ fn install_fake_curl(bin: &Path) {
 fn runtime_fingerprint(deployed: &Path) -> String {
     let digest = Sha256::digest(fs::read(deployed).expect("runtime bytes"));
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-
-/// The marketplace root a developer passes to `--plugin-source`, staged by the
-/// same script the release runs.
-fn stage_bundle(into: &Path) -> std::path::PathBuf {
-    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
-    let staged = into.join("plugin-source");
-    let status = Command::new("sh")
-        .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
-        .arg(&staged)
-        .status()
-        .expect("the staging script runs");
-    assert!(status.success(), "the staging script failed");
-    staged
 }
 
 /// Where init deploys the harness binary: private to appa, never on PATH.

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -12,16 +12,19 @@ use axum::routing::post;
 const TURN_ENDS: [&str; 3] = ["Stop", "StopFailure", "SubagentStop"];
 
 fn turn_end_command() -> &'static str {
-    "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; \
-     [ -x \"$b\" ] || b=appa; \"$b\" hook --turn-end || exit 0"
+    "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" --turn-end || exit 0"
 }
 
-/// Where the shipped commands look for the binary first. Without it they would
-/// find whatever appa this machine has installed, not the one built here.
-fn install_dir() -> &'static std::path::Path {
+/// The binary the shipped commands must reach. A deployed tree has this
+/// rendered into appa-paths.sh as an absolute path; the checkout's development
+/// copy takes it from the environment, which is what lets a checkout run
+/// against the binary built here rather than whatever appa this machine has.
+fn built_binary() -> &'static std::path::Path {
     std::path::Path::new(env!("CARGO_BIN_EXE_appa"))
-        .parent()
-        .expect("the built binary sits in a directory")
+}
+
+fn plugin_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../integrations/claude-code/plugin")
 }
 
 fn shipped(file: &str) -> serde_json::Value {
@@ -39,20 +42,16 @@ fn plugin_file(file: &str) -> std::path::PathBuf {
 }
 
 #[test]
-fn runtime_starters_can_replace_the_retired_binary_name() {
+fn runtime_starters_stop_only_the_binary_this_deployment_installed() {
     let posix =
         std::fs::read_to_string(plugin_file("hooks/ensure-runtime.sh")).expect("the POSIX runtime starter is readable");
     assert!(
-        posix.contains("appa | */appa | appa-runtime | */appa-runtime"),
-        "the POSIX starter must recognize a stale pre-0.5 runtime",
+        posix.contains("appa | */appa)"),
+        "the POSIX starter must check the stale process's name before signalling it",
     );
 
     let windows =
         std::fs::read_to_string(plugin_file("hooks/hook.ps1")).expect("the Windows runtime starter is readable");
-    assert!(
-        windows.contains("$process.ProcessName -eq \"appa-runtime\""),
-        "the Windows starter must recognize a stale pre-0.5 runtime",
-    );
     assert!(
         windows.contains("[StringComparison]::OrdinalIgnoreCase"),
         "the Windows starter must verify the stale process's installed path",
@@ -176,8 +175,8 @@ fn shipped_command() -> String {
         Some(
             command
                 .replace(
-                    "; \"$b\" hook",
-                    "; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && \"$b\" hook",
+                    "; sh",
+                    "; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && sh",
                 )
                 .as_str()
         ),
@@ -195,7 +194,8 @@ fn run_gated(command: &str, url: &str, gated: bool) -> (i32, String) {
         .arg("-c")
         .arg(command)
         .env("APPA_RUNTIME_URL", url)
-        .env("APPA_INSTALL_DIR", install_dir())
+        .env("CLAUDE_PLUGIN_ROOT", plugin_root())
+        .env("APPA_BIN", built_binary())
         .env("APPA_GATE", if gated { "1" } else { "0" })
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -42,23 +42,6 @@ fn plugin_file(file: &str) -> std::path::PathBuf {
 }
 
 #[test]
-fn runtime_starters_stop_only_the_binary_this_deployment_installed() {
-    let posix =
-        std::fs::read_to_string(plugin_file("hooks/ensure-runtime.sh")).expect("the POSIX runtime starter is readable");
-    assert!(
-        posix.contains("appa | */appa)"),
-        "the POSIX starter must check the stale process's name before signalling it",
-    );
-
-    let windows =
-        std::fs::read_to_string(plugin_file("hooks/hook.ps1")).expect("the Windows runtime starter is readable");
-    assert!(
-        windows.contains("[StringComparison]::OrdinalIgnoreCase"),
-        "the Windows starter must verify the stale process's installed path",
-    );
-}
-
-#[test]
 fn an_ungated_session_has_no_appa_statusline() {
     let output = Command::new("sh")
         .arg(plugin_file("statusline.sh"))

--- a/appa-runtime/tests/real_claude.rs
+++ b/appa-runtime/tests/real_claude.rs
@@ -15,17 +15,8 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-fn stage_bundle(into: &Path) -> std::path::PathBuf {
-    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
-    let staged = into.join("plugin-source");
-    let status = Command::new("sh")
-        .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
-        .arg(&staged)
-        .status()
-        .expect("the staging script runs");
-    assert!(status.success(), "the staging script failed");
-    staged
-}
+mod common;
+use common::stage_bundle;
 
 fn claude(config: &Path, arguments: &[&str]) -> std::process::Output {
     Command::new("claude")

--- a/appa-runtime/tests/real_claude.rs
+++ b/appa-runtime/tests/real_claude.rs
@@ -1,0 +1,132 @@
+#![cfg(unix)]
+//! Claude Code's own plugin semantics, captured against the real CLI.
+//!
+//! These are the facts init's sequence depends on, and none of them is stated
+//! anywhere in this repository: they were established by running `claude`
+//! against an isolated `CLAUDE_CONFIG_DIR`. They are pinned here so a change in
+//! Claude's behaviour surfaces as a failing test rather than as a broken
+//! install.
+//!
+//! Ignored by default: they need a real `claude` on PATH and mutate its plugin
+//! registry, in an isolated config directory. Run with
+//! `cargo test -- --ignored real_claude`.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn stage_bundle(into: &Path) -> std::path::PathBuf {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let staged = into.join("plugin-source");
+    let status = Command::new("sh")
+        .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
+        .arg(&staged)
+        .status()
+        .expect("the staging script runs");
+    assert!(status.success(), "the staging script failed");
+    staged
+}
+
+fn claude(config: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new("claude")
+        .args(arguments)
+        .env("CLAUDE_CONFIG_DIR", config)
+        .output()
+        .expect("the claude CLI runs")
+}
+
+fn registry(config: &Path) -> serde_json::Value {
+    let path = config.join("plugins/installed_plugins.json");
+    serde_json::from_slice(&fs::read(path).expect("the plugin registry is readable"))
+        .expect("the plugin registry parses")
+}
+
+#[test]
+#[ignore = "needs a real claude CLI and mutates its plugin registry"]
+fn real_claude_keeps_the_marketplace_directory_and_copies_the_plugin() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    // A path with a space: marketplace registration and plugin installation
+    // must both survive one.
+    let root = directory.path().join("a space");
+    fs::create_dir_all(&root).expect("the working root");
+    let config = root.join("claude config");
+    fs::create_dir_all(&config).expect("the isolated Claude config directory");
+    let source = stage_bundle(&root);
+
+    let added = claude(
+        &config,
+        &["plugin", "marketplace", "add", source.to_str().expect("UTF-8 path")],
+    );
+    assert!(
+        added.status.success(),
+        "marketplace add failed: {}",
+        String::from_utf8_lossy(&added.stderr),
+    );
+
+    let installed = claude(&config, &["plugin", "install", "appa-runtime@appa", "--scope", "user"]);
+    assert!(
+        installed.status.success(),
+        "plugin install failed: {}",
+        String::from_utf8_lossy(&installed.stderr),
+    );
+
+    // A local marketplace directory is recorded, not cloned: init can therefore
+    // register an immutable deployment directory and rely on Claude reading it
+    // from there.
+    let marketplaces: serde_json::Value = serde_json::from_slice(
+        &fs::read(config.join("plugins/marketplaces.json")).expect("the marketplace registry is readable"),
+    )
+    .expect("the marketplace registry parses");
+    let recorded = marketplaces["marketplaces"]["appa"]["source"]["path"]
+        .as_str()
+        .expect("a local marketplace records its directory");
+    assert_eq!(
+        Path::new(recorded),
+        source,
+        "Claude no longer keeps a local marketplace's own directory",
+    );
+
+    // The plugin itself is copied to an installPath under Claude's cache, so
+    // editing the source afterwards does not reach an installed session.
+    let entry = &registry(&config)["plugins"]["appa-runtime@appa"][0];
+    let install_path = entry["installPath"].as_str().expect("an installed plugin has a path");
+    assert_ne!(
+        Path::new(install_path),
+        source.join("plugin"),
+        "Claude no longer copies an installed plugin out of its marketplace",
+    );
+    assert!(
+        Path::new(install_path).join("hooks/hooks.json").is_file(),
+        "the copied plugin is missing its hook map",
+    );
+
+    // Re-installing the same version is a no-op that does not refresh the copy,
+    // which is why init removes the marketplace and re-adds it rather than
+    // installing over the top.
+    let marker = Path::new(install_path).join("hooks/hooks.json");
+    let before = fs::metadata(&marker).expect("hook map metadata");
+    let reinstalled = claude(&config, &["plugin", "install", "appa-runtime@appa", "--scope", "user"]);
+    assert!(reinstalled.status.success());
+    let after = fs::metadata(&marker).expect("hook map metadata");
+    assert_eq!(
+        before.modified().ok(),
+        after.modified().ok(),
+        "a same-version reinstall now refreshes the copy; init's remove-then-add may be unnecessary",
+    );
+
+    // Uninstall removes the registry entry, which is what init's rollback
+    // relies on being able to undo.
+    let uninstalled = claude(
+        &config,
+        &["plugin", "uninstall", "appa-runtime@appa", "--scope", "user", "--yes"],
+    );
+    assert!(
+        uninstalled.status.success(),
+        "plugin uninstall failed: {}",
+        String::from_utf8_lossy(&uninstalled.stderr),
+    );
+    let remaining = registry(&config)["plugins"]["appa-runtime@appa"]
+        .as_array()
+        .map_or(0, Vec::len);
+    assert_eq!(remaining, 0, "uninstall left the plugin registered");
+}

--- a/appa-runtime/tests/real_claude.rs
+++ b/appa-runtime/tests/real_claude.rs
@@ -94,14 +94,20 @@ fn real_claude_keeps_the_marketplace_directory_and_copies_the_plugin() {
     // Re-installing the same version is a no-op that does not refresh the copy,
     // which is why init removes the marketplace and re-adds it rather than
     // installing over the top.
+    //
+    // Marking the installed copy rather than comparing timestamps: a refresh
+    // that copies unchanged bytes can preserve or coarsely round the
+    // modification time, and then a timestamp comparison reports a no-op it
+    // never observed. Edited content survives only if nothing was copied over
+    // it, whether the refresh would replace the tree or write through it.
     let marker = Path::new(install_path).join("hooks/hooks.json");
-    let before = fs::metadata(&marker).expect("hook map metadata");
+    let marked = "{\"appa-reinstall-probe\": true}\n";
+    fs::write(&marker, marked).expect("the installed hook map is marked");
     let reinstalled = claude(&config, &["plugin", "install", "appa-runtime@appa", "--scope", "user"]);
     assert!(reinstalled.status.success());
-    let after = fs::metadata(&marker).expect("hook map metadata");
     assert_eq!(
-        before.modified().ok(),
-        after.modified().ok(),
+        fs::read_to_string(&marker).expect("hook map contents"),
+        marked,
         "a same-version reinstall now refreshes the copy; init's remove-then-add may be unnecessary",
     );
 

--- a/appa-runtime/tests/rendered_hooks.rs
+++ b/appa-runtime/tests/rendered_hooks.rs
@@ -1,0 +1,264 @@
+#![cfg(unix)]
+//! What a *rendered* deployment's hooks actually execute.
+//!
+//! The guarantee under test is narrow and stated as such: a deployed tree
+//! performs no PATH resolution for the `appa` binary. It still invokes `sh`,
+//! `curl` and `uname` by name, and that is unchanged.
+//!
+//! Proving it by scanning the rendered files would prove nothing, so every
+//! assertion here comes from execution: a hostile `appa` sits first on `PATH`,
+//! hostile `APPA_BIN` and `APPA_INSTALL_DIR` sit in the environment, and the
+//! test asserts which binary ran and where its bytes landed.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+
+use appa_runtime::plugin_bundle::{Endpoint, Population, materialize};
+
+fn executable(path: &Path) {
+    let mut permissions = fs::metadata(path).expect("fixture metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("the fixture is executable");
+}
+
+/// A marketplace root staged by the same script the release runs.
+fn stage_bundle(into: &Path) -> std::path::PathBuf {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let staged = into.join("plugin-source");
+    let status = Command::new("sh")
+        .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
+        .arg(&staged)
+        .status()
+        .expect("the staging script runs");
+    assert!(status.success(), "the staging script failed");
+    staged
+}
+
+/// A runtime stand-in on a free loopback port. Records the paths it is asked
+/// for and answers every hook, so the test can assert that the bytes a hook
+/// posted arrived at the deployment's own endpoint.
+fn recording_runtime() -> (Endpoint, mpsc::Receiver<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("a loopback port");
+    let endpoint = Endpoint::parse(&format!(
+        "http://{}",
+        listener.local_addr().expect("the bound address")
+    ))
+    .expect("the bound address is a usable endpoint");
+    let (record, recorded) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for connection in listener.incoming() {
+            let Ok(mut connection) = connection else {
+                return;
+            };
+            let mut reader = BufReader::new(connection.try_clone().expect("the stream clones"));
+            let mut request = String::new();
+            if reader.read_line(&mut request).is_err() {
+                continue;
+            }
+            let request = request.trim_end().to_owned();
+            // A healthy answer, so the SessionStart starter finds the runtime up
+            // and chains straight through to the hook rather than trying to
+            // start one.
+            let (content_type, body) = if request.starts_with("GET /health") {
+                ("text/plain", "ok")
+            } else {
+                ("application/json", "{}")
+            };
+            if record.send(request).is_err() {
+                return;
+            }
+            let answer = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = connection.write_all(answer.as_bytes());
+            let _ = connection.flush();
+        }
+    });
+
+    (endpoint, recorded)
+}
+
+/// Every hook command the rendered map registers, with the event it belongs to.
+fn rendered_commands(deployment: &Path) -> Vec<(String, String)> {
+    let hooks: serde_json::Value = serde_json::from_slice(
+        &fs::read(deployment.join("plugin/hooks/hooks.json")).expect("the rendered hook map is readable"),
+    )
+    .expect("the rendered hook map parses");
+
+    let mut commands = Vec::new();
+    for (event, groups) in hooks["hooks"].as_object().expect("the map is an object") {
+        for group in groups.as_array().expect("each event carries groups") {
+            for hook in group["hooks"].as_array().expect("each group carries hooks") {
+                let command = hook["command"].as_str().expect("each hook carries a command");
+                // The context hook only prints a file; it posts nothing.
+                if command.contains("session-context.md") {
+                    continue;
+                }
+                commands.push((event.clone(), command.to_owned()));
+            }
+        }
+    }
+    assert!(!commands.is_empty(), "the rendered map registered no commands");
+    commands
+}
+
+#[test]
+fn rendered_hooks_run_the_deployed_binary_and_post_to_the_deployment_endpoint() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let root = directory.path();
+    let source = stage_bundle(root);
+    let (endpoint, recorded) = recording_runtime();
+
+    // The binary this deployment installs, on a path that is not on PATH.
+    let deployed_bin = root.join("data/bin");
+    fs::create_dir_all(&deployed_bin).expect("the private binary directory");
+    let deployed = deployed_bin.join("appa");
+    fs::copy(env!("CARGO_BIN_EXE_appa"), &deployed).expect("the deployed binary is copied");
+    executable(&deployed);
+
+    let config = root.join("config/appa.toml");
+    fs::create_dir_all(config.parent().expect("config has a parent")).expect("config directory");
+
+    let deployment = materialize(
+        Population::Tree(&source),
+        &root.join("data/deployments"),
+        &deployed,
+        &config,
+        &root.join("data"),
+        &endpoint,
+    )
+    .expect("the deployment materializes");
+
+    // A hostile appa, first on PATH, that fails loudly and records the fact.
+    let poison_dir = root.join("poison");
+    fs::create_dir_all(&poison_dir).expect("the poison directory");
+    let poison_log = root.join("poisoned.log");
+    let poison = poison_dir.join("appa");
+    fs::write(
+        &poison,
+        format!(
+            "#!/bin/sh\nprintf 'ran\\n' >> {}\nexit 1\n",
+            poison_log.display()
+        ),
+    )
+    .expect("the poisoned appa is written");
+    executable(&poison);
+
+    let path = format!(
+        "{}:{}",
+        poison_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    for (event, command) in rendered_commands(&deployment.root) {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .env("PATH", &path)
+            // Hostile values for every variable a deployed tree must ignore.
+            .env("APPA_BIN", &poison)
+            .env("APPA_INSTALL_DIR", &poison_dir)
+            .env("APPA_GATE", "1")
+            .env("CLAUDE_PLUGIN_ROOT", deployment.root.join("plugin"))
+            .env_remove("APPA_RUNTIME_URL")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap_or_else(|error| panic!("the {event} hook spawns: {error}"));
+        let _ = child
+            .stdin
+            .as_mut()
+            .expect("the child has a stdin pipe")
+            .write_all(br#"{"hook_event_name":"PreToolUse","session_id":"rendered-test"}"#);
+        let _ = child.wait();
+
+        // The bytes have to land somewhere: an endpoint the rendering missed
+        // would fail here even if it were spelled in a way no scan could catch.
+        // SessionStart probes /health through its starter first, so the posted
+        // event is whichever request in this hook's chain reaches /hook.
+        let mut posted = false;
+        while let Ok(request) = recorded.recv_timeout(std::time::Duration::from_secs(20)) {
+            if request.starts_with("POST /hook ") {
+                posted = true;
+                break;
+            }
+            assert!(
+                request.starts_with("GET /health"),
+                "the {event} hook made an unexpected request: {request:?}",
+            );
+        }
+        assert!(
+            posted,
+            "the {event} hook posted no event to the deployment's endpoint",
+        );
+    }
+
+    assert!(
+        !poison_log.exists(),
+        "a rendered hook ran the appa on PATH: {}",
+        fs::read_to_string(&poison_log).unwrap_or_default(),
+    );
+}
+
+#[test]
+fn the_session_start_starter_resolves_its_paths_without_claude_plugin_root() {
+    // init runs the starter directly, without CLAUDE_PLUGIN_ROOT, so the
+    // `$(dirname "$0")` lookup inside it is load-bearing rather than incidental.
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let root = directory.path();
+    let source = stage_bundle(root);
+    let (endpoint, _recorded) = recording_runtime();
+
+    let deployed = root.join("data/bin/appa");
+    fs::create_dir_all(deployed.parent().expect("a parent")).expect("the private binary directory");
+    // A stand-in: the starter must resolve and execute this exact path, and
+    // nothing here needs a real runtime to prove that.
+    fs::write(&deployed, "#!/bin/sh\nexit 0\n").expect("the deployed stand-in is written");
+    executable(&deployed);
+
+    let deployment = materialize(
+        Population::Tree(&source),
+        &root.join("data/deployments"),
+        &deployed,
+        &root.join("config/appa.toml"),
+        &root.join("data"),
+        &endpoint,
+    )
+    .expect("the deployment materializes");
+
+    let starter = deployment.root.join("plugin/hooks/ensure-runtime.sh");
+    let rendered = fs::read_to_string(deployment.root.join("plugin/hooks/appa-paths.sh"))
+        .expect("the rendered paths file is readable");
+    assert!(
+        rendered.contains(&format!("APPA_BIN='{}'", deployed.display())),
+        "the starter's paths file does not name the deployed binary: {rendered}",
+    );
+    assert!(
+        rendered.contains(&format!("APPA_ENDPOINT='{}'", endpoint.url())),
+        "the starter's paths file does not carry the deployment endpoint: {rendered}",
+    );
+
+    let output = Command::new("sh")
+        .arg(&starter)
+        .env_remove("CLAUDE_PLUGIN_ROOT")
+        .env_remove("APPA_RUNTIME_URL")
+        .env("APPA_BIN", "/nonexistent/hostile/appa")
+        .output()
+        .expect("the starter runs");
+    // Nothing answers the recording endpoint's /health with `ok`, so the
+    // starter tries to start the stand-in and then times out. What matters is
+    // that it never reported a missing binary: it resolved the rendered path.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("appa is not installed"),
+        "the starter failed to resolve the rendered binary path: {stderr}",
+    );
+}

--- a/appa-runtime/tests/rendered_hooks.rs
+++ b/appa-runtime/tests/rendered_hooks.rs
@@ -72,6 +72,16 @@ fn recording_runtime() -> (Endpoint, mpsc::Receiver<String>) {
     (endpoint, recorded)
 }
 
+/// An endpoint nothing is listening on: bound to learn a free port, then
+/// released. A starter probing this one finds no runtime and proceeds to start
+/// the binary its paths file names, which is the branch under test.
+fn dead_endpoint() -> Endpoint {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("a loopback port");
+    let address = listener.local_addr().expect("the bound address");
+    drop(listener);
+    Endpoint::parse(&format!("http://{address}")).expect("the released address is a usable endpoint")
+}
+
 /// Every hook command the rendered map registers, with the event it belongs to.
 fn rendered_commands(deployment: &Path) -> Vec<(String, String)> {
     let hooks: serde_json::Value = serde_json::from_slice(
@@ -186,19 +196,26 @@ fn rendered_hooks_run_the_deployed_binary_and_post_to_the_deployment_endpoint() 
 }
 
 #[test]
-fn the_session_start_starter_resolves_its_paths_without_claude_plugin_root() {
+fn the_session_start_starter_starts_the_binary_its_deployment_installed() {
     // init runs the starter directly, without CLAUDE_PLUGIN_ROOT, so the
-    // `$(dirname "$0")` lookup inside it is load-bearing rather than incidental.
+    // directory lookup inside it is load-bearing rather than incidental. The
+    // endpoint is dead on purpose: a starter that finds a healthy runtime exits
+    // before it ever resolves a binary, which would prove nothing at all.
     let directory = tempfile::tempdir().expect("temporary directory");
     let root = directory.path();
     let source = stage_bundle(root);
-    let (endpoint, _recorded) = recording_runtime();
+    let endpoint = dead_endpoint();
 
     let deployed = root.join("data/bin/appa");
+    let started = root.join("started");
     fs::create_dir_all(deployed.parent().expect("a parent")).expect("the private binary directory");
-    // A stand-in: the starter must resolve and execute this exact path, and
-    // nothing here needs a real runtime to prove that.
-    fs::write(&deployed, "#!/bin/sh\nexit 0\n").expect("the deployed stand-in is written");
+    // A stand-in that records having run. It never becomes healthy, so the
+    // starter goes on to fail -- the marker, not the exit status, is the proof.
+    fs::write(
+        &deployed,
+        format!("#!/bin/sh\nprintf 'started\\n' > '{}'\nexit 0\n", started.display()),
+    )
+    .expect("the deployed stand-in is written");
     executable(&deployed);
 
     let deployment = materialize(
@@ -211,31 +228,27 @@ fn the_session_start_starter_resolves_its_paths_without_claude_plugin_root() {
     )
     .expect("the deployment materializes");
 
-    let starter = deployment.root.join("plugin/hooks/ensure-runtime.sh");
-    let rendered = fs::read_to_string(deployment.root.join("plugin/hooks/appa-paths.sh"))
-        .expect("the rendered paths file is readable");
-    assert!(
-        rendered.contains(&format!("APPA_BIN='{}'", deployed.display())),
-        "the starter's paths file does not name the deployed binary: {rendered}",
-    );
-    assert!(
-        rendered.contains(&format!("APPA_ENDPOINT='{}'", endpoint.url())),
-        "the starter's paths file does not carry the deployment endpoint: {rendered}",
-    );
-
-    let output = Command::new("sh")
-        .arg(&starter)
+    let mut child = Command::new("sh")
+        .arg(deployment.root.join("plugin/hooks/ensure-runtime.sh"))
         .env_remove("CLAUDE_PLUGIN_ROOT")
         .env_remove("APPA_RUNTIME_URL")
+        // Everything the starter could resolve through instead is hostile.
         .env("APPA_BIN", "/nonexistent/hostile/appa")
-        .output()
+        .env("APPA_INSTALL_DIR", "/nonexistent/hostile")
+        .spawn()
         .expect("the starter runs");
-    // Nothing answers the recording endpoint's /health with `ok`, so the
-    // starter tries to start the stand-in and then times out. What matters is
-    // that it never reported a missing binary: it resolved the rendered path.
-    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The starter waits 20 seconds for health it will never see; the marker
+    // appears as soon as it has resolved and executed the rendered path.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    while std::time::Instant::now() < deadline && !started.is_file() {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+
     assert!(
-        !stderr.contains("appa is not installed"),
-        "the starter failed to resolve the rendered binary path: {stderr}",
+        started.is_file(),
+        "the starter did not execute the binary its paths file names",
     );
 }

--- a/appa-runtime/tests/rendered_hooks.rs
+++ b/appa-runtime/tests/rendered_hooks.rs
@@ -44,11 +44,8 @@ fn stage_bundle(into: &Path) -> std::path::PathBuf {
 /// posted arrived at the deployment's own endpoint.
 fn recording_runtime() -> (Endpoint, mpsc::Receiver<String>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("a loopback port");
-    let endpoint = Endpoint::parse(&format!(
-        "http://{}",
-        listener.local_addr().expect("the bound address")
-    ))
-    .expect("the bound address is a usable endpoint");
+    let endpoint = Endpoint::parse(&format!("http://{}", listener.local_addr().expect("the bound address")))
+        .expect("the bound address is a usable endpoint");
     let (record, recorded) = mpsc::channel();
 
     std::thread::spawn(move || {
@@ -143,19 +140,12 @@ fn rendered_hooks_run_the_deployed_binary_and_post_to_the_deployment_endpoint() 
     let poison = poison_dir.join("appa");
     fs::write(
         &poison,
-        format!(
-            "#!/bin/sh\nprintf 'ran\\n' >> {}\nexit 1\n",
-            poison_log.display()
-        ),
+        format!("#!/bin/sh\nprintf 'ran\\n' >> {}\nexit 1\n", poison_log.display()),
     )
     .expect("the poisoned appa is written");
     executable(&poison);
 
-    let path = format!(
-        "{}:{}",
-        poison_dir.display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
+    let path = format!("{}:{}", poison_dir.display(), std::env::var("PATH").unwrap_or_default());
 
     for (event, command) in rendered_commands(&deployment.root) {
         let mut child = Command::new("sh")
@@ -195,10 +185,7 @@ fn rendered_hooks_run_the_deployed_binary_and_post_to_the_deployment_endpoint() 
                 "the {event} hook made an unexpected request: {request:?}",
             );
         }
-        assert!(
-            posted,
-            "the {event} hook posted no event to the deployment's endpoint",
-        );
+        assert!(posted, "the {event} hook posted no event to the deployment's endpoint",);
     }
 
     assert!(

--- a/appa-runtime/tests/rendered_hooks.rs
+++ b/appa-runtime/tests/rendered_hooks.rs
@@ -20,23 +20,13 @@ use std::sync::mpsc;
 
 use appa_runtime::plugin_bundle::{Endpoint, Population, materialize};
 
+mod common;
+use common::stage_bundle;
+
 fn executable(path: &Path) {
     let mut permissions = fs::metadata(path).expect("fixture metadata").permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(path, permissions).expect("the fixture is executable");
-}
-
-/// A marketplace root staged by the same script the release runs.
-fn stage_bundle(into: &Path) -> std::path::PathBuf {
-    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
-    let staged = into.join("plugin-source");
-    let status = Command::new("sh")
-        .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
-        .arg(&staged)
-        .status()
-        .expect("the staging script runs");
-    assert!(status.success(), "the staging script failed");
-    staged
 }
 
 /// A runtime stand-in on a free loopback port. Records the paths it is asked

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -47,17 +47,36 @@ appa init claude-code
 
 Init installs `clappa` beside `appa` so the short command works in later examples.
 
-From a checkout, `appa init` finds `integrations/claude-code` and registers that
-exact local marketplace. From an extracted release it uses the marketplace
-shipped beside the binaries. Otherwise it uses `archestra-ai/OpenAPPA`. It
-uninstalls an existing user-scoped APPA plugin and replaces its marketplace
+`appa init` installs one bundle: the plugin belonging to the running binary's
+own release, and that binary. Each build knows the SHA-256 of its release's
+plugin artifact and accepts no other bytes, so version X can never install
+version Y's plugin. The artifact is downloaded once, verified against that
+digest before anything outside a temporary file changes, and cached, so a later
+init needs no network. The result does not depend on the working directory.
+
+A build from a checkout has no baked-in digest. It refuses to download and asks
+for an explicit source:
+
+```sh
+sh scripts/appa-stage-plugin-bundle.sh /tmp/appa-plugin
+appa init claude-code --plugin-source /tmp/appa-plugin
+```
+
+Init uninstalls an existing user-scoped APPA plugin and replaces its marketplace
 before installing, so branch tests never stack two APPA hook sets.
 
-Initialization deploys the same `appa` build for its internal `runtime` command, creates the starting
-policy only when it is missing, installs `clappa`, preserves a custom Claude
-statusline, registers the plugin, and starts the runtime through the same
-starter used at SessionStart. A successful command therefore proves that one
-runtime and one plugin from the selected source are active.
+Initialization deploys the `appa` binary to a private path under the data
+directory and renders that exact path into the hooks, so a hook never resolves
+`appa` through `PATH`. It creates the starting policy only when it is missing,
+installs `clappa`, preserves a custom Claude statusline, registers the plugin,
+and starts the runtime through the same starter used at SessionStart. A
+successful command therefore proves that one runtime and one plugin from the
+selected source are active.
+
+Deployments are content-addressed and immutable: Claude is pointed at a
+directory that cannot change under it, rather than at a checkout or a remote
+marketplace. Re-running init repairs a deployment whose structure or rendered
+paths are wrong and is otherwise a no-op.
 
 Linux binaries require glibc 2.34 or newer. Alpine and other musl-only
 systems are not supported by the release assets.
@@ -69,9 +88,13 @@ the PowerShell adapter on native Windows; WSL uses the POSIX hooks.
 
 | System | Runtime | Policy | Database |
 | --- | --- | --- | --- |
-| Linux | `~/.local/bin/appa runtime` | `~/.config/appa/appa.toml` | `~/.local/share/appa/` |
-| macOS | `~/.local/bin/appa runtime` | `~/Library/Application Support/appa/appa.toml` | `~/Library/Application Support/appa/` |
+| Linux | `~/.local/share/appa/bin/appa runtime` | `~/.config/appa/appa.toml` | `~/.local/share/appa/` |
+| macOS | `~/Library/Application Support/appa/bin/appa runtime` | `~/Library/Application Support/appa/appa.toml` | `~/Library/Application Support/appa/` |
 | Windows | `%LOCALAPPDATA%\appa\bin\appa.exe runtime` | `%APPDATA%\appa\appa.toml` | `%LOCALAPPDATA%\appa\` |
+
+The harness binary is APPA's own, not something you put on `PATH`: hooks name
+that absolute path. `clappa` and the statusline stay where a shell and Claude's
+settings can find them.
 
 The runtime creates the starting policy only when the policy path does
 not exist. It never replaces the policy or database.
@@ -177,9 +200,22 @@ Claude usage, so nothing runs it automatically.
 ## Upgrade
 
 Install the new `appa` package, then rerun `appa init claude-code`. Init replaces
-the deployed runtime and the APPA marketplace together, preserves policy and
-database files, and restarts a runtime that reports its installed binary as
-stale.
+the deployed runtime and the APPA marketplace together, always as one bundle,
+and preserves policy and database files.
+
+**Restart any running `clappa` session after an upgrade.** Claude loads a
+session's hooks at session start, and the hook wire between plugin and runtime
+carries no version, so a session running across an upgrade keeps talking to the
+runtime it started with.
+
+Init stops a runtime that is still executing the path a previous init deployed
+to, and aborts before touching Claude if it cannot, rather than registering a
+new plugin against an old runtime. That covers the paths your current
+environment resolves to. A runtime left by an init run under a different
+`APPA_INSTALL_DIR` or `APPA_DATA_DIR` executes a path this init never computes:
+it is reported so you can stop it yourself, never killed. An `appa` left at the
+old install path is named in the receipt and never deleted; remove it when you
+are ready.
 
 ## Uninstall
 
@@ -187,7 +223,8 @@ stale.
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 pkill -f 'appa runtime'
-rm ~/.local/bin/appa ~/.cargo/bin/clappa ~/.local/bin/appa-statusline.sh
+rm -rf ~/.local/share/appa/bin ~/.local/share/appa/deployments ~/.local/share/appa/cache
+rm -f ~/.cargo/bin/clappa ~/.local/bin/appa-statusline.sh
 cargo uninstall appa
 
 # drop the statusline entry appa init wrote, and keep one of your own:

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -37,30 +37,33 @@ receives it, in the `Agent` tool's result.
 
 ## Install
 
-This flow needs Cargo, the `claude` command, and `curl`. Install the native CLI
-and let it initialize Claude Code:
-
-```sh
-cargo install --path appa-runtime --force
-appa init claude-code
-```
-
-Init installs `clappa` beside `appa` so the short command works in later examples.
+This flow needs the `claude` command, `curl`, and Cargo when building from a checkout.
 
 `appa init` installs one bundle: the plugin belonging to the running binary's
 own release, and that binary. Each build knows the SHA-256 of its release's
 plugin artifact and accepts no other bytes, so version X can never install
-version Y's plugin. The artifact is downloaded once, verified against that
-digest before anything outside a temporary file changes, and cached, so a later
-init needs no network. The result does not depend on the working directory.
+version Y's plugin. The result does not depend on the working directory.
 
-A build from a checkout has no baked-in digest. It refuses to download and asks
-for an explicit source:
+From a release binary, that digest is baked in. The artifact is downloaded once,
+verified against the digest before anything outside a temporary file changes,
+and cached, so a later init needs no network:
 
 ```sh
-sh scripts/appa-stage-plugin-bundle.sh /tmp/appa-plugin
-appa init claude-code --plugin-source /tmp/appa-plugin
+appa init claude-code
 ```
+
+A build from a checkout has no baked-in digest, because the digest exists only
+once a release has published the artifact. Such a build refuses to download and
+requires an explicit source: stage the bundle from the same checkout and name it.
+
+```sh
+cargo install --path appa-runtime --force
+plugin=$(mktemp -d)/bundle
+sh scripts/appa-stage-plugin-bundle.sh "$plugin"
+appa init claude-code --plugin-source "$plugin"
+```
+
+Init installs `clappa` beside `appa` so the short command works in later examples.
 
 Init uninstalls an existing user-scoped APPA plugin and replaces its marketplace
 before installing, so branch tests never stack two APPA hook sets.

--- a/integrations/claude-code/plugin/hooks/appa-paths.ps1
+++ b/integrations/claude-code/plugin/hooks/appa-paths.ps1
@@ -1,0 +1,30 @@
+# Development copy. `appa init claude-code` overwrites this file in the
+# deployment it materializes, with the absolute paths that init resolved and no
+# environment fallback at all.
+#
+# This copy exists so a checkout stays usable with --plugin-dir, where nothing
+# has been rendered yet.
+$AppaBin = if ($env:APPA_BIN) {
+    $env:APPA_BIN
+} elseif ($env:APPA_INSTALL_DIR) {
+    Join-Path $env:APPA_INSTALL_DIR 'appa.exe'
+} else {
+    Join-Path $env:LOCALAPPDATA 'appa\bin\appa.exe'
+}
+
+$AppaDataDir = if ($env:APPA_DATA_DIR) {
+    $env:APPA_DATA_DIR
+} else {
+    Join-Path $env:LOCALAPPDATA 'appa'
+}
+
+$AppaConfig = if ($env:APPA_CONFIG) {
+    $env:APPA_CONFIG
+} elseif ($env:APPA_CONFIG_DIR) {
+    Join-Path $env:APPA_CONFIG_DIR 'appa.toml'
+} else {
+    Join-Path $env:APPDATA 'appa\appa.toml'
+}
+
+$AppaEndpoint = if ($env:APPA_ENDPOINT) { $env:APPA_ENDPOINT } else { 'http://127.0.0.1:8787' }
+$AppaListen = if ($env:APPA_LISTEN) { $env:APPA_LISTEN } else { '127.0.0.1:8787' }

--- a/integrations/claude-code/plugin/hooks/appa-paths.sh
+++ b/integrations/claude-code/plugin/hooks/appa-paths.sh
@@ -1,0 +1,23 @@
+# Development copy. `appa init claude-code` overwrites this file in the
+# deployment it materializes, with the absolute paths that init resolved and no
+# environment fallback at all.
+#
+# This copy exists so `claude --plugin-dir integrations/claude-code/plugin` and
+# live-gate-check.py keep working against a checkout, where nothing has been
+# rendered yet.
+: "${APPA_BIN:=appa}"
+: "${APPA_ENDPOINT:=http://127.0.0.1:8787}"
+: "${APPA_LISTEN:=127.0.0.1:8787}"
+
+case "$(uname -s)" in
+  Darwin)
+    : "${APPA_CONFIG:=$HOME/Library/Application Support/appa/appa.toml}"
+    : "${APPA_DATA_DIR:=$HOME/Library/Application Support/appa}"
+    ;;
+  *)
+    : "${APPA_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/appa/appa.toml}"
+    : "${APPA_DATA_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/appa}"
+    ;;
+esac
+
+export APPA_BIN APPA_CONFIG APPA_DATA_DIR APPA_ENDPOINT APPA_LISTEN

--- a/integrations/claude-code/plugin/hooks/appa-paths.sh
+++ b/integrations/claude-code/plugin/hooks/appa-paths.sh
@@ -11,7 +11,10 @@ if [ -z "${APPA_BIN:-}" ]; then
   if [ -n "${APPA_INSTALL_DIR:-}" ]; then
     APPA_BIN="$APPA_INSTALL_DIR/appa"
   else
-    APPA_BIN=appa
+    # Resolved to a path, not left as a bare name: the starter tests
+    # `[ -x "$APPA_BIN" ]`, which no command name satisfies. When nothing is on
+    # PATH the name stays, and the starter reports it as not installed.
+    APPA_BIN=$(command -v appa 2>/dev/null || echo appa)
   fi
 fi
 : "${APPA_ENDPOINT:=http://127.0.0.1:8787}"

--- a/integrations/claude-code/plugin/hooks/appa-paths.sh
+++ b/integrations/claude-code/plugin/hooks/appa-paths.sh
@@ -5,19 +5,28 @@
 # This copy exists so `claude --plugin-dir integrations/claude-code/plugin` and
 # live-gate-check.py keep working against a checkout, where nothing has been
 # rendered yet.
-: "${APPA_BIN:=appa}"
+# The same precedence the PowerShell copy applies: an explicit value, then the
+# directory override init itself honours, then the platform default.
+if [ -z "${APPA_BIN:-}" ]; then
+  if [ -n "${APPA_INSTALL_DIR:-}" ]; then
+    APPA_BIN="$APPA_INSTALL_DIR/appa"
+  else
+    APPA_BIN=appa
+  fi
+fi
 : "${APPA_ENDPOINT:=http://127.0.0.1:8787}"
 : "${APPA_LISTEN:=127.0.0.1:8787}"
 
 case "$(uname -s)" in
   Darwin)
-    : "${APPA_CONFIG:=$HOME/Library/Application Support/appa/appa.toml}"
+    : "${APPA_CONFIG_DIR:=$HOME/Library/Application Support/appa}"
     : "${APPA_DATA_DIR:=$HOME/Library/Application Support/appa}"
     ;;
   *)
-    : "${APPA_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/appa/appa.toml}"
+    : "${APPA_CONFIG_DIR:=${XDG_CONFIG_HOME:-$HOME/.config}/appa}"
     : "${APPA_DATA_DIR:=${XDG_DATA_HOME:-$HOME/.local/share}/appa}"
     ;;
 esac
+: "${APPA_CONFIG:=$APPA_CONFIG_DIR/appa.toml}"
 
 export APPA_BIN APPA_CONFIG APPA_DATA_DIR APPA_ENDPOINT APPA_LISTEN

--- a/integrations/claude-code/plugin/hooks/ensure-runtime.sh
+++ b/integrations/claude-code/plugin/hooks/ensure-runtime.sh
@@ -8,7 +8,8 @@
 # runtime answers; any other exit makes the chained protection hook block,
 # and tells the install that it has nothing to report as running.
 # Installing the binary is not this script's job: `appa init claude-code`
-# installs it before registering this plugin.
+# installs it before registering this plugin, and renders its absolute path
+# into appa-paths.sh beside this file. Nothing here consults PATH.
 #
 # Concurrent starts need no lock. The runtime binds the loopback port, so
 # the first process to bind serves and every later one exits at once with
@@ -18,7 +19,12 @@
 # every start after it.
 set -u
 
-runtime_url=${APPA_RUNTIME_URL:-http://127.0.0.1:8787}
+# shellcheck source=integrations/claude-code/plugin/hooks/appa-paths.sh
+. "$(dirname "$0")/appa-paths.sh"
+
+# APPA_RUNTIME_URL keeps both of its jobs: the URL a client talks to, and the
+# signal that the runtime answering it is the user's own to restart.
+runtime_url=${APPA_RUNTIME_URL:-$APPA_ENDPOINT}
 
 # One cheap probe. A dead loopback port refuses at once on most systems but
 # hangs under some network stacks (WSL2 mirrored networking), where the
@@ -99,34 +105,19 @@ case $answer in
   stale\ *) stop_stale_runtime "${answer#stale }" || exit 1 ;;
 esac
 
-case "$(uname -s)" in
-  Darwin)
-    config_dir=${APPA_CONFIG_DIR:-"$HOME/Library/Application Support/appa"}
-    data_dir=${APPA_DATA_DIR:-"$HOME/Library/Application Support/appa"}
-    ;;
-  *)
-    config_dir=${APPA_CONFIG_DIR:-"${XDG_CONFIG_HOME:-$HOME/.config}/appa"}
-    data_dir=${APPA_DATA_DIR:-"${XDG_DATA_HOME:-$HOME/.local/share}/appa"}
-    ;;
-esac
-
-expected_binary=${APPA_INSTALL_DIR:-"$HOME/.local/bin"}/appa
-binary=$expected_binary
-if [ ! -x "$binary" ]; then
-  binary=$(command -v appa 2>/dev/null) || {
-    printf 'appa protection: appa is not installed; expected at %s. Run in a plain terminal: appa init claude-code\n' \
-      "$expected_binary" >&2
-    exit 1
-  }
+if [ ! -x "$APPA_BIN" ]; then
+  printf 'appa protection: appa is not installed at %s. Run in a plain terminal: appa init claude-code\n' \
+    "$APPA_BIN" >&2
+  exit 1
 fi
 
 # The runtime writes the default policy on its first start and refuses to
-# start when it cannot. Both directories must exist first: they are one
-# path on macOS and two different paths everywhere else.
-mkdir -p "$config_dir" "$data_dir"
+# start when it cannot.
+mkdir -p "$(dirname "$APPA_CONFIG")" "$APPA_DATA_DIR"
 
-nohup "$binary" runtime --config "$config_dir/appa.toml" --db "$data_dir/appa.db" \
-  >>"$data_dir/runtime.stdout.log" 2>>"$data_dir/runtime.stderr.log" \
+nohup "$APPA_BIN" runtime --listen "$APPA_LISTEN" \
+  --config "$APPA_CONFIG" --db "$APPA_DATA_DIR/appa.db" \
+  >>"$APPA_DATA_DIR/runtime.stdout.log" 2>>"$APPA_DATA_DIR/runtime.stderr.log" \
   </dev/null &
 
 # The whole start must finish inside the timeout hooks.json declares for
@@ -141,5 +132,5 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
   sleep 1
 done
 printf 'appa protection: runtime did not become healthy at %s. Its own error is the last line of %s\n' \
-  "$runtime_url" "$data_dir/runtime.stderr.log" >&2
+  "$runtime_url" "$APPA_DATA_DIR/runtime.stderr.log" >&2
 exit 1

--- a/integrations/claude-code/plugin/hooks/ensure-runtime.sh
+++ b/integrations/claude-code/plugin/hooks/ensure-runtime.sh
@@ -49,8 +49,7 @@ healthy() {
 # here makes the install take effect, at the cost of the protected
 # sessions already open, whose hooks fail closed until the start below
 # answers. The pid arrives in an HTTP body from whoever holds the port,
-# so only this user's own appa process is ever signalled. The retired
-# appa-runtime name is accepted so init can replace pre-0.5 installs.
+# so only this user's own appa process is ever signalled.
 # Returns 0 once the port refuses, which is the start's normal starting
 # point; exits 0 itself when another starter has already replaced the
 # runtime, and 1 when the stale runtime cannot be stopped.
@@ -70,7 +69,7 @@ stop_stale_runtime() {
       return 1
     fi
     case $(ps -o comm= -p "$1" 2>/dev/null) in
-      appa | */appa | appa-runtime | */appa-runtime) ;;
+      appa | */appa) ;;
       *)
         printf 'appa protection: pid %s is not appa runtime; not stopping it\n' "$1" >&2
         return 1

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -155,7 +155,7 @@ if ($EnsureRuntime) {
     if (Test-RuntimeHealthy) {
         exit 0
     }
-    [Console]::Error.WriteLine("appa protection: runtime did not become healthy at $runtimeUrl. Its own error is the last line of $(Join-Path $dataDir 'runtime.stderr.log')")
+    [Console]::Error.WriteLine("appa protection: runtime did not become healthy at $runtimeUrl. Its own error is the last line of $(Join-Path $AppaDataDir 'runtime.stderr.log')")
     exit 1
 }
 

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -101,18 +101,25 @@ function Stop-StaleRuntime {
 # of the install starts it through -EnsureRuntime. A runtime whose binary
 # an install replaced is stopped first. Installing the binary is
 # not this script's job: `appa init claude-code` does that first.
+#
+# Returns $true only while a healthy runtime answers, and $false on every way
+# of failing to get one -- a stale runtime that would not stop, a missing
+# binary, a start that never became healthy. The caller must block on $false:
+# posting anyway would send the event to the stale runtime this install just
+# replaced, which is the skew the whole bundle exists to prevent.
 function Start-RuntimeIfDown {
     if (Test-RuntimeHealthy) {
-        return
+        return $true
     }
     if (-not (Stop-StaleRuntime)) {
-        return
+        return $false
     }
     if (Test-RuntimeHealthy) {
-        return
+        return $true
     }
     if (-not (Test-Path -LiteralPath $binary)) {
-        return
+        [Console]::Error.WriteLine("appa protection: appa is not installed; expected at $binary")
+        return $false
     }
     # The runtime writes the default policy on its first start and refuses
     # to start when it cannot. The policy and the database live in two
@@ -135,10 +142,11 @@ function Start-RuntimeIfDown {
     $deadline = (Get-Date).AddSeconds(20)
     while ((Get-Date) -lt $deadline) {
         if (Test-RuntimeHealthy) {
-            return
+            return $true
         }
         Start-Sleep -Seconds 1
     }
+    $false
 }
 
 # The last step of the install starts the runtime through this switch, so
@@ -151,8 +159,7 @@ if ($EnsureRuntime) {
         [Console]::Error.WriteLine("appa protection: appa is not installed; expected at $binary")
         exit 1
     }
-    Start-RuntimeIfDown
-    if (Test-RuntimeHealthy) {
+    if (Start-RuntimeIfDown) {
         exit 0
     }
     [Console]::Error.WriteLine("appa protection: runtime did not become healthy at $runtimeUrl. Its own error is the last line of $(Join-Path $AppaDataDir 'runtime.stderr.log')")
@@ -177,7 +184,14 @@ try {
         $hookInput = $null
     }
     if ($null -ne $hookInput -and $hookInput.hook_event_name -eq "SessionStart") {
-        Start-RuntimeIfDown
+        # The POSIX map chains `ensure-runtime.sh && hook.sh || exit 2`, so a
+        # starter that fails there never reaches the post. This is that chain:
+        # throwing hands the failure to the same catch every other unanswered
+        # hook takes, which blocks. Posting anyway would send the event to the
+        # stale runtime the install just replaced.
+        if (-not (Start-RuntimeIfDown)) {
+            throw "the runtime at $runtimeUrl is not healthy and could not be started"
+        }
     }
     $timeout = if ($null -ne $hookInput -and $turnEnds -contains $hookInput.hook_event_name) { 30 } else { 120 }
     $response = Invoke-WebRequest -Uri "$runtimeUrl/hook" -Method Post `

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -10,11 +10,11 @@ param(
 # Installing the runtime is `appa init claude-code`'s job.
 $protected = $env:APPA_GATE -eq "1"
 
-$dataDir = if ($env:APPA_DATA_DIR) { $env:APPA_DATA_DIR } else { Join-Path $env:LOCALAPPDATA "appa" }
-$configDir = if ($env:APPA_CONFIG_DIR) { $env:APPA_CONFIG_DIR } else { Join-Path $env:APPDATA "appa" }
-$installDir = if ($env:APPA_INSTALL_DIR) { $env:APPA_INSTALL_DIR } else { Join-Path $dataDir "bin" }
-$binary = Join-Path $installDir "appa.exe"
-$legacyBinary = Join-Path $installDir "appa-runtime.exe"
+# appa init claude-code renders these into the deployment: the absolute binary,
+# config and data paths it resolved, and the endpoint every consumer shares.
+# Nothing here consults PATH or APPA_INSTALL_DIR.
+. (Join-Path $PSScriptRoot "appa-paths.ps1")
+$binary = $AppaBin
 
 if ($SessionContext) {
     if (-not $protected) {
@@ -24,10 +24,12 @@ if ($SessionContext) {
     exit 0
 }
 
+# APPA_RUNTIME_URL keeps both of its jobs: the URL a client talks to, and the
+# signal that the runtime answering it is the user's own to restart.
 $runtimeUrl = if ($env:APPA_RUNTIME_URL) {
     $env:APPA_RUNTIME_URL.TrimEnd("/")
 } else {
-    "http://127.0.0.1:8787"
+    $AppaEndpoint
 }
 
 function Get-HealthAnswer {
@@ -54,8 +56,7 @@ function Test-RuntimeHealthy {
 # makes the install take effect, at the cost of the protected sessions
 # already open, whose hooks fail closed until the start answers. The pid
 # arrives in an HTTP body from whoever holds the port, so only a process
-# named appa is ever stopped. The retired appa-runtime name is accepted
-# so init can replace pre-0.5 installs. Returns $true once the port refuses
+# named appa is ever stopped. Returns $true once the port refuses
 # or another starter has already replaced the runtime, $false when the
 # stale runtime cannot be stopped.
 function Stop-StaleRuntime {
@@ -68,13 +69,7 @@ function Stop-StaleRuntime {
     # the wait below sees the port refuse or that starter's replacement.
     $process = Get-Process -Id $stalePid -ErrorAction SilentlyContinue
     if ($null -ne $process) {
-        $expectedPath = if ($process.ProcessName -eq "appa") {
-            $binary
-        } elseif ($process.ProcessName -eq "appa-runtime") {
-            $legacyBinary
-        } else {
-            $null
-        }
+        $expectedPath = if ($process.ProcessName -eq "appa") { $binary } else { $null }
         if ($null -eq $expectedPath -or -not [String]::Equals(
             $process.Path,
             $expectedPath,
@@ -122,15 +117,15 @@ function Start-RuntimeIfDown {
     # The runtime writes the default policy on its first start and refuses
     # to start when it cannot. The policy and the database live in two
     # different directories on Windows, so both must exist first.
-    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-    New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+    New-Item -ItemType Directory -Path (Split-Path -Parent $AppaConfig) -Force | Out-Null
+    New-Item -ItemType Directory -Path $AppaDataDir -Force | Out-Null
     # Start-Process joins ArgumentList into one Windows command line. Quote the
     # path tokens explicitly so the standard user directories may contain spaces.
-    $configPath = Join-Path $configDir "appa.toml"
-    $databasePath = Join-Path $dataDir "appa.db"
+    $databasePath = Join-Path $AppaDataDir "appa.db"
     Start-Process -FilePath $binary -WindowStyle Hidden -ArgumentList @(
         "runtime",
-        "--config", "`"$configPath`"",
+        "--listen", $AppaListen,
+        "--config", "`"$AppaConfig`"",
         "--db", "`"$databasePath`""
     ) | Out-Null
     # A wall-clock budget, not a count of probes: one probe is instant

--- a/integrations/claude-code/plugin/hooks/hook.sh
+++ b/integrations/claude-code/plugin/hooks/hook.sh
@@ -6,7 +6,13 @@
 # the event they are registered for.
 set -eu
 
+# Parameter expansion rather than `dirname`: this runs on every gated tool call,
+# and a command substitution would fork a shell and exec a binary each time.
+case "$0" in
+  */*) appa_hooks_dir=${0%/*} ;;
+  *) appa_hooks_dir=. ;;
+esac
 # shellcheck source=integrations/claude-code/plugin/hooks/appa-paths.sh
-. "$(dirname "$0")/appa-paths.sh"
+. "$appa_hooks_dir/appa-paths.sh"
 
 exec "$APPA_BIN" hook --url "${APPA_RUNTIME_URL:-$APPA_ENDPOINT}" "$@"

--- a/integrations/claude-code/plugin/hooks/hook.sh
+++ b/integrations/claude-code/plugin/hooks/hook.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Post one hook event through the appa binary this deployment installed.
+#
+# A dumb invoker, deliberately: it reads no event name and makes no decision.
+# Each event's guard, blocking exit code and timeout stay in hooks.json, beside
+# the event they are registered for.
+set -eu
+
+# shellcheck source=integrations/claude-code/plugin/hooks/appa-paths.sh
+. "$(dirname "$0")/appa-paths.sh"
+
+exec "$APPA_BIN" hook --url "${APPA_RUNTIME_URL:-$APPA_ENDPOINT}" "$@"

--- a/integrations/claude-code/plugin/hooks/hooks.json
+++ b/integrations/claude-code/plugin/hooks/hooks.json
@@ -1,12 +1,12 @@
 {
-  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and the plugin prints nothing into the session; appa init claude-code installs this plugin and runtime as one fail-closed replacement. In a protected session every hook posts its event to the appa-runtime process and prints the runtime's answer. The poster is `appa hook`: the installed runtime binary run as its own client, so a hook spends one process where a shell and a curl spent two, and the install path grows nothing. Each command resolves that binary where the install puts it and falls back to PATH. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health and replaces a running one that answers stale, because an install replaced its binary on disk; init runs the same script as its last step, so a protected session normally finds the runtime already up. `appa hook` prints the answer and exits non-zero on a non-2xx one and on a connection failure. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. Every hook declares a timeout above its own client deadline, and SessionStart's also covers the starter's 20-second budget. Claude Code kills a hook that outruns the timeout and then lets the action proceed, because it never reads the killed hook's exit code, so an undeclared timeout is the one way these hooks fail open. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They pass --turn-end, which discards the answer, always exits 0, and takes the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The flag says so here rather than the client reading the event name, so a hook's blocking outcome is declared beside the event it is registered for and nothing in a posted event can move it. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
+  "description": "Hooks protect only sessions launched with APPA_GATE=1 (the clappa alias). The guard reads the Claude Code process environment, fixed at launch, so a session cannot turn the protection off. Without the variable every hook exits 0 and the plugin prints nothing into the session; appa init claude-code installs this plugin and runtime as one fail-closed replacement. In a protected session every hook posts its event to the appa-runtime process and prints the runtime's answer. The poster is `appa hook`: the installed runtime binary run as its own client, so a hook spends one process where a shell and a curl spent two, and the install path grows nothing. Every command reaches that binary through hook.sh, which reads the absolute path appa init rendered into appa-paths.sh beside it. A deployed tree resolves the binary through no PATH lookup and honours no APPA_BIN from the environment, so the plugin and the binary it posts to are the pair one init installed. SessionStart first runs ensure-runtime.sh, which starts the installed runtime when nothing healthy answers /health and replaces a running one that answers stale, because an install replaced its binary on disk; init runs the same script as its last step, so a protected session normally finds the runtime already up. `appa hook` prints the answer and exits non-zero on a non-2xx one and on a connection failure. The trailing exit 2 makes every failure the blocking hook outcome: no answer from the runtime blocks the action. SessionStart itself cannot block the session; the UserPromptSubmit hook blocks the first prompt instead. The 120-second deadline outlasts the runtime's own evidence round trips; a hook that still times out blocks, never passes. Every hook declares a timeout above its own client deadline, and SessionStart's also covers the starter's 20-second budget. Claude Code kills a hook that outruns the timeout and then lets the action proceed, because it never reads the killed hook's exit code, so an undeclared timeout is the one way these hooks fail open. The context hook is advice, not enforcement, so its failure does not block. Stop, StopFailure and SubagentStop are the exception to the trailing exit 2: they report a finished turn, which decides nothing, and blocking on this hook holds the actor in a turn it has already finished. They pass --turn-end, which discards the answer, always exits 0, and takes the shorter deadline because a turn end waits on no evidence round trip, so a runtime that is down costs a call left open, never a turn that cannot end. The flag says so here rather than the client reading the event name, so a hook's blocking outcome is declared beside the event it is registered for and nothing in a posted event can move it. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && \"$b\" hook || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" || exit 2",
             "timeout": 150
           },
           {
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" || exit 2",
             "timeout": 130
           }
         ]
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" || exit 2",
             "timeout": 130
           }
         ]
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" || exit 2",
             "timeout": 130
           }
         ]
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook --turn-end || exit 0",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" --turn-end || exit 0",
             "timeout": 40
           }
         ]
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook --turn-end || exit 0",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" --turn-end || exit 0",
             "timeout": 40
           }
         ]
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" || exit 2",
             "timeout": 130
           }
         ]
@@ -89,7 +89,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook --turn-end || exit 0",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" --turn-end || exit 0",
             "timeout": 40
           }
         ]
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; b=${APPA_INSTALL_DIR:-$HOME/.local/bin}/appa; [ -x \"$b\" ] || b=appa; \"$b\" hook || exit 2",
+            "command": "[ \"${APPA_GATE:-}\" = 1 ] || exit 0; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/hook.sh\" || exit 2",
             "timeout": 130
           }
         ]

--- a/scripts/appa-stage-plugin-bundle.sh
+++ b/scripts/appa-stage-plugin-bundle.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Stage the platform-independent APPA plugin bundle into <outdir>.
+#
+# The staged tree is a Claude Code marketplace root: the directory named by
+# `claude plugin marketplace add`, and the layout `skills/appa-guide/SKILL.md`
+# reads as <marketplace-root>. The release packages it as
+# appa-plugin-<version>.tar.gz, and `appa init claude-code` accepts exactly the
+# bytes whose SHA-256 its own build baked in.
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: appa-stage-plugin-bundle.sh <outdir>" >&2
+  exit 2
+fi
+
+outdir=$1
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+
+if [ -e "$outdir" ] && [ -n "$(ls -A -- "$outdir" 2>/dev/null)" ]; then
+  echo "appa-stage-plugin-bundle: $outdir exists and is not empty" >&2
+  exit 1
+fi
+
+mkdir -p -- "$outdir"
+outdir=$(CDPATH='' cd -- "$outdir" && pwd)
+
+cp -R -- "$repo/integrations/claude-code/.claude-plugin" "$outdir/.claude-plugin"
+cp -R -- "$repo/integrations/claude-code/plugin" "$outdir/plugin"
+cp -R -- "$repo/integrations/claude-code/examples" "$outdir/examples"
+cp -R -- "$repo/batteries" "$outdir/batteries"
+cp -- "$repo/integrations/claude-code/README.md" "$outdir/README.md"
+cp -- "$repo/integrations/claude-code/live-gate-check.py" "$outdir/live-gate-check.py"
+
+mkdir -p -- "$outdir/website/content/docs"
+cp -- "$repo/website/content/docs/contracts.md" "$outdir/website/content/docs/contracts.md"
+
+# Modes are applied by init when it materializes a deployment; these are for
+# anyone who unpacks the archive by hand.
+find "$outdir" -type d -exec chmod 755 {} +
+find "$outdir" -type f -exec chmod 644 {} +
+chmod 755 "$outdir/plugin/statusline.sh" "$outdir/plugin/hooks/ensure-runtime.sh"
+
+for required in \
+  .claude-plugin/marketplace.json \
+  plugin/.claude-plugin/plugin.json \
+  plugin/hooks/hooks.json \
+  plugin/hooks/hooks.windows.json \
+  batteries/README.md \
+  website/content/docs/contracts.md
+do
+  if [ ! -f "$outdir/$required" ]; then
+    echo "appa-stage-plugin-bundle: staged tree is missing $required" >&2
+    exit 1
+  fi
+done

--- a/scripts/appa-stage-plugin-bundle.sh
+++ b/scripts/appa-stage-plugin-bundle.sh
@@ -16,29 +16,35 @@ fi
 outdir=$1
 repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 
-if [ -e "$outdir" ] && [ -n "$(ls -A -- "$outdir" 2>/dev/null)" ]; then
-  echo "appa-stage-plugin-bundle: $outdir exists and is not empty" >&2
+# The output directory must not exist: a single `mkdir` both reserves it and
+# proves it is ours. Checking emptiness and then creating would leave a window
+# in which anything under an attacker-writable parent such as /tmp could be
+# swapped for a symlink, and every copy and chmod below would follow it.
+if ! mkdir -- "$outdir" 2>/dev/null; then
+  echo "appa-stage-plugin-bundle: cannot create $outdir: it must not exist yet, and its parent must" >&2
   exit 1
 fi
 
-mkdir -p -- "$outdir"
-outdir=$(CDPATH='' cd -- "$outdir" && pwd)
+# Everything is written through this working directory rather than through the
+# pathname, so the destination stays the directory just created even if the name
+# is replaced afterwards.
+CDPATH='' cd -- "$outdir" || exit 1
 
-cp -R -- "$repo/integrations/claude-code/.claude-plugin" "$outdir/.claude-plugin"
-cp -R -- "$repo/integrations/claude-code/plugin" "$outdir/plugin"
-cp -R -- "$repo/integrations/claude-code/examples" "$outdir/examples"
-cp -R -- "$repo/batteries" "$outdir/batteries"
-cp -- "$repo/integrations/claude-code/README.md" "$outdir/README.md"
-cp -- "$repo/integrations/claude-code/live-gate-check.py" "$outdir/live-gate-check.py"
+cp -R -- "$repo/integrations/claude-code/.claude-plugin" ./.claude-plugin
+cp -R -- "$repo/integrations/claude-code/plugin" ./plugin
+cp -R -- "$repo/integrations/claude-code/examples" ./examples
+cp -R -- "$repo/batteries" ./batteries
+cp -- "$repo/integrations/claude-code/README.md" ./README.md
+cp -- "$repo/integrations/claude-code/live-gate-check.py" ./live-gate-check.py
 
-mkdir -p -- "$outdir/website/content/docs"
-cp -- "$repo/website/content/docs/contracts.md" "$outdir/website/content/docs/contracts.md"
+mkdir -p -- ./website/content/docs
+cp -- "$repo/website/content/docs/contracts.md" ./website/content/docs/contracts.md
 
 # Modes are applied by init when it materializes a deployment; these are for
 # anyone who unpacks the archive by hand.
-find "$outdir" -type d -exec chmod 755 {} +
-find "$outdir" -type f -exec chmod 644 {} +
-chmod 755 "$outdir/plugin/statusline.sh" "$outdir/plugin/hooks/ensure-runtime.sh"
+find . -type d -exec chmod 755 {} +
+find . -type f -exec chmod 644 {} +
+chmod 755 ./plugin/statusline.sh ./plugin/hooks/ensure-runtime.sh
 
 for required in \
   .claude-plugin/marketplace.json \
@@ -48,7 +54,7 @@ for required in \
   batteries/README.md \
   website/content/docs/contracts.md
 do
-  if [ ! -f "$outdir/$required" ]; then
+  if [ ! -f "./$required" ]; then
     echo "appa-stage-plugin-bundle: staged tree is missing $required" >&2
     exit 1
   fi

--- a/scripts/appa-stage-plugin-bundle.sh
+++ b/scripts/appa-stage-plugin-bundle.sh
@@ -6,6 +6,11 @@
 # reads as <marketplace-root>. The release packages it as
 # appa-plugin-<version>.tar.gz, and `appa init claude-code` accepts exactly the
 # bytes whose SHA-256 its own build baked in.
+#
+# `plugin_bundle::validate_tree` is the single definition of the shape this must
+# produce, and it runs against this script's real output in the init and
+# rendered-hook tests, so a bundle that loses a required file fails CI here
+# rather than at someone's install.
 set -eu
 
 if [ "$#" -ne 1 ]; then
@@ -45,17 +50,3 @@ cp -- "$repo/website/content/docs/contracts.md" ./website/content/docs/contracts
 find . -type d -exec chmod 755 {} +
 find . -type f -exec chmod 644 {} +
 chmod 755 ./plugin/statusline.sh ./plugin/hooks/ensure-runtime.sh
-
-for required in \
-  .claude-plugin/marketplace.json \
-  plugin/.claude-plugin/plugin.json \
-  plugin/hooks/hooks.json \
-  plugin/hooks/hooks.windows.json \
-  batteries/README.md \
-  website/content/docs/contracts.md
-do
-  if [ ! -f "./$required" ]; then
-    echo "appa-stage-plugin-bundle: staged tree is missing $required" >&2
-    exit 1
-  fi
-done

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -13,16 +13,20 @@ You need Cargo, Claude Code, and `curl`.
 
 ```sh
 cargo install --path appa-runtime --force
-appa init claude-code
+plugin=$(mktemp -d)/bundle
+sh scripts/appa-stage-plugin-bundle.sh "$plugin"
+appa init claude-code --plugin-source "$plugin"
 ```
 
 Initialization installs `clappa` beside `appa` so the short command works below.
 
 The native `appa` command installs the runtime, the matching Claude Code
-plugin, the statusline, and `clappa`, a protected way to start Claude Code.
-From a checkout it uses that checkout's plugin, replacing an existing APPA
-installation instead of stacking another hook set. It preserves an existing
-policy and custom statusline. It does not replace `claude` or change how
+plugin, the statusline, and `clappa`, a protected way to start Claude Code. Each
+build accepts exactly one plugin artifact: a release binary knows the digest of
+its own release's artifact and downloads it, and a build from a checkout has no
+such digest and is given the bundle staged from that checkout. Init replaces an
+existing APPA installation instead of stacking another hook set. It preserves an
+existing policy and custom statusline. It does not replace `claude` or change how
 ordinary sessions start.
 
 ## 1. Teach OpenAPPA about your tools

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -136,7 +136,8 @@ To uninstall OpenAPPA from Claude Code, remove the plugin, stop the local runtim
 claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 pkill -f 'appa runtime'
-rm ~/.local/bin/appa ~/.cargo/bin/clappa ~/.local/bin/appa-statusline.sh
+rm -rf ~/.local/share/appa/bin ~/.local/share/appa/deployments ~/.local/share/appa/cache
+rm -f ~/.cargo/bin/clappa ~/.local/bin/appa-statusline.sh
 cargo uninstall appa
 
 # drop the statusline entry appa init wrote, and keep one of your own:


### PR DESCRIPTION
## Why

`appa init claude-code` could install a plugin from the current checkout while
Claude's hooks resolved a different `appa` from `PATH`. In practice, an older
binary could install a newer plugin and then fail when that plugin called a
subcommand it did not support.

This PR makes the plugin and runtime one installation unit.

## What changes

- **Release binaries install their matching plugin.** The release workflow
  builds one platform-independent plugin archive, computes its SHA-256, and
  bakes that digest into every binary. A normal `appa init claude-code`
  downloads and verifies that exact archive, then caches it for later runs.
- **Hooks use the binary installed by init.** The plugin is materialized into a
  content-addressed deployment with absolute runtime, config, data, and endpoint
  paths. Deployed hooks no longer discover `appa` through `PATH` or `APPA_BIN`.
- **Upgrades fail closed.** Init checks the runtime endpoint before changing
  Claude, performs the plugin switch and runtime verification inside the
  recovery path, and enables `clappa` only after the installed runtime answers
  with the expected binary fingerprint.
- **Existing state is preserved.** Policy and database files remain in their
  current config and data directories. A one-time migration handles the retired
  runtime location.
- **Development builds have an explicit path.** Checkout builds do not guess a
  release artifact. Stage the local bundle and pass
  `--plugin-source <marketplace-root>` instead.

## User-visible behavior

For a released binary, installation remains:

```sh
appa init claude-code
```

After upgrading, rerun init and restart existing Claude sessions. The hook wire
is not versioned yet, so sessions started before the upgrade are not migrated in
place.

## Verification

Tests cover release-digest rejection, verified cache reuse, deterministic local
source deployments, rollback, reruns, legacy-runtime migration, hostile `PATH`
and environment overrides, non-default endpoints, and paths containing spaces
and shell metacharacters. Rendered hooks are executed in integration tests to
prove that they call the private binary and reach the rendered endpoint.

CI also validates the staged plugin bundle, parses the PowerShell hooks, and
runs the deployment tests on macOS in addition to the regular Rust checks.

## Known limitations

- Old deployment directories are not reclaimed yet.
- Existing Claude sessions must be restarted after an upgrade.
- On Windows, retired-runtime discovery matches executable identity without the
  additional subcommand check used on Unix.
