### PR TITLE
docs: reorganize docs nav categories

### DIFF
--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -1,7 +1,7 @@
 ---
 title: Batteries
-category: Integration
-order: 7
+category: Deep Dive
+order: 4
 description: Combine OpenAPPA configs and run annotator scripts.
 ---
 

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Code
-category: Integration
+category: Integrations
 order: 5
 description: Start with one protected Claude Code session, then carry the same policy boundary across your agents.
 ---

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -1,11 +1,13 @@
 ---
-title: kagent integration
-nav_title: kagent
+title: kAgent
+nav_title: kAgent
+category: Integrations
+order: 6
 description: Proposal for a dynamically supplied OpenAPPA ADK extension in kagent.
 ---
 
 :::proposal
-name: kagent integration
+name: kAgent
 date: 2026-08-27
 :::
 


### PR DESCRIPTION
- Move Batteries to Deep Dive (after Policy reference)
- Rename Integration category to Integrations
- Add kagent doc back to the nav under Integrations, titled kAgent