### PR TITLE
docs: redesign kagent integration for dynamic ADK plugins

### DIFF
--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -1,238 +1,1062 @@
-# kagent integration implementation plan
+# kagent dynamic ADK extension implementation plan
 
-Status: proposed
-
-Source baselines:
+Source baseline:
 
 - kagent commit `9e246fd3797457b18fc277680be1629a0f57fce0`
-- Google ADK Go tag `v2.2.0`
-- OpenAPPA runtime contract in `appa-runtime-api/src/lib.rs`
+- Google ADK Go `v2.2.0` at `b264039aaec43baedc123e5b9a0cf87681d0bbca`
+- Substrate `v0.0.20`
+- OpenAPPA `origin/main` at `df69b8a1adf9206cc2923b95fadd17f9d26224ae`
 
 The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent).
 
+## Accepted design decisions
+
+The human reviewer selected these constraints:
+
+1. Run the dynamic OpenAPPA ADK extension as a digest-pinned OCI companion container.
+2. Permit generic non-OpenAPPA lifecycle infrastructure when ADK callbacks cannot cover readiness, egress, snapshots, or process lifecycle.
+3. Classify a crash after execution acknowledgement and before terminal completion as `Indeterminate` inside OpenAPPA.
+4. Pin one extension revision per live scope and drain old scopes during upgrades.
+5. Publish the OpenAPPA proposal and plugin, plus a separate kagent generic-host PR to a private fork.
+
+These decisions are normative for the first implementation and PoC.
+
 ## Goal
 
-Add an optional OpenAPPA profile to the kagent Go runtime without changing behavior for existing Harnesses.
+Add a generic dynamically supplied ADK extension system to the kagent fork.
 
-The code MUST preserve four invariants:
+Ship OpenAPPA as an independently built sidecar that uses this generic system.
 
-1. OpenAPPA authorizes the final JSON argument value passed to `tool.Run`.
-2. No consumer receives a result before OpenAPPA admission.
-3. Every root, child, call, and terminal outcome has stable identity.
-4. kagent refuses any enabled path that lacks a dispatch or result boundary.
+The kagent fork MUST contain no OpenAPPA logic or OpenAPPA-specific data model.
 
-## Deliverables
+The combined system MUST preserve these invariants:
 
-| Owner | Change |
+1. kagent executes only a matching immutable payload from a valid generic `permit` decision.
+2. Raw execution output reaches no protected sink before a matching generic `commit` decision.
+3. Every content-bearing model, session, child, A2A, memory, UI, log, telemetry, and storage path crosses an exclusive generic gate.
+4. Extension ordering and phase ownership are immutable for one Revision.
+5. Required extension failure blocks readiness or freezes the affected scope.
+6. kagent never parses a plugin policy, fact, Label, remedy, consult, or extension-specific state.
+7. The OpenAPPA sidecar owns all OpenAPPA state, semantics, recovery, and external consults.
+8. One extension artifact and protocol selection remain pinned for each live scope.
+
+## Evidence and adopted patterns
+
+The design follows primary sources from widely adopted plugin systems.
+
+| Source | Applied design |
 |---|---|
-| `go/api/v1alpha3` | Add optional OpenAPPA Harness configuration and local child collaboration mode |
-| `go/core/v2/translator/kagent` | Resolve policy, compile profile data, and validate path coverage |
-| `go/core/v2/substrate` | Include policy and egress digests in the prepared revision and `ActorTemplate` |
-| `go/adk/pkg/agent` | Register OpenAPPA callbacks on the root and every local child |
-| `go/adk/pkg/config` | Materialize the policy bundle from compiled Actor configuration |
-| `go/adk/pkg/runner` | Register the task plugin and memory decorator |
-| `go/adk/pkg/tools` | Wrap final tool execution and preserve remote A2A context and `TaskState` |
-| `go/adk/cmd/openappa-supervisor` | Start and monitor `appa-runtime` and `kagent-go-adk` |
-| `go/core/internal/grpcserver` | Route protected MCP App internal calls to the owning Actor |
-| `appa-adapter-kagent` | Translate kagent JSON to `HookEvent` and `HookDecision` |
-| Helm chart and `kagentctl` | Install the profile and create protected `AgentInstance` resources |
+| [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin) | Out-of-process RPC, handshake, protocol majors, health, and process isolation |
+| [go-plugin internals](https://github.com/hashicorp/go-plugin/blob/v1.8.0/docs/internals.md) | Explicit launch handshake and compatible protocol selection |
+| [Terraform plugin protocol](https://developer.hashicorp.com/terraform/plugin/terraform-plugin-protocol) | Separate artifact versions and wire compatibility |
+| [Kubernetes device plugins](https://v1-32.docs.kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) | Serve before register, Unix-socket gRPC, capability discovery, and re-registration |
+| [VS Code extension manifest](https://code.visualstudio.com/api/references/extension-manifest) | Declarative capabilities, compatibility ranges, activation, and contribution points |
+| [Envoy xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) | Versioned resources and explicit ACK or NACK |
+| [Docker plugin configuration](https://docs.docker.com/engine/extend/config/) | Reviewable image, socket, mount, network, device, and capability requests |
+| [gRPC health checking](https://grpc.io/docs/guides/health-checking/) | Standard sidecar health protocol |
+| [Buf breaking checks](https://buf.build/docs/breaking/) | Protocol compatibility enforcement in CI |
 
-## Package the profile
+Do not use Go's standard [`plugin`](https://pkg.go.dev/plugin) package. It has strict toolchain coupling, shared memory, platform limits, no unload, weak race-detector support, and no independent lifecycle.
 
-Extend `KagentHarness` with an optional `OpenAPPA` block containing a same-namespace policy `ConfigMap` reference.
+## Current source constraints
 
-The compiler MUST:
+Current ADK and kagent lack the full required boundary set.
 
-1. Resolve and validate the policy bundle.
-2. Include all policy bytes and external endpoint destinations in the revision digest.
-3. Require an explicit external LLM URL when policy can invoke one.
-4. Add the validated files and digest to `AgentConfig.OpenAPPA` in `KAGENT_CONFIG_JSON`.
-5. Set `APPA_CONFIG`, `APPA_DB`, and `APPA_RUNTIME_URL` for the Actor image.
+| Requirement | Source evidence | Current limitation |
+|---|---|---|
+| Dynamic ADK plugin object | [kagent runner adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/runner/adapter.go#L74-L95) | It installs compiled Go plugin objects only |
+| Provider-final catalog | [ADK](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/internal/llminternal/base_flow.go#L707-L730) and [Bedrock](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/bedrock.go#L730-L808) | No callback sees final names and schemas |
+| Pre-plugin dispatch | [ADK tool flow](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/internal/llminternal/base_flow.go#L1251-L1285) | Plugin callbacks see mutable arguments first |
+| Event drop before persistence | [ADK runner](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/runner/runner.go#L316-L355) | `OnEvent` cannot drop and is not exclusive |
+| User input gate | [ADK user callback](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/runner/runner.go#L613-L668) | Existing callback is usable but not dynamic |
+| Child terminal gate | [ADK task wrapper](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/agent/llmagent/llm_agent_wrapper.go#L486-L590) | No pre-persistence child return callback |
+| Automatic memory | [ADK preloader](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/tool/preloadmemorytool/tool.go#L72-L97) | Raw memory reaches model instructions outside tool callbacks |
+| MCP transport | [ADK client](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/tool/mcptoolset/client.go#L67-L134) | It retries and hides raw arguments |
+| Remote A2A | [kagent tool](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/tools/remote_a2a_tool.go#L25-L145) | It forwards credentials and resolves Cards lazily |
+| Content telemetry | [kagent attributes](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/telemetry/attributes.go#L37-L47) | Payload attributes exist before a policy plugin can remove them |
+| Readiness | [kagent A2A server](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/a2a/server/server.go#L127-L144) | `/readyz` returns success without extension recovery |
+| Snapshot lifecycle | [kagent ActorTemplate](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L65-L88) | No extension quiescence or generation attestation |
 
-`go/adk/pkg/config` decodes `AgentConfig.OpenAPPA`, verifies the digest, and writes files atomically under `/data/openappa/policy/<digest>`.
+Substrate can run [up to ten peer containers](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L305).
 
-The Actor image contains `kagent-openappa-supervisor`, `kagent-go-adk`, and `appa-runtime`.
+It gates Actor readiness on configured probes. Pinned kagent currently emits one workload container.
 
-The supervisor starts `appa-runtime`, waits for `/health`, then starts `kagent-go-adk`. It forwards signals and exits when either child exits.
+The baseline Container API lacks several required primitives.
 
-`/readyz` fails whenever `appa-runtime` is unavailable. Runtime state remains at `/data/openappa/appa.db`.
+These include shared memory, projected configuration, per-container identity, filesystem controls, seccomp, and enforced egress.
 
-The OCI chart at `ghcr.io/archestra-ai/charts/kagent-openappa` pins the control-plane and Actor image digests.
+Add these as generic Substrate primitives. The compiler and Actor activation MUST reject an extension whose required primitive cannot be enforced.
 
-Chart values map to these Harness fields:
+## Ownership and forbidden dependencies
+
+### kagent fork owns
+
+- Generic extension API types and generated gRPC client.
+- Generic manifest validation and immutable Revision compilation.
+- Generic sidecar container, volume, socket, secret, egress, readiness, and snapshot rendering.
+- Generic ADK callback proxies and added extension points.
+- Immutable ADK descriptor and payload snapshots.
+- Generic execution proxy and sink barriers.
+- Generic interaction and remote metadata relay.
+- Host-native ADK session and A2A task state.
+
+### OpenAPPA plugin owns
+
+- OpenAPPA policy parsing and `[deployment]` validation.
+- Engine and runtime adapter behavior.
+- OpenAPPA facts, call state, consult evidence, offers, and remedies.
+- OpenAPPA-specific readiness and host-inventory validation.
+- OpenAPPA-specific dynamic tools.
+- Annotator, Membership Resolver, Authority, and Sanitizer calls.
+- OpenAPPA interaction, delegation, recovery, and snapshot state.
+- Plugin-side durable database and migrations.
+
+### kagent fork MUST NOT contain
+
+- A package, module, field, enum, callback, table, or error code named for OpenAPPA.
+- OpenAPPA policy, Label, trajectory, ReaderId, Authority, Annotator, Sanitizer, Membership, remedy, effect, attention, or fact types.
+- OpenAPPA tool names or special-case routing.
+- OpenAPPA database paths or schema migrations.
+- OpenAPPA readiness, coverage, consult, or audit logic.
+
+Add CI rules that reject imports and identifiers from a maintained forbidden list in the kagent generic-host packages.
+
+## Repository deliverables
+
+### kagent private fork
+
+| Owner | Generic change |
+|---|---|
+| `go/api/v1alpha3` | Add ordered dynamic extension declarations to Harness |
+| `go/core/v2/translator` | Validate generic manifests, references, capabilities, and immutable Revision data |
+| `go/core/v2/substrate` | Render multiple extension containers, private sockets, projected config and secrets, state volumes, egress, and probes |
+| `go/adk/pkg/extensions/protocol` | Generated neutral protobuf messages and client |
+| `go/adk/pkg/extensions/host` | Negotiation, ordering, health, deadlines, retries, and generic decisions |
+| ADK fork | Add provider catalog, pre-plugin dispatch, event, child, memory, transport, session, and publication points |
+| `go/adk/pkg/runner` | Build the dynamic proxy list and enforce final ordering |
+| `go/adk/pkg/tools` | Generic immutable execution proxy and remote request hooks |
+| `go/adk/pkg/a2a` | Generic interaction relay and pre-publication gate |
+| `go/adk/pkg/session` | Generic pre-append gate and delivery deduplication |
+| telemetry | Enforce immutable content-free protected workload settings before provider construction |
+
+### OpenAPPA repository
+
+| Owner | OpenAPPA component |
+|---|---|
+| `appa-kagent-plugin-protocol` | OpenAPPA-side generated client/server binding to the neutral protocol |
+| `appa-kagent-plugin` | gRPC sidecar, ADK event mapping, readiness, dynamic tools, interactions, and recovery |
+| `appa-runtime-api` | Missing response emission, structured remedy, MRTR, and exact dispatch APIs required by the plugin |
+| `appa-runtime` | Engine session ownership, consults, durable plugin state, and protocol mapping |
+| OCI packaging | Signed sidecar image, manifest, SBOM, provenance, and migrations |
+| Integration tests | Fake generic host plus full kagent/sidecar end-to-end suite |
+
+## Generic Harness API
+
+Add an ordered extension list to the Harness workload declaration:
 
 ```yaml
-openappa:
-  policyRef: customer-support-policy
-  harness:
-    enabled: false
-  allowedAgentTemplates:
-    matchLabels:
-      openappa: enabled
-substrate:
-  workerPoolRef: default
-  snapshotLocation: s3://kagent-snapshots/openappa
+workload:
+  image: ghcr.io/private-kagent/kagent-go-adk@sha256:<digest>
+  extensions:
+    - name: policy-gate
+      image: ghcr.io/archestra-ai/openappa-adk-plugin@sha256:<digest>
+      manifestDigest: sha256:<digest>
+      signaturePolicyRef: required-extension-signers-v1
+      required: true
+      failureMode: closed
+      order: 10
+      protocol:
+        minMajor: 1
+        maxMajor: 1
+      socket:
+        path: /run/kagent/extensions/policy-gate.sock
+      config:
+        configMapRef:
+          name: customer-support-policy-v1
+      secrets:
+        - secretRef:
+            name: policy-gate-secrets-v1
+      state:
+        volumeName: policy-gate-state
+        mountPath: /var/lib/kagent-extension
+      egress:
+        - host: api.policy-provider.example
+          port: 443
+      readiness:
+        path: /readyz
+        port: 8082
+      resources:
+        cpu: "2"
+        memory: 2Gi
 ```
 
-Installation is two-phase:
+The kagent compiler treats `config` and secret content as opaque.
 
-1. Apply CRDs and upgrade the control plane with `openappa.harness.enabled=false`.
-2. Wait for the controller Deployment and service endpoint.
-3. Upgrade again with `openappa.harness.enabled=true`.
-4. Label each admitted `AgentTemplate` and wait for its Harness-specific `Ready=True` condition.
+It validates reference scope, signatures, digests, volume ownership, egress shape, protocol ranges, resource limits, socket uniqueness, and ordering.
 
-`kagentctl agent-instance create --template <name> --harness kagent-openappa` maps directly to `AgentInstanceService.CreateAgentInstance`.
+For every ConfigMap and Secret reference, the generic controller reads bytes only to hash and copy them. It never parses their plugin meaning.
 
-## Add the Go ADK extension
+Create immutable Revision-owned ConfigMap and Secret copies with generated names bound to content digest, source UID, and source resource version.
 
-The Go extension owns transport and correlation. It contains no policy logic.
+Store only digests and generated object references in the Revision. Do not store secret bytes in the Revision or ActorTemplate.
 
-Keep current exported builder signatures. Add extension-aware variants that accept one optional `OpenAPPAExtensions` value and pass it recursively to local children.
+Mount only the immutable generated copies into the extension container.
 
-Register the OpenAPPA plugin first in `PluginConfig.Plugins`. Reject kagent `RequireApproval` and any other callback or plugin that can short-circuit `BeforeTool`.
+Admission prevents update or deletion while a live Revision references the copy.
 
-Wrap every executable tool with `OpenAPPATool`. Its `Run` method compares the final argument bytes with the authorized snapshot immediately before delegating to the underlying tool.
+Policy, provider credential, CA, or plugin secret rotation always creates a new Revision and follows pin-and-drain.
 
-A mismatch closes the open dispatch as indeterminate and refuses underlying execution.
+Per-activation mTLS and message-authentication credentials are separate ephemeral boot credentials. They cannot replace immutable plugin configuration.
 
-| ADK point | OpenAPPA action |
+The immutable Revision stores canonical generic extension declarations and provenance.
+
+## Generic extension manifest
+
+Each image contains a signed manifest:
+
+```json
+{
+  "schema_version": 1,
+  "plugin_id": "org.example.policy-gate",
+  "artifact_version": "0.1.0",
+  "artifact_digest": "sha256:...",
+  "protocol": { "min_major": 1, "max_major": 1 },
+  "state_schema_version": 1,
+  "capabilities": {
+    "required": [
+      "catalog.logical.v1",
+      "catalog.provider_final.v1",
+      "model.propose.v1",
+      "tool.propose.v1",
+      "execution.begin.v1",
+      "tool.complete.v1",
+      "event.gate.v1",
+      "session.persist.v1",
+      "a2a.publish.v1",
+      "remote.request.v1"
+    ],
+    "optional": [
+      "child.lifecycle.v1",
+      "remote.lifecycle.v1",
+      "interaction.relay.v1",
+      "snapshot.lifecycle.v1"
+    ]
+  },
+  "phase_claims": {
+    "tool.propose": "exclusive",
+    "tool.complete": "exclusive",
+    "model.propose": "exclusive",
+    "model.event": "exclusive",
+    "session.persist": "exclusive",
+    "a2a.publish": "exclusive",
+    "remote.request": "exclusive"
+  },
+  "limits": {
+    "max_inline_bytes": 1048576,
+    "max_callback_ms": 5000,
+    "max_interaction_ms": 86400000
+  },
+  "failure_mode": "closed"
+}
+```
+
+Manifest capabilities describe host mechanics only.
+
+The compiler rejects duplicate plugin IDs, phase conflicts, unsupported required capabilities, invalid failure modes, excessive limits, or signature mismatch.
+
+## Protocol services
+
+Define `kagent.extension.v1` with these generic RPCs:
+
+| RPC | Purpose |
 |---|---|
-| `BeforeToolCallbacks` | Snapshot final arguments and send `ToolCall` |
-| `OnToolErrorCallbacks` | Record failure state and replace unsafe error text |
-| `AfterToolCallbacks` | Send one terminal `ToolResult` for each released call |
-| `BeforeModelCallbacks` | Confirm model-bound results already passed admission |
-| `BeforeAgentCallbacks` | Select or bind the local child trajectory |
-| `AfterModelCallbacks` | Gate deferred ADK task dispatch |
-| `plugin.OnEventCallback` | Gate the synthesized task return before persistence |
-| `plugin.OnUserMessageCallback` | Reject forged task responses |
+| `GetExtensionInfo` | Return artifact, protocol, manifest, and state schema identity |
+| `Negotiate` | Select protocol and capabilities for one host inventory |
+| `Activate` | Accept the immutable Revision and host inventory digest |
+| `InvokePhase` | Process one immutable ADK or lifecycle event |
+| `Quiesce` | Stop new plugin work and commit one state generation |
+| `ValidateRestore` | Accept or reject a restored host and plugin inventory |
+| `Shutdown` | Drain and terminate cleanly |
 
-The OpenAPPA `OnToolError` plugin callback runs before kagent error logging. It stores failure state and returns `{"error":"tool execution failed"}`.
+Use the standard gRPC health service on the same Unix socket.
 
-The first `AfterTool` callback sends the terminal outcome. `ReplaceOutput` or `Block` returns admitted replacement content and stops later callback observation.
+The protocol package MUST contain neutral types only.
 
-The pending-call store uses the function-call ID as its key and synchronizes access.
+### Transport authentication
 
-| State | Meaning | `AfterTool` action |
-|---|---|---|
-| `Released` | OpenAPPA returned `AllowCall` | Send one terminal outcome |
-| `Denied` | OpenAPPA denied dispatch | Preserve the denial and send no outcome |
-| `SnapshotFailed` | Arguments could not serialize | Refuse and send no outcome |
-| `DeferredTask` | ADK emitted task-mode placeholder callbacks | Let the task plugin own both boundaries |
-| Missing | Another callback bypassed OpenAPPA | Replace all output with a refusal |
+The generic launcher mints one ephemeral Actor CA, host certificate, extension certificate, boot epoch, and message-authentication key for each activation.
 
-## Bind the executed call
+Use mTLS on the Unix socket. Certificate SANs bind Actor UID, Revision, container identity, extension ID, and boot epoch.
 
-The OpenAPPA `BeforeTool` callback serializes the ADK argument map and stores the authorized bytes.
+Mount certificates and the message key through read-only per-container projected secrets. Never place them in the ActorTemplate environment.
 
-Send those bytes as `RawValue`. Do not require model-provider transport bytes.
+Every protobuf message carries protocol, extension, Actor, boot epoch, sequence, and channel digest.
 
-Immediately before execution, `OpenAPPATool.Run` serializes the final map again and requires byte equality with the authorized snapshot.
+It also carries key ID, algorithm, and HMAC-SHA256 over deterministic protobuf encoding.
 
-On equality, the wrapper recursively copies the JSON map and passes only that unshared copy to the underlying tool.
+The receiver verifies mTLS peer identity, channel binding, HMAC, sequence, deadline, event digest, and boot epoch before processing.
 
-Serialization failure or mismatch refuses the call and closes the dispatch as indeterminate.
+Persist event IDs and terminal decisions in the plugin store for replay-safe duplicate handling. A duplicate event returns the exact original terminal decision.
 
-Keep the serialized call in memory until `AfterTool`. Send the same bytes with `ToolResult` because the runtime identifies outcomes through canonical call arguments.
+Reject an old boot epoch except during the explicit `recovery.reconcile` phase for recorded event IDs.
 
-Allow only one open dispatch per trajectory. Hold a trajectory permit from pre-dispatch until terminal outcome admission.
+## Negotiation and readiness
 
-Cancellation reports `ToolOutcome::Indeterminate` before permit release. Actor recovery sends `TurnEnd` before the next call.
+Startup order:
 
-## Cover each execution path
+1. Substrate starts the kagent and extension containers.
+2. The sidecar creates its `0700` socket directory, verifies config, opens state, and serves gRPC.
+3. kagent verifies peer identity and the per-launch socket secret.
+4. kagent calls `GetExtensionInfo` and checks the manifest against the Revision.
+5. kagent sends its generic host inventory to `Negotiate`.
+6. The extension selects one protocol major and enabled capability set.
+7. kagent calls `Activate` with the immutable Revision and inventory digest.
+8. The extension returns accepted or rejected with a stable generic reason code.
+9. `/readyz` becomes true only after every required extension and host-native recovery check succeeds.
 
-| Path | Implementation |
+The host inventory includes every executable path and content sink. It MUST include provider, ADK, kagent, and Substrate versions.
+
+No kagent code decides whether an OpenAPPA policy is covered. The OpenAPPA plugin accepts or rejects the generic inventory.
+
+## Multiple extension ordering
+
+The Revision establishes a total order by `order`, then immutable extension ID.
+
+Phase ownership modes:
+
+| Mode | Behavior |
 |---|---|
-| Normal function, MCP, skill, or memory tool | Existing tool callbacks |
-| Local `chat` | Gate `transfer_to_agent` and keep the parent trajectory |
-| Local `single_turn` | `BeforeTool` prepares spawn, `BeforeAgent` sends `ChildStart`, `AfterTool` sends `SpawnResult` |
-| Local `task` | `AfterModel` prepares spawn, `BeforeAgent` sends `ChildStart`, `OnEvent` sends `SpawnResult` |
-| Remote A2A | Allocate isolated context before dispatch, send `ChildStart`, preserve terminal `TaskState`, send `SpawnResult` |
-| Automatic `preload_memory` | Wrap `memory.Service` and bind the acting trajectory through context |
-| MCP App internal call | Route the request to the owning Actor with a short-lived trajectory capability |
-| Registered long-running work | Add optional `BeforeBackgroundStart` and `OnBackgroundResult` parameters to kagent launch and resume functions |
+| `exclusive` | One extension owns uncommitted content and final decision for that phase |
+| `transform` | Extension receives only content committed by all earlier exclusive owners |
+| `observe_committed` | Extension receives metadata or committed content and cannot modify it |
 
-ADK task placeholder callbacks MUST emit no OpenAPPA event. The task plugin is the only owner of task dispatch and return.
+Only one extension can own an exclusive phase.
 
-Remote A2A rules:
+The host rejects a phase conflict before Actor readiness.
 
-- Require `isolateSessions=true` and bind the authenticated endpoint to an OpenAPPA-capable Harness.
-- Allow content from a direct message or `completed` task only.
-- Pause on `input_required` or `auth_required`.
-- Report `failed`, `canceled`, and `rejected` without content.
-- Continue waiting or fail on `submitted`, `working`, or unknown state.
+No runtime plugin, configured callback, or A2A executor plugin can be appended after final ordering validation.
 
-The first implementation refuses streaming chunks, provider-native tools, unregistered background work, notification-only results, and uninstrumented non-Go frameworks.
+The host keeps one durable generic sequencer per scope.
 
-## Keep result publication ordered
+It assigns the next sequence before callback fan-out and permits one active exclusive phase in that scope.
 
-OpenAPPA admission MUST finish before kagent constructs or publishes result content.
+The first release refuses multiple same-scope function calls in one model response.
 
-Apply this barrier before model input, parent return, A2A streams, memory, MCP App UI, content logs, and background storage.
+Parallel work requires an explicit `child.propose` transition and a new child scope before execution.
 
-For MCP App internal calls, extend tool and resource requests with `agent_instance_id`, `request_id`, and an opaque capability.
+Same-scope callback reentry fails immediately. It never waits on its own sequencer lease.
 
-The Actor mints a random 256-bit capability only after admission of the model-called App result.
+## Event envelope
 
-Store only its hash. Bind it to root trajectory, actor, caller identity, MCP server, allowed tool or resource scope, and expiry.
+Every event is immutable:
 
-The controller forwards the request to the owning Actor and performs no direct MCP execution.
+```protobuf
+message ExtensionEvent {
+  uint32 protocol_major = 1;
+  string extension_id = 2;
+  string actor_uid = 3;
+  string boot_epoch = 4;
+  bytes channel_binding_digest = 5;
+  string event_id = 6;
+  bytes event_digest = 7;
+  string instance_id = 8;
+  string revision_id = 9;
+  string scope_id = 10;
+  optional string parent_scope_id = 11;
+  optional string operation_id = 12;
+  optional string descriptor_id = 13;
+  uint64 sequence = 14;
+  string phase = 15;
+  google.protobuf.Timestamp deadline = 16;
+  Payload payload = 17;
+  repeated HostAttestation host_attestations = 18;
+  MessageAuthentication authentication = 19;
+}
 
-The Actor rejects missing, expired, replayed, used-request, caller, scope, server, actor, or trajectory mismatches before `ToolCall`.
+message Payload {
+  string codec = 1;
+  bytes inline_bytes = 2;
+  optional BlobReference blob = 3;
+  bytes digest = 4;
+}
 
-After the Actor validates the capability, it runs both OpenAPPA gates and records the `request_id` against replay.
+message HostAttestation {
+  AttestationKind kind = 1;
+  string issuer = 2;
+  bytes credential = 3;
+  bytes binding_digest = 4;
+  google.protobuf.Timestamp expires_at = 5;
+}
 
-## Preserve remedy control
+enum AttestationKind {
+  ATTESTATION_KIND_UNSPECIFIED = 0;
+  AUTHENTICATED_PRINCIPAL = 1;
+  WORKLOAD_IDENTITY = 2;
+  REQUEST_BINDING = 3;
+}
 
-Register the local `appa-runtime` MCP endpoint on the root and every protected local child.
+message MessageAuthentication {
+  string key_id = 1;
+  string algorithm = 2;
+  bytes mac = 3;
+}
+```
 
-`execute_remedy_plan` MUST bind its offer to the acting trajectory. The control tool never executes a substituted call itself.
+The host generates IDs and sequence numbers. They carry no plugin semantics.
 
-The next model-proposed call crosses normal dispatch enforcement with the returned tool name and JSON arguments.
+Large payloads use one sealed temporary blob on a shared memory-backed volume.
 
-## Existing-cluster adoption
+Only the host and selected extension can read it.
 
-Do not mutate an existing `AgentInstance` into the OpenAPPA profile.
+The host deletes the blob after terminal decision or deadline.
 
-1. Run the two-phase Helm upgrade.
-2. Create a new protected instance from the existing `AgentTemplate`.
-3. Route only new root tasks and contexts to the new instance ID.
-4. Keep existing task and context IDs pinned to the old instance until terminal or canceled.
-5. Suspend the old instance.
+## Generic decisions
 
-The protected instance starts a new ADK session, OpenAPPA database, and root trajectory family. Do not import the old model transcript.
+```protobuf
+message ExtensionDecision {
+  uint32 protocol_major = 1;
+  string extension_id = 2;
+  string actor_uid = 3;
+  string boot_epoch = 4;
+  bytes channel_binding_digest = 5;
+  string event_id = 6;
+  bytes event_digest = 7;
+  string extension_revision = 8;
+  uint64 sequence = 9;
+  google.protobuf.Timestamp expires_at = 10;
+  MessageAuthentication authentication = 11;
+  oneof decision {
+    Permit permit = 20;
+    Suppress suppress = 21;
+    Hold hold = 22;
+    Commit commit = 23;
+    EventDecision event = 24;
+    Fail fail = 25;
+    Interaction interaction = 26;
+  }
+}
+```
 
-Rollback resumes the old instance and routes new roots back to it.
+Decision semantics:
 
-Protected task and context IDs remain on the protected instance until terminal or canceled. Rollback never merges OpenAPPA logs.
-
-## Upstream sequence
-
-| PR | Generic kagent change |
+| Decision | Generic host action |
 |---|---|
-| 1 | Add extension-aware Go ADK builders |
-| 2 | Add local collaboration mode to `AgentToolBinding` |
-| 3 | Add task dispatch and return plugin seams |
-| 4 | Preserve remote A2A `TaskState` and preallocate context IDs |
-| 5 | Add result-publication barriers and dynamic path validation |
-| 6 | Add background-work lifecycle callbacks |
+| `permit` | Execute the bound original or replacement payload once |
+| `suppress` | Do not execute or publish |
+| `hold` | Pause one generic scope without user interaction |
+| `interaction` | Publish a neutral versioned interaction request and await `interaction.response` |
+| `commit` | Deliver original, replacement, or no result bytes |
+| `event` | Drop, replace, or emit one event |
+| `fail` | Emit a host-defined content-free failure |
 
-The OpenAPPA Harness profile, policy compiler, Go extension, and Rust adapter remain integration-specific.
+Every decision binds the producing extension, source event, payload digest, expiry, and permitted next phase.
 
-## Verification
+The host rejects mismatched, expired, duplicated, reordered, or unknown decisions.
 
-| Area | Required coverage |
+## Generic ADK extension points
+
+### Current callback proxy
+
+Wrap current `plugin.Plugin` callbacks with one generic out-of-process proxy:
+
+- `BeforeRunCallback`
+- `AfterRunCallback`
+- `OnUserMessageCallback`
+- `BeforeAgentCallback`
+- `AfterAgentCallback`
+- `BeforeModelCallback`
+- `AfterModelCallback`
+- `OnModelErrorCallback`
+- `BeforeToolCallback`
+- `AfterToolCallback`
+- `OnToolErrorCallback`
+- `OnEventCallback`
+
+These callbacks remain available to ordinary extensions. Required exclusive phases use stronger points below.
+
+### Provider-final catalog
+
+Add a provider adapter callback after final name and schema conversion but before request transmission.
+
+It returns the exact provider-visible catalog and reversible logical-name map.
+
+Add a raw function-call callback on provider response decoding. It returns the provider tool-call ID, mapped logical name, and original JSON argument token bytes.
+
+The host strictly parses and canonicalizes those bytes. It refuses an adapter that exposes only a decoded `map[string]any` or `float64` number path.
+
+Pinned OpenAI code currently decodes arguments through `json.Unmarshal` into a map: [source](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/openai_responses.go#L258-L271).
+
+Reject provider-name collisions before sending the request.
+
+Refuse providers that cannot expose this callback.
+
+### Pre-plugin tool proposal
+
+Add an exclusive gate at the beginning of `Flow.callTool`, before `pluginManager.RunBeforeToolCallback`.
+
+The host creates an immutable RFC 8785 snapshot and descriptor digest before callback fan-out.
+
+No plugin sees mutable uncommitted arguments before the exclusive owner decides.
+
+### Model request gate
+
+Add an exclusive `model.propose` gate after all request processors and model callbacks, but before telemetry or provider transmission.
+
+It receives the exact canonical provider request, endpoint, model, tool catalog, history, instructions, memory, admitted tool results, and retry identity.
+
+Only a matching permit can send the request to the provider.
+
+Apply this gate to standard generation, live flow, realtime sends, history sends, embedding requests, and every provider adapter.
+
+Refuse a provider path that cannot expose its final request before network transmission.
+
+Provider retry uses the same event ID and exact request digest. A changed request requires a new phase event.
+
+### Model response gate
+
+Add one gate after model callbacks and before every `handleFunctionCalls` path, including live streaming flow.
+
+It can replace the complete model response or suppress all contained calls.
+
+### Event gate
+
+Add `Drop`, `Replace`, and `Emit` before `plugin.OnEventCallback`, session append, runner yield, and task state publication.
+
+No callback runs between the terminal event decision and the protected sink.
+
+The first release sends every partial assistant event to the exclusive gate and drops it before persistence or yield.
+
+Only one terminal text response can be emitted. Inline data, files, artifacts, citations, thought parts, and multiple terminal responses are refused until their codecs exist.
+
+The terminal event includes a closed authenticated-principal attestation. The host does not interpret the plugin's recipient policy.
+
+### Session persistence gate
+
+Add a generic pre-append hook for user, function-response, model, task, child, and resumed interaction events.
+
+The hook receives exact event bytes and stable session lineage.
+
+### A2A publication gate
+
+Add a replaceable event gate after ADK-to-A2A conversion and before stream or task publication.
+
+It receives authenticated caller attestation as generic transport metadata.
+
+### Child lifecycle
+
+Add generic phases for child proposal, start, state, terminal return, and parent delivery.
+
+The host preallocates stable child and parent scope IDs.
+
+### Memory lifecycle
+
+Replace stock automatic preload with generic `memory.propose` and `memory.complete` phases around `SearchMemory`.
+
+No memory content enters model instructions before commit.
+
+Expose the embedding-provider request, retrieved content, `load_memory`, `preload_memory`, `save_memory`, and persistent memory write as separate generic operation phases.
+
+Include embedding endpoints and memory stores in the immutable host sink inventory.
+
+### MCP transport
+
+Add a generic raw JSON-RPC interceptor that supports exact `params.arguments` injection and terminal response capture.
+
+Disable automatic retry after request bytes can reach the MCP server.
+
+Run MCP discovery during Revision preparation. Pin server identity, transport, tool descriptors, schemas, raw metadata, and discovery generation.
+
+Discovery failure MUST reject preparation. It cannot be logged and skipped.
+
+Controller-originated MCP App tool and resource calls enter through a generic `external.operation` phase before any network request.
+
+The host mints a one-use generic request capability bound to instance, caller, server, scope, operation, expiry, and request ID.
+
+### Remote A2A lifecycle
+
+Add generic phases for prepared Agent Card, outbound request metadata, task state, input-required state, and terminal result.
+
+Strip caller credentials and reserved lineage before the phase call.
+
+Snapshot the exact endpoint, Agent Card digest, headers, task and context IDs, body, retry identity, and transport settings.
+
+Send that complete normalized outbound request through exclusive `remote.request`.
+
+Network transmission requires a matching `permit` bound to the exact request digest.
+
+Accept header or body changes only as replacement payload in the generic decision envelope.
+
+Prepare and pin the Agent Card and endpoint in the Revision. Runtime Card refresh is refused.
+
+Preserve raw `submitted`, `working`, `input_required`, `auth_required`, `completed`, `failed`, `canceled`, `rejected`, and unknown states.
+
+Do not extract content before the exclusive extension commits the terminal state and payload.
+
+## Mechanical execution protocol
+
+The host owns the actual invocation of in-process ADK tools.
+
+For each tool call:
+
+1. Capture provider mapping, dispatch descriptor, and immutable argument bytes.
+2. Invoke `tool.propose` on the exclusive extension.
+3. Accept only a matching unexpired `permit`.
+4. Persist the generic event and decision IDs in host-native delivery state when needed.
+5. Invoke `execution.begin` and require plugin acknowledgement.
+6. Execute the permitted private payload exactly once.
+7. Invoke `tool.complete` with raw output or terminal execution status.
+8. Accept only a matching `commit`.
+9. Construct the `FunctionResponse` from committed bytes only.
+
+The execution proxy MUST ignore the original mutable ADK map after snapshot creation.
+
+The proxy MUST NOT understand why the extension permitted, replaced, withheld, or failed the operation.
+
+## Result and sink ordering
+
+Raw output cannot reach:
+
+- Later callbacks.
+- ADK session persistence.
+- Parent or child delivery.
+- Model context.
+- A2A task or stream publication.
+- Memory or UI publication.
+- Content logs, traces, metrics, or snapshots.
+
+The exclusive extension receives raw output first.
+
+The host constructs downstream content only from the terminal generic commit.
+
+Before sink publication, write one durable host outbox record keyed by event ID and committed payload digest.
+
+Publish with that stable idempotency key, then mark the outbox row delivered.
+
+Recovery retries only the same outbox event and payload digest.
+
+ADK session append and its outbox row MUST share one transaction.
+
+A2A, memory, UI, and other external sinks MUST accept the host event ID as an idempotency key.
+
+Refuse a protected sink that lacks idempotent publication. The proposal does not claim exactly-once delivery without sink support.
+
+Protected host construction disables content telemetry before providers, Runner, tools, and log callbacks initialize.
+
+This is an immutable workload property. Extension manifests cannot enable or disable host telemetry.
+
+Fork every content-capable telemetry constructor to omit payload fields at creation time.
+
+This includes model, tool, Runner, A2A, and MCP instrumentation.
+
+Remove kagent's standard serialized tool-argument callback from protected workloads.
+
+The host inventory lists every telemetry constructor and exporter with its content-free implementation digest.
+
+At readiness, run a synthetic canary payload through model, tool, session, A2A, memory, and MCP instrumentation.
+
+Search captured records for the canary digest and bytes. Any content-bearing record keeps the Actor unready.
+
+## Dynamic tools and interactions
+
+An extension can contribute a generic tool descriptor through its signed manifest.
+
+kagent does not special-case contributed tool names.
+
+Sidecar-contributed tools execute only through `extension_tool.propose`, `extension_tool.execute`, and `extension_tool.complete` phase envelopes.
+
+No manifest can declare a bespoke executor endpoint.
+
+The OpenAPPA plugin can contribute its control tool and map those generic phases internally to remedies.
+
+For interaction:
+
+1. The plugin returns `interaction` with a versioned neutral presentation document.
+2. kagent moves the task to `input_required` without creating a model-visible result.
+3. The gateway authenticates the responder and relays opaque response bytes.
+4. kagent sends `interaction.response` through `InvokePhase` with the host interaction ID and closed host attestation.
+5. The plugin finds private continuation state by host event ID and validates meaning, replay, expiry, and remote-hop state.
+6. The host resumes only after a terminal generic decision.
+
+The host does not define approve, decline, cancel, Authority, remedy, or offer fields.
+
+The neutral presentation schema supports title, message, bounded text input, boolean input, and single- or multi-select fields.
+
+The host assigns the interaction ID and binds it to source event, scope, and extension revision.
+
+It also binds caller attestation, schema digest, and expiry.
+
+The host persists only that generic interaction record and submitted field values.
+
+The plugin stores all continuation meaning in its private state keyed by the source event ID.
+
+## OpenAPPA plugin mapping
+
+The OpenAPPA companion translates generic phases into private OpenAPPA runtime events.
+
+| Generic phase | OpenAPPA-side responsibility |
 |---|---|
-| Compatibility | Existing Harnesses, builders, CRDs, callbacks, approval, and concurrency remain unchanged without the profile |
-| Tool calls | Allow, deny, argument snapshot, mutation attempt, serialization error, failure, cancellation, and replacement |
-| Callback safety | Short-circuit rejection, native approval, error logger order, missing state, and post-authorization mutation |
-| Concurrency | Same-trajectory serialization, child parallelism, cancellation, panic, and permit cleanup |
-| Local children | `chat`, `single_turn`, `task`, forged response, pause, resume, cancellation, and restart |
-| Remote A2A | Isolation, endpoint binding, direct message, every task state, replacement, and mismatch |
-| Memory and MCP Apps | Preload context, result barrier, capability expiry, resource read, and UI publication |
-| MCP App capability | Caller, actor, trajectory, server, scope, expiry, request replay, and capability mismatch |
-| Policy and discovery | Policy digest, egress allowlist, explicit LLM URL, MCP discovery failure, and dynamic tool validation |
-| Remedies | Offer trajectory binding, stale offer, authorization, substitution, returned value, decline, and no answer |
-| Migration | CRD order, two-phase Helm upgrade, ready revision, task affinity, fresh session, replacement, and rollback |
-| Runtime | Health, process exit, database persistence, policy revision, and recovery |
+| host inventory activation | Compile `[deployment]`, check path and sink coverage, and attest readiness |
+| catalog phases | Validate descriptor and source identity against policy coverage |
+| `model.propose` | Check model-provider flow against the current Label and declared provider surface |
+| `tool.propose` | Resolve canonical call, Annotator, Membership, requirements, offers, and dispatch |
+| `execution.begin` | Persist exact release and execution acknowledgement |
+| `tool.complete` | Admit, replace, withhold, or settle terminal outcome |
+| child phases | Fork, child identity, return policy, return admission, and merge |
+| `remote.request` | Check outbound remote flow and return opaque replacement or permit metadata |
+| model and publication events | `assistant.response` emission and admitted event digest |
+| `interaction` and `interaction.response` | Remedy, Authority, and other interaction semantics |
+| remote phases | Delegation, remote state, conservative contract, and return handling |
+| snapshot lifecycle | Commit and validate OpenAPPA plugin state generation |
 
-The implementation is complete when every enabled path reaches its required dispatch and result boundary.
+All OpenAPPA consult kinds, backends, Labels, Values, facts, remedies, effects, and audit records remain inside this component.
+
+### Activation and deployment profile
+
+The plugin compiles one immutable `[deployment]` profile from its private policy configuration.
+
+It requires enforced host execution, harness binding, a concrete starting Label, and explicit confined result points.
+
+It also requires child controls, confined child returns, and no open provider surface.
+
+It verifies the reciprocal host source-to-sink inventory. An empty Engine open-vector set alone is insufficient.
+
+Missing provider, tool, child, memory, MCP, A2A, interaction, telemetry, snapshot, or publication capability rejects `Activate`.
+
+### Exact call and dynamic contract handling
+
+For `tool.propose`, the plugin receives the logical descriptor, provider-final descriptor, reversible name map, source identity, and raw canonical argument bytes.
+
+It performs strict canonical call resolution inside the sidecar.
+
+The plugin handles contracts, Annotators, mandates, Membership evidence, requirement gaps, effects, and remedy plans.
+
+Successful Annotator and Membership evidence remains pinned in the plugin store. Input derivation reselects and re-annotates rewritten calls when required.
+
+The generic `permit` carries only an opaque lease and execution payload digest.
+
+kagent never sees the OpenAPPA dispatch ID or decision meaning.
+
+### Execution and result admission
+
+On `execution.begin`, the plugin persists the OpenAPPA dispatch occurrence and execution acknowledgement before responding.
+
+On `tool.complete`, it maps success, failure, and unknown outcome into current Engine semantics.
+
+Only success commits effects. Failure clears reservations. Conservative uncertainty remains `Indeterminate` and retains effect reservations.
+
+The terminal generic `commit` contains only the admitted original, replacement, or empty payload.
+
+### Children and native attestation
+
+The plugin maps generic child phases to prepared forks, child identities, return policy, return shape, child result, and parent merge.
+
+It supports native `attest-schema` only when the host inventory proves local isolation, structured output, confined return, and exact fork-bound shape.
+
+Remote child results cannot use local `attest-schema` in the first release.
+
+### Remedies and interactions
+
+The sidecar-contributed control tool is an ordinary generic contributed tool to kagent.
+
+Inside the sidecar, it maps to the current remedy families and runtime outcomes.
+
+The plugin owns exact offer binding, authorized and substituted calls, returned Values, decline, no-answer, redispatch, MRTR state, and Authority evidence.
+
+Generic `interaction` and `interaction.response` phases transport presentation and answers. kagent never receives an offer ID or OpenAPPA continuation.
+
+### Assistant response emission
+
+The plugin receives terminal response bytes and the closed authenticated-principal attestation through `model.event` and `a2a.publish` phases.
+
+It maps the principal to its private reader configuration and checks the reserved `assistant.response` emission against the current trajectory Label.
+
+The plugin returns generic `event` with emit, replacement, or drop. kagent does not know the reader or policy reason.
+
+### Replay
+
+The plugin persists OpenAPPA facts and validates them through the Engine before use.
+
+Replay reuses recorded annotations, membership expansions, Authority evidence, Sanitizer derivations, dispatch occurrences, child facts, and emission decisions without external reconsult.
+
+## Plugin state and host state
+
+The OpenAPPA plugin owns one private durable state volume.
+
+It stores:
+
+- Engine facts and runtime projections.
+- Policy and deployment identity.
+- Call permits, execution acknowledgements, outcomes, and delivery receipts.
+- Annotator and Membership evidence.
+- Remedy, interaction, and remote delegation state.
+- Plugin migrations and snapshot generations.
+
+kagent stores only normal ADK sessions, A2A tasks, and narrow generic delivery records.
+
+Each delivery record contains event ID, event digest, extension revision, phase, host lifecycle state, expiry, and optional delivered-payload digest.
+
+It contains no extension handle, policy decision, continuation, or semantic outcome.
+
+kagent MUST NOT persist opaque plugin handles after their generic delivery lifecycle ends.
+
+## Recovery
+
+At restart:
+
+1. kagent reconstructs host-native session, task, child, and undelivered event inventory.
+2. The sidecar opens and migrates its private store.
+3. kagent negotiates the same pinned extension revision.
+4. kagent sends one `recovery.reconcile` event through `InvokePhase` for each unresolved host event ID.
+5. The plugin returns replayed commit, suppress, hold, or fail through the ordinary decision envelope.
+6. kagent deduplicates delivery by host event ID.
+
+Crash classification:
+
+- Before plugin acknowledgement of `execution.begin`: no execution started.
+- After acknowledgement and before terminal completion: plugin records `Indeterminate` internally.
+- After a persisted terminal commit: replay the same generic delivery decision.
+
+The first release accepts this conservative uncertainty window. kagent adds no OpenAPPA-aware execution ledger.
+
+## Snapshots
+
+Snapshot lifecycle is generic and outside ADK callback execution. The user explicitly approved this lifecycle infrastructure.
+
+The controller allocates one monotonically increasing Actor generation and fencing epoch.
+
+Every host-native and extension-owned state write MUST carry the current epoch. A stale Actor or restored process cannot write after a newer generation activates.
+
+Persist a generic host snapshot transaction with these states:
+
+`Active -> Quiescing -> ExtensionsSealed -> HostSealed -> ProviderCommitted -> Complete`.
+
+Sequence:
+
+1. Reject new roots and tool proposals.
+2. Drain or cancel active host operations.
+3. Call `Quiesce` on every required extension in deterministic order.
+4. Receive signed extension generation metadata and file digests.
+5. Checkpoint host-native stores.
+6. Ask Substrate to create one encrypted snapshot generation.
+7. Bind provider snapshot identity, key version, host files, extension files, and completion marker.
+8. Call `ValidateRestore` before any restored Actor becomes ready.
+
+The OpenAPPA state volume is mounted only in the OpenAPPA sidecar.
+
+Each extension manifest binds generation, fencing epoch, state schema, file digests, WAL state, policy-independent extension revision, and encryption-key version.
+
+The host manifest binds its session and delivery files plus every signed extension manifest.
+
+Publish `Complete` only after the provider confirms the snapshot identity and all file digests.
+
+Recovery rules:
+
+- Before `ExtensionsSealed`: abort the snapshot and resume the old generation.
+- After `ExtensionsSealed` but before `ProviderCommitted`: keep the Actor quiesced and retry or abort through each extension.
+- After `ProviderCommitted` but before `Complete`: verify provider identity and digests, then finish the same transaction.
+- On any digest, epoch, signature, or state-schema mismatch: reject restore and remain unready.
+
+Use `ReadWriteOncePod` plus the durable epoch. Volume access mode alone is not a fencing mechanism.
+
+## Readiness and failure behavior
+
+`/readyz` returns success only when:
+
+- Every required sidecar container is healthy.
+- Artifact, manifest, protocol, and workload identities match the Revision.
+- Capability and phase negotiation succeeded.
+- Every exclusive phase has one owner.
+- The extension accepted the full host inventory.
+- Host and plugin recovery completed.
+- Egress, secret, volume, and snapshot attestations passed.
+
+Failure rules:
+
+| Failure point | Host behavior |
+|---|---|
+| Before permit | Suppress execution and return content-free failure |
+| After execution acknowledgement | Withhold result and freeze scope pending recovery |
+| Before event publication | Drop or replace with content-free failure |
+| Required extension unhealthy | Mark Actor unready and reject new work |
+| Protocol or manifest mismatch | Refuse activation |
+| Unknown or expired handle | Refuse the operation |
+
+Required extension calls fail closed. Optional extensions cannot claim exclusive phases.
+
+## Egress and secrets
+
+The generic extension declaration lists destinations and secret references.
+
+The kagent controller validates generic shape and includes hashes in the Revision.
+
+Substrate MUST enforce per-container egress through an authenticated gateway. Current destination metadata alone is insufficient.
+
+Install Actor-wide default-deny CNI egress. Permit only the cluster DNS resolver and authenticated egress gateway addresses.
+
+Block direct external TCP, UDP, node, control-plane, and cloud metadata-service routes.
+
+Each container authenticates to the gateway with its workload identity. The gateway selects the allowlist for that exact Actor, Revision, and container.
+
+The gateway resolves external DNS and enforces scheme, host, port, and TLS or SPIFFE identity.
+
+It also enforces IP ranges, redirects, and DNS rebinding rules.
+
+The Actor MUST remain unready when CNI isolation, gateway routing, DNS policy, or workload identity cannot be installed and attested.
+
+Add projected Secret and ConfigMap volume support so secret bytes do not appear as literal ActorTemplate environment values.
+
+The sidecar receives only declared mounts, secrets, and egress.
+
+## Security and trust boundary
+
+Require signed OCI image and manifest artifacts, allowed signer identities, SBOM, and build provenance.
+
+Publish the extension manifest as OCI media type `application/vnd.kagent.extension.manifest.v1+json`.
+
+Publish SPDX JSON SBOM and in-toto SLSA provenance as OCI referrers to the same image subject digest.
+
+Publish a Sigstore signature envelope for the complete artifact set.
+
+It binds image, manifest, SBOM, provenance, signer identity, and Rekor inclusion proof.
+
+The generic trust policy pins allowed registry, issuer, subject identity, and minimum provenance level.
+
+The controller verifies all referrer subject links and signatures before Revision creation. Cluster admission verifies the same Revision attestation before Actor launch.
+
+Admission MUST reject tag-only images, missing or mismatched referrers, unsigned manifests, disallowed registries, unknown signers, and Revision overrides.
+
+Restrict Harness, AgentTemplate, AgentInstance, Revision, ActorTemplate, Secret, and direct workload mutation through RBAC and admission policy.
+
+Run the sidecar as a dedicated non-root UID with read-only root filesystem, `allowPrivilegeEscalation: false`, dropped Linux capabilities, and RuntimeDefault seccomp.
+
+Mount its private state with single-writer fencing. Use `ReadWriteOncePod` or one external transactional writer lease per plugin revision.
+
+The kagent process is part of the trusted computing base. In-process tool code shares that process and can reach the private client socket as the host identity.
+
+The sidecar boundary isolates OpenAPPA memory and state from ordinary accidental faults. It does not sandbox malicious code already executing inside kagent.
+
+Use one per-launch secret and workload identity on the Unix gRPC channel. Bind every event to boot epoch, instance, Revision, extension, sequence, and digest.
+
+RPC deadlines are mandatory. Disable hedging. Retry an extension RPC only with the same idempotent event ID.
+
+Never retry a tool transport after request bytes can have reached the tool.
+
+The generic scope lock is non-reentrant. A nested operation must create a declared child scope or fail before waiting.
+
+Bound callback queues, child concurrency, interaction lifetime, and extension restart backoff.
+
+## Plugin upgrades
+
+Pin the extension artifact, manifest, protocol, and state schema to every live scope.
+
+Before first dispatch, persist an immutable mapping from root, task, context, child, and interaction scope to ActorTemplate and extension Revision.
+
+Every resume, remote response, interaction response, capability, and late event routes through that mapping.
+
+Controller lifecycle is `Active -> Draining -> Drained -> Suspended`.
+
+Upgrade sequence:
+
+1. Prepare and activate the new sidecar revision against the new host inventory.
+2. Atomically stop old-root admission and route new roots to the new Revision.
+3. Keep existing scopes on the old sidecar revision.
+4. Keep the old workload ready for its assigned scopes only.
+5. Drain old scopes until terminal or deadline.
+6. Record every forced remainder as generic uncertain termination for plugin reconciliation.
+7. Snapshot and suspend the old instance only after pending work reaches zero or reconciliation completes.
+
+Rollback is another atomic new-root routing transition. It never moves a live scope between revisions.
+
+No between-turn or immediate hot swap exists in the first release.
+
+## Generic kagent PR sequence
+
+| PR | Change |
+|---|---|
+| 1 | Add generic Harness extension API, manifests, Revision data, and signature policy |
+| 2 | Render sidecar containers, projected config and secrets, socket and state volumes, egress, and readiness |
+| 3 | Add neutral protobuf protocol, negotiation, health, and generic extension host |
+| 4 | Add provider-final catalog and reversible name-map hooks |
+| 5 | Add pre-plugin tool proposal and immutable execution proxy |
+| 6 | Add model response and exclusive event gates for standard and live flows |
+| 7 | Add session persistence and A2A publication gates |
+| 8 | Add child, task, remote, memory, and interaction lifecycle phases |
+| 9 | Add raw MCP transport interceptor and no-retry semantics |
+| 10 | Add immutable content-free telemetry, readiness, snapshot, recovery, and drain lifecycle |
+
+Each PR is generic. Test fixtures MUST use neutral fake extensions and contain no OpenAPPA import or name in production packages.
+
+## OpenAPPA plugin sequence
+
+| PR slice | Change |
+|---|---|
+| 1 | Neutral protocol binding, sidecar handshake, inventory validation, and health |
+| 2 | Tool proposal, permit, begin, complete, commit, and conservative recovery |
+| 3 | Event, session, assistant response, and publication gates |
+| 4 | Child, task, remote, memory, and MCP mappings |
+| 5 | Dynamic remedy tool, interaction relay, and durable continuation |
+| 6 | Plugin state, snapshots, migrations, signed manifest, image, SBOM, and provenance |
+
+## Verification matrix
+
+### Generic host unit tests
+
+- Manifest signature, digest, protocol range, and capability validation.
+- Deterministic ordering and exclusive-phase conflicts.
+- Socket identity and launch-secret validation.
+- Event canonicalization, digest, deadline, and sequence checks.
+- Permit, commit, event, hold, interaction, and fail decision validation.
+- Unknown, expired, replayed, cross-scope, and reordered handles.
+- Payload inline and sealed-blob limits.
+- Required sidecar health and readiness transitions.
+- Pin-and-drain upgrade routing.
+- Forbidden dependency and identifier checks.
+
+### Generic ADK integration tests
+
+- Provider-final catalog and name-collision rejection.
+- Pre-plugin argument ownership and mutation attempts.
+- Ordinary tool allow, replace, suppress, error, panic, and timeout.
+- No duplicate execution after transport uncertainty.
+- Standard and live model response gates.
+- Event drop before plugin observation, session append, and yield.
+- Forged inbound `FunctionResponse` rejection.
+- Local chat, single-turn, task, and terminal child return.
+- Automatic memory before-search and after-result gates.
+- Raw MCP arguments, response, reconnect, and no-retry behavior.
+- Remote immutable Card, credential stripping, task states, and terminal result.
+- A2A publication and authenticated interaction relay.
+- Content telemetry disabled before payload creation.
+
+### Sidecar lifecycle tests
+
+- Container and protocol readiness ordering.
+- Required sidecar crash before and during operations.
+- Bounded restart and re-registration.
+- State volume isolation from kagent.
+- Egress and secret mount enforcement.
+- Quiesce, encrypted snapshot, partial snapshot rejection, and restore validation.
+- Old and new plugin revisions draining concurrently without scope migration.
+
+### OpenAPPA plugin tests
+
+- Host inventory acceptance and every missing-capability refusal.
+- Deployment profile and sink coverage validation.
+- Annotator, Membership, Authority, Sanitizer, and native attestation paths.
+- Remedy families and every runtime outcome.
+- Result, child-return, and assistant response admission.
+- Human interaction accept, decline, cancel, expiry, replay, and remote hops.
+- Crash before permit, before begin acknowledgement, during execution, after result, and after commit.
+- Replay of exact terminal decisions and `Indeterminate` effect handling.
+
+### End-to-end GCP acceptance
+
+- Build and deploy the generic kagent host and OpenAPPA sidecar as separate images.
+- Verify dynamic manifest installation without recompiling kagent.
+- Run ordinary, MCP, memory, local child, remote child, HITL, final response, and migration scenarios.
+- Inject plugin, host, network, tool, model, and snapshot failures.
+- Inspect logs, traces, session state, plugin state, A2A output, and snapshots for prohibited raw content.
+- Repeat all crash and restart windows until deterministic assertions pass.
+- Manually verify desktop and API interaction flows.
+
+The PoC is complete only when every required capability passes and no partial-capability mode reports ready.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -1,256 +1,499 @@
 ---
 title: kagent integration
-category: Integration
-order: 8
-description: Proposal for enforcing OpenAPPA policy in the kagent Go runtime.
+nav_title: kagent
+description: Proposal for a dynamically supplied OpenAPPA ADK extension in kagent.
 ---
 
 :::proposal
 name: kagent integration
-date: 2026-08-28
-author: Mark Novikov
+date: 2026-08-27
+:::
 
-This proposal adds an OpenAPPA execution profile to the kagent Go runtime.
+This proposal adds a generic dynamic ADK extension host to the kagent Go fork.
 
-The profile authorizes the exact arguments that kagent passes to a tool. It also controls the result before any consumer receives it.
+OpenAPPA ships as a separate OCI companion container. The kagent fork contains no OpenAPPA policy, Label, trajectory, remedy, consult, runtime, or persistence logic.
 
-The profile refuses a path when kagent cannot observe both boundaries.
+The combined protected instance enforces four contracts:
+
+1. The host executes only the immutable payload permitted by the required extension.
+2. Raw tool and child results remain withheld until the extension commits a delivery payload.
+3. Model, session, A2A, memory, UI, log, telemetry, and storage publication cross exclusive extension gates.
+4. The instance remains unready when its generic host inventory cannot satisfy every required extension capability.
 
 This proposal uses [kagent commit `9e246fd37`](https://github.com/kagent-dev/kagent/commit/9e246fd3797457b18fc277680be1629a0f57fce0) as its source baseline.
 
-OpenAPPA policy semantics remain in [How it works](/how-it-works) and [Policy contracts](/contracts). This proposal covers only the kagent integration.
+It also uses Google ADK Go 2.2.0 and Substrate 0.0.20.
 
-## Gate ordinary tool calls twice
+OpenAPPA policy semantics remain in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
-kagent uses Google ADK to run model, tool, and child-agent steps. An ordinary ADK function tool uses two existing boundaries:
+## Keep the fork generic
 
-1. `BeforeToolCallbacks` send `HookEvent::ToolCall` before tool dispatch.
-2. `AfterToolCallbacks` send one terminal `HookEvent::ToolResult` after execution or error handling.
+The kagent fork implements only generic extension infrastructure:
 
-```text
-Model              Google ADK         Go extension        appa-runtime       Tool
-  | FunctionCall       |                   |                    |              |
-  |------------------->| BeforeTool       |                    |              |
-  |                    |------------------>| ToolCall           |              |
-  |                    |                   |------------------->|              |
-  |                    |                   |<-------------------| Allow / deny |
-  |                    |-----------------------------------------------> Run   |
-  |                    |<----------------------------------------------- result |
-  |                    | AfterTool        |                    |              |
-  |                    |------------------>| ToolResult         |              |
-  |                    |                   |------------------->|              |
-  |                    |                   |<-------------------| result rule  |
-  |<-------------------| admitted result  |                    |              |
-```
+- Dynamic extension configuration and artifact verification.
+- Version and capability negotiation.
+- Immutable ADK event snapshots.
+- New generic ADK callback and barrier points.
+- Generic execution, event, interaction, and lifecycle decisions.
+- Generic sidecar readiness, egress, volume, snapshot, and drain handling.
 
-OpenAPPA can block dispatch, keep the result, replace it, or withhold it before model delivery.
+The fork MUST NOT import an OpenAPPA crate, Go package, protobuf package, policy schema, wire enum, or generated type.
 
-## Install with Helm
+The generic protocol MUST NOT contain OpenAPPA domain terms.
 
-The integration release publishes one OCI Helm chart. It pins both images and includes an OpenAPPA `Harness` template.
+Examples include Label, Trajectory, Authority, Annotator, Sanitizer, Membership Resolver, remedy plan, ReaderId, and effect.
 
-The chart disables that template by default.
+The OpenAPPA companion owns:
 
-Create the policy `ConfigMap`:
+- Policy loading and `[deployment]` validation.
+- OpenAPPA Engine and runtime calls.
+- Facts, call correlation, consult pins, offers, continuations, and recovery.
+- Annotator, Membership Resolver, Authority, and Sanitizer implementations.
+- OpenAPPA-specific A2A delegation and human-review meaning.
+- Plugin-side durable state and schema migrations.
 
-```sh
-kubectl create namespace kagent --dry-run=client -o yaml | kubectl apply -f -
-kubectl -n kagent create configmap customer-support-policy \
-  --from-file=appa.toml=./appa.toml \
-  --dry-run=client -o yaml | kubectl apply -f -
-```
+kagent sees only generic ADK payloads, phase names, digests, deadlines, decisions, and opaque handles.
 
-Apply the generated CRDs, then install or upgrade kagent:
+## Use an OCI companion container
+
+The selected process model is a digest-pinned OCI companion container in the same Substrate Actor.
+
+Substrate already supports [multiple containers with independent readiness probes](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L356). Pinned kagent currently emits [one container](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L32-L91).
+
+The baseline lacks shared memory sockets, projected config and secrets, per-container identity, filesystem controls, seccomp, and enforced egress.
+
+These are required generic Substrate additions. Extension activation fails when any declared primitive is unavailable.
+
+The generic fork adds extension containers without adding an OpenAPPA-specific sidecar role.
+
+The kagent process and extension communicate over gRPC on a private Unix-domain socket. A shared memory-backed socket volume carries no durable state.
+
+Substrate mints per-activation mTLS identities, a boot epoch, and a message-authentication key.
+
+Every event and decision binds the Actor UID, extension ID, protocol major, boot epoch, sequence, channel digest, deadline, and HMAC.
+
+The extension receives a separate durable state volume. The kagent container cannot mount that volume.
+
+The extension receives opaque configuration and secret mounts. kagent verifies source references and digests but does not parse their content.
+
+The extension image runs as a dedicated UID with a read-only root filesystem and no Linux capabilities.
+
+It also has bounded resources and deny-by-default egress.
+
+Actor-wide CNI policy permits only cluster DNS and an authenticated egress gateway. The gateway enforces per-container destination, TLS identity, redirect, and DNS-rebinding rules.
+
+The kagent process and its in-process tools remain in the trusted computing base. The sidecar isolates OpenAPPA memory and state but cannot sandbox malicious code already running as kagent.
+
+## Follow proven plugin patterns
+
+The protocol borrows established mechanisms rather than using Go shared-library loading.
+
+| Source | Adopted mechanism |
+|---|---|
+| [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin) | Out-of-process RPC, handshake, protocol-major negotiation, health, process isolation, and explicit lifecycle |
+| [Terraform provider protocol](https://developer.hashicorp.com/terraform/plugin/terraform-plugin-protocol) | Artifact version separate from wire compatibility and strict protocol negotiation |
+| [Kubernetes device plugins](https://v1-32.docs.kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) | Serve before registration, Unix-socket gRPC, capability discovery, health, and re-registration |
+| [VS Code extension manifests](https://code.visualstudio.com/api/references/extension-manifest) | Declarative contribution points, compatibility ranges, activation, and reviewable requested capabilities |
+| [Envoy xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) | Versioned configuration with explicit accept or reject behavior |
+
+The design does not use the Go [`plugin`](https://pkg.go.dev/plugin) package. Its toolchain coupling, platform limits, race-detector limitations, shared address space, and unload restrictions conflict with independently shipped extensions.
+
+## Configure extensions dynamically
+
+A Harness can declare several ordered dynamic extensions. Each declaration is generic:
 
 ```yaml
-# openappa-values.yaml
-openappa:
-  policyRef: customer-support-policy
-  harness:
-    enabled: false
-  allowedAgentTemplates:
-    matchLabels:
-      openappa: enabled
-substrate:
-  workerPoolRef: default
-  snapshotLocation: s3://kagent-snapshots/openappa
+extensions:
+  - name: policy-gate
+    image: ghcr.io/archestra-ai/openappa-adk-plugin@sha256:<digest>
+    manifestDigest: sha256:<digest>
+    protocol: kagent.extension.v1
+    required: true
+    failureMode: closed
+    order: 10
+    socket: /run/kagent/extensions/policy-gate.sock
+    config:
+      configMapRef:
+        name: customer-support-policy-v1
+    secrets:
+      - secretRef:
+          name: openappa-plugin-secrets-v1
+    state:
+      durableDir: openappa-plugin-state
+    egress:
+      - api.policy-provider.example:443
+    readiness:
+      path: /readyz
+      port: 8082
 ```
+
+The generic compiler verifies:
+
+- OCI digest and signature policy.
+- Manifest digest and protocol range.
+- Canonical opaque configuration digest.
+- Secret and volume references without reading plugin semantics.
+- Declared capabilities, exclusive phases, deadlines, limits, and failure mode.
+- Socket, state, egress, readiness, and resource declarations.
+
+The controller resolves opaque ConfigMap and Secret bytes only to hash and copy them.
+
+It mounts immutable Revision-owned copies and stores no secret bytes in the Revision. Any policy, credential, CA, or secret change creates a new Revision.
+
+The immutable Revision includes these generic values. A plugin revision never changes inside a live scope.
+
+## Negotiate a neutral protocol
+
+The sidecar starts before registration and serves the private socket.
+
+The host performs these steps:
+
+1. Verify the sidecar workload identity and per-launch socket secret.
+2. Call `GetExtensionInfo` for plugin ID, artifact version, protocol range, state schema, and manifest digest.
+3. Send the complete generic host capability and sink inventory.
+4. Select one protocol major and capability set.
+5. Require the extension to accept the inventory digest and return ready.
+6. Enable the extension only after both container readiness and protocol readiness succeed.
+
+The inventory describes mechanics, not OpenAPPA policy:
+
+- ADK and provider versions.
+- Available callback phases and their ordering.
+- Tool, child, remote, memory, MCP, interaction, event, session, and publication paths.
+- Provider-final descriptor and name-mapping support.
+- Immutable JSON and raw transport codecs.
+- Content-bearing sinks and telemetry surfaces.
+- Snapshot, recovery, and drain capabilities.
+
+The OpenAPPA sidecar validates its own policy against that inventory.
+
+kagent treats the signed ready response as a generic required-extension attestation.
+
+## Add generic ADK extension points
+
+Current ADK callbacks cover only part of the required lifecycle.
+
+| Boundary | Baseline status | Generic fork addition |
+|---|---|---|
+| Ordinary `BeforeTool`, `AfterTool`, and tool error | Existing plugin callbacks | Dynamic out-of-process proxy and deterministic ordering |
+| User message before persistence | Existing `OnUserMessageCallback` | Generic pre-persistence phase keyed by host event ID |
+| Model response before normal function dispatch | Existing `AfterModelCallback` on the standard path | One shared gate for standard and live paths |
+| Final model request before provider transmission | Missing | Exclusive `model.propose` gate for standard, live, realtime, history, and embedding paths |
+| Provider-final tool catalog | Missing | Final descriptor and reversible provider-name callback |
+| Before every plugin sees tool arguments | Missing | Exclusive pre-plugin dispatch gate |
+| Immutable argument ownership | Missing | Host-owned RFC 8785 snapshot and private execution payload |
+| Event drop before session persistence and yield | Missing | Exclusive `Drop`, `Replace`, or `Emit` event gate |
+| Child and task terminal return | Missing | Child terminal and parent-return gates |
+| Final A2A publication | Missing | Replaceable pre-publication gate |
+| Automatic memory preload | Outside tool callbacks | Synthetic memory operation lifecycle |
+| Raw MCP transport and no-retry dispatch | Outside plugin callbacks | Generic transport interceptor and execution proxy |
+| Remote A2A request before network transmission | Existing custom tool, no gate | Exclusive `remote.request` snapshot and permit phase |
+| Snapshot, readiness, egress, and drain | Outside ADK | Generic extension lifecycle interface |
+
+The user approved the generic lifecycle interface. Strict callback-only integration would remove several required guarantees.
+
+Those guarantees include snapshots, readiness, raw MCP, telemetry, and publication.
+
+No OpenAPPA payload or decision uses a direct kagent API. Enforcement data crosses only the generic ADK extension protocol.
+
+The only non-ADK messages are generic sidecar lifecycle, readiness, workload identity, opaque configuration, volume, egress, and snapshot metadata.
+
+## Keep extension ordering deterministic
+
+The Revision defines one total extension order.
+
+An extension manifest declares each phase as `exclusive`, `transform`, `observe_committed`, or unused.
+
+Only one extension can own an exclusive phase. Revision preparation rejects an ownership conflict.
+
+The OpenAPPA plugin requires exclusive ownership of all uncommitted content phases.
+
+Other extensions can observe metadata or already committed content only after that exclusive gate.
+
+No runtime plugin can be appended after manifest verification.
+
+## Use immutable event envelopes
+
+Every host event has a generic immutable envelope:
+
+```json
+{
+  "protocol": "1.0",
+  "event_id": "opaque-host-id",
+  "event_digest": "sha256:...",
+  "instance_id": "opaque",
+  "scope_id": "opaque",
+  "parent_scope_id": null,
+  "operation_id": "opaque",
+  "descriptor_id": "opaque",
+  "sequence": 42,
+  "phase": "tool.propose",
+  "deadline": "2026-09-01T00:00:00Z",
+  "payload": {
+    "codec": "rfc8785-json",
+    "bytes": "<bounded bytes or blob reference>",
+    "digest": "sha256:..."
+  }
+}
+```
+
+The host IDs are generic and unguessable. They bind instance, Revision, scope, phase, descriptor, operation, expiry, and allowed use.
+
+The sidecar can return an opaque lease for one immediate mechanical next phase.
+
+The host never parses a lease or persists it beyond that delivery lifecycle.
+
+The sidecar resolves held interactions and recovery state from its private store by host event ID.
+
+## Use generic decisions
+
+The sidecar returns only generic host decisions:
+
+| Decision | Host behavior |
+|---|---|
+| `permit` | Execute the original or replacement immutable payload once |
+| `suppress` | Execute or publish nothing |
+| `hold` | Pause one generic scope without requesting user input |
+| `interaction` | Publish a neutral interaction request and wait for a generic response event |
+| `commit` | Deliver original, replacement, or no result bytes |
+| `event` | Drop, replace, or emit one ADK, session, or A2A event |
+| `fail` | Emit a host-defined content-free failure |
+
+A decision binds the event digest, extension revision, deadline, and permitted next phase.
+
+The host executes no replacement that lacks a matching permit. It publishes no content that lacks a matching commit or event decision.
+
+## Gate one tool lifecycle mechanically
+
+```text
+ADK proposes a tool call
+  -> host captures final descriptor and immutable arguments
+  -> sidecar: tool.propose
+  <- sidecar: permit(exact payload digest, opaque lease)
+  -> sidecar: execution.begin
+  <- sidecar: acknowledged
+  -> host invokes the tool once with the permitted private payload
+  -> sidecar: tool.complete(raw result or terminal status)
+  <- sidecar: commit(original, replacement, or no bytes)
+  -> host constructs the FunctionResponse from committed bytes only
+```
+
+The extension sees the provider-final descriptor, actual source identity, exact canonical arguments, and generic execution context.
+
+The host blocks name collisions, descriptor drift, mutable argument reuse, callback bypass, and automatic transport retry before plugin policy runs.
+
+## Gate the model provider request
+
+After all request processors and model callbacks, the host snapshots the exact provider request.
+
+The snapshot includes endpoint, model, catalog, history, instructions, memory, and admitted results.
+
+It sends `model.propose` before telemetry or network transmission. Only a matching permit can send that exact request.
+
+The same gate covers standard generation, live flow, realtime sends, history sends, embeddings, and every provider adapter.
+
+## Gate every result and response sink
+
+The generic event gate runs before any plugin callback can observe uncommitted event content.
+
+It runs before ADK session append, runner yield, parent return, task state, and A2A conversion.
+
+It also runs before A2A publication, memory insertion, UI publication, content logs, trace attributes, and background storage.
+
+The gate supports `Drop`, `Replace`, and `Emit`. No callback runs between the final event decision and the protected sink.
+
+The first release drops every partial assistant event before persistence and yield.
+
+It emits one terminal text response only. It refuses files, data parts, artifacts, citations, thought content, and multiple terminal responses.
+
+The OpenAPPA plugin maps these generic events to its own admission and `assistant.response` logic internally.
+
+Protected host construction always disables content-bearing telemetry and argument logging before Runner creation.
+
+This immutable kagent workload property does not depend on an extension manifest or decision.
+
+Readiness sends a canary through every model, tool, session, A2A, memory, MCP, and exporter path. Any captured canary content keeps the Actor unready.
+
+## Cover children, remote agents, and interactions
+
+The host exposes generic child phases:
+
+- `child.propose`
+- `child.started`
+- `child.terminal`
+- `remote_child.state`
+- `remote_child.terminal`
+
+A child starts only after a permit bound to its parent scope and prepared child descriptor.
+
+No child result reaches a parent before a matching commit.
+
+The remote client extension point exposes prepared Agent Card identity, outgoing headers, task state, and terminal content.
+
+The host strips caller credentials and reserved lineage headers.
+
+It sends the complete normalized outbound request through `remote.request` and accepts header or body replacement only through the generic decision envelope.
+
+For human interaction, `interaction` carries a versioned neutral presentation document and host interaction ID.
+
+kagent moves the task to `input_required`, authenticates the responder, and emits `interaction.response` through the ordinary extension phase API.
+
+It does not interpret approve, decline, cancel, Authority, offer, or remedy meaning.
+
+The OpenAPPA plugin owns response meaning, replay protection, expiry, remote-hop state, and resume decisions.
+
+## Keep OpenAPPA semantics inside the sidecar
+
+The OpenAPPA sidecar maps generic phases to current Engine and runtime behavior.
+
+It alone compiles the concrete `[deployment]` profile, validates the host inventory, and refuses readiness when coverage is incomplete.
+
+It alone implements:
+
+- Canonical call and result correlation.
+- Annotator routing, mandates, pins, and rewrite semantics.
+- Membership resolution and operation evidence.
+- Authority and Sanitizer consults.
+- `attest-schema` child-return handling.
+- Remedy plans and runtime outcome translation.
+- Label, Value, effect, child, offer, and emission facts.
+- OpenAPPA audit and recovery state.
+
+The kagent fork does not know these concepts.
+
+## Keep state ownership separate
+
+kagent keeps its ordinary ADK session and A2A task stores.
+
+Its only extension record contains host event ID, digest, extension revision, phase, delivery state, expiry, and optional delivered-payload digest.
+
+The OpenAPPA sidecar keeps all OpenAPPA state in its private volume.
+
+This state includes facts, leases, journals, consult pins, remedies, interactions, delegations, and delivery receipts.
+
+kagent stores no OpenAPPA journal, token, fact, offer, Label, decision, or runtime database.
+
+Generic host event IDs support delivery deduplication. They do not encode plugin meaning.
+
+Before a snapshot, the generic lifecycle host stops new work and asks every required extension to quiesce.
+
+The sidecar returns a signed state-generation manifest. Substrate then checkpoints host-native and extension-owned volumes and attests the encrypted snapshot generation.
+
+A durable fencing epoch accompanies every state write. The host records one atomic snapshot transaction from quiescing through provider completion.
+
+Restore remains blocked until every required extension validates its own generation and accepts the host inventory.
+
+## Classify uncertain crashes conservatively
+
+The selected first-release recovery rule is conservative.
+
+A crash before the sidecar acknowledges `execution.begin` means the host did not execute the tool.
+
+A crash after that acknowledgement and before a terminal result is `Indeterminate` to the OpenAPPA sidecar.
+
+The kagent host does not keep an OpenAPPA-aware execution journal to narrow this window.
+
+The host emits `recovery.reconcile` through the ordinary extension phase API.
+
+The affected generic scope remains frozen until the sidecar returns `suppress`, `hold`, replayed `commit`, or terminal `fail`.
+
+## Pin and drain plugin upgrades
+
+One plugin artifact and protocol selection remain pinned for each live scope.
+
+The controller durably maps every root, task, context, child, and interaction scope to its ActorTemplate and extension Revision before dispatch.
+
+New roots can use a new plugin revision only after it accepts the new host inventory and reports ready.
+
+Existing scopes drain on the old sidecar revision. The host never hot-swaps a plugin between turns or during a tool lifecycle.
+
+The old workload rejects new roots but remains available for its assigned scopes until terminal or deadline.
+
+The plugin owns any state migration. An incompatible revision requires instance replacement and drain.
+
+## Install the generic host and OpenAPPA plugin
+
+Installation has two independently versioned artifacts:
+
+1. A kagent fork with the generic dynamic extension host and generic ADK/lifecycle points.
+2. The OpenAPPA ADK plugin companion image and its signed manifest.
+
+Create immutable policy configuration for the sidecar:
 
 ```sh
-helm show crds oci://ghcr.io/archestra-ai/charts/kagent-openappa \
-  --version <release-version> | kubectl apply -f -
-
-helm upgrade --install kagent \
-  oci://ghcr.io/archestra-ai/charts/kagent-openappa \
-  --version <release-version> \
-  --namespace kagent \
-  --values openappa-values.yaml \
-  --atomic --wait --timeout 5m
+kubectl -n kagent create configmap customer-support-policy-v1 \
+  --from-file=appa.toml=./appa.toml \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n kagent patch configmap customer-support-policy-v1 \
+  --type=merge -p '{"immutable":true}'
 ```
 
-Wait for the patched controller and its service endpoint:
+The generic Harness references the extension image and opaque configuration. The kagent controller never parses `appa.toml`.
 
-```sh
-kubectl -n kagent rollout status deployment/kagent-controller --timeout=5m
-kubectl -n kagent wait endpoints/kagent-controller \
-  --for='jsonpath={.subsets[0].addresses[0].ip}' --timeout=5m
-```
+The OpenAPPA plugin reports unready until its policy, state, runtime, host inventory, and required generic phases validate.
 
-Create the chart-managed `Harness`, label the `AgentTemplate` that may use it, and wait for preparation:
-
-```sh
-helm upgrade kagent oci://ghcr.io/archestra-ai/charts/kagent-openappa \
-  --version <release-version> \
-  --namespace kagent \
-  --values openappa-values.yaml \
-  --set openappa.harness.enabled=true \
-  --atomic --wait --timeout 5m
-
-kubectl -n kagent label agenttemplate customer-support-agent openappa=enabled
-kubectl -n kagent wait agenttemplate/customer-support-agent \
-  --for='jsonpath={.status.harnesses[?(@.harness=="kagent-openappa")].conditions[?(@.type=="Ready")].status}=True' \
-  --timeout=5m
-```
-
-The integration adds a `kagentctl` command for creating the protected instance:
-
-```sh
-kagentctl agent-instance create customer-support \
-  --namespace kagent \
-  --template customer-support-agent \
-  --harness kagent-openappa
-```
-
-`--harness kagent-openappa` sets the `harness` field in `CreateAgentInstance` to that Kubernetes resource name.
-
-kagent resolves the same-namespace `Harness` and `AgentTemplate`, then starts their latest ready revision.
+Create a new `AgentInstance` from the prepared Harness. Existing instances cannot change their pinned extension set.
 
 ## Architecture
 
 ```text
-+---------------------------- Kubernetes cluster -----------------------------+
-|                                                                              |
-|  kubectl / Helm -> Kubernetes API -> patched kagent controller               |
-|                    Harness + AgentTemplate + policy ConfigMap                 |
-|                                      |                                       |
-|                                      | prepared Revision + ActorTemplate      |
-|                                      v                                       |
-|  Application -- A2A --> +------------- Substrate Actor -------------------+  |
-|                          |                                                  |  |
-|  Model provider <------> |  kagent-go-adk                                  |  |
-|  Tools / MCP / A2A <-->  |  Google ADK + OpenAPPA Go extension             |  |
-|                          |           | ToolCall / ToolResult                |  |
-|                          |           v /hook        ^ HookDecision          |  |
-|                          |  appa-runtime -> appa-adapter-kagent -> Engine   |  |
-|                          |                                  |               |  |
-|                          |                                  v               |  |
-|                          |                        /data/openappa/appa.db      |  |
-|                          +--------------------------------------------------+  |
-|                                                                              |
-+------------------------------------------------------------------------------+
++----------------------------- Kubernetes / Substrate Actor ----------------------+
+|                                                                                  |
+|  kagent controller -> immutable Revision -> ActorTemplate                        |
+|                                |                                                 |
+|                 +--------------+----------------+                                |
+|                 |                               |                                |
+|                 v                               v                                |
+|  +-----------------------------+  Unix gRPC  +--------------------------------+  |
+|  | kagent-go-adk               |<----------->| dynamic ADK extension sidecar |  |
+|  |                             | private UDS |                                |  |
+|  | generic extension host      |             | OpenAPPA plugin server        |  |
+|  | generic ADK barriers        |             | appa-runtime + Engine         |  |
+|  | generic execution proxy     |             | policy and consults           |  |
+|  | sessions.db / A2A state     |             | private plugin state          |  |
+|  +-------------+---------------+             +----------------+---------------+  |
+|                |                                                  |              |
+|                v                                                  v              |
+|       model / tools / MCP / A2A                         declared external endpoints|
+|                                                                                  |
++----------------------------------------------------------------------------------+
 ```
 
-The Actor image runs `kagent-go-adk` and `appa-runtime` as separate processes. The Actor becomes ready after `appa-runtime` passes its health check.
+The Unix socket and generic event protocol are the only enforcement-data interface between kagent and the OpenAPPA component.
 
-The Go extension implements existing ADK callbacks inside `kagent-go-adk`. It sends kagent `JSON` to the local `/hook` endpoint.
+## Refuse incomplete coverage
 
-Substrate mounts the `ActorTemplate` `/data` directory. OpenAPPA stores its database at `/data/openappa/appa.db`.
+The protected instance remains unready when any required phase is missing, shared, reordered, bypassable, or unsupported.
 
-## Map every execution path
+The first release refuses:
 
-Most paths use existing Google ADK callbacks. The table marks proposed kagent callbacks explicitly.
-
-| Execution path | Dispatch boundary | Result boundary |
-|---|---|---|
-| Normal function, MCP, skill, or model-called memory tool | `BeforeToolCallbacks` → `HookEvent::ToolCall` | `OnToolErrorCallbacks`, then `AfterToolCallbacks` → `HookEvent::ToolResult` |
-| Local ADK `chat` transfer | `BeforeToolCallbacks` on `transfer_to_agent` → `HookEvent::ToolCall` | No bounded child result. `BeforeAgentCallbacks` keep the same trajectory |
-| Local ADK `single_turn` | `BeforeToolCallbacks` → `ToolCall`. `BeforeAgentCallbacks` → `ChildStart` | `AfterToolCallbacks` → `SpawnResult` |
-| Local ADK `task` | `AfterModelCallbacks` → `ToolCall`. `BeforeAgentCallbacks` → `ChildStart` | `plugin.OnEventCallback` → `SpawnResult` |
-| Remote A2A agent | `BeforeToolCallbacks` → `ToolCall` and `ChildStart` | `AfterToolCallbacks` → `SpawnResult` |
-| Automatic `preload_memory` | Context-bound `memory.Service` decorator before `Search` | The same decorator before model delivery |
-| MCP App internal tool or resource | Proposed owning-Actor gate → `ToolCall` | The same proposed gate → `ToolResult` |
-| Registered long-running work | Proposed `BeforeBackgroundStart` → `ToolCall` and `ChildStart` | Proposed `OnBackgroundResult` → `SpawnResult` |
-
-For `single_turn`, `task`, remote A2A, and registered long-running work, the child return follows this sequence:
-
-```text
-Parent ADK -> Go extension: path-specific dispatch callback
-Go extension -> appa-runtime: ToolCall(spawn = true)
-appa-runtime -> Go extension: AllowCall + prepared child binding
-Go extension -> appa-runtime: ChildStart(actual child ID)
-Child, remote agent, or worker -> Go extension: terminal result
-Go extension -> appa-runtime: SpawnResult
-appa-runtime -> Go extension: Ack | ChildReturn | Block
-Go extension -> Parent ADK: admitted child result
-```
-
-`BeforeModelCallbacks` confirm that each model-bound result already passed admission. `plugin.OnUserMessageCallback` rejects forged task responses.
-
-Trusted deployment configuration must bind the authenticated remote endpoint to an isolated OpenAPPA `Harness`.
-
-A direct message or `completed` task can return content. `input_required` and `auth_required` pause the remote call.
-
-`failed`, `canceled`, and `rejected` produce a failed `SpawnResult` without content. `submitted` and `working` continue waiting or fail without a parent result.
-
-## Check first-release limits
-
-The first implementation refuses these paths:
-
-- Streaming tool chunks and provider-native tools.
-- Unregistered background work, asynchronous MCP jobs, and notification-only results.
-- Remote or BYO agents without a compatible OpenAPPA adapter.
-- Python ADK, OpenAI Agents, LangGraph, and CrewAI without framework adapters.
-
-The implementation plan contains the complete supported and refused path catalog.
-
-## Fail closed
-
-kagent prepares no revision until coverage validation passes. The `Actor` accepts no work until `appa-runtime` reports ready.
-
-A runtime failure before dispatch blocks the call. A runtime failure after execution withholds the result.
-
-The profile rejects kagent `RequireApproval` configuration.
-
-The runtime currently registers `MakeApprovalCallback` first in `BeforeToolCallbacks`, so it can return before the OpenAPPA callback.
-
-The profile also rejects any added callback or plugin that can bypass an OpenAPPA boundary.
-
-Cancellation reports `ToolOutcome::Indeterminate` before the profile releases the trajectory permit.
-
-After Actor recovery, the profile sends `TurnEnd` before a new call to close an unknown outstanding dispatch.
-
-One trajectory runs one tool call at a time. Separate child trajectories can run concurrently.
+- Provider-native tools without host dispatch and result boundaries.
+- Stock MCP transport when raw argument injection and no-retry execution are unavailable.
+- Automatic memory preload without the synthetic lifecycle extension.
+- Dynamic tool catalogs that change inside a prepared Revision.
+- Runtime plugins or callbacks appended after manifest verification.
+- Content telemetry that cannot be disabled before payload creation.
+- Remote A2A paths without immutable Card, header replacement, state preservation, and terminal gates.
+- Streaming assistant content before the exclusive publication gate.
+- Hot plugin swaps and mixed plugin revisions inside one scope.
+- Any partial capability mode for the required OpenAPPA plugin.
 
 ## Move an existing agent
 
-An existing `AgentInstance` cannot change its `Harness`. Replace it with a new protected instance:
+An existing `AgentInstance` cannot add a new dynamic extension set.
 
-1. Run the Helm upgrade and readiness commands above.
-2. Create a protected instance from the existing `AgentTemplate`.
-3. Update the application to use the new `AgentInstance` ID.
-4. Let requests already assigned to the old instance finish there.
-5. Suspend the old instance.
+Create a replacement protected instance and route new roots to it.
 
-```sh
-kagentctl agent-instance create customer-support-openappa \
-  --namespace kagent \
-  --template customer-support-agent \
-  --harness kagent-openappa
+Keep existing task and context IDs on the old instance until a fixed drain deadline.
 
-kagentctl agent-instance suspend <old-instance-id> --namespace kagent
-```
+At the deadline, cancel remaining old work and suspend the old instance.
 
-The protected instance starts a new OpenAPPA database and a new model session. It does not import the old transcript.
+The replacement starts new ADK session and OpenAPPA plugin state. It imports neither the old transcript nor old plugin state unless the plugin explicitly validates a migration.
 
-To revert, resume the old instance and point the application back to its ID:
-
-```sh
-kagentctl agent-instance resume <old-instance-id> --namespace kagent
-```
+Rollback resumes the old instance and restores routing. It never merges state between plugin revisions.
 
 ## Implementation plan
 
-The [kagent implementation plan](https://github.com/archestra-ai/OpenAPPA/blob/main/integrations/kagent/IMPLEMENTATION.md) contains exact APIs, source ownership, and callback ordering.
+The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the generic protocol, source ownership, and new ADK extension points.
 
-It also contains coverage tests and the upstream contribution sequence.
-:::
+It also defines sidecar lifecycle, OpenAPPA mapping, and the verification matrix.


### PR DESCRIPTION
## Summary
- replace the OpenAPPA-specific kagent fork design with a neutral dynamic ADK extension protocol
- run OpenAPPA as a digest-pinned OCI companion sidecar with private state and generic Unix gRPC phases
- specify provider, tool, result, child, remote, memory, MCP, interaction, publication, recovery, snapshot, and upgrade coverage
- ground the design in pinned kagent/ADK/Substrate source and established HashiCorp, Kubernetes, VS Code, and Envoy plugin patterns

## Validation
- independent separation and architecture reviews: no high or medium findings
- strict STE scores: 0.45 and 0.82 per 100 words
- website typecheck and production build pass

## Publication state
Draft while the OpenAPPA sidecar PoC and the private-fork kagent generic-host PoC are implemented and validated in GCP. Do not merge yet.

Follow-up to #113. Task: T-1176.