### PR TITLE
docs: drop the proposal wrapper from the Batteries page

### DIFF
--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -5,11 +5,6 @@ order: 7
 description: Combine OpenAPPA configs and run annotator scripts.
 ---
 
-:::proposal
-name: Batteries
-date: 2026-08-21
-author: Ildar Iskhakov
-
 A battery is an OpenAPPA config for a set of tools, such as Claude Code or Slack. It may include small scripts that make decisions for each tool call.
 
 ```text
@@ -243,4 +238,3 @@ The error names the annotator and the problem. It does not show the data the ann
 Annotator scripts run as trusted local code. Review what they can read, run, and send.
 
 A production file annotator must check full paths, hidden folders, symbolic links, files ignored by Git, and files outside the project.
-:::


### PR DESCRIPTION
Batteries ship as ordinary OpenAPPA config, so the page no longer needs the proposal presentation.

Removes the `:::proposal` fence and its `name`/`date`/`author` lines from `website/content/docs/batteries.md`, plus the closing `:::`. No prose changes. The unrelated `:::battery-rule-order:::` directive stays.