### PR TITLE
docs: keep Google ADK unmodified in the kagent proposal

### DIFF
--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -1,11 +1,11 @@
-# kagent dynamic ADK extension implementation plan
+# kagent dynamic extension implementation plan
 
 Source baseline:
 
 - kagent commit `9e246fd3797457b18fc277680be1629a0f57fce0`
 - Google ADK Go `v2.2.0` at `b264039aaec43baedc123e5b9a0cf87681d0bbca`
 - Substrate `v0.0.20`
-- OpenAPPA `origin/main` at `df69b8a1adf9206cc2923b95fadd17f9d26224ae`
+- OpenAPPA `origin/main` at `77230bbb177d72ac740173036b715ff2b3f1ae24`
 
 The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent).
 
@@ -13,19 +13,24 @@ The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/
 
 The human reviewer selected these constraints:
 
-1. Run the dynamic OpenAPPA ADK extension as a digest-pinned OCI companion container.
+1. Run the dynamic OpenAPPA extension as a digest-pinned OCI companion container.
 2. Permit generic non-OpenAPPA lifecycle infrastructure when ADK callbacks cannot cover readiness, egress, snapshots, or process lifecycle.
 3. Classify a crash after execution acknowledgement and before terminal completion as `Indeterminate` inside OpenAPPA.
 4. Pin one extension revision per live scope and drain old scopes during upgrades.
 5. Publish the OpenAPPA proposal and plugin, plus a separate kagent generic-host PR to a private fork.
+6. Keep Google ADK Go as an unmodified upstream dependency.
 
 These decisions are normative for the first implementation and PoC.
 
 ## Goal
 
-Add a generic dynamically supplied ADK extension system to the kagent fork.
+Add a generic dynamically supplied extension system to the kagent fork.
 
 Ship OpenAPPA as an independently built sidecar that uses this generic system.
+
+Use only public Google ADK interfaces and kagent-owned integration points. Do not fork, vendor, copy, patch, replace, or import internal Google ADK packages.
+
+If those surfaces cannot enforce a required boundary, report that capability as unavailable and refuse protected-workload activation.
 
 The kagent fork MUST contain no OpenAPPA logic or OpenAPPA-specific data model.
 
@@ -39,6 +44,7 @@ The combined system MUST preserve these invariants:
 6. kagent never parses a plugin policy, fact, Label, remedy, consult, or extension-specific state.
 7. The OpenAPPA sidecar owns all OpenAPPA state, semantics, recovery, and external consults.
 8. One extension artifact and protocol selection remain pinned for each live scope.
+9. No invariant depends on a change to Google ADK source.
 
 ## Evidence and adopted patterns
 
@@ -60,22 +66,24 @@ Do not use Go's standard [`plugin`](https://pkg.go.dev/plugin) package. It has s
 
 ## Current source constraints
 
-Current ADK and kagent lack the full required boundary set.
+Current public ADK and kagent surfaces lack the full required boundary set.
 
-| Requirement | Source evidence | Current limitation |
+| Requirement | Source evidence | Allowed integration path |
 |---|---|---|
-| Dynamic ADK plugin object | [kagent runner adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/runner/adapter.go#L74-L95) | It installs compiled Go plugin objects only |
-| Provider-final catalog | [ADK](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/internal/llminternal/base_flow.go#L707-L730) and [Bedrock](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/bedrock.go#L730-L808) | No callback sees final names and schemas |
-| Pre-plugin dispatch | [ADK tool flow](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/internal/llminternal/base_flow.go#L1251-L1285) | Plugin callbacks see mutable arguments first |
-| Event drop before persistence | [ADK runner](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/runner/runner.go#L316-L355) | `OnEvent` cannot drop and is not exclusive |
-| User input gate | [ADK user callback](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/runner/runner.go#L613-L668) | Existing callback is usable but not dynamic |
-| Child terminal gate | [ADK task wrapper](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/agent/llmagent/llm_agent_wrapper.go#L486-L590) | No pre-persistence child return callback |
-| Automatic memory | [ADK preloader](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/tool/preloadmemorytool/tool.go#L72-L97) | Raw memory reaches model instructions outside tool callbacks |
-| MCP transport | [ADK client](https://github.com/google/adk-go/blob/b264039aaec43baedc123e5b9a0cf87681d0bbca/tool/mcptoolset/client.go#L67-L134) | It retries and hides raw arguments |
-| Remote A2A | [kagent tool](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/tools/remote_a2a_tool.go#L25-L145) | It forwards credentials and resolves Cards lazily |
-| Content telemetry | [kagent attributes](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/telemetry/attributes.go#L37-L47) | Payload attributes exist before a policy plugin can remove them |
-| Readiness | [kagent A2A server](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/a2a/server/server.go#L127-L144) | `/readyz` returns success without extension recovery |
-| Snapshot lifecycle | [kagent ActorTemplate](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L65-L88) | No extension quiescence or generation attestation |
+| Dynamic plugin object | [kagent runner adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/runner/adapter.go#L74-L95) | Install one generic out-of-process proxy through the existing plugin surface |
+| Provider-final catalog | Public model interface and [kagent Bedrock adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/bedrock.go#L730-L808) | Add the gate to kagent-owned adapters; refuse opaque upstream providers |
+| Pre-plugin dispatch | Existing public tool callbacks | Install the proxy first and disable later untrusted callbacks in protected workloads |
+| Event persistence | Public session service and Runner output | Wrap both surfaces in kagent; refuse any direct backing-store or yield path |
+| User input gate | Existing public `OnUserMessageCallback` | Route it through the dynamic proxy and session wrapper |
+| Child terminal gate | Public Agent, Runner, and session interfaces | Correlate child scopes in kagent wrappers; refuse unobservable paths |
+| Automatic memory | Public memory and tool interfaces | Disable stock preload and use a gated kagent-owned implementation |
+| MCP transport | Public tool interface | Use a kagent-owned no-retry transport; refuse the stock opaque client |
+| Remote A2A | [kagent tool](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/tools/remote_a2a_tool.go#L25-L145) | Wrap request and result handling in the kagent fork |
+| Content telemetry | Public configuration plus [kagent attributes](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/telemetry/attributes.go#L37-L47) | Disable upstream content capture and use content-free kagent wiring |
+| Readiness | [kagent A2A server](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/a2a/server/server.go#L127-L144) | Gate kagent readiness on generic extension recovery |
+| Snapshot lifecycle | [kagent ActorTemplate](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L65-L88) | Add generic lifecycle handling outside ADK |
+
+Source links into Google ADK explain observed behavior only. They are not implementation targets.
 
 Substrate can run [up to ten peer containers](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L305).
 
@@ -94,8 +102,9 @@ Add these as generic Substrate primitives. The compiler and Actor activation MUS
 - Generic extension API types and generated gRPC client.
 - Generic manifest validation and immutable Revision compilation.
 - Generic sidecar container, volume, socket, secret, egress, readiness, and snapshot rendering.
-- Generic ADK callback proxies and added extension points.
-- Immutable ADK descriptor and payload snapshots.
+- Dynamic proxies for existing public ADK callbacks.
+- Wrappers for public ADK model, tool, session, memory, Agent, and Runner interfaces.
+- Immutable descriptor and payload snapshots in kagent-owned adapters.
 - Generic execution proxy and sink barriers.
 - Generic interaction and remote metadata relay.
 - Host-native ADK session and A2A task state.
@@ -118,6 +127,7 @@ Add these as generic Substrate primitives. The compiler and Actor activation MUS
 - OpenAPPA tool names or special-case routing.
 - OpenAPPA database paths or schema migrations.
 - OpenAPPA readiness, coverage, consult, or audit logic.
+- A Google ADK fork, vendored or copied ADK source, replacement module, source patch, or import from an ADK `internal` package.
 
 Add CI rules that reject imports and identifiers from a maintained forbidden list in the kagent generic-host packages.
 
@@ -132,9 +142,8 @@ Add CI rules that reject imports and identifiers from a maintained forbidden lis
 | `go/core/v2/substrate` | Render multiple extension containers, private sockets, projected config and secrets, state volumes, egress, and probes |
 | `go/adk/pkg/extensions/protocol` | Generated neutral protobuf messages and client |
 | `go/adk/pkg/extensions/host` | Negotiation, ordering, health, deadlines, retries, and generic decisions |
-| ADK fork | Add provider catalog, pre-plugin dispatch, event, child, memory, transport, session, and publication points |
-| `go/adk/pkg/runner` | Build the dynamic proxy list and enforce final ordering |
-| `go/adk/pkg/tools` | Generic immutable execution proxy and remote request hooks |
+| `go/adk/pkg/runner` | Construct the dynamic proxy as the only content-bearing public ADK callback path |
+| `go/adk/pkg/tools` | Generic immutable execution proxy and remote request wrappers |
 | `go/adk/pkg/a2a` | Generic interaction relay and pre-publication gate |
 | `go/adk/pkg/session` | Generic pre-append gate and delivery deduplication |
 | telemetry | Enforce immutable content-free protected workload settings before provider construction |
@@ -144,7 +153,7 @@ Add CI rules that reject imports and identifiers from a maintained forbidden lis
 | Owner | OpenAPPA component |
 |---|---|
 | `appa-kagent-plugin-protocol` | OpenAPPA-side generated client/server binding to the neutral protocol |
-| `appa-kagent-plugin` | gRPC sidecar, ADK event mapping, readiness, dynamic tools, interactions, and recovery |
+| `appa-kagent-plugin` | gRPC sidecar, generic host-phase mapping, readiness, dynamic tools, interactions, and recovery |
 | `appa-runtime-api` | Missing response emission, structured remedy, MRTR, and exact dispatch APIs required by the plugin |
 | `appa-runtime` | Engine session ownership, consults, durable plugin state, and protocol mapping |
 | OCI packaging | Signed sidecar image, manifest, SBOM, provenance, and migrations |
@@ -159,7 +168,7 @@ workload:
   image: ghcr.io/private-kagent/kagent-go-adk@sha256:<digest>
   extensions:
     - name: policy-gate
-      image: ghcr.io/archestra-ai/openappa-adk-plugin@sha256:<digest>
+      image: ghcr.io/archestra-ai/openappa-kagent-plugin@sha256:<digest>
       manifestDigest: sha256:<digest>
       signaturePolicyRef: required-extension-signers-v1
       required: true
@@ -233,11 +242,10 @@ Each image contains a signed manifest:
       "event.gate.v1",
       "session.persist.v1",
       "a2a.publish.v1",
-      "remote.request.v1"
-    ],
-    "optional": [
+      "remote.request.v1",
       "child.lifecycle.v1",
-      "remote.lifecycle.v1",
+      "memory.lifecycle.v1",
+      "mcp.transport.v1",
       "interaction.relay.v1",
       "snapshot.lifecycle.v1"
     ]
@@ -273,7 +281,7 @@ Define `kagent.extension.v1` with these generic RPCs:
 | `GetExtensionInfo` | Return artifact, protocol, manifest, and state schema identity |
 | `Negotiate` | Select protocol and capabilities for one host inventory |
 | `Activate` | Accept the immutable Revision and host inventory digest |
-| `InvokePhase` | Process one immutable ADK or lifecycle event |
+| `InvokePhase` | Process one immutable generic host or lifecycle event |
 | `Quiesce` | Stop new plugin work and commit one state generation |
 | `ValidateRestore` | Accept or reject a restored host and plugin inventory |
 | `Shutdown` | Drain and terminate cleanly |
@@ -281,6 +289,8 @@ Define `kagent.extension.v1` with these generic RPCs:
 Use the standard gRPC health service on the same Unix socket.
 
 The protocol package MUST contain neutral types only.
+
+It MUST NOT carry Google ADK Go types, ADK-private representations, or copied ADK source.
 
 ### Transport authentication
 
@@ -453,11 +463,17 @@ Every decision binds the producing extension, source event, payload digest, expi
 
 The host rejects mismatched, expired, duplicated, reordered, or unknown decisions.
 
-## Generic ADK extension points
+## Public ADK and kagent integration points
+
+Google ADK Go remains the upstream `v2.2.0` module. Do not use a `replace` directive, vendored or copied source, patches, or `internal` imports.
+
+Each integration below must use a public ADK interface or code owned by the kagent fork.
+
+For a protected workload, an unavailable required boundary rejects `Activate` and keeps the Actor unready.
 
 ### Current callback proxy
 
-Wrap current `plugin.Plugin` callbacks with one generic out-of-process proxy:
+Wrap current public `plugin.Plugin` callbacks with one generic out-of-process proxy:
 
 - `BeforeRunCallback`
 - `AfterRunCallback`
@@ -472,15 +488,19 @@ Wrap current `plugin.Plugin` callbacks with one generic out-of-process proxy:
 - `OnToolErrorCallback`
 - `OnEventCallback`
 
-These callbacks remain available to ordinary extensions. Required exclusive phases use stronger points below.
+Install this proxy first in the immutable callback order.
+
+Protected workloads disable any later callback that can observe or change uncommitted content before the proxy decision.
+
+Required phases use public-interface wrappers and kagent-owned barriers below. They do not add callbacks to Google ADK.
 
 ### Provider-final catalog
 
-Add a provider adapter callback after final name and schema conversion but before request transmission.
+Add a generic gate inside each kagent-owned provider adapter after final name and schema conversion but before request transmission.
 
 It returns the exact provider-visible catalog and reversible logical-name map.
 
-Add a raw function-call callback on provider response decoding. It returns the provider tool-call ID, mapped logical name, and original JSON argument token bytes.
+The kagent-owned decoder also returns the provider tool-call ID, mapped logical name, and original JSON argument token bytes.
 
 The host strictly parses and canonicalizes those bytes. It refuses an adapter that exposes only a decoded `map[string]any` or `float64` number path.
 
@@ -488,41 +508,51 @@ Pinned OpenAI code currently decodes arguments through `json.Unmarshal` into a m
 
 Reject provider-name collisions before sending the request.
 
-Refuse providers that cannot expose this callback.
+Only a kagent-owned provider adapter, or a public wrapper proven to expose the final outgoing request, qualifies. All other providers are unavailable.
 
-### Pre-plugin tool proposal
+### Tool proposal
 
-Add an exclusive gate at the beginning of `Flow.callTool`, before `pluginManager.RunBeforeToolCallback`.
+kagent constructs the Runner so the generic proxy is the only content-bearing public ADK callback path.
 
-The host creates an immutable RFC 8785 snapshot and descriptor digest before callback fan-out.
+Correlate that callback with raw bytes captured by the kagent-owned provider adapter. Then create an immutable RFC 8785 snapshot and descriptor digest.
 
-No plugin sees mutable uncommitted arguments before the exclusive owner decides.
+If kagent cannot exclude competing callbacks, the callback capability is unavailable.
+
+Refuse tool calls when the provider path did not expose raw arguments before ADK decoded them.
 
 ### Model request gate
 
-Add an exclusive `model.propose` gate after all request processors and model callbacks, but before telemetry or provider transmission.
+Place an exclusive `model.propose` gate in each kagent-owned provider adapter after request conversion and before telemetry or network transmission.
+
+A public model wrapper qualifies only when it exposes that same final outgoing request.
+
+For live and realtime sends, wrap the public ADK live-session send interface in kagent-owned code and gate before delegating.
 
 It receives the exact canonical provider request, endpoint, model, tool catalog, history, instructions, memory, admitted tool results, and retry identity.
 
 Only a matching permit can send the request to the provider.
 
-Apply this gate to standard generation, live flow, realtime sends, history sends, embedding requests, and every provider adapter.
+Declare a separate capability for standard generation, live flow, realtime sends, history sends, and embedding requests.
 
-Refuse a provider path that cannot expose its final request before network transmission.
+Refuse each path that cannot expose its final request through a kagent-owned adapter or a proven public wrapper.
 
 Provider retry uses the same event ID and exact request digest. A changed request requires a new phase event.
 
 ### Model response gate
 
-Add one gate after model callbacks and before every `handleFunctionCalls` path, including live streaming flow.
+Use the public `AfterModelCallback` as the standard response gate.
+
+For kagent-owned live and streaming adapters, gate the complete response before kagent dispatches calls or publishes content.
 
 It can replace the complete model response or suppress all contained calls.
 
+Refuse a live or streaming path that bypasses these surfaces.
+
 ### Event gate
 
-Add `Drop`, `Replace`, and `Emit` before `plugin.OnEventCallback`, session append, runner yield, and task state publication.
+Implement `Drop`, `Replace`, and `Emit` in kagent wrappers around the public session service and Runner output.
 
-No callback runs between the terminal event decision and the protected sink.
+Do not install other content-bearing `OnEventCallback` implementations in a protected workload.
 
 The first release sends every partial assistant event to the exclusive gate and drops it before persistence or yield.
 
@@ -532,25 +562,29 @@ The terminal event includes a closed authenticated-principal attestation. The ho
 
 ### Session persistence gate
 
-Add a generic pre-append hook for user, function-response, model, task, child, and resumed interaction events.
+Use a kagent-owned session implementation and backing store for user, function-response, model, task, child, and resumed interaction events.
 
-The hook receives exact event bytes and stable session lineage.
+The wrapper receives exact event bytes and stable session lineage.
+
+If the backing store cannot share one transaction with the host outbox, session persistence is unavailable.
 
 ### A2A publication gate
 
-Add a replaceable event gate after ADK-to-A2A conversion and before stream or task publication.
+Add a kagent-owned barrier before ADK-to-A2A conversion and before stream or task publication.
 
 It receives authenticated caller attestation as generic transport metadata.
 
 ### Child lifecycle
 
-Add generic phases for child proposal, start, state, terminal return, and parent delivery.
+Use public Agent, Runner, and session interfaces for child proposal, start, state, terminal return, and parent delivery.
 
 The host preallocates stable child and parent scope IDs.
 
 ### Memory lifecycle
 
-Replace stock automatic preload with generic `memory.propose` and `memory.complete` phases around `SearchMemory`.
+Disable stock automatic preload. Supply a kagent-owned implementation through public memory and tool interfaces.
+
+Wrap `SearchMemory` with generic `memory.propose` and `memory.complete` phases.
 
 No memory content enters model instructions before commit.
 
@@ -560,7 +594,9 @@ Include embedding endpoints and memory stores in the immutable host sink invento
 
 ### MCP transport
 
-Add a generic raw JSON-RPC interceptor that supports exact `params.arguments` injection and terminal response capture.
+Do not use the upstream opaque MCP client in protected workloads.
+
+Supply a kagent-owned tool implementation with raw JSON-RPC argument injection and terminal response capture.
 
 Disable automatic retry after request bytes can reach the MCP server.
 
@@ -634,7 +670,7 @@ Publish with that stable idempotency key, then mark the outbox row delivered.
 
 Recovery retries only the same outbox event and payload digest.
 
-ADK session append and its outbox row MUST share one transaction.
+The kagent-owned session store and its outbox row MUST share one transaction.
 
 A2A, memory, UI, and other external sinks MUST accept the host event ID as an idempotency key.
 
@@ -644,9 +680,11 @@ Protected host construction disables content telemetry before providers, Runner,
 
 This is an immutable workload property. Extension manifests cannot enable or disable host telemetry.
 
-Fork every content-capable telemetry constructor to omit payload fields at creation time.
+Configure upstream ADK telemetry through supported public options so it emits no content.
 
-This includes model, tool, Runner, A2A, and MCP instrumentation.
+Use content-free constructors for kagent-owned model, tool, Runner, A2A, and MCP instrumentation.
+
+Refuse a component when its content telemetry cannot be disabled without modifying Google ADK.
 
 Remove kagent's standard serialized tool-argument callback from protected workloads.
 
@@ -976,15 +1014,17 @@ No between-turn or immediate hot swap exists in the first release.
 | 1 | Add generic Harness extension API, manifests, Revision data, and signature policy |
 | 2 | Render sidecar containers, projected config and secrets, socket and state volumes, egress, and readiness |
 | 3 | Add neutral protobuf protocol, negotiation, health, and generic extension host |
-| 4 | Add provider-final catalog and reversible name-map hooks |
-| 5 | Add pre-plugin tool proposal and immutable execution proxy |
-| 6 | Add model response and exclusive event gates for standard and live flows |
-| 7 | Add session persistence and A2A publication gates |
-| 8 | Add child, task, remote, memory, and interaction lifecycle phases |
-| 9 | Add raw MCP transport interceptor and no-retry semantics |
-| 10 | Add immutable content-free telemetry, readiness, snapshot, recovery, and drain lifecycle |
+| 4 | Gate provider-final requests and catalogs in kagent-owned model adapters |
+| 5 | Install the first public tool callback proxy and kagent-owned execution wrappers |
+| 6 | Gate model responses through public callbacks and kagent-owned output wrappers |
+| 7 | Wrap the public session service and kagent A2A publication code |
+| 8 | Wrap public Agent, Runner, memory, remote, and interaction surfaces |
+| 9 | Add a kagent-owned raw MCP transport with no-retry semantics |
+| 10 | Configure upstream telemetry and add kagent readiness, snapshot, recovery, and drain lifecycle |
 
 Each PR is generic. Test fixtures MUST use neutral fake extensions and contain no OpenAPPA import or name in production packages.
+
+No PR changes Google ADK source, copies it, replaces its module, vendors it, or imports one of its `internal` packages.
 
 ## OpenAPPA plugin sequence
 
@@ -1012,7 +1052,10 @@ Each PR is generic. Test fixtures MUST use neutral fake extensions and contain n
 - Pin-and-drain upgrade routing.
 - Forbidden dependency and identifier checks.
 
-### Generic ADK integration tests
+### Public ADK and kagent integration tests
+
+- CI resolves `google.golang.org/adk/v2` from a clean module cache and asserts the pinned version and checksum.
+- CI rejects `replace` in `go.mod` or `go.work`, a `vendor/` tree, copied ADK source, any ADK source patch, and any ADK `internal` import in production packages.
 
 - Provider-final catalog and name-collision rejection.
 - Pre-plugin argument ownership and mutation attempts.

--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -64,7 +64,7 @@ The design follows primary sources from widely adopted plugin systems.
 | [gRPC health checking](https://grpc.io/docs/guides/health-checking/) | Standard sidecar health protocol |
 | [Buf breaking checks](https://buf.build/docs/breaking/) | Protocol compatibility enforcement in CI |
 
-The design excludes Go's standard [`plugin`](https://pkg.go.dev/plugin) package.
+The design excludes the standard Go [`plugin`](https://pkg.go.dev/plugin) package.
 
 That package has strict toolchain coupling, shared memory, platform limits, no unload, weak race-detector support, and no independent lifecycle.
 
@@ -74,16 +74,16 @@ Current public ADK and kagent surfaces lack the full required boundary set.
 
 | Requirement | Source evidence | Allowed integration path |
 |---|---|---|
-| Dynamic plugin object | [kagent runner adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/runner/adapter.go#L74-L95) | Install one generic out-of-process proxy through the existing plugin surface |
-| Provider-final catalog | Public model interface and [kagent Bedrock adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/bedrock.go#L730-L808) | Add the gate to kagent-owned adapters; refuse opaque upstream providers |
-| Pre-plugin dispatch | Existing public tool callbacks | Install the proxy first and disable later untrusted callbacks in protected workloads |
-| Event persistence | Public session service and Runner output | Wrap both surfaces in kagent; refuse any direct backing-store or yield path |
-| User input gate | Existing public `OnUserMessageCallback` | Route it through the dynamic proxy and session wrapper |
-| Child terminal gate | Public Agent, Runner, and session interfaces | Correlate child scopes in kagent wrappers; refuse unobservable paths |
-| Automatic memory | Public memory and tool interfaces | Disable stock preload and use a gated kagent-owned implementation |
-| MCP transport | Public tool interface | Use a kagent-owned no-retry transport; refuse the stock opaque client |
-| Remote A2A | [kagent tool](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/tools/remote_a2a_tool.go#L25-L145) | Wrap request and result handling in the kagent fork |
-| Content telemetry | Public configuration plus [kagent attributes](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/telemetry/attributes.go#L37-L47) | Disable upstream content capture and use content-free kagent wiring |
+| Dynamic plugin object | [kagent runner adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/runner/adapter.go#L74-L95) | Generic proxy through the existing plugin surface |
+| Provider-final catalog | [kagent Bedrock adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/bedrock.go#L730-L808) | Gate in kagent-owned adapters, with opaque providers unavailable |
+| Pre-plugin dispatch | Existing public tool callbacks | Sole content-bearing proxy in protected workloads |
+| Event persistence | Public session service and Runner output | Kagent-owned wrappers, with direct paths unavailable |
+| User input gate | Existing public `OnUserMessageCallback` | Dynamic proxy and session wrapper |
+| Child terminal gate | Public Agent, Runner, and session interfaces | Child-scope correlation, with unobservable paths unavailable |
+| Automatic memory | Public memory and tool interfaces | Stock preload disabled, kagent-owned gate enabled |
+| MCP transport | Public tool interface | Kagent-owned no-retry transport |
+| Remote A2A | [kagent tool](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/tools/remote_a2a_tool.go#L25-L145) | Kagent-owned request and result wrappers |
+| Content telemetry | [kagent attributes](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/telemetry/attributes.go#L37-L47) | Public controls and content-free kagent wiring |
 | Readiness | [kagent A2A server](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/a2a/server/server.go#L127-L144) | Gate kagent readiness on generic extension recovery |
 | Snapshot lifecycle | [kagent ActorTemplate](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L65-L88) | Add generic lifecycle handling outside ADK |
 
@@ -332,7 +332,7 @@ Startup order:
 
 The host inventory includes every executable path and content sink. It MUST include provider, ADK, kagent, and Substrate versions.
 
-No kagent code decides whether an OpenAPPA policy is covered. The OpenAPPA plugin accepts or rejects the generic inventory.
+The OpenAPPA plugin decides whether the generic inventory covers its policy. Kagent does not interpret that decision.
 
 ## Multiple extension ordering
 
@@ -350,7 +350,7 @@ Only one extension can own an exclusive phase.
 
 The host rejects a phase conflict before Actor readiness.
 
-No runtime plugin, configured callback, or A2A executor plugin can be appended after final ordering validation.
+Final ordering validation fixes the runtime plugin, configured callback, and A2A executor lists.
 
 The host keeps one durable generic sequencer per scope.
 
@@ -566,9 +566,11 @@ A protected workload contains no other content-bearing `OnEventCallback` impleme
 
 The first release sends every partial assistant event to the exclusive gate and drops it before persistence or yield.
 
-Only one terminal text response can be emitted. Inline data, files, artifacts, citations, thought parts, and multiple terminal responses are refused until their codecs exist.
+The host emits only one terminal text response.
 
-The terminal event includes a closed authenticated-principal attestation. The host does not interpret the plugin's recipient policy.
+The host refuses other content forms until their codecs exist.
+
+The terminal event includes a closed authenticated-principal attestation. The host does not interpret the recipient policy from the plugin.
 
 ### Session persistence gate
 
@@ -614,7 +616,7 @@ Revision preparation runs MCP discovery.
 
 The Revision pins the server, transport, tool descriptors, schemas, raw metadata, and discovery generation.
 
-Discovery failure MUST reject preparation. It cannot be logged and skipped.
+Discovery failure rejects Revision preparation. The host does not skip the failure.
 
 Controller-originated MCP App tool and resource calls enter through a generic `external.operation` phase before any network request.
 
@@ -642,7 +644,7 @@ The host extracts no content before the exclusive extension commits the terminal
 
 ## Mechanical execution protocol
 
-The host owns the actual invocation of in-process ADK tools.
+The kagent-owned tool wrapper invokes each ADK tool through the public tool interface.
 
 For each tool call:
 
@@ -700,7 +702,7 @@ Kagent-owned model, tool, Runner, A2A, and MCP instrumentation uses content-free
 
 The host refuses a component when public options cannot disable its content telemetry.
 
-Protected workloads exclude kagent's standard serialized tool-argument callback.
+Protected workloads exclude the standard serialized tool-argument callback from kagent.
 
 The host inventory lists every telemetry constructor and exporter with its content-free implementation digest.
 
@@ -780,7 +782,7 @@ Missing provider, tool, child, memory, MCP, A2A, interaction, telemetry, snapsho
 
 For `tool.propose`, the plugin receives the logical descriptor, provider-final descriptor, reversible name map, source identity, and raw canonical argument bytes.
 
-It performs strict canonical call resolution inside the sidecar.
+It resolves the canonical call inside the sidecar.
 
 The plugin handles contracts, Annotators, mandates, Membership evidence, requirement gaps, effects, and remedy plans.
 
@@ -866,7 +868,7 @@ At restart:
 
 Crash classification:
 
-- Before plugin acknowledgement of `execution.begin`: no execution started.
+- Before `execution.begin` acknowledgement: the tool did not start.
 - After acknowledgement and before terminal completion: plugin records `Indeterminate` internally.
 - After a persisted terminal commit: replay the same generic delivery decision.
 
@@ -895,7 +897,7 @@ Sequence:
 7. The manifest binds the provider snapshot, key version, files, and completion marker.
 8. The host calls `ValidateRestore` before a restored Actor becomes ready.
 
-The OpenAPPA state volume is mounted only in the OpenAPPA sidecar.
+Only the OpenAPPA sidecar mounts the OpenAPPA state volume.
 
 Each extension manifest binds generation, fencing epoch, state schema, file digests, WAL state, policy-independent extension revision, and encryption-key version.
 
@@ -955,7 +957,7 @@ The gateway resolves external DNS and enforces scheme, host, port, and TLS or SP
 
 It also enforces IP ranges, redirects, and DNS rebinding rules.
 
-The Actor MUST remain unready when CNI isolation, gateway routing, DNS policy, or workload identity cannot be installed and attested.
+The Actor remains unready if CNI isolation, gateway routing, DNS policy, or workload identity lacks attestation.
 
 Projected Secret and ConfigMap volumes keep secret bytes out of literal ActorTemplate environment values.
 
@@ -1055,7 +1057,7 @@ No PR changes Google ADK source, copies it, replaces its module, vendors it, or 
 | PR slice | Change |
 |---|---|
 | 1 | Neutral protocol binding, sidecar handshake, inventory validation, and health |
-| 2 | Tool proposal, permit, begin, complete, commit, and conservative recovery |
+| 2 | Tool proposal, permit, execution acknowledgement, completion, commit, and recovery |
 | 3 | Event, session, assistant response, and publication gates |
 | 4 | Child, task, remote, memory, and MCP mappings |
 | 5 | Dynamic remedy tool, interaction relay, and durable continuation |
@@ -1113,7 +1115,7 @@ No PR changes Google ADK source, copies it, replaces its module, vendors it, or 
 - Remedy families and every runtime outcome.
 - Result, child-return, and assistant response admission.
 - Human interaction accept, decline, cancel, expiry, replay, and remote hops.
-- Crash before permit, before begin acknowledgement, during execution, after result, and after commit.
+- Crash windows before permit, before execution acknowledgement, during execution, after result, and after commit.
 - Replay of exact terminal decisions and `Indeterminate` effect handling.
 
 ### End-to-end GCP acceptance

--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -13,24 +13,26 @@ The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/
 
 The human reviewer selected these constraints:
 
-1. Run the dynamic OpenAPPA extension as a digest-pinned OCI companion container.
-2. Permit generic non-OpenAPPA lifecycle infrastructure when ADK callbacks cannot cover readiness, egress, snapshots, or process lifecycle.
-3. Classify a crash after execution acknowledgement and before terminal completion as `Indeterminate` inside OpenAPPA.
-4. Pin one extension revision per live scope and drain old scopes during upgrades.
-5. Publish the OpenAPPA proposal and plugin, plus a separate kagent generic-host PR to a private fork.
-6. Keep Google ADK Go as an unmodified upstream dependency.
+1. The OpenAPPA extension runs as a digest-pinned OCI companion container.
+2. Generic lifecycle infrastructure covers readiness, egress, snapshots, and process lifecycle outside ADK callbacks.
+3. OpenAPPA classifies a crash after execution acknowledgement as `Indeterminate` until terminal completion.
+4. Each live scope uses one extension revision. Old scopes drain during upgrades.
+5. The OpenAPPA and private kagent repositories contain separate plugin and generic-host changes.
+6. Google ADK Go remains an unmodified upstream dependency.
 
 These decisions are normative for the first implementation and PoC.
 
 ## Goal
 
-Add a generic dynamically supplied extension system to the kagent fork.
+The kagent fork contains a generic dynamically supplied extension system.
 
-Ship OpenAPPA as an independently built sidecar that uses this generic system.
+OpenAPPA ships as an independently built sidecar that uses this generic system.
 
-Use only public Google ADK interfaces and kagent-owned integration points. Do not fork, vendor, copy, patch, replace, or import internal Google ADK packages.
+The implementation uses only public Google ADK interfaces and kagent-owned integration points.
 
-If those surfaces cannot enforce a required boundary, report that capability as unavailable and refuse protected-workload activation.
+The implementation excludes forks, vendored or copied source, patches, module replacement, and internal Google ADK packages.
+
+A missing required boundary makes its capability unavailable. Protected-workload activation then fails.
 
 The kagent fork MUST contain no OpenAPPA logic or OpenAPPA-specific data model.
 
@@ -62,7 +64,9 @@ The design follows primary sources from widely adopted plugin systems.
 | [gRPC health checking](https://grpc.io/docs/guides/health-checking/) | Standard sidecar health protocol |
 | [Buf breaking checks](https://buf.build/docs/breaking/) | Protocol compatibility enforcement in CI |
 
-Do not use Go's standard [`plugin`](https://pkg.go.dev/plugin) package. It has strict toolchain coupling, shared memory, platform limits, no unload, weak race-detector support, and no independent lifecycle.
+The design excludes Go's standard [`plugin`](https://pkg.go.dev/plugin) package.
+
+That package has strict toolchain coupling, shared memory, platform limits, no unload, weak race-detector support, and no independent lifecycle.
 
 ## Current source constraints
 
@@ -93,7 +97,7 @@ The baseline Container API lacks several required primitives.
 
 These include shared memory, projected configuration, per-container identity, filesystem controls, seccomp, and enforced egress.
 
-Add these as generic Substrate primitives. The compiler and Actor activation MUST reject an extension whose required primitive cannot be enforced.
+Generic Substrate primitives supply these features. The compiler and Actor activation reject an extension when a required primitive is unavailable.
 
 ## Ownership and forbidden dependencies
 
@@ -129,7 +133,7 @@ Add these as generic Substrate primitives. The compiler and Actor activation MUS
 - OpenAPPA readiness, coverage, consult, or audit logic.
 - A Google ADK fork, vendored or copied ADK source, replacement module, source patch, or import from an ADK `internal` package.
 
-Add CI rules that reject imports and identifiers from a maintained forbidden list in the kagent generic-host packages.
+CI rules reject imports and identifiers from a maintained forbidden list in the kagent generic-host packages.
 
 ## Repository deliverables
 
@@ -161,7 +165,7 @@ Add CI rules that reject imports and identifiers from a maintained forbidden lis
 
 ## Generic Harness API
 
-Add an ordered extension list to the Harness workload declaration:
+The Harness workload declaration contains an ordered extension list:
 
 ```yaml
 workload:
@@ -205,11 +209,11 @@ It validates reference scope, signatures, digests, volume ownership, egress shap
 
 For every ConfigMap and Secret reference, the generic controller reads bytes only to hash and copy them. It never parses their plugin meaning.
 
-Create immutable Revision-owned ConfigMap and Secret copies with generated names bound to content digest, source UID, and source resource version.
+The controller creates immutable Revision-owned ConfigMap and Secret copies. Generated names bind the digest, source UID, and source resource version.
 
-Store only digests and generated object references in the Revision. Do not store secret bytes in the Revision or ActorTemplate.
+The Revision stores only digests and generated object references. The Revision and ActorTemplate contain no secret bytes.
 
-Mount only the immutable generated copies into the extension container.
+The extension container mounts only the immutable generated copies.
 
 Admission prevents update or deletion while a live Revision references the copy.
 
@@ -274,7 +278,7 @@ The compiler rejects duplicate plugin IDs, phase conflicts, unsupported required
 
 ## Protocol services
 
-Define `kagent.extension.v1` with these generic RPCs:
+The `kagent.extension.v1` protocol defines these generic RPCs:
 
 | RPC | Purpose |
 |---|---|
@@ -286,7 +290,7 @@ Define `kagent.extension.v1` with these generic RPCs:
 | `ValidateRestore` | Accept or reject a restored host and plugin inventory |
 | `Shutdown` | Drain and terminate cleanly |
 
-Use the standard gRPC health service on the same Unix socket.
+The sidecar supplies the standard gRPC health service on the same Unix socket.
 
 The protocol package MUST contain neutral types only.
 
@@ -296,9 +300,9 @@ It MUST NOT carry Google ADK Go types, ADK-private representations, or copied AD
 
 The generic launcher mints one ephemeral Actor CA, host certificate, extension certificate, boot epoch, and message-authentication key for each activation.
 
-Use mTLS on the Unix socket. Certificate SANs bind Actor UID, Revision, container identity, extension ID, and boot epoch.
+The Unix socket uses mTLS. Certificate SANs bind Actor UID, Revision, container identity, extension ID, and boot epoch.
 
-Mount certificates and the message key through read-only per-container projected secrets. Never place them in the ActorTemplate environment.
+Read-only per-container projected secrets supply certificates and the message key. The ActorTemplate environment contains neither value.
 
 Every protobuf message carries protocol, extension, Actor, boot epoch, sequence, and channel digest.
 
@@ -306,9 +310,11 @@ It also carries key ID, algorithm, and HMAC-SHA256 over deterministic protobuf e
 
 The receiver verifies mTLS peer identity, channel binding, HMAC, sequence, deadline, event digest, and boot epoch before processing.
 
-Persist event IDs and terminal decisions in the plugin store for replay-safe duplicate handling. A duplicate event returns the exact original terminal decision.
+The plugin store persists event IDs and terminal decisions for replay-safe duplicate handling.
 
-Reject an old boot epoch except during the explicit `recovery.reconcile` phase for recorded event IDs.
+A duplicate event returns the exact original terminal decision.
+
+The receiver rejects an old boot epoch outside `recovery.reconcile` for a recorded event ID.
 
 ## Negotiation and readiness
 
@@ -473,7 +479,7 @@ For a protected workload, an unavailable required boundary rejects `Activate` an
 
 ### Current callback proxy
 
-Wrap current public `plugin.Plugin` callbacks with one generic out-of-process proxy:
+The host wraps current public `plugin.Plugin` callbacks with one generic out-of-process proxy:
 
 - `BeforeRunCallback`
 - `AfterRunCallback`
@@ -488,7 +494,7 @@ Wrap current public `plugin.Plugin` callbacks with one generic out-of-process pr
 - `OnToolErrorCallback`
 - `OnEventCallback`
 
-Install this proxy first in the immutable callback order.
+The Runner installs this proxy as its only content-bearing callback path.
 
 Protected workloads disable any later callback that can observe or change uncommitted content before the proxy decision.
 
@@ -496,7 +502,9 @@ Required phases use public-interface wrappers and kagent-owned barriers below. T
 
 ### Provider-final catalog
 
-Add a generic gate inside each kagent-owned provider adapter after final name and schema conversion but before request transmission.
+Each kagent-owned provider adapter contains a generic gate after final name and schema conversion.
+
+The gate runs before request transmission.
 
 It returns the exact provider-visible catalog and reversible logical-name map.
 
@@ -506,7 +514,7 @@ The host strictly parses and canonicalizes those bytes. It refuses an adapter th
 
 Pinned OpenAI code currently decodes arguments through `json.Unmarshal` into a map: [source](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/openai_responses.go#L258-L271).
 
-Reject provider-name collisions before sending the request.
+The adapter rejects provider-name collisions before it sends the request.
 
 Only a kagent-owned provider adapter, or a public wrapper proven to expose the final outgoing request, qualifies. All other providers are unavailable.
 
@@ -514,11 +522,13 @@ Only a kagent-owned provider adapter, or a public wrapper proven to expose the f
 
 kagent constructs the Runner so the generic proxy is the only content-bearing public ADK callback path.
 
-Correlate that callback with raw bytes captured by the kagent-owned provider adapter. Then create an immutable RFC 8785 snapshot and descriptor digest.
+The host correlates that callback with raw bytes from the kagent-owned provider adapter.
+
+The host then creates an immutable RFC 8785 snapshot and descriptor digest.
 
 If kagent cannot exclude competing callbacks, the callback capability is unavailable.
 
-Refuse tool calls when the provider path did not expose raw arguments before ADK decoded them.
+The host refuses a tool call when the provider path did not expose raw arguments before ADK decoded them.
 
 ### Model request gate
 
@@ -532,27 +542,27 @@ It receives the exact canonical provider request, endpoint, model, tool catalog,
 
 Only a matching permit can send the request to the provider.
 
-Declare a separate capability for standard generation, live flow, realtime sends, history sends, and embedding requests.
+The manifest declares separate capabilities for standard, live, realtime, history, and embedding requests.
 
-Refuse each path that cannot expose its final request through a kagent-owned adapter or a proven public wrapper.
+The host refuses each path that cannot expose its final request through an approved adapter or wrapper.
 
 Provider retry uses the same event ID and exact request digest. A changed request requires a new phase event.
 
 ### Model response gate
 
-Use the public `AfterModelCallback` as the standard response gate.
+The standard response gate uses the public `AfterModelCallback`.
 
 For kagent-owned live and streaming adapters, gate the complete response before kagent dispatches calls or publishes content.
 
 It can replace the complete model response or suppress all contained calls.
 
-Refuse a live or streaming path that bypasses these surfaces.
+The host refuses a live or streaming path that bypasses these surfaces.
 
 ### Event gate
 
-Implement `Drop`, `Replace`, and `Emit` in kagent wrappers around the public session service and Runner output.
+Kagent wrappers implement `Drop`, `Replace`, and `Emit` around the public session service and Runner output.
 
-Do not install other content-bearing `OnEventCallback` implementations in a protected workload.
+A protected workload contains no other content-bearing `OnEventCallback` implementation.
 
 The first release sends every partial assistant event to the exclusive gate and drops it before persistence or yield.
 
@@ -562,7 +572,7 @@ The terminal event includes a closed authenticated-principal attestation. The ho
 
 ### Session persistence gate
 
-Use a kagent-owned session implementation and backing store for user, function-response, model, task, child, and resumed interaction events.
+A kagent-owned session implementation stores user, function-response, model, task, child, and resumed interaction events.
 
 The wrapper receives exact event bytes and stable session lineage.
 
@@ -570,37 +580,39 @@ If the backing store cannot share one transaction with the host outbox, session 
 
 ### A2A publication gate
 
-Add a kagent-owned barrier before ADK-to-A2A conversion and before stream or task publication.
+A kagent-owned barrier runs before ADK-to-A2A conversion and before stream or task publication.
 
 It receives authenticated caller attestation as generic transport metadata.
 
 ### Child lifecycle
 
-Use public Agent, Runner, and session interfaces for child proposal, start, state, terminal return, and parent delivery.
+Kagent-owned wrappers use public Agent, Runner, and session interfaces for the child lifecycle.
 
 The host preallocates stable child and parent scope IDs.
 
 ### Memory lifecycle
 
-Disable stock automatic preload. Supply a kagent-owned implementation through public memory and tool interfaces.
+Protected workloads disable stock automatic preload. A kagent-owned implementation uses public memory and tool interfaces.
 
-Wrap `SearchMemory` with generic `memory.propose` and `memory.complete` phases.
+The kagent-owned implementation wraps `SearchMemory` with `memory.propose` and `memory.complete` phases.
 
 No memory content enters model instructions before commit.
 
-Expose the embedding-provider request, retrieved content, `load_memory`, `preload_memory`, `save_memory`, and persistent memory write as separate generic operation phases.
+Separate phases expose the embedding request, retrieved content, memory tools, preload, and persistent memory write.
 
-Include embedding endpoints and memory stores in the immutable host sink inventory.
+The immutable host sink inventory includes embedding endpoints and memory stores.
 
 ### MCP transport
 
-Do not use the upstream opaque MCP client in protected workloads.
+Protected workloads exclude the upstream opaque MCP client.
 
-Supply a kagent-owned tool implementation with raw JSON-RPC argument injection and terminal response capture.
+A kagent-owned tool supplies raw JSON-RPC argument injection and terminal response capture.
 
-Disable automatic retry after request bytes can reach the MCP server.
+The kagent-owned transport disables automatic retry after request bytes can reach the MCP server.
 
-Run MCP discovery during Revision preparation. Pin server identity, transport, tool descriptors, schemas, raw metadata, and discovery generation.
+Revision preparation runs MCP discovery.
+
+The Revision pins the server, transport, tool descriptors, schemas, raw metadata, and discovery generation.
 
 Discovery failure MUST reject preparation. It cannot be logged and skipped.
 
@@ -610,23 +622,23 @@ The host mints a one-use generic request capability bound to instance, caller, s
 
 ### Remote A2A lifecycle
 
-Add generic phases for prepared Agent Card, outbound request metadata, task state, input-required state, and terminal result.
+Generic phases carry the prepared Agent Card, request metadata, task states, and terminal result.
 
-Strip caller credentials and reserved lineage before the phase call.
+The kagent remote tool strips caller credentials and reserved lineage before the phase call.
 
 Snapshot the exact endpoint, Agent Card digest, headers, task and context IDs, body, retry identity, and transport settings.
 
-Send that complete normalized outbound request through exclusive `remote.request`.
+The kagent remote tool sends the normalized outbound request through exclusive `remote.request`.
 
 Network transmission requires a matching `permit` bound to the exact request digest.
 
-Accept header or body changes only as replacement payload in the generic decision envelope.
+The host accepts header or body changes only as a replacement payload in the generic decision envelope.
 
-Prepare and pin the Agent Card and endpoint in the Revision. Runtime Card refresh is refused.
+Revision preparation pins the Agent Card and endpoint. The host refuses runtime Card refresh.
 
-Preserve raw `submitted`, `working`, `input_required`, `auth_required`, `completed`, `failed`, `canceled`, `rejected`, and unknown states.
+The host preserves raw `submitted`, `working`, `input_required`, `auth_required`, `completed`, `failed`, `canceled`, `rejected`, and unknown states.
 
-Do not extract content before the exclusive extension commits the terminal state and payload.
+The host extracts no content before the exclusive extension commits the terminal state and payload.
 
 ## Mechanical execution protocol
 
@@ -634,15 +646,15 @@ The host owns the actual invocation of in-process ADK tools.
 
 For each tool call:
 
-1. Capture provider mapping, dispatch descriptor, and immutable argument bytes.
-2. Invoke `tool.propose` on the exclusive extension.
-3. Accept only a matching unexpired `permit`.
-4. Persist the generic event and decision IDs in host-native delivery state when needed.
-5. Invoke `execution.begin` and require plugin acknowledgement.
-6. Execute the permitted private payload exactly once.
-7. Invoke `tool.complete` with raw output or terminal execution status.
-8. Accept only a matching `commit`.
-9. Construct the `FunctionResponse` from committed bytes only.
+1. The host captures the provider mapping, dispatch descriptor, and immutable argument bytes.
+2. The host invokes `tool.propose` on the exclusive extension.
+3. The host accepts only a matching unexpired `permit`.
+4. The host persists the generic event and decision IDs when needed.
+5. The host invokes `execution.begin` and requires plugin acknowledgement.
+6. The tool wrapper executes the permitted private payload exactly once.
+7. The host invokes `tool.complete` with raw output or terminal status.
+8. The host accepts only a matching `commit`.
+9. The host constructs the `FunctionResponse` from committed bytes only.
 
 The execution proxy MUST ignore the original mutable ADK map after snapshot creation.
 
@@ -664,9 +676,9 @@ The exclusive extension receives raw output first.
 
 The host constructs downstream content only from the terminal generic commit.
 
-Before sink publication, write one durable host outbox record keyed by event ID and committed payload digest.
+Before sink publication, the host writes one durable outbox record for the event ID and committed payload digest.
 
-Publish with that stable idempotency key, then mark the outbox row delivered.
+The sink publishes with that stable idempotency key. The host then marks the outbox row delivered.
 
 Recovery retries only the same outbox event and payload digest.
 
@@ -674,25 +686,29 @@ The kagent-owned session store and its outbox row MUST share one transaction.
 
 A2A, memory, UI, and other external sinks MUST accept the host event ID as an idempotency key.
 
-Refuse a protected sink that lacks idempotent publication. The proposal does not claim exactly-once delivery without sink support.
+The host refuses a protected sink that lacks idempotent publication.
+
+The proposal does not claim exactly-once delivery without sink support.
 
 Protected host construction disables content telemetry before providers, Runner, tools, and log callbacks initialize.
 
 This is an immutable workload property. Extension manifests cannot enable or disable host telemetry.
 
-Configure upstream ADK telemetry through supported public options so it emits no content.
+Supported public options configure upstream ADK telemetry without content.
 
-Use content-free constructors for kagent-owned model, tool, Runner, A2A, and MCP instrumentation.
+Kagent-owned model, tool, Runner, A2A, and MCP instrumentation uses content-free constructors.
 
-Refuse a component when its content telemetry cannot be disabled without modifying Google ADK.
+The host refuses a component when public options cannot disable its content telemetry.
 
-Remove kagent's standard serialized tool-argument callback from protected workloads.
+Protected workloads exclude kagent's standard serialized tool-argument callback.
 
 The host inventory lists every telemetry constructor and exporter with its content-free implementation digest.
 
-At readiness, run a synthetic canary payload through model, tool, session, A2A, memory, and MCP instrumentation.
+The readiness test sends a synthetic canary through model, tool, session, A2A, memory, and MCP instrumentation.
 
-Search captured records for the canary digest and bytes. Any content-bearing record keeps the Actor unready.
+The readiness test searches captured records for the canary digest and bytes.
+
+Any content-bearing record keeps the Actor unready.
 
 ## Dynamic tools and interactions
 
@@ -864,20 +880,20 @@ The controller allocates one monotonically increasing Actor generation and fenci
 
 Every host-native and extension-owned state write MUST carry the current epoch. A stale Actor or restored process cannot write after a newer generation activates.
 
-Persist a generic host snapshot transaction with these states:
+The generic host persists a snapshot transaction with these states:
 
 `Active -> Quiescing -> ExtensionsSealed -> HostSealed -> ProviderCommitted -> Complete`.
 
 Sequence:
 
-1. Reject new roots and tool proposals.
-2. Drain or cancel active host operations.
-3. Call `Quiesce` on every required extension in deterministic order.
-4. Receive signed extension generation metadata and file digests.
-5. Checkpoint host-native stores.
-6. Ask Substrate to create one encrypted snapshot generation.
-7. Bind provider snapshot identity, key version, host files, extension files, and completion marker.
-8. Call `ValidateRestore` before any restored Actor becomes ready.
+1. The host rejects new roots and tool proposals.
+2. The host drains or cancels active operations.
+3. The host calls `Quiesce` on each required extension in deterministic order.
+4. The host receives signed extension generation metadata and file digests.
+5. The host checkpoints its stores.
+6. Substrate creates one encrypted snapshot generation.
+7. The manifest binds the provider snapshot, key version, files, and completion marker.
+8. The host calls `ValidateRestore` before a restored Actor becomes ready.
 
 The OpenAPPA state volume is mounted only in the OpenAPPA sidecar.
 
@@ -885,7 +901,7 @@ Each extension manifest binds generation, fencing epoch, state schema, file dige
 
 The host manifest binds its session and delivery files plus every signed extension manifest.
 
-Publish `Complete` only after the provider confirms the snapshot identity and all file digests.
+The host publishes `Complete` after the provider confirms the snapshot identity and all file digests.
 
 Recovery rules:
 
@@ -894,7 +910,7 @@ Recovery rules:
 - After `ProviderCommitted` but before `Complete`: verify provider identity and digests, then finish the same transaction.
 - On any digest, epoch, signature, or state-schema mismatch: reject restore and remain unready.
 
-Use `ReadWriteOncePod` plus the durable epoch. Volume access mode alone is not a fencing mechanism.
+The design uses `ReadWriteOncePod` with the durable epoch. Volume access mode alone is not a fencing mechanism.
 
 ## Readiness and failure behavior
 
@@ -929,9 +945,9 @@ The kagent controller validates generic shape and includes hashes in the Revisio
 
 Substrate MUST enforce per-container egress through an authenticated gateway. Current destination metadata alone is insufficient.
 
-Install Actor-wide default-deny CNI egress. Permit only the cluster DNS resolver and authenticated egress gateway addresses.
+The Actor uses default-deny CNI egress. It permits only cluster DNS and authenticated egress gateway addresses.
 
-Block direct external TCP, UDP, node, control-plane, and cloud metadata-service routes.
+The network policy blocks direct external TCP, UDP, node, control-plane, and cloud metadata-service routes.
 
 Each container authenticates to the gateway with its workload identity. The gateway selects the allowlist for that exact Actor, Revision, and container.
 
@@ -941,19 +957,19 @@ It also enforces IP ranges, redirects, and DNS rebinding rules.
 
 The Actor MUST remain unready when CNI isolation, gateway routing, DNS policy, or workload identity cannot be installed and attested.
 
-Add projected Secret and ConfigMap volume support so secret bytes do not appear as literal ActorTemplate environment values.
+Projected Secret and ConfigMap volumes keep secret bytes out of literal ActorTemplate environment values.
 
 The sidecar receives only declared mounts, secrets, and egress.
 
 ## Security and trust boundary
 
-Require signed OCI image and manifest artifacts, allowed signer identities, SBOM, and build provenance.
+Admission requires signed OCI image and manifest artifacts, allowed signer identities, an SBOM, and build provenance.
 
-Publish the extension manifest as OCI media type `application/vnd.kagent.extension.manifest.v1+json`.
+The registry stores the extension manifest as OCI media type `application/vnd.kagent.extension.manifest.v1+json`.
 
-Publish SPDX JSON SBOM and in-toto SLSA provenance as OCI referrers to the same image subject digest.
+The registry stores SPDX JSON SBOM and SLSA provenance as referrers to the image digest.
 
-Publish a Sigstore signature envelope for the complete artifact set.
+The artifact set includes a Sigstore signature envelope.
 
 It binds image, manifest, SBOM, provenance, signer identity, and Rekor inclusion proof.
 
@@ -963,31 +979,39 @@ The controller verifies all referrer subject links and signatures before Revisio
 
 Admission MUST reject tag-only images, missing or mismatched referrers, unsigned manifests, disallowed registries, unknown signers, and Revision overrides.
 
-Restrict Harness, AgentTemplate, AgentInstance, Revision, ActorTemplate, Secret, and direct workload mutation through RBAC and admission policy.
+RBAC and admission policy restrict Harness, AgentTemplate, AgentInstance, Revision, ActorTemplate, Secret, and direct workload mutation.
 
-Run the sidecar as a dedicated non-root UID with read-only root filesystem, `allowPrivilegeEscalation: false`, dropped Linux capabilities, and RuntimeDefault seccomp.
+The sidecar uses a dedicated non-root UID and a read-only root filesystem.
 
-Mount its private state with single-writer fencing. Use `ReadWriteOncePod` or one external transactional writer lease per plugin revision.
+It also uses `allowPrivilegeEscalation: false`, no Linux capabilities, and RuntimeDefault seccomp.
+
+The private state mount uses single-writer fencing.
+
+Each plugin revision uses `ReadWriteOncePod` or one external transactional writer lease.
 
 The kagent process is part of the trusted computing base. In-process tool code shares that process and can reach the private client socket as the host identity.
 
 The sidecar boundary isolates OpenAPPA memory and state from ordinary accidental faults. It does not sandbox malicious code already executing inside kagent.
 
-Use one per-launch secret and workload identity on the Unix gRPC channel. Bind every event to boot epoch, instance, Revision, extension, sequence, and digest.
+The Unix gRPC channel uses one per-launch secret and workload identity.
 
-RPC deadlines are mandatory. Disable hedging. Retry an extension RPC only with the same idempotent event ID.
+Every event binds to the boot epoch, instance, Revision, extension, sequence, and digest.
 
-Never retry a tool transport after request bytes can have reached the tool.
+RPC deadlines are mandatory. The host disables hedging.
+
+The host retries an extension RPC only with the same idempotent event ID.
+
+The host never retries a tool transport after request bytes can reach the tool.
 
 The generic scope lock is non-reentrant. A nested operation must create a declared child scope or fail before waiting.
 
-Bound callback queues, child concurrency, interaction lifetime, and extension restart backoff.
+The host bounds callback queues, child concurrency, interaction lifetime, and extension restart backoff.
 
 ## Plugin upgrades
 
-Pin the extension artifact, manifest, protocol, and state schema to every live scope.
+Every live scope pins the extension artifact, manifest, protocol, and state schema.
 
-Before first dispatch, persist an immutable mapping from root, task, context, child, and interaction scope to ActorTemplate and extension Revision.
+Before first dispatch, the controller persists an immutable scope mapping to the ActorTemplate and extension Revision.
 
 Every resume, remote response, interaction response, capability, and late event routes through that mapping.
 
@@ -995,13 +1019,13 @@ Controller lifecycle is `Active -> Draining -> Drained -> Suspended`.
 
 Upgrade sequence:
 
-1. Prepare and activate the new sidecar revision against the new host inventory.
-2. Atomically stop old-root admission and route new roots to the new Revision.
-3. Keep existing scopes on the old sidecar revision.
-4. Keep the old workload ready for its assigned scopes only.
-5. Drain old scopes until terminal or deadline.
-6. Record every forced remainder as generic uncertain termination for plugin reconciliation.
-7. Snapshot and suspend the old instance only after pending work reaches zero or reconciliation completes.
+1. The controller prepares and activates the new sidecar revision.
+2. The controller stops old-root admission and routes new roots atomically.
+3. Existing scopes remain on the old sidecar revision.
+4. The old workload remains ready only for its assigned scopes.
+5. Old scopes drain until terminal state or deadline.
+6. The controller records each forced remainder as uncertain termination.
+7. The controller snapshots and suspends the old instance after reconciliation completes.
 
 Rollback is another atomic new-root routing transition. It never moves a live scope between revisions.
 
@@ -1011,16 +1035,16 @@ No between-turn or immediate hot swap exists in the first release.
 
 | PR | Change |
 |---|---|
-| 1 | Add generic Harness extension API, manifests, Revision data, and signature policy |
-| 2 | Render sidecar containers, projected config and secrets, socket and state volumes, egress, and readiness |
-| 3 | Add neutral protobuf protocol, negotiation, health, and generic extension host |
-| 4 | Gate provider-final requests and catalogs in kagent-owned model adapters |
-| 5 | Install the first public tool callback proxy and kagent-owned execution wrappers |
-| 6 | Gate model responses through public callbacks and kagent-owned output wrappers |
-| 7 | Wrap the public session service and kagent A2A publication code |
-| 8 | Wrap public Agent, Runner, memory, remote, and interaction surfaces |
-| 9 | Add a kagent-owned raw MCP transport with no-retry semantics |
-| 10 | Configure upstream telemetry and add kagent readiness, snapshot, recovery, and drain lifecycle |
+| 1 | Generic Harness API, manifests, Revision data, and signature policy |
+| 2 | Sidecar containers, projected data, volumes, egress, and readiness |
+| 3 | Neutral protocol, negotiation, health, and generic extension host |
+| 4 | Provider-final request and catalog gates in kagent-owned adapters |
+| 5 | Sole content-bearing callback proxy and kagent-owned tool wrappers |
+| 6 | Model response gates in public callbacks and kagent-owned output wrappers |
+| 7 | Kagent-owned session service and A2A publication barriers |
+| 8 | Agent, Runner, memory, remote, and interaction wrappers |
+| 9 | Kagent-owned raw MCP transport with no-retry semantics |
+| 10 | Content-free telemetry, readiness, snapshots, recovery, and drain lifecycle |
 
 Each PR is generic. Test fixtures MUST use neutral fake extensions and contain no OpenAPPA import or name in production packages.
 
@@ -1094,12 +1118,12 @@ No PR changes Google ADK source, copies it, replaces its module, vendors it, or 
 
 ### End-to-end GCP acceptance
 
-- Build and deploy the generic kagent host and OpenAPPA sidecar as separate images.
-- Verify dynamic manifest installation without recompiling kagent.
-- Run ordinary, MCP, memory, local child, remote child, HITL, final response, and migration scenarios.
-- Inject plugin, host, network, tool, model, and snapshot failures.
-- Inspect logs, traces, session state, plugin state, A2A output, and snapshots for prohibited raw content.
-- Repeat all crash and restart windows until deterministic assertions pass.
+- Separate generic-host and OpenAPPA-sidecar images.
+- Dynamic manifest installation without kagent recompilation.
+- Ordinary, MCP, memory, child, HITL, final-response, and migration scenarios.
+- Plugin, host, network, tool, model, and snapshot failure injection.
+- Prohibited-content checks across logs, traces, state, A2A output, and snapshots.
+- Repeated crash and restart windows with deterministic assertions.
 - Manually verify desktop and API interaction flows.
 
 The PoC is complete only when every required capability passes and no partial-capability mode reports ready.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -30,7 +30,7 @@ Google ADK remains an unmodified upstream dependency. The design does not fork, 
 
 OpenAPPA policy semantics remain in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
-## Keep kagent changes generic
+## Generic kagent changes
 
 The kagent fork implements only generic extension infrastructure:
 
@@ -65,7 +65,7 @@ The OpenAPPA companion owns:
 
 kagent sees only generic host payloads, phase names, digests, deadlines, decisions, and opaque handles.
 
-## Use an OCI companion container
+## OCI companion container
 
 The selected process model is a digest-pinned OCI companion container in the same Substrate Actor.
 
@@ -95,7 +95,7 @@ Actor-wide CNI policy permits only cluster DNS and an authenticated egress gatew
 
 The kagent process and its in-process tools remain in the trusted computing base. The sidecar isolates OpenAPPA memory and state but cannot sandbox malicious code already running as kagent.
 
-## Follow proven plugin patterns
+## Established plugin patterns
 
 The protocol borrows established mechanisms rather than using Go shared-library loading.
 
@@ -109,7 +109,7 @@ The protocol borrows established mechanisms rather than using Go shared-library 
 
 The design does not use the Go [`plugin`](https://pkg.go.dev/plugin) package. Its toolchain coupling, platform limits, race-detector limitations, shared address space, and unload restrictions conflict with independently shipped extensions.
 
-## Configure extensions dynamically
+## Dynamic extension configuration
 
 A Harness can declare several ordered dynamic extensions. Each declaration is generic:
 
@@ -153,18 +153,18 @@ It mounts immutable Revision-owned copies and stores no secret bytes in the Revi
 
 The immutable Revision includes these generic values. A plugin revision never changes inside a live scope.
 
-## Negotiate a neutral protocol
+## Neutral protocol negotiation
 
 The sidecar starts before registration and serves the private socket.
 
 The host performs these steps:
 
-1. Verify the sidecar workload identity and per-launch socket secret.
-2. Call `GetExtensionInfo` for plugin ID, artifact version, protocol range, state schema, and manifest digest.
-3. Send the complete generic host capability and sink inventory.
-4. Select one protocol major and capability set.
-5. Require the extension to accept the inventory digest and return ready.
-6. Enable the extension only after both container readiness and protocol readiness succeed.
+1. The host verifies the sidecar workload identity and per-launch socket secret.
+2. The host calls `GetExtensionInfo` for the plugin and protocol identities.
+3. The host sends the complete capability and sink inventory.
+4. The host selects one protocol major and capability set.
+5. The extension accepts the inventory digest and reports its ready state.
+6. The host enables the extension after container and protocol readiness succeed.
 
 The inventory describes mechanics, not OpenAPPA policy:
 
@@ -180,7 +180,7 @@ The OpenAPPA sidecar validates its own policy against that inventory.
 
 kagent treats the signed ready response as a generic required-extension attestation.
 
-## Use existing ADK and kagent surfaces
+## Existing ADK and kagent surfaces
 
 Current public ADK interfaces cover only part of the required lifecycle.
 
@@ -209,7 +209,7 @@ No OpenAPPA payload or decision uses a direct kagent API.
 
 All host-side enforcement data crosses only the generic extension protocol. It contains no ADK Go types or OpenAPPA policy types.
 
-## Keep extension ordering deterministic
+## Deterministic extension ordering
 
 The Revision defines one total extension order.
 
@@ -223,7 +223,7 @@ Other extensions can observe metadata or already committed content only after th
 
 No runtime plugin can be appended after manifest verification.
 
-## Use immutable event envelopes
+## Immutable event envelopes
 
 Every host event has a generic immutable envelope:
 
@@ -256,7 +256,7 @@ The host never parses a lease or persists it beyond that delivery lifecycle.
 
 The sidecar resolves held interactions and recovery state from its private store by host event ID.
 
-## Use generic decisions
+## Generic decisions
 
 The sidecar returns only generic host decisions:
 
@@ -274,7 +274,7 @@ A decision binds the event digest, extension revision, deadline, and permitted n
 
 The host executes no replacement that lacks a matching permit. It publishes no content that lacks a matching commit or event decision.
 
-## Gate one tool lifecycle mechanically
+## Mechanical tool lifecycle gate
 
 ```text
 ADK proposes a tool call
@@ -293,7 +293,7 @@ The extension sees the provider-final descriptor, actual source identity, exact 
 
 The host blocks name collisions, descriptor drift, mutable argument reuse, callback bypass, and automatic transport retry before plugin policy runs.
 
-## Gate the model provider request
+## Model provider request gate
 
 After all request processors and model callbacks, the host snapshots the exact provider request.
 
@@ -305,7 +305,7 @@ The same gate covers each enabled standard, live, realtime, history, and embeddi
 
 A live or realtime send uses a kagent-owned wrapper around the public live-session send interface. An unsupported path remains disabled.
 
-## Gate every result and response sink
+## Result and response sink gates
 
 The generic event gate runs before any plugin callback can observe uncommitted event content.
 
@@ -327,7 +327,7 @@ This immutable kagent workload property does not depend on an extension manifest
 
 Readiness sends a canary through every model, tool, session, A2A, memory, MCP, and exporter path. Any captured canary content keeps the Actor unready.
 
-## Cover children, remote agents, and interactions
+## Child, remote agent, and interaction coverage
 
 The host exposes generic child phases:
 
@@ -355,7 +355,7 @@ It does not interpret approve, decline, cancel, Authority, offer, or remedy mean
 
 The OpenAPPA plugin owns response meaning, replay protection, expiry, remote-hop state, and resume decisions.
 
-## Keep OpenAPPA semantics inside the sidecar
+## OpenAPPA semantics in the sidecar
 
 The OpenAPPA sidecar maps generic phases to current Engine and runtime behavior.
 
@@ -374,7 +374,7 @@ It alone implements:
 
 The kagent fork does not know these concepts.
 
-## Keep state ownership separate
+## Separate state ownership
 
 kagent keeps its ordinary ADK session and A2A task stores.
 
@@ -396,7 +396,7 @@ A durable fencing epoch accompanies every state write. The host records one atom
 
 Restore remains blocked until every required extension validates its own generation and accepts the host inventory.
 
-## Classify uncertain crashes conservatively
+## Conservative crash classification
 
 The selected first-release recovery rule is conservative.
 
@@ -410,7 +410,7 @@ The host emits `recovery.reconcile` through the ordinary extension phase API.
 
 The affected generic scope remains frozen until the sidecar returns `suppress`, `hold`, replayed `commit`, or terminal `fail`.
 
-## Pin and drain plugin upgrades
+## Pinned revisions and upgrade drain
 
 One plugin artifact and protocol selection remain pinned for each live scope.
 
@@ -424,14 +424,14 @@ The old workload rejects new roots but remains available for its assigned scopes
 
 The plugin owns any state migration. An incompatible revision requires instance replacement and drain.
 
-## Install the generic host and OpenAPPA plugin
+## Generic host and plugin installation
 
 Installation has two independently versioned artifacts:
 
 1. A kagent fork with the generic dynamic extension host, public-ADK adapters, and generic lifecycle points.
 2. The OpenAPPA kagent plugin companion image and its signed manifest.
 
-Create immutable policy configuration for the sidecar:
+The following commands create immutable policy configuration for the sidecar:
 
 ```sh
 kubectl -n kagent create configmap customer-support-policy-v1 \
@@ -445,7 +445,7 @@ The generic Harness references the extension image and opaque configuration. The
 
 The OpenAPPA plugin reports unready until its policy, state, runtime, host inventory, and required generic phases validate.
 
-Create a new `AgentInstance` from the prepared Harness. Existing instances cannot change their pinned extension set.
+A prepared Harness creates a new `AgentInstance`. Existing instances cannot change their pinned extension set.
 
 ## Architecture
 
@@ -474,7 +474,7 @@ Create a new `AgentInstance` from the prepared Harness. Existing instances canno
 
 The Unix socket and generic event protocol are the only enforcement-data interface between kagent and the OpenAPPA component.
 
-## Refuse incomplete coverage
+## Incomplete coverage refusal
 
 The protected instance remains unready when any required phase is missing, shared, reordered, bypassable, or unsupported.
 
@@ -492,13 +492,13 @@ The first release refuses:
 - Any partial capability mode for the required OpenAPPA plugin.
 - Any path that would require patched, vendored, copied, replaced, or internal Google ADK code.
 
-## Move an existing agent
+## Existing agent migration
 
 An existing `AgentInstance` cannot add a new dynamic extension set.
 
-Create a replacement protected instance and route new roots to it.
+The controller creates a replacement protected instance and routes new roots to it.
 
-Keep existing task and context IDs on the old instance until a fixed drain deadline.
+Existing task and context IDs remain on the old instance until a fixed drain deadline.
 
 At the deadline, cancel remaining old work and suspend the old instance.
 

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -48,7 +48,7 @@ The fork MUST NOT modify Google ADK source, copy it, or replace its module. A mi
 
 The wrapper MUST live in kagent-owned code and use only public ADK imports. It MUST NOT copy ADK source or reproduce an internal package.
 
-If neither surface provides the boundary, the host reports the capability as unavailable. A required extension then refuses activation.
+If neither surface has the boundary, the host reports the capability as unavailable. A required extension then refuses activation.
 
 The generic protocol MUST NOT contain OpenAPPA domain terms.
 
@@ -73,7 +73,7 @@ Substrate already supports [multiple containers with independent readiness probe
 
 The baseline lacks shared memory sockets, projected config and secrets, per-container identity, filesystem controls, seccomp, and enforced egress.
 
-These are required generic Substrate additions. Extension activation fails when any declared primitive is unavailable.
+Generic Substrate work adds these required features. Extension activation fails when a declared primitive is unavailable.
 
 The generic fork adds extension containers without adding an OpenAPPA-specific sidecar role.
 
@@ -89,7 +89,7 @@ The extension receives opaque configuration and secret mounts. kagent verifies s
 
 The extension image runs as a dedicated UID with a read-only root filesystem and no Linux capabilities.
 
-It also has bounded resources and deny-by-default egress.
+Resource limits and deny-by-default egress also apply.
 
 Actor-wide CNI policy permits only cluster DNS and an authenticated egress gateway. The gateway enforces per-container destination, TLS identity, redirect, and DNS-rebinding rules.
 
@@ -157,7 +157,7 @@ The immutable Revision includes these generic values. A plugin revision never ch
 
 The sidecar starts before registration and serves the private socket.
 
-The host performs these steps:
+The host uses this sequence:
 
 1. The host verifies the sidecar workload identity and per-launch socket secret.
 2. The host calls `GetExtensionInfo` for the plugin and protocol identities.
@@ -186,19 +186,19 @@ Current public ADK interfaces cover only part of the required lifecycle.
 
 | Boundary | Existing public surface | kagent-owned integration |
 |---|---|---|
-| Ordinary tool callbacks | `BeforeTool`, `AfterTool`, and tool-error callbacks | Install the dynamic proxy first in a fixed callback order |
-| User input | `OnUserMessageCallback` and injected session service | Proxy the callback and gate append in the session-service wrapper |
-| Model request | Injected model interface and kagent-owned provider adapters | Gate the provider-final request; refuse opaque upstream providers |
-| Provider-final tool catalog | Kagent-owned provider adapters | Export final descriptors and a reversible provider-name map |
-| Raw function-call arguments | Kagent-owned provider decoders | Preserve token bytes before ADK map decoding; refuse opaque decoders |
-| Tool execution | Public tool interface and existing tool callbacks | Wrap the tool and make the dynamic proxy the first callback |
-| Model response | Existing model callbacks and injected model wrapper | Gate supported standard or live paths; refuse bypassing paths |
-| Session persistence | Injected session service | Gate exact bytes before the backing service appends them |
-| Runner and task publication | Public Runner output plus kagent-owned A2A code | Gate before kagent yields, stores, or publishes content |
-| Child return | Public Agent, Runner, and session interfaces | Correlate child scopes in kagent wrappers; refuse unobservable paths |
-| Memory | Public memory and tool interfaces | Disable stock preload and use a gated kagent-owned implementation |
-| MCP | Public tool interface | Use a kagent-owned no-retry transport; refuse stock opaque transport |
-| Remote A2A | Existing kagent remote tool | Wrap request and result handling in the kagent fork |
+| Ordinary tool callbacks | `BeforeTool`, `AfterTool`, and tool-error callbacks | Sole content-bearing dynamic proxy |
+| User input | `OnUserMessageCallback` and injected session service | Callback proxy and session append gate |
+| Model request | Injected model interface and kagent-owned provider adapters | Provider-final gate, with opaque upstream providers unavailable |
+| Provider-final tool catalog | Kagent-owned provider adapters | Final descriptors and reversible provider-name map |
+| Raw function-call arguments | Kagent-owned provider decoders | Token preservation before ADK map decoding |
+| Tool execution | Public tool interface and existing tool callbacks | Tool wrapper and sole content-bearing proxy |
+| Model response | Existing model callbacks and injected model wrapper | Standard and supported live-path gates |
+| Session persistence | Injected session service | Exact-byte gate before backing-store append |
+| Runner and task publication | Public Runner output plus kagent-owned A2A code | Barrier before yield, storage, or publication |
+| Child return | Public Agent, Runner, and session interfaces | Child-scope correlation, with unobservable paths unavailable |
+| Memory | Public memory and tool interfaces | Stock preload disabled, kagent-owned gate enabled |
+| MCP | Public tool interface | Kagent-owned no-retry transport |
+| Remote A2A | Existing kagent remote tool | Kagent-owned request and result wrappers |
 | Snapshot, readiness, egress, and drain | Outside ADK | Use the generic kagent and Substrate lifecycle interface |
 
 The protected profile uses only these public interfaces and kagent-owned integration points. It disables any path that can bypass them.
@@ -221,7 +221,7 @@ The OpenAPPA plugin requires exclusive ownership of all uncommitted content phas
 
 Other extensions can observe metadata or already committed content only after that exclusive gate.
 
-No runtime plugin can be appended after manifest verification.
+The fixed manifest excludes runtime plugin additions after verification.
 
 ## Immutable event envelopes
 
@@ -476,7 +476,7 @@ The Unix socket and generic event protocol are the only enforcement-data interfa
 
 ## Incomplete coverage refusal
 
-The protected instance remains unready when any required phase is missing, shared, reordered, bypassable, or unsupported.
+The protected instance remains unready if a required phase lacks sole, fixed, supported ownership.
 
 The first release refuses:
 
@@ -485,7 +485,7 @@ The first release refuses:
 - Automatic memory preload without the synthetic lifecycle extension.
 - Dynamic tool catalogs that change inside a prepared Revision.
 - Runtime plugins or callbacks appended after manifest verification.
-- Content telemetry that cannot be disabled before payload creation.
+- Components without a public content-telemetry control.
 - Remote A2A paths without immutable Card, header replacement, state preservation, and terminal gates.
 - Streaming assistant content before the exclusive publication gate.
 - Hot plugin swaps and mixed plugin revisions inside one scope.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -3,7 +3,7 @@ title: kAgent
 nav_title: kAgent
 category: Integrations
 order: 6
-description: Proposal for a dynamically supplied OpenAPPA ADK extension in kagent.
+description: Proposal for a dynamically supplied OpenAPPA extension in kagent without forking Google ADK.
 ---
 
 :::proposal
@@ -11,7 +11,7 @@ name: kAgent
 date: 2026-08-27
 :::
 
-This proposal adds a generic dynamic ADK extension host to the kagent Go fork.
+This proposal adds a generic out-of-process extension host to the kagent Go fork.
 
 OpenAPPA ships as a separate OCI companion container. The kagent fork contains no OpenAPPA policy, Label, trajectory, remedy, consult, runtime, or persistence logic.
 
@@ -19,27 +19,36 @@ The combined protected instance enforces four contracts:
 
 1. The host executes only the immutable payload permitted by the required extension.
 2. Raw tool and child results remain withheld until the extension commits a delivery payload.
-3. Model, session, A2A, memory, UI, log, telemetry, and storage publication cross exclusive extension gates.
+3. Every enabled model, session, A2A, memory, UI, log, telemetry, and storage path crosses an exclusive extension gate.
 4. The instance remains unready when its generic host inventory cannot satisfy every required extension capability.
 
 This proposal uses [kagent commit `9e246fd37`](https://github.com/kagent-dev/kagent/commit/9e246fd3797457b18fc277680be1629a0f57fce0) as its source baseline.
 
 It also uses Google ADK Go 2.2.0 and Substrate 0.0.20.
 
+Google ADK remains an unmodified upstream dependency. The design does not fork, vendor, copy, patch, replace, or import internal Google ADK packages.
+
 OpenAPPA policy semantics remain in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
-## Keep the fork generic
+## Keep kagent changes generic
 
 The kagent fork implements only generic extension infrastructure:
 
 - Dynamic extension configuration and artifact verification.
 - Version and capability negotiation.
-- Immutable ADK event snapshots.
-- New generic ADK callback and barrier points.
+- Dynamic proxies for existing public ADK callbacks.
+- Generic wrappers around public ADK model, tool, session, memory, and Runner interfaces.
+- Generic barriers in kagent-owned provider, tool, A2A, publication, and lifecycle code.
 - Generic execution, event, interaction, and lifecycle decisions.
 - Generic sidecar readiness, egress, volume, snapshot, and drain handling.
 
 The fork MUST NOT import an OpenAPPA crate, Go package, protobuf package, policy schema, wire enum, or generated type.
+
+The fork MUST NOT modify Google ADK source, copy it, or replace its module. A missing boundary must use a public ADK interface or a kagent-owned wrapper.
+
+The wrapper MUST live in kagent-owned code and use only public ADK imports. It MUST NOT copy ADK source or reproduce an internal package.
+
+If neither surface provides the boundary, the host reports the capability as unavailable. A required extension then refuses activation.
 
 The generic protocol MUST NOT contain OpenAPPA domain terms.
 
@@ -54,7 +63,7 @@ The OpenAPPA companion owns:
 - OpenAPPA-specific A2A delegation and human-review meaning.
 - Plugin-side durable state and schema migrations.
 
-kagent sees only generic ADK payloads, phase names, digests, deadlines, decisions, and opaque handles.
+kagent sees only generic host payloads, phase names, digests, deadlines, decisions, and opaque handles.
 
 ## Use an OCI companion container
 
@@ -107,7 +116,7 @@ A Harness can declare several ordered dynamic extensions. Each declaration is ge
 ```yaml
 extensions:
   - name: policy-gate
-    image: ghcr.io/archestra-ai/openappa-adk-plugin@sha256:<digest>
+    image: ghcr.io/archestra-ai/openappa-kagent-plugin@sha256:<digest>
     manifestDigest: sha256:<digest>
     protocol: kagent.extension.v1
     required: true
@@ -171,34 +180,34 @@ The OpenAPPA sidecar validates its own policy against that inventory.
 
 kagent treats the signed ready response as a generic required-extension attestation.
 
-## Add generic ADK extension points
+## Use existing ADK and kagent surfaces
 
-Current ADK callbacks cover only part of the required lifecycle.
+Current public ADK interfaces cover only part of the required lifecycle.
 
-| Boundary | Baseline status | Generic fork addition |
+| Boundary | Existing public surface | kagent-owned integration |
 |---|---|---|
-| Ordinary `BeforeTool`, `AfterTool`, and tool error | Existing plugin callbacks | Dynamic out-of-process proxy and deterministic ordering |
-| User message before persistence | Existing `OnUserMessageCallback` | Generic pre-persistence phase keyed by host event ID |
-| Model response before normal function dispatch | Existing `AfterModelCallback` on the standard path | One shared gate for standard and live paths |
-| Final model request before provider transmission | Missing | Exclusive `model.propose` gate for standard, live, realtime, history, and embedding paths |
-| Provider-final tool catalog | Missing | Final descriptor and reversible provider-name callback |
-| Before every plugin sees tool arguments | Missing | Exclusive pre-plugin dispatch gate |
-| Immutable argument ownership | Missing | Host-owned RFC 8785 snapshot and private execution payload |
-| Event drop before session persistence and yield | Missing | Exclusive `Drop`, `Replace`, or `Emit` event gate |
-| Child and task terminal return | Missing | Child terminal and parent-return gates |
-| Final A2A publication | Missing | Replaceable pre-publication gate |
-| Automatic memory preload | Outside tool callbacks | Synthetic memory operation lifecycle |
-| Raw MCP transport and no-retry dispatch | Outside plugin callbacks | Generic transport interceptor and execution proxy |
-| Remote A2A request before network transmission | Existing custom tool, no gate | Exclusive `remote.request` snapshot and permit phase |
-| Snapshot, readiness, egress, and drain | Outside ADK | Generic extension lifecycle interface |
+| Ordinary tool callbacks | `BeforeTool`, `AfterTool`, and tool-error callbacks | Install the dynamic proxy first in a fixed callback order |
+| User input | `OnUserMessageCallback` and injected session service | Proxy the callback and gate append in the session-service wrapper |
+| Model request | Injected model interface and kagent-owned provider adapters | Gate the provider-final request; refuse opaque upstream providers |
+| Provider-final tool catalog | Kagent-owned provider adapters | Export final descriptors and a reversible provider-name map |
+| Raw function-call arguments | Kagent-owned provider decoders | Preserve token bytes before ADK map decoding; refuse opaque decoders |
+| Tool execution | Public tool interface and existing tool callbacks | Wrap the tool and make the dynamic proxy the first callback |
+| Model response | Existing model callbacks and injected model wrapper | Gate supported standard or live paths; refuse bypassing paths |
+| Session persistence | Injected session service | Gate exact bytes before the backing service appends them |
+| Runner and task publication | Public Runner output plus kagent-owned A2A code | Gate before kagent yields, stores, or publishes content |
+| Child return | Public Agent, Runner, and session interfaces | Correlate child scopes in kagent wrappers; refuse unobservable paths |
+| Memory | Public memory and tool interfaces | Disable stock preload and use a gated kagent-owned implementation |
+| MCP | Public tool interface | Use a kagent-owned no-retry transport; refuse stock opaque transport |
+| Remote A2A | Existing kagent remote tool | Wrap request and result handling in the kagent fork |
+| Snapshot, readiness, egress, and drain | Outside ADK | Use the generic kagent and Substrate lifecycle interface |
 
-The user approved the generic lifecycle interface. Strict callback-only integration would remove several required guarantees.
+The protected profile uses only these public interfaces and kagent-owned integration points. It disables any path that can bypass them.
 
-Those guarantees include snapshots, readiness, raw MCP, telemetry, and publication.
+No guarantee in this proposal requires a change to Google ADK source.
 
-No OpenAPPA payload or decision uses a direct kagent API. Enforcement data crosses only the generic ADK extension protocol.
+No OpenAPPA payload or decision uses a direct kagent API.
 
-The only non-ADK messages are generic sidecar lifecycle, readiness, workload identity, opaque configuration, volume, egress, and snapshot metadata.
+All host-side enforcement data crosses only the generic extension protocol. It contains no ADK Go types or OpenAPPA policy types.
 
 ## Keep extension ordering deterministic
 
@@ -292,7 +301,9 @@ The snapshot includes endpoint, model, catalog, history, instructions, memory, a
 
 It sends `model.propose` before telemetry or network transmission. Only a matching permit can send that exact request.
 
-The same gate covers standard generation, live flow, realtime sends, history sends, embeddings, and every provider adapter.
+The same gate covers each enabled standard, live, realtime, history, and embedding path.
+
+A live or realtime send uses a kagent-owned wrapper around the public live-session send interface. An unsupported path remains disabled.
 
 ## Gate every result and response sink
 
@@ -417,8 +428,8 @@ The plugin owns any state migration. An incompatible revision requires instance 
 
 Installation has two independently versioned artifacts:
 
-1. A kagent fork with the generic dynamic extension host and generic ADK/lifecycle points.
-2. The OpenAPPA ADK plugin companion image and its signed manifest.
+1. A kagent fork with the generic dynamic extension host, public-ADK adapters, and generic lifecycle points.
+2. The OpenAPPA kagent plugin companion image and its signed manifest.
 
 Create immutable policy configuration for the sidecar:
 
@@ -447,10 +458,10 @@ Create a new `AgentInstance` from the prepared Harness. Existing instances canno
 |                 |                               |                                |
 |                 v                               v                                |
 |  +-----------------------------+  Unix gRPC  +--------------------------------+  |
-|  | kagent-go-adk               |<----------->| dynamic ADK extension sidecar |  |
+|  | kagent + upstream ADK       |<----------->| dynamic extension sidecar     |  |
 |  |                             | private UDS |                                |  |
 |  | generic extension host      |             | OpenAPPA plugin server        |  |
-|  | generic ADK barriers        |             | appa-runtime + Engine         |  |
+|  | public ADK wrappers         |             | appa-runtime + Engine         |  |
 |  | generic execution proxy     |             | policy and consults           |  |
 |  | sessions.db / A2A state     |             | private plugin state          |  |
 |  +-------------+---------------+             +----------------+---------------+  |
@@ -479,6 +490,7 @@ The first release refuses:
 - Streaming assistant content before the exclusive publication gate.
 - Hot plugin swaps and mixed plugin revisions inside one scope.
 - Any partial capability mode for the required OpenAPPA plugin.
+- Any path that would require patched, vendored, copied, replaced, or internal Google ADK code.
 
 ## Move an existing agent
 
@@ -496,6 +508,6 @@ Rollback resumes the old instance and restores routing. It never merges state be
 
 ## Implementation plan
 
-The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the generic protocol, source ownership, and new ADK extension points.
+The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the generic protocol, source ownership, public ADK adapters, and kagent-owned barriers.
 
 It also defines sidecar lifecycle, OpenAPPA mapping, and the verification matrix.


### PR DESCRIPTION
## Summary
- keep Google ADK Go as an unmodified upstream dependency
- move required gates onto public ADK interfaces and kagent-owned wrappers
- refuse protected activation when a required boundary would need patched, copied, or internal ADK code

Follow-up to #128. Task: T-1176.

## Validation
- website typecheck and production build pass