### PR TITLE
docs: split kagent adapter from appa-runtime

### DIFF
--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -1,178 +1,93 @@
-# kagent dynamic extension implementation plan
+# kagent dynamic adapter implementation plan
 
 Source baseline:
 
 - kagent commit `9e246fd3797457b18fc277680be1629a0f57fce0`
 - Google ADK Go `v2.2.0` at `b264039aaec43baedc123e5b9a0cf87681d0bbca`
 - Substrate `v0.0.20`
-- OpenAPPA `origin/main` at `77230bbb177d72ac740173036b715ff2b3f1ae24`
+- OpenAPPA `origin/main` at `d87d6f822fdde2968d607b05f2be4c6140b67342`
 
 The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent).
 
-## Accepted design decisions
+## Architecture decision
 
-The human reviewer selected these constraints:
+`appa-adapter-kagent` is the OpenAPPA kagent adapter. It maps generic kagent harness events to the existing `appa-runtime` `/hook` HTTP interface.
 
-1. The OpenAPPA extension runs as a digest-pinned OCI companion container.
-2. Generic lifecycle infrastructure covers readiness, egress, snapshots, and process lifecycle outside ADK callbacks.
-3. OpenAPPA classifies a crash after execution acknowledgement as `Indeterminate` until terminal completion.
-4. Each live scope uses one extension revision. Old scopes drain during upgrades.
-5. The OpenAPPA and private kagent repositories contain separate plugin and generic-host changes.
-6. Google ADK Go remains an unmodified upstream dependency.
+The adapter follows the `appa-adapter-claude-code` boundary. It depends on `appa-runtime-api` for hook wire types and codecs. It does not link `appa-runtime`, call the Engine, own policy, or open `appa.db`.
 
-These decisions are normative for the first implementation and PoC.
+`appa-runtime` is a separate logical process. It owns policy loading, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`. The adapter sends a bound `/hook` request and maps its bound response to the generic kagent decision wire.
 
-## Goal
+The adapter fails closed when `APPA_RUNTIME_URL` is unavailable, unauthenticated, expired, mismatched, or unreachable. A runtime response without the required identity and revision binding fails closed.
 
-The kagent fork contains a generic dynamically supplied extension system.
-
-OpenAPPA ships as an independently built sidecar that uses this generic system.
-
-The implementation uses only public Google ADK interfaces and kagent-owned integration points.
-
-The implementation excludes forks, vendored or copied source, patches, module replacement, and internal Google ADK packages.
-
-A missing required boundary makes its capability unavailable. Protected-workload activation then fails.
-
-The kagent fork MUST contain no OpenAPPA logic or OpenAPPA-specific data model.
-
-The combined system MUST preserve these invariants:
-
-1. kagent executes only a matching immutable payload from a valid generic `permit` decision.
-2. Raw execution output reaches no protected sink before a matching generic `commit` decision.
-3. Every content-bearing model, session, child, A2A, memory, UI, log, telemetry, and storage path crosses an exclusive generic gate.
-4. Extension ordering and phase ownership are immutable for one Revision.
-5. Required extension failure blocks readiness or freezes the affected scope.
-6. kagent never parses a plugin policy, fact, Label, remedy, consult, or extension-specific state.
-7. The OpenAPPA sidecar owns all OpenAPPA state, semantics, recovery, and external consults.
-8. One extension artifact and protocol selection remain pinned for each live scope.
-9. No invariant depends on a change to Google ADK source.
-
-## Evidence and adopted patterns
-
-The design follows primary sources from widely adopted plugin systems.
-
-| Source | Applied design |
-|---|---|
-| [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin) | Out-of-process RPC, handshake, protocol majors, health, and process isolation |
-| [go-plugin internals](https://github.com/hashicorp/go-plugin/blob/v1.8.0/docs/internals.md) | Explicit launch handshake and compatible protocol selection |
-| [Terraform plugin protocol](https://developer.hashicorp.com/terraform/plugin/terraform-plugin-protocol) | Separate artifact versions and wire compatibility |
-| [Kubernetes device plugins](https://v1-32.docs.kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) | Serve before register, Unix-socket gRPC, capability discovery, and re-registration |
-| [VS Code extension manifest](https://code.visualstudio.com/api/references/extension-manifest) | Declarative capabilities, compatibility ranges, activation, and contribution points |
-| [Envoy xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) | Versioned resources and explicit ACK or NACK |
-| [Docker plugin configuration](https://docs.docker.com/engine/extend/config/) | Reviewable image, socket, mount, network, device, and capability requests |
-| [gRPC health checking](https://grpc.io/docs/guides/health-checking/) | Standard sidecar health protocol |
-| [Buf breaking checks](https://buf.build/docs/breaking/) | Protocol compatibility enforcement in CI |
-
-The design excludes the standard Go [`plugin`](https://pkg.go.dev/plugin) package.
-
-That package has strict toolchain coupling, shared memory, platform limits, no unload, weak race-detector support, and no independent lifecycle.
-
-## Current source constraints
-
-Current public ADK and kagent surfaces lack the full required boundary set.
-
-| Requirement | Source evidence | Allowed integration path |
-|---|---|---|
-| Dynamic plugin object | [kagent runner adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/runner/adapter.go#L74-L95) | Generic proxy through the existing plugin surface |
-| Provider-final catalog | [kagent Bedrock adapter](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/bedrock.go#L730-L808) | Gate in kagent-owned adapters, with opaque providers unavailable |
-| Pre-plugin dispatch | Existing public tool callbacks | Sole content-bearing proxy in protected workloads |
-| Event persistence | Public session service and Runner output | Kagent-owned wrappers, with direct paths unavailable |
-| User input gate | Existing public `OnUserMessageCallback` | Dynamic proxy and session wrapper |
-| Child terminal gate | Public Agent, Runner, and session interfaces | Child-scope correlation, with unobservable paths unavailable |
-| Automatic memory | Public memory and tool interfaces | Stock preload disabled, kagent-owned gate enabled |
-| MCP transport | Public tool interface | Kagent-owned no-retry transport |
-| Remote A2A | [kagent tool](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/tools/remote_a2a_tool.go#L25-L145) | Kagent-owned request and result wrappers |
-| Content telemetry | [kagent attributes](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/telemetry/attributes.go#L37-L47) | Public controls and content-free kagent wiring |
-| Readiness | [kagent A2A server](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/a2a/server/server.go#L127-L144) | Gate kagent readiness on generic extension recovery |
-| Snapshot lifecycle | [kagent ActorTemplate](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L65-L88) | Add generic lifecycle handling outside ADK |
-
-Source links into Google ADK explain observed behavior only. They are not implementation targets.
-
-Substrate can run [up to ten peer containers](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L305).
-
-It gates Actor readiness on configured probes. Pinned kagent currently emits one workload container.
-
-The baseline Container API lacks several required primitives.
-
-These include shared memory, projected configuration, per-container identity, filesystem controls, seccomp, and enforced egress.
-
-Generic Substrate primitives supply these features. The compiler and Actor activation reject an extension when a required primitive is unavailable.
+Google ADK Go remains an unmodified upstream dependency. The implementation has no fork, vendored or copied source, patch, module replacement, or `internal` import.
 
 ## Ownership and forbidden dependencies
 
-### kagent fork owns
+| Owner | Responsibilities |
+|---|---|
+| kagent fork | Neutral extension API, manifest and Revision validation, sidecar rendering, public-ADK wrappers, payload snapshots, generic decisions, host sink barriers, and host-native session and A2A state |
+| `appa-adapter-kagent` | Generic protocol negotiation, mTLS and HMAC channel state, event replay and delivery ledger, lifecycle relay, and kagent wire to `/hook` codec |
+| `appa-runtime` | Runtime API, policy, Engine, consults, remedies, trajectory state, recovery, audit, policy configuration, and `appa.db` |
 
-- Generic extension API types and generated gRPC client.
-- Generic manifest validation and immutable Revision compilation.
-- Generic sidecar container, volume, socket, secret, egress, readiness, and snapshot rendering.
-- Dynamic proxies for existing public ADK callbacks.
-- Wrappers for public ADK model, tool, session, memory, Agent, and Runner interfaces.
-- Immutable descriptor and payload snapshots in kagent-owned adapters.
-- Generic execution proxy and sink barriers.
-- Generic interaction and remote metadata relay.
-- Host-native ADK session and A2A task state.
+`appa-adapter-kagent` has no OpenAPPA policy parser, `[deployment]` validation, Engine dependency, Engine call, consult backend, remedy planner, trajectory store, recovery classifier, dynamic policy tool, policy schema migration, or `appa.db` path.
 
-### OpenAPPA plugin owns
+The adapter ledger contains only generic protocol values: event ID and digest, actor and extension IDs, adapter artifact digest, runtime identity, policy revision, boot epoch, channel digest, sequence, expiry, delivery status, and response digest. It contains no Label, Value, fact, offer, continuation, dispatch identifier, policy decision, consult evidence, or runtime database record.
 
-- OpenAPPA policy parsing and `[deployment]` validation.
-- Engine and runtime adapter behavior.
-- OpenAPPA facts, call state, consult evidence, offers, and remedies.
-- OpenAPPA-specific readiness and host-inventory validation.
-- OpenAPPA-specific dynamic tools.
-- Annotator, Membership Resolver, Authority, and Sanitizer calls.
-- OpenAPPA interaction, delegation, recovery, and snapshot state.
-- Plugin-side durable database and migrations.
+The kagent fork has no OpenAPPA named package, field, enum, callback, table, error code, tool route, policy type, or database migration. CI scans the generic-host packages for the maintained forbidden set.
 
-### kagent fork MUST NOT contain
+## Deployment profiles
 
-- A package, module, field, enum, callback, table, or error code named for OpenAPPA.
-- OpenAPPA policy, Label, trajectory, ReaderId, Authority, Annotator, Sanitizer, Membership, remedy, effect, attention, or fact types.
-- OpenAPPA tool names or special-case routing.
-- OpenAPPA database paths or schema migrations.
-- OpenAPPA readiness, coverage, consult, or audit logic.
-- A Google ADK fork, vendored or copied ADK source, replacement module, source patch, or import from an ADK `internal` package.
+### Quickstart profile
 
-CI rules reject imports and identifiers from a maintained forbidden list in the kagent generic-host packages.
+Quickstart has one digest-pinned OpenAPPA companion container and two processes:
+
+```text
++---------------------------- OpenAPPA companion container ----------------------------+
+| appa-adapter-kagent                                                          :8082   |
+| private kagent UDS gRPC -> neutral event -> /hook request                            |
+|                                      | APPA_RUNTIME_URL=http://127.0.0.1:8787         |
+| appa runtime --adapter kagent        | policy, Engine, consults, remedies, appa.db   |
+| HTTP listener: 127.0.0.1:8787 only   |                                                |
++---------------------------------------------------------------------------------------+
+```
+
+The runtime port has loopback binding only. The container has no service, ingress, or network-policy exception for this port. Only `appa-runtime` mounts the policy, credentials, and `appa.db` volume. The adapter mounts only its generic delivery ledger and connection material.
+
+### Remote configuration profile
+
+Remote configuration uses the same adapter artifact. `APPA_RUNTIME_URL` identifies an authenticated HTTPS gateway or runtime instance.
+
+```text
+kagent host -> private UDS -> appa-adapter-kagent -> mTLS HTTPS -> bound runtime gateway -> appa-runtime
+```
+
+The adapter trusts a configured CA and remote workload identity. The remote gateway authenticates the adapter workload identity. It forwards only to the runtime identity bound by the immutable Revision. The runtime verifies Actor UID, extension ID, adapter artifact digest, runtime identity, policy revision, boot epoch, sequence, event digest, and request channel digest.
+
+The runtime response binds the same values and its accepted policy revision. Redirects, certificate mismatch, identity mismatch, endpoint mismatch, policy revision mismatch, unknown runtime identity, and expired bindings fail closed. Remote configuration gives the adapter no runtime policy mount or `appa.db` volume.
 
 ## Repository deliverables
 
-### kagent private fork
-
-| Owner | Generic change |
+| Owner | Component |
 |---|---|
-| `go/api/v1alpha3` | Add ordered dynamic extension declarations to Harness |
-| `go/core/v2/translator` | Validate generic manifests, references, capabilities, and immutable Revision data |
-| `go/core/v2/substrate` | Render multiple extension containers, private sockets, projected config and secrets, state volumes, egress, and probes |
-| `go/adk/pkg/extensions/protocol` | Generated neutral protobuf messages and client |
-| `go/adk/pkg/extensions/host` | Negotiation, ordering, health, deadlines, retries, and generic decisions |
-| `go/adk/pkg/runner` | Construct the dynamic proxy as the only content-bearing public ADK callback path |
-| `go/adk/pkg/tools` | Generic immutable execution proxy and remote request wrappers |
-| `go/adk/pkg/a2a` | Generic interaction relay and pre-publication gate |
-| `go/adk/pkg/session` | Generic pre-append gate and delivery deduplication |
-| telemetry | Enforce immutable content-free protected workload settings before provider construction |
+| OpenAPPA repository | `appa-adapter-kagent` crate and binary |
+| OpenAPPA repository | `appa-adapter-kagent-protocol` crate for neutral kagent wire bindings |
+| OpenAPPA repository | `appa-runtime-api` hook types and codecs shared by the runtime and adapters |
+| OpenAPPA repository | `appa-runtime` `/hook` binding validation, runtime mapping, policy, Engine, and `appa.db` ownership |
+| OCI packaging | `appa-adapter-kagent` image, quickstart companion image, manifests, SBOM, and provenance |
+| kagent private fork | Generic host and public-ADK integration changes |
 
-### OpenAPPA repository
-
-| Owner | OpenAPPA component |
-|---|---|
-| `appa-kagent-plugin-protocol` | OpenAPPA-side generated client/server binding to the neutral protocol |
-| `appa-kagent-plugin` | gRPC sidecar, generic host-phase mapping, readiness, dynamic tools, interactions, and recovery |
-| `appa-runtime-api` | Missing response emission, structured remedy, MRTR, and exact dispatch APIs required by the plugin |
-| `appa-runtime` | Engine session ownership, consults, durable plugin state, and protocol mapping |
-| OCI packaging | Signed sidecar image, manifest, SBOM, provenance, and migrations |
-| Integration tests | Fake generic host plus full kagent/sidecar end-to-end suite |
+The adapter binary is `appa-adapter-kagent`. The quickstart runtime process is `appa runtime --adapter kagent`. The adapter image is `ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>`. The quickstart companion image contains this adapter and the runtime binary.
 
 ## Generic Harness API
 
-The Harness workload declaration contains an ordered extension list:
+The generic Harness declaration contains an ordered adapter list:
 
 ```yaml
 workload:
   image: ghcr.io/private-kagent/kagent-go-adk@sha256:<digest>
   extensions:
     - name: policy-gate
-      image: ghcr.io/archestra-ai/openappa-kagent-plugin@sha256:<digest>
+      image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
       manifestDigest: sha256:<digest>
       signaturePolicyRef: required-extension-signers-v1
       required: true
@@ -183,949 +98,194 @@ workload:
         maxMajor: 1
       socket:
         path: /run/kagent/extensions/policy-gate.sock
-      config:
-        configMapRef:
-          name: customer-support-policy-v1
-      secrets:
-        - secretRef:
-            name: policy-gate-secrets-v1
-      state:
-        volumeName: policy-gate-state
-        mountPath: /var/lib/kagent-extension
+      adapter:
+        runtimeUrlEnv: APPA_RUNTIME_URL
+        runtimeBinding:
+          runtimeId: customer-support-runtime-a
+          policyRevision: customer-support-policy-v1
+          remoteIdentity: spiffe://policy.example/runtime/customer-support-runtime-a
+          caConfigMapRef: runtime-gateway-ca-v1
+      ledger:
+        volumeName: policy-gate-delivery-ledger
+        mountPath: /var/lib/appa-adapter-kagent
       egress:
-        - host: api.policy-provider.example
+        - host: runtime-gateway.policy.example
           port: 443
       readiness:
         path: /readyz
         port: 8082
-      resources:
-        cpu: "2"
-        memory: 2Gi
 ```
 
-The kagent compiler treats `config` and secret content as opaque.
+The generic compiler validates image and manifest digests, signatures, references, protocol ranges, socket uniqueness, ledger ownership, resource limits, egress shape, and ordering. It treats adapter and runtime configuration as opaque. The immutable Revision stores only their digests and generated references.
 
-It validates reference scope, signatures, digests, volume ownership, egress shape, protocol ranges, resource limits, socket uniqueness, and ordering.
+The quickstart manifest adds a runtime process and mounts to the companion container. Its runtime listener remains `127.0.0.1`. The remote manifest adds no runtime volume.
 
-For every ConfigMap and Secret reference, the generic controller reads bytes only to hash and copy them. It never parses their plugin meaning.
-
-The controller creates immutable Revision-owned ConfigMap and Secret copies. Generated names bind the digest, source UID, and source resource version.
-
-The Revision stores only digests and generated object references. The Revision and ActorTemplate contain no secret bytes.
-
-The extension container mounts only the immutable generated copies.
-
-Admission prevents update or deletion while a live Revision references the copy.
-
-Policy, provider credential, CA, or plugin secret rotation always creates a new Revision and follows pin-and-drain.
-
-Per-activation mTLS and message-authentication credentials are separate ephemeral boot credentials. They cannot replace immutable plugin configuration.
-
-The immutable Revision stores canonical generic extension declarations and provenance.
-
-## Generic extension manifest
-
-Each image contains a signed manifest:
-
-```json
-{
-  "schema_version": 1,
-  "plugin_id": "org.example.policy-gate",
-  "artifact_version": "0.1.0",
-  "artifact_digest": "sha256:...",
-  "protocol": { "min_major": 1, "max_major": 1 },
-  "state_schema_version": 1,
-  "capabilities": {
-    "required": [
-      "catalog.logical.v1",
-      "catalog.provider_final.v1",
-      "model.propose.v1",
-      "tool.propose.v1",
-      "execution.begin.v1",
-      "tool.complete.v1",
-      "event.gate.v1",
-      "session.persist.v1",
-      "a2a.publish.v1",
-      "remote.request.v1",
-      "child.lifecycle.v1",
-      "memory.lifecycle.v1",
-      "mcp.transport.v1",
-      "interaction.relay.v1",
-      "snapshot.lifecycle.v1"
-    ]
-  },
-  "phase_claims": {
-    "tool.propose": "exclusive",
-    "tool.complete": "exclusive",
-    "model.propose": "exclusive",
-    "model.event": "exclusive",
-    "session.persist": "exclusive",
-    "a2a.publish": "exclusive",
-    "remote.request": "exclusive"
-  },
-  "limits": {
-    "max_inline_bytes": 1048576,
-    "max_callback_ms": 5000,
-    "max_interaction_ms": 86400000
-  },
-  "failure_mode": "closed"
-}
-```
-
-Manifest capabilities describe host mechanics only.
-
-The compiler rejects duplicate plugin IDs, phase conflicts, unsupported required capabilities, invalid failure modes, excessive limits, or signature mismatch.
-
-## Protocol services
+## Neutral protocol
 
 The `kagent.extension.v1` protocol defines these generic RPCs:
 
 | RPC | Purpose |
 |---|---|
-| `GetExtensionInfo` | Return artifact, protocol, manifest, and state schema identity |
+| `GetExtensionInfo` | Return adapter artifact, protocol, manifest, and ledger schema identity |
 | `Negotiate` | Select protocol and capabilities for one host inventory |
 | `Activate` | Accept the immutable Revision and host inventory digest |
-| `InvokePhase` | Process one immutable generic host or lifecycle event |
-| `Quiesce` | Stop new plugin work and commit one state generation |
-| `ValidateRestore` | Accept or reject a restored host and plugin inventory |
+| `InvokePhase` | Relay one immutable generic host or lifecycle event |
+| `Quiesce` | Seal adapter delivery state and relay lifecycle quiescence |
+| `ValidateRestore` | Validate restored host, adapter, and runtime bindings |
 | `Shutdown` | Drain and terminate cleanly |
 
-The sidecar supplies the standard gRPC health service on the same Unix socket.
+The protocol contains neutral types only. It contains no Google ADK Go types, OpenAPPA policy types, or runtime types.
 
-The protocol package MUST contain neutral types only.
+The launcher creates one ephemeral Actor CA, host certificate, adapter certificate, boot epoch, and message-authentication key per activation. The Unix socket uses mTLS. Certificate SANs bind Actor UID, Revision, container identity, extension ID, and boot epoch.
 
-It MUST NOT carry Google ADK Go types, ADK-private representations, or copied ADK source.
+Every event and decision carries protocol major, actor, extension, boot epoch, channel binding digest, event ID, event digest, Revision, scope, sequence, deadline, and HMAC-SHA256 over deterministic protobuf bytes. The adapter verifies peer identity, HMAC, deadline, sequence, and binding before it sends `/hook`.
 
-### Transport authentication
+## Hook relay and revision binding
 
-The generic launcher mints one ephemeral Actor CA, host certificate, extension certificate, boot epoch, and message-authentication key for each activation.
+The adapter converts a neutral phase event to the existing hook request codec. It adds a transport binding outside the policy payload:
 
-The Unix socket uses mTLS. Certificate SANs bind Actor UID, Revision, container identity, extension ID, and boot epoch.
-
-Read-only per-container projected secrets supply certificates and the message key. The ActorTemplate environment contains neither value.
-
-Every protobuf message carries protocol, extension, Actor, boot epoch, sequence, and channel digest.
-
-It also carries key ID, algorithm, and HMAC-SHA256 over deterministic protobuf encoding.
-
-The receiver verifies mTLS peer identity, channel binding, HMAC, sequence, deadline, event digest, and boot epoch before processing.
-
-The plugin store persists event IDs and terminal decisions for replay-safe duplicate handling.
-
-A duplicate event returns the exact original terminal decision.
-
-The receiver rejects an old boot epoch outside `recovery.reconcile` for a recorded event ID.
-
-## Negotiation and readiness
-
-Startup order:
-
-1. Substrate starts the kagent and extension containers.
-2. The sidecar creates its `0700` socket directory, verifies config, opens state, and serves gRPC.
-3. kagent verifies peer identity and the per-launch socket secret.
-4. kagent calls `GetExtensionInfo` and checks the manifest against the Revision.
-5. kagent sends its generic host inventory to `Negotiate`.
-6. The extension selects one protocol major and enabled capability set.
-7. kagent calls `Activate` with the immutable Revision and inventory digest.
-8. The extension returns accepted or rejected with a stable generic reason code.
-9. `/readyz` becomes true only after every required extension and host-native recovery check succeeds.
-
-The host inventory includes every executable path and content sink. It MUST include provider, ADK, kagent, and Substrate versions.
-
-The OpenAPPA plugin decides whether the generic inventory covers its policy. Kagent does not interpret that decision.
-
-## Multiple extension ordering
-
-The Revision establishes a total order by `order`, then immutable extension ID.
-
-Phase ownership modes:
-
-| Mode | Behavior |
-|---|---|
-| `exclusive` | One extension owns uncommitted content and final decision for that phase |
-| `transform` | Extension receives only content committed by all earlier exclusive owners |
-| `observe_committed` | Extension receives metadata or committed content and cannot modify it |
-
-Only one extension can own an exclusive phase.
-
-The host rejects a phase conflict before Actor readiness.
-
-Final ordering validation fixes the runtime plugin, configured callback, and A2A executor lists.
-
-The host keeps one durable generic sequencer per scope.
-
-It assigns the next sequence before callback fan-out and permits one active exclusive phase in that scope.
-
-The first release refuses multiple same-scope function calls in one model response.
-
-Parallel work requires an explicit `child.propose` transition and a new child scope before execution.
-
-Same-scope callback reentry fails immediately. It never waits on its own sequencer lease.
-
-## Event envelope
-
-Every event is immutable:
-
-```protobuf
-message ExtensionEvent {
-  uint32 protocol_major = 1;
-  string extension_id = 2;
-  string actor_uid = 3;
-  string boot_epoch = 4;
-  bytes channel_binding_digest = 5;
-  string event_id = 6;
-  bytes event_digest = 7;
-  string instance_id = 8;
-  string revision_id = 9;
-  string scope_id = 10;
-  optional string parent_scope_id = 11;
-  optional string operation_id = 12;
-  optional string descriptor_id = 13;
-  uint64 sequence = 14;
-  string phase = 15;
-  google.protobuf.Timestamp deadline = 16;
-  Payload payload = 17;
-  repeated HostAttestation host_attestations = 18;
-  MessageAuthentication authentication = 19;
-}
-
-message Payload {
-  string codec = 1;
-  bytes inline_bytes = 2;
-  optional BlobReference blob = 3;
-  bytes digest = 4;
-}
-
-message HostAttestation {
-  AttestationKind kind = 1;
-  string issuer = 2;
-  bytes credential = 3;
-  bytes binding_digest = 4;
-  google.protobuf.Timestamp expires_at = 5;
-}
-
-enum AttestationKind {
-  ATTESTATION_KIND_UNSPECIFIED = 0;
-  AUTHENTICATED_PRINCIPAL = 1;
-  WORKLOAD_IDENTITY = 2;
-  REQUEST_BINDING = 3;
-}
-
-message MessageAuthentication {
-  string key_id = 1;
-  string algorithm = 2;
-  bytes mac = 3;
+```json
+{
+  "runtime_id": "customer-support-runtime-a",
+  "policy_revision": "customer-support-policy-v1",
+  "actor_uid": "actor-opaque-id",
+  "extension_id": "policy-gate",
+  "adapter_artifact_digest": "sha256:...",
+  "kagent_revision": "revision-opaque-id",
+  "boot_epoch": "epoch-opaque-id",
+  "sequence": 42,
+  "event_id": "event-opaque-id",
+  "event_digest": "sha256:...",
+  "channel_binding_digest": "sha256:...",
+  "deadline": "2026-09-01T00:00:00Z"
 }
 ```
 
-The host generates IDs and sequence numbers. They carry no plugin semantics.
+The runtime authenticates and validates this binding before it admits the hook event. Its response contains the same binding, the accepted runtime identity, the accepted policy revision, response digest, and terminal hook decision.
 
-Large payloads use one sealed temporary blob on a shared memory-backed volume.
+The adapter maps only a fully matched runtime response to `permit`, `suppress`, `hold`, `interaction`, `commit`, `event`, or `fail`. It does not derive a fallback decision. An unavailable runtime produces the generic content-free failure or scope freeze required by the phase.
 
-Only the host and selected extension can read it.
+The adapter ledger returns the original response only for an identical event digest and complete binding. Runtime recovery remains authoritative for any unresolved or semantically indeterminate event.
 
-The host deletes the blob after terminal decision or deadline.
+## kagent integration points
 
-## Generic decisions
+The kagent fork uses public Google ADK interfaces and kagent-owned code only:
 
-```protobuf
-message ExtensionDecision {
-  uint32 protocol_major = 1;
-  string extension_id = 2;
-  string actor_uid = 3;
-  string boot_epoch = 4;
-  bytes channel_binding_digest = 5;
-  string event_id = 6;
-  bytes event_digest = 7;
-  string extension_revision = 8;
-  uint64 sequence = 9;
-  google.protobuf.Timestamp expires_at = 10;
-  MessageAuthentication authentication = 11;
-  oneof decision {
-    Permit permit = 20;
-    Suppress suppress = 21;
-    Hold hold = 22;
-    Commit commit = 23;
-    EventDecision event = 24;
-    Fail fail = 25;
-    Interaction interaction = 26;
-  }
-}
-```
-
-Decision semantics:
-
-| Decision | Generic host action |
+| Boundary | Generic integration |
 |---|---|
-| `permit` | Execute the bound original or replacement payload once |
-| `suppress` | Do not execute or publish |
-| `hold` | Pause one generic scope without user interaction |
-| `interaction` | Publish a neutral versioned interaction request and await `interaction.response` |
-| `commit` | Deliver original, replacement, or no result bytes |
-| `event` | Drop, replace, or emit one event |
-| `fail` | Emit a host-defined content-free failure |
+| Public callbacks | One content-bearing out-of-process proxy |
+| Provider-final catalog and request | Kagent-owned adapter before telemetry and network transmission |
+| Tool call | Immutable raw argument snapshot, execution wrapper, and terminal result relay |
+| Model response and event | Gate before dispatch, persistence, yield, or publication |
+| Session and A2A | Exact-byte pre-append and pre-publication barriers |
+| Child, memory, MCP, remote A2A | Public-interface wrappers and generic lifecycle phases |
+| Snapshot, readiness, egress, drain | Generic kagent and Substrate lifecycle interface |
 
-Every decision binds the producing extension, source event, payload digest, expiry, and permitted next phase.
+An unavailable required boundary rejects activation. Protected workloads disable opaque provider paths, direct content callbacks, automatic memory preload, unbounded tool catalogs, unverified MCP transport, content-bearing telemetry, unpinned remote A2A paths, and streaming before the publication gate.
 
-The host rejects mismatched, expired, duplicated, reordered, or unknown decisions.
+The generic host executes only a matching immutable `permit` payload. Raw output reaches no protected sink before a matching `commit`. Generic extension ordering and phase ownership remain immutable for one Revision.
 
-## Public ADK and kagent integration points
+## Runtime mapping
 
-Google ADK Go remains the upstream `v2.2.0` module. Do not use a `replace` directive, vendored or copied source, patches, or `internal` imports.
+`appa-runtime` receives the adapter's `/hook` event. It validates the bound runtime identity and policy revision. It maps the event to runtime admission and owns all OpenAPPA behavior:
 
-Each integration below must use a public ADK interface or code owned by the kagent fork.
+- Policy parsing and `[deployment]` validation.
+- Engine decisions, Value and Label handling, and trajectory state.
+- Annotator, Membership Resolver, Authority, and Sanitizer consults.
+- Canonical call and result correlation, remedy plans, and interactions.
+- Child, remote delegation, assistant response, audit, and recovery behavior.
+- `appa.db`, policy migrations, and runtime state generations.
 
-For a protected workload, an unavailable required boundary rejects `Activate` and keeps the Actor unready.
+The adapter has no policy-specific dynamic tool. A runtime remedy or interaction remains runtime state until its bound hook result crosses the adapter. The host receives only a neutral interaction or terminal decision.
 
-### Current callback proxy
+## State, recovery, and snapshots
 
-The host wraps current public `plugin.Plugin` callbacks with one generic out-of-process proxy:
-
-- `BeforeRunCallback`
-- `AfterRunCallback`
-- `OnUserMessageCallback`
-- `BeforeAgentCallback`
-- `AfterAgentCallback`
-- `BeforeModelCallback`
-- `AfterModelCallback`
-- `OnModelErrorCallback`
-- `BeforeToolCallback`
-- `AfterToolCallback`
-- `OnToolErrorCallback`
-- `OnEventCallback`
-
-The Runner installs this proxy as its only content-bearing callback path.
-
-Protected workloads disable any later callback that can observe or change uncommitted content before the proxy decision.
-
-Required phases use public-interface wrappers and kagent-owned barriers below. They do not add callbacks to Google ADK.
-
-### Provider-final catalog
-
-Each kagent-owned provider adapter contains a generic gate after final name and schema conversion.
-
-The gate runs before request transmission.
-
-It returns the exact provider-visible catalog and reversible logical-name map.
-
-The kagent-owned decoder also returns the provider tool-call ID, mapped logical name, and original JSON argument token bytes.
-
-The host strictly parses and canonicalizes those bytes. It refuses an adapter that exposes only a decoded `map[string]any` or `float64` number path.
-
-Pinned OpenAI code currently decodes arguments through `json.Unmarshal` into a map: [source](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/adk/pkg/models/openai_responses.go#L258-L271).
-
-The adapter rejects provider-name collisions before it sends the request.
-
-Only a kagent-owned provider adapter, or a public wrapper proven to expose the final outgoing request, qualifies. All other providers are unavailable.
-
-### Tool proposal
-
-kagent constructs the Runner so the generic proxy is the only content-bearing public ADK callback path.
-
-The host correlates that callback with raw bytes from the kagent-owned provider adapter.
-
-The host then creates an immutable RFC 8785 snapshot and descriptor digest.
-
-If kagent cannot exclude competing callbacks, the callback capability is unavailable.
-
-The host refuses a tool call when the provider path did not expose raw arguments before ADK decoded them.
-
-### Model request gate
-
-Place an exclusive `model.propose` gate in each kagent-owned provider adapter after request conversion and before telemetry or network transmission.
-
-A public model wrapper qualifies only when it exposes that same final outgoing request.
-
-For live and realtime sends, wrap the public ADK live-session send interface in kagent-owned code and gate before delegating.
-
-It receives the exact canonical provider request, endpoint, model, tool catalog, history, instructions, memory, admitted tool results, and retry identity.
-
-Only a matching permit can send the request to the provider.
-
-The manifest declares separate capabilities for standard, live, realtime, history, and embedding requests.
-
-The host refuses each path that cannot expose its final request through an approved adapter or wrapper.
-
-Provider retry uses the same event ID and exact request digest. A changed request requires a new phase event.
-
-### Model response gate
-
-The standard response gate uses the public `AfterModelCallback`.
-
-For kagent-owned live and streaming adapters, gate the complete response before kagent dispatches calls or publishes content.
-
-It can replace the complete model response or suppress all contained calls.
-
-The host refuses a live or streaming path that bypasses these surfaces.
-
-### Event gate
-
-Kagent wrappers implement `Drop`, `Replace`, and `Emit` around the public session service and Runner output.
-
-A protected workload contains no other content-bearing `OnEventCallback` implementation.
-
-The first release sends every partial assistant event to the exclusive gate and drops it before persistence or yield.
-
-The host emits only one terminal text response.
-
-The host refuses other content forms until their codecs exist.
-
-The terminal event includes a closed authenticated-principal attestation. The host does not interpret the recipient policy from the plugin.
-
-### Session persistence gate
-
-A kagent-owned session implementation stores user, function-response, model, task, child, and resumed interaction events.
-
-The wrapper receives exact event bytes and stable session lineage.
-
-If the backing store cannot share one transaction with the host outbox, session persistence is unavailable.
-
-### A2A publication gate
-
-A kagent-owned barrier runs before ADK-to-A2A conversion and before stream or task publication.
-
-It receives authenticated caller attestation as generic transport metadata.
-
-### Child lifecycle
-
-Kagent-owned wrappers use public Agent, Runner, and session interfaces for the child lifecycle.
-
-The host preallocates stable child and parent scope IDs.
-
-### Memory lifecycle
-
-Protected workloads disable stock automatic preload. A kagent-owned implementation uses public memory and tool interfaces.
-
-The kagent-owned implementation wraps `SearchMemory` with `memory.propose` and `memory.complete` phases.
-
-No memory content enters model instructions before commit.
-
-Separate phases expose the embedding request, retrieved content, memory tools, preload, and persistent memory write.
-
-The immutable host sink inventory includes embedding endpoints and memory stores.
-
-### MCP transport
-
-Protected workloads exclude the upstream opaque MCP client.
-
-A kagent-owned tool supplies raw JSON-RPC argument injection and terminal response capture.
-
-The kagent-owned transport disables automatic retry after request bytes can reach the MCP server.
-
-Revision preparation runs MCP discovery.
-
-The Revision pins the server, transport, tool descriptors, schemas, raw metadata, and discovery generation.
-
-Discovery failure rejects Revision preparation. The host does not skip the failure.
-
-Controller-originated MCP App tool and resource calls enter through a generic `external.operation` phase before any network request.
-
-The host mints a one-use generic request capability bound to instance, caller, server, scope, operation, expiry, and request ID.
-
-### Remote A2A lifecycle
-
-Generic phases carry the prepared Agent Card, request metadata, task states, and terminal result.
-
-The kagent remote tool strips caller credentials and reserved lineage before the phase call.
-
-Snapshot the exact endpoint, Agent Card digest, headers, task and context IDs, body, retry identity, and transport settings.
-
-The kagent remote tool sends the normalized outbound request through exclusive `remote.request`.
-
-Network transmission requires a matching `permit` bound to the exact request digest.
-
-The host accepts header or body changes only as a replacement payload in the generic decision envelope.
-
-Revision preparation pins the Agent Card and endpoint. The host refuses runtime Card refresh.
-
-The host preserves raw `submitted`, `working`, `input_required`, `auth_required`, `completed`, `failed`, `canceled`, `rejected`, and unknown states.
-
-The host extracts no content before the exclusive extension commits the terminal state and payload.
-
-## Mechanical execution protocol
-
-The kagent-owned tool wrapper invokes each ADK tool through the public tool interface.
-
-For each tool call:
-
-1. The host captures the provider mapping, dispatch descriptor, and immutable argument bytes.
-2. The host invokes `tool.propose` on the exclusive extension.
-3. The host accepts only a matching unexpired `permit`.
-4. The host persists the generic event and decision IDs when needed.
-5. The host invokes `execution.begin` and requires plugin acknowledgement.
-6. The tool wrapper executes the permitted private payload exactly once.
-7. The host invokes `tool.complete` with raw output or terminal status.
-8. The host accepts only a matching `commit`.
-9. The host constructs the `FunctionResponse` from committed bytes only.
-
-The execution proxy MUST ignore the original mutable ADK map after snapshot creation.
-
-The proxy MUST NOT understand why the extension permitted, replaced, withheld, or failed the operation.
-
-## Result and sink ordering
-
-Raw output cannot reach:
-
-- Later callbacks.
-- ADK session persistence.
-- Parent or child delivery.
-- Model context.
-- A2A task or stream publication.
-- Memory or UI publication.
-- Content logs, traces, metrics, or snapshots.
-
-The exclusive extension receives raw output first.
-
-The host constructs downstream content only from the terminal generic commit.
-
-Before sink publication, the host writes one durable outbox record for the event ID and committed payload digest.
-
-The sink publishes with that stable idempotency key. The host then marks the outbox row delivered.
-
-Recovery retries only the same outbox event and payload digest.
-
-The kagent-owned session store and its outbox row MUST share one transaction.
-
-A2A, memory, UI, and other external sinks MUST accept the host event ID as an idempotency key.
-
-The host refuses a protected sink that lacks idempotent publication.
-
-The proposal does not claim exactly-once delivery without sink support.
-
-Protected host construction disables content telemetry before providers, Runner, tools, and log callbacks initialize.
-
-This is an immutable workload property. Extension manifests cannot enable or disable host telemetry.
-
-Supported public options configure upstream ADK telemetry without content.
-
-Kagent-owned model, tool, Runner, A2A, and MCP instrumentation uses content-free constructors.
-
-The host refuses a component when public options cannot disable its content telemetry.
-
-Protected workloads exclude the standard serialized tool-argument callback from kagent.
-
-The host inventory lists every telemetry constructor and exporter with its content-free implementation digest.
-
-The readiness test sends a synthetic canary through model, tool, session, A2A, memory, and MCP instrumentation.
-
-The readiness test searches captured records for the canary digest and bytes.
-
-Any content-bearing record keeps the Actor unready.
-
-## Dynamic tools and interactions
-
-An extension can contribute a generic tool descriptor through its signed manifest.
-
-kagent does not special-case contributed tool names.
-
-Sidecar-contributed tools execute only through `extension_tool.propose`, `extension_tool.execute`, and `extension_tool.complete` phase envelopes.
-
-No manifest can declare a bespoke executor endpoint.
-
-The OpenAPPA plugin can contribute its control tool and map those generic phases internally to remedies.
-
-For interaction:
-
-1. The plugin returns `interaction` with a versioned neutral presentation document.
-2. kagent moves the task to `input_required` without creating a model-visible result.
-3. The gateway authenticates the responder and relays opaque response bytes.
-4. kagent sends `interaction.response` through `InvokePhase` with the host interaction ID and closed host attestation.
-5. The plugin finds private continuation state by host event ID and validates meaning, replay, expiry, and remote-hop state.
-6. The host resumes only after a terminal generic decision.
-
-The host does not define approve, decline, cancel, Authority, remedy, or offer fields.
-
-The neutral presentation schema supports title, message, bounded text input, boolean input, and single- or multi-select fields.
-
-The host assigns the interaction ID and binds it to source event, scope, and extension revision.
-
-It also binds caller attestation, schema digest, and expiry.
-
-The host persists only that generic interaction record and submitted field values.
-
-The plugin stores all continuation meaning in its private state keyed by the source event ID.
-
-## OpenAPPA plugin mapping
-
-The OpenAPPA companion translates generic phases into private OpenAPPA runtime events.
-
-| Generic phase | OpenAPPA-side responsibility |
+| Store | State |
 |---|---|
-| host inventory activation | Compile `[deployment]`, check path and sink coverage, and attest readiness |
-| catalog phases | Validate descriptor and source identity against policy coverage |
-| `model.propose` | Check model-provider flow against the current Label and declared provider surface |
-| `tool.propose` | Resolve canonical call, Annotator, Membership, requirements, offers, and dispatch |
-| `execution.begin` | Persist exact release and execution acknowledgement |
-| `tool.complete` | Admit, replace, withhold, or settle terminal outcome |
-| child phases | Fork, child identity, return policy, return admission, and merge |
-| `remote.request` | Check outbound remote flow and return opaque replacement or permit metadata |
-| model and publication events | `assistant.response` emission and admitted event digest |
-| `interaction` and `interaction.response` | Remedy, Authority, and other interaction semantics |
-| remote phases | Delegation, remote state, conservative contract, and return handling |
-| snapshot lifecycle | Commit and validate OpenAPPA plugin state generation |
+| kagent host | ADK sessions, A2A tasks, generic host event IDs, and host outbox records |
+| `appa-adapter-kagent` | Negotiation, channel HMAC state, event digest, replay status, delivery status, lifecycle relay status, and expiry |
+| `appa-runtime` | Policy identity, `appa.db`, Engine facts, trajectory state, consult evidence, remedies, interactions, delegation, audit, and recovery |
 
-All OpenAPPA consult kinds, backends, Labels, Values, facts, remedies, effects, and audit records remain inside this component.
+The adapter ledger cannot become a policy cache. It never persists a semantic decision or continuation.
 
-### Activation and deployment profile
+During recovery, kagent reconstructs host-native work and sends unresolved generic events to the adapter. The adapter re-establishes the pinned runtime binding and relays each event to `/hook`. `appa-runtime` resolves replay and indeterminate outcomes. The adapter maps the bound result back to the generic decision wire.
 
-The plugin compiles one immutable `[deployment]` profile from its private policy configuration.
+During snapshots, the host stops new work and calls `Quiesce`. The adapter seals its generic ledger and relays the lifecycle event. The runtime seals and validates `appa.db` and its trajectory generation. Restore readiness requires matching host, adapter, runtime, and policy-revision bindings. The adapter has no authority to accept an `appa.db` generation.
 
-It requires enforced host execution, harness binding, a concrete starting Label, and explicit confined result points.
+## Security and network boundary
 
-It also requires child controls, confined child returns, and no open provider surface.
+Admission requires signed OCI image and manifest artifacts, an SBOM, and provenance. The generic trust policy pins the allowed registry, signer identity, and minimum provenance level. Tag-only images, mismatched referrers, unsigned manifests, and Revision overrides fail admission.
 
-It verifies the reciprocal host source-to-sink inventory. An empty Engine open-vector set alone is insufficient.
+The adapter uses a dedicated non-root UID, read-only root filesystem, `allowPrivilegeEscalation: false`, no Linux capabilities, and RuntimeDefault seccomp. The adapter ledger uses single-writer fencing. The runtime volume uses separate fencing and belongs only to runtime.
 
-Missing provider, tool, child, memory, MCP, A2A, interaction, telemetry, snapshot, or publication capability rejects `Activate`.
+Default-deny CNI egress permits cluster DNS and the authenticated egress gateway. Remote profile egress permits only the bound HTTPS runtime gateway. The gateway enforces workload identity, destination, TLS identity, redirect, IP-range, and DNS-rebinding policy.
 
-### Exact call and dynamic contract handling
+Quickstart does not use network egress to reach the runtime. Its `APPA_RUNTIME_URL` is loopback only. This profile does not weaken loopback binding.
 
-For `tool.propose`, the plugin receives the logical descriptor, provider-final descriptor, reversible name map, source identity, and raw canonical argument bytes.
+## Revision drain
 
-It resolves the canonical call inside the sidecar.
+Every live scope pins the adapter artifact, adapter manifest, generic protocol, runtime identity, policy revision, and runtime authentication binding. A change creates a new Revision.
 
-The plugin handles contracts, Annotators, mandates, Membership evidence, requirement gaps, effects, and remedy plans.
+New roots use the new binding after its adapter and runtime report ready. Existing scopes remain on the previous binding through terminal state or drain deadline. No between-turn hot swap exists. A rollback is another new-root routing transition. It does not move a live scope or merge runtime state.
 
-Successful Annotator and Membership evidence remains pinned in the plugin store. Input derivation reselects and re-annotates rewritten calls when required.
+## PR sequence
 
-The generic `permit` carries only an opaque lease and execution payload digest.
-
-kagent never sees the OpenAPPA dispatch ID or decision meaning.
-
-### Execution and result admission
-
-On `execution.begin`, the plugin persists the OpenAPPA dispatch occurrence and execution acknowledgement before responding.
-
-On `tool.complete`, it maps success, failure, and unknown outcome into current Engine semantics.
-
-Only success commits effects. Failure clears reservations. Conservative uncertainty remains `Indeterminate` and retains effect reservations.
-
-The terminal generic `commit` contains only the admitted original, replacement, or empty payload.
-
-### Children and native attestation
-
-The plugin maps generic child phases to prepared forks, child identities, return policy, return shape, child result, and parent merge.
-
-It supports native `attest-schema` only when the host inventory proves local isolation, structured output, confined return, and exact fork-bound shape.
-
-Remote child results cannot use local `attest-schema` in the first release.
-
-### Remedies and interactions
-
-The sidecar-contributed control tool is an ordinary generic contributed tool to kagent.
-
-Inside the sidecar, it maps to the current remedy families and runtime outcomes.
-
-The plugin owns exact offer binding, authorized and substituted calls, returned Values, decline, no-answer, redispatch, MRTR state, and Authority evidence.
-
-Generic `interaction` and `interaction.response` phases transport presentation and answers. kagent never receives an offer ID or OpenAPPA continuation.
-
-### Assistant response emission
-
-The plugin receives terminal response bytes and the closed authenticated-principal attestation through `model.event` and `a2a.publish` phases.
-
-It maps the principal to its private reader configuration and checks the reserved `assistant.response` emission against the current trajectory Label.
-
-The plugin returns generic `event` with emit, replacement, or drop. kagent does not know the reader or policy reason.
-
-### Replay
-
-The plugin persists OpenAPPA facts and validates them through the Engine before use.
-
-Replay reuses recorded annotations, membership expansions, Authority evidence, Sanitizer derivations, dispatch occurrences, child facts, and emission decisions without external reconsult.
-
-## Plugin state and host state
-
-The OpenAPPA plugin owns one private durable state volume.
-
-It stores:
-
-- Engine facts and runtime projections.
-- Policy and deployment identity.
-- Call permits, execution acknowledgements, outcomes, and delivery receipts.
-- Annotator and Membership evidence.
-- Remedy, interaction, and remote delegation state.
-- Plugin migrations and snapshot generations.
-
-kagent stores only normal ADK sessions, A2A tasks, and narrow generic delivery records.
-
-Each delivery record contains event ID, event digest, extension revision, phase, host lifecycle state, expiry, and optional delivered-payload digest.
-
-It contains no extension handle, policy decision, continuation, or semantic outcome.
-
-kagent MUST NOT persist opaque plugin handles after their generic delivery lifecycle ends.
-
-## Recovery
-
-At restart:
-
-1. kagent reconstructs host-native session, task, child, and undelivered event inventory.
-2. The sidecar opens and migrates its private store.
-3. kagent negotiates the same pinned extension revision.
-4. kagent sends one `recovery.reconcile` event through `InvokePhase` for each unresolved host event ID.
-5. The plugin returns replayed commit, suppress, hold, or fail through the ordinary decision envelope.
-6. kagent deduplicates delivery by host event ID.
-
-Crash classification:
-
-- Before `execution.begin` acknowledgement: the tool did not start.
-- After acknowledgement and before terminal completion: plugin records `Indeterminate` internally.
-- After a persisted terminal commit: replay the same generic delivery decision.
-
-The first release accepts this conservative uncertainty window. kagent adds no OpenAPPA-aware execution ledger.
-
-## Snapshots
-
-Snapshot lifecycle is generic and outside ADK callback execution. The user explicitly approved this lifecycle infrastructure.
-
-The controller allocates one monotonically increasing Actor generation and fencing epoch.
-
-Every host-native and extension-owned state write MUST carry the current epoch. A stale Actor or restored process cannot write after a newer generation activates.
-
-The generic host persists a snapshot transaction with these states:
-
-`Active -> Quiescing -> ExtensionsSealed -> HostSealed -> ProviderCommitted -> Complete`.
-
-Sequence:
-
-1. The host rejects new roots and tool proposals.
-2. The host drains or cancels active operations.
-3. The host calls `Quiesce` on each required extension in deterministic order.
-4. The host receives signed extension generation metadata and file digests.
-5. The host checkpoints its stores.
-6. Substrate creates one encrypted snapshot generation.
-7. The manifest binds the provider snapshot, key version, files, and completion marker.
-8. The host calls `ValidateRestore` before a restored Actor becomes ready.
-
-Only the OpenAPPA sidecar mounts the OpenAPPA state volume.
-
-Each extension manifest binds generation, fencing epoch, state schema, file digests, WAL state, policy-independent extension revision, and encryption-key version.
-
-The host manifest binds its session and delivery files plus every signed extension manifest.
-
-The host publishes `Complete` after the provider confirms the snapshot identity and all file digests.
-
-Recovery rules:
-
-- Before `ExtensionsSealed`: abort the snapshot and resume the old generation.
-- After `ExtensionsSealed` but before `ProviderCommitted`: keep the Actor quiesced and retry or abort through each extension.
-- After `ProviderCommitted` but before `Complete`: verify provider identity and digests, then finish the same transaction.
-- On any digest, epoch, signature, or state-schema mismatch: reject restore and remain unready.
-
-The design uses `ReadWriteOncePod` with the durable epoch. Volume access mode alone is not a fencing mechanism.
-
-## Readiness and failure behavior
-
-`/readyz` returns success only when:
-
-- Every required sidecar container is healthy.
-- Artifact, manifest, protocol, and workload identities match the Revision.
-- Capability and phase negotiation succeeded.
-- Every exclusive phase has one owner.
-- The extension accepted the full host inventory.
-- Host and plugin recovery completed.
-- Egress, secret, volume, and snapshot attestations passed.
-
-Failure rules:
-
-| Failure point | Host behavior |
-|---|---|
-| Before permit | Suppress execution and return content-free failure |
-| After execution acknowledgement | Withhold result and freeze scope pending recovery |
-| Before event publication | Drop or replace with content-free failure |
-| Required extension unhealthy | Mark Actor unready and reject new work |
-| Protocol or manifest mismatch | Refuse activation |
-| Unknown or expired handle | Refuse the operation |
-
-Required extension calls fail closed. Optional extensions cannot claim exclusive phases.
-
-## Egress and secrets
-
-The generic extension declaration lists destinations and secret references.
-
-The kagent controller validates generic shape and includes hashes in the Revision.
-
-Substrate MUST enforce per-container egress through an authenticated gateway. Current destination metadata alone is insufficient.
-
-The Actor uses default-deny CNI egress. It permits only cluster DNS and authenticated egress gateway addresses.
-
-The network policy blocks direct external TCP, UDP, node, control-plane, and cloud metadata-service routes.
-
-Each container authenticates to the gateway with its workload identity. The gateway selects the allowlist for that exact Actor, Revision, and container.
-
-The gateway resolves external DNS and enforces scheme, host, port, and TLS or SPIFFE identity.
-
-It also enforces IP ranges, redirects, and DNS rebinding rules.
-
-The Actor remains unready if CNI isolation, gateway routing, DNS policy, or workload identity lacks attestation.
-
-Projected Secret and ConfigMap volumes keep secret bytes out of literal ActorTemplate environment values.
-
-The sidecar receives only declared mounts, secrets, and egress.
-
-## Security and trust boundary
-
-Admission requires signed OCI image and manifest artifacts, allowed signer identities, an SBOM, and build provenance.
-
-The registry stores the extension manifest as OCI media type `application/vnd.kagent.extension.manifest.v1+json`.
-
-The registry stores SPDX JSON SBOM and SLSA provenance as referrers to the image digest.
-
-The artifact set includes a Sigstore signature envelope.
-
-It binds image, manifest, SBOM, provenance, signer identity, and Rekor inclusion proof.
-
-The generic trust policy pins allowed registry, issuer, subject identity, and minimum provenance level.
-
-The controller verifies all referrer subject links and signatures before Revision creation. Cluster admission verifies the same Revision attestation before Actor launch.
-
-Admission MUST reject tag-only images, missing or mismatched referrers, unsigned manifests, disallowed registries, unknown signers, and Revision overrides.
-
-RBAC and admission policy restrict Harness, AgentTemplate, AgentInstance, Revision, ActorTemplate, Secret, and direct workload mutation.
-
-The sidecar uses a dedicated non-root UID and a read-only root filesystem.
-
-It also uses `allowPrivilegeEscalation: false`, no Linux capabilities, and RuntimeDefault seccomp.
-
-The private state mount uses single-writer fencing.
-
-Each plugin revision uses `ReadWriteOncePod` or one external transactional writer lease.
-
-The kagent process is part of the trusted computing base. In-process tool code shares that process and can reach the private client socket as the host identity.
-
-The sidecar boundary isolates OpenAPPA memory and state from ordinary accidental faults. It does not sandbox malicious code already executing inside kagent.
-
-The Unix gRPC channel uses one per-launch secret and workload identity.
-
-Every event binds to the boot epoch, instance, Revision, extension, sequence, and digest.
-
-RPC deadlines are mandatory. The host disables hedging.
-
-The host retries an extension RPC only with the same idempotent event ID.
-
-The host never retries a tool transport after request bytes can reach the tool.
-
-The generic scope lock is non-reentrant. A nested operation must create a declared child scope or fail before waiting.
-
-The host bounds callback queues, child concurrency, interaction lifetime, and extension restart backoff.
-
-## Plugin upgrades
-
-Every live scope pins the extension artifact, manifest, protocol, and state schema.
-
-Before first dispatch, the controller persists an immutable scope mapping to the ActorTemplate and extension Revision.
-
-Every resume, remote response, interaction response, capability, and late event routes through that mapping.
-
-Controller lifecycle is `Active -> Draining -> Drained -> Suspended`.
-
-Upgrade sequence:
-
-1. The controller prepares and activates the new sidecar revision.
-2. The controller stops old-root admission and routes new roots atomically.
-3. Existing scopes remain on the old sidecar revision.
-4. The old workload remains ready only for its assigned scopes.
-5. Old scopes drain until terminal state or deadline.
-6. The controller records each forced remainder as uncertain termination.
-7. The controller snapshots and suspends the old instance after reconciliation completes.
-
-Rollback is another atomic new-root routing transition. It never moves a live scope between revisions.
-
-No between-turn or immediate hot swap exists in the first release.
-
-## Generic kagent PR sequence
+### Generic kagent fork
 
 | PR | Change |
 |---|---|
-| 1 | Generic Harness API, manifests, Revision data, and signature policy |
-| 2 | Sidecar containers, projected data, volumes, egress, and readiness |
-| 3 | Neutral protocol, negotiation, health, and generic extension host |
+| 1 | Generic Harness API, adapter manifests, Revision data, and signature policy |
+| 2 | Adapter containers, private sockets, adapter-ledger volumes, egress, and readiness |
+| 3 | Neutral protocol, negotiation, health, HMAC, and generic extension host |
 | 4 | Provider-final request and catalog gates in kagent-owned adapters |
 | 5 | Sole content-bearing callback proxy and kagent-owned tool wrappers |
-| 6 | Model response gates in public callbacks and kagent-owned output wrappers |
-| 7 | Kagent-owned session service and A2A publication barriers |
-| 8 | Agent, Runner, memory, remote, and interaction wrappers |
-| 9 | Kagent-owned raw MCP transport with no-retry semantics |
-| 10 | Content-free telemetry, readiness, snapshots, recovery, and drain lifecycle |
+| 6 | Model response gates, session barriers, A2A publication barriers, and content-free telemetry |
+| 7 | Agent, Runner, memory, remote, MCP, interaction, snapshot, recovery, and drain wrappers |
 
-Each PR is generic. Test fixtures MUST use neutral fake extensions and contain no OpenAPPA import or name in production packages.
+Each generic PR uses neutral fake adapters. Production packages have no OpenAPPA import or name. No PR changes Google ADK source or imports an ADK `internal` package.
 
-No PR changes Google ADK source, copies it, replaces its module, vendors it, or imports one of its `internal` packages.
+### OpenAPPA repository
 
-## OpenAPPA plugin sequence
-
-| PR slice | Change |
+| PR | Change |
 |---|---|
-| 1 | Neutral protocol binding, sidecar handshake, inventory validation, and health |
-| 2 | Tool proposal, permit, execution acknowledgement, completion, commit, and recovery |
-| 3 | Event, session, assistant response, and publication gates |
-| 4 | Child, task, remote, memory, and MCP mappings |
-| 5 | Dynamic remedy tool, interaction relay, and durable continuation |
-| 6 | Plugin state, snapshots, migrations, signed manifest, image, SBOM, and provenance |
+| 1 | `appa-adapter-kagent-protocol`, `appa-adapter-kagent`, UDS handshake, HMAC, and neutral inventory relay |
+| 2 | `/hook` request and response binding, `APPA_RUNTIME_URL`, fail-closed transport, and runtime identity validation |
+| 3 | Generic event relay, replay and delivery ledger, lifecycle relay, and quickstart companion image |
+| 4 | Remote HTTPS gateway authentication, CA pinning, runtime identity, policy-revision binding, manifest, SBOM, and provenance |
+| 5 | Runtime `/hook` mappings for tool, model, event, child, memory, MCP, remote, interaction, recovery, and snapshot phases |
+
+The runtime PRs retain exclusive ownership of policy, Engine, consults, remedies, trajectory state, recovery semantics, and `appa.db`.
 
 ## Verification matrix
 
-### Generic host unit tests
+### Generic host tests
 
-- Manifest signature, digest, protocol range, and capability validation.
-- Deterministic ordering and exclusive-phase conflicts.
-- Socket identity and launch-secret validation.
-- Event canonicalization, digest, deadline, and sequence checks.
-- Permit, commit, event, hold, interaction, and fail decision validation.
-- Unknown, expired, replayed, cross-scope, and reordered handles.
-- Payload inline and sealed-blob limits.
-- Required sidecar health and readiness transitions.
-- Pin-and-drain upgrade routing.
-- Forbidden dependency and identifier checks.
+- Manifest signature, adapter digest, protocol range, capability, and ordering validation.
+- Socket identity, launch-secret, mTLS, HMAC, event digest, deadline, sequence, and channel-binding validation.
+- Immutable payload, permit, commit, event, hold, interaction, and fail decision validation.
+- Required adapter health, activation, pin-and-drain, and incomplete-coverage refusal.
+- No Google ADK fork, vendor tree, source copy, patch, module replacement, or `internal` import.
 
-### Public ADK and kagent integration tests
+### Adapter tests
 
-- CI resolves `google.golang.org/adk/v2` from a clean module cache and asserts the pinned version and checksum.
-- CI rejects `replace` in `go.mod` or `go.work`, a `vendor/` tree, copied ADK source, any ADK source patch, and any ADK `internal` import in production packages.
+- No link dependency from `appa-adapter-kagent` to `appa-runtime` or `appa-engine`.
+- No adapter policy parser, Engine call, policy schema migration, or `appa.db` path.
+- Harness event to `/hook` wire mapping and response-to-neutral-decision mapping.
+- Quickstart loopback URL, loopback-only runtime listener, and unavailable runtime fail-closed behavior.
+- Remote HTTPS CA pinning, workload authentication, runtime identity, Actor, extension, artifact, and policy-revision binding.
+- Rejected redirect, invalid certificate, stale epoch, duplicate event, changed event digest, changed runtime identity, and changed policy revision.
+- Generic ledger replay and delivery behavior without policy or trajectory records.
+- Quiesce, restore, shutdown, and drain lifecycle relay behavior.
 
-- Provider-final catalog and name-collision rejection.
-- Pre-plugin argument ownership and mutation attempts.
-- Ordinary tool allow, replace, suppress, error, panic, and timeout.
-- No duplicate execution after transport uncertainty.
-- Standard and live model response gates.
-- Event drop before plugin observation, session append, and yield.
-- Forged inbound `FunctionResponse` rejection.
-- Local chat, single-turn, task, and terminal child return.
-- Automatic memory before-search and after-result gates.
-- Raw MCP arguments, response, reconnect, and no-retry behavior.
-- Remote immutable Card, credential stripping, task states, and terminal result.
-- A2A publication and authenticated interaction relay.
-- Content telemetry disabled before payload creation.
+### Runtime and end-to-end tests
 
-### Sidecar lifecycle tests
+- Runtime ownership of policy, Engine, consults, remedies, trajectory state, recovery, and `appa.db`.
+- Tool allow, replacement, suppression, terminal failure, timeout, and crash-window behavior through the adapter.
+- Model, session, child, A2A, memory, MCP, remote, interaction, and assistant-response gate coverage.
+- Replay of terminal runtime decisions and runtime handling of indeterminate execution.
+- Separate kagent host, adapter, and runtime state inspection.
+- Quickstart two-process companion acceptance with runtime loopback binding.
+- Remote gateway acceptance with authenticated HTTPS and revision-pinned runtime routing.
+- Prohibited-content checks across logs, traces, adapter ledger, host state, A2A output, and snapshots.
 
-- Container and protocol readiness ordering.
-- Required sidecar crash before and during operations.
-- Bounded restart and re-registration.
-- State volume isolation from kagent.
-- Egress and secret mount enforcement.
-- Quiesce, encrypted snapshot, partial snapshot rejection, and restore validation.
-- Old and new plugin revisions draining concurrently without scope migration.
-
-### OpenAPPA plugin tests
-
-- Host inventory acceptance and every missing-capability refusal.
-- Deployment profile and sink coverage validation.
-- Annotator, Membership, Authority, Sanitizer, and native attestation paths.
-- Remedy families and every runtime outcome.
-- Result, child-return, and assistant response admission.
-- Human interaction accept, decline, cancel, expiry, replay, and remote hops.
-- Crash windows before permit, before execution acknowledgement, during execution, after result, and after commit.
-- Replay of exact terminal decisions and `Indeterminate` effect handling.
-
-### End-to-end GCP acceptance
-
-- Separate generic-host and OpenAPPA-sidecar images.
-- Dynamic manifest installation without kagent recompilation.
-- Ordinary, MCP, memory, child, HITL, final-response, and migration scenarios.
-- Plugin, host, network, tool, model, and snapshot failure injection.
-- Prohibited-content checks across logs, traces, state, A2A output, and snapshots.
-- Repeated crash and restart windows with deterministic assertions.
-- Manually verify desktop and API interaction flows.
-
-The PoC is complete only when every required capability passes and no partial-capability mode reports ready.
+The proof of completion requires every required capability to pass. No partial-capability mode reports ready.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -3,7 +3,7 @@ title: kAgent
 nav_title: kAgent
 category: Integrations
 order: 6
-description: Proposal for a dynamically supplied OpenAPPA extension in kagent without forking Google ADK.
+description: Proposal for an OpenAPPA adapter for kagent without forking Google ADK.
 ---
 
 :::proposal
@@ -13,26 +13,31 @@ date: 2026-08-27
 
 This proposal adds a generic out-of-process extension host to the kagent Go fork.
 
-OpenAPPA ships as a separate OCI companion container. The kagent fork contains no OpenAPPA policy, Label, trajectory, remedy, consult, runtime, or persistence logic.
+OpenAPPA uses `appa-adapter-kagent` as the kagent extension. The adapter maps the generic kagent harness wire to the existing `appa-runtime` `/hook` HTTP interface. The adapter does not link `appa-runtime`, own policy, call the Engine, or own `appa.db`.
 
-The combined protected instance enforces four contracts:
+`appa-runtime` is a separate logical process. It owns policy loading, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`. The adapter fails closed when `APPA_RUNTIME_URL` is unavailable or rejects a bound request.
 
-1. The host executes only the immutable payload permitted by the required extension.
-2. Raw tool and child results remain withheld until the extension commits a delivery payload.
-3. Every enabled model, session, A2A, memory, UI, log, telemetry, and storage path crosses an exclusive extension gate.
-4. The instance remains unready when its generic host inventory cannot satisfy every required extension capability.
+The kagent fork contains no OpenAPPA policy, Label, trajectory, remedy, consult, runtime, or persistence logic. Google ADK remains an unmodified upstream dependency. The design does not fork, vendor, copy, patch, replace, or import internal Google ADK packages.
 
-This proposal uses [kagent commit `9e246fd37`](https://github.com/kagent-dev/kagent/commit/9e246fd3797457b18fc277680be1629a0f57fce0) as its source baseline.
-
-It also uses Google ADK Go 2.2.0 and Substrate 0.0.20.
-
-Google ADK remains an unmodified upstream dependency. The design does not fork, vendor, copy, patch, replace, or import internal Google ADK packages.
+This proposal uses [kagent commit `9e246fd37`](https://github.com/kagent-dev/kagent/commit/9e246fd3797457b18fc277680be1629a0f57fce0) as its source baseline. It also uses Google ADK Go 2.2.0 and Substrate 0.0.20.
 
 OpenAPPA policy semantics remain in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
+## Ownership
+
+| Component | Ownership |
+|---|---|
+| kagent fork | Neutral extension protocol, Harness Revision, public-ADK wrappers, immutable payload snapshots, host sink barriers, and host-native session and A2A state |
+| `appa-adapter-kagent` | Generic kagent protocol negotiation, channel HMAC state, replay and delivery ledger, lifecycle relay, and harness-wire to `/hook` mapping |
+| `appa-runtime` | Policy, Engine, consults, remedy plans, trajectory state, recovery semantics, runtime API, and `appa.db` |
+
+The adapter has no OpenAPPA semantic state. Its replay and delivery ledger contains only generic event and delivery bindings. It contains no policy decision, Label, trajectory fact, consult result, remedy, continuation, dispatch identifier, or `appa.db` data.
+
+The kagent fork sees only generic host payloads, phase names, digests, deadlines, decisions, and opaque handles. It does not parse OpenAPPA configuration or response meaning.
+
 ## Generic kagent changes
 
-The kagent fork implements only generic extension infrastructure:
+The fork implements generic extension infrastructure only:
 
 - Dynamic extension configuration and artifact verification.
 - Version and capability negotiation.
@@ -42,472 +47,178 @@ The kagent fork implements only generic extension infrastructure:
 - Generic execution, event, interaction, and lifecycle decisions.
 - Generic sidecar readiness, egress, volume, snapshot, and drain handling.
 
-The fork MUST NOT import an OpenAPPA crate, Go package, protobuf package, policy schema, wire enum, or generated type.
+The fork has no OpenAPPA crate, Go package, protobuf package, policy schema, wire enum, generated type, special tool route, or database migration. A missing public ADK boundary makes its generic capability unavailable. A required adapter then rejects activation.
 
-The fork MUST NOT modify Google ADK source, copy it, or replace its module. A missing boundary must use a public ADK interface or a kagent-owned wrapper.
+The protected instance enforces four contracts:
 
-The wrapper MUST live in kagent-owned code and use only public ADK imports. It MUST NOT copy ADK source or reproduce an internal package.
+1. The host executes only the immutable payload permitted by the required extension.
+2. Raw tool and child results remain withheld until the extension commits a delivery payload.
+3. Every enabled model, session, A2A, memory, UI, log, telemetry, and storage path crosses an exclusive extension gate.
+4. The instance remains unready when its generic inventory cannot satisfy every required adapter capability.
 
-If neither surface has the boundary, the host reports the capability as unavailable. A required extension then refuses activation.
+## Adapter and runtime boundary
 
-The generic protocol MUST NOT contain OpenAPPA domain terms.
+The kagent extension protocol remains neutral. It uses private Unix-domain-socket gRPC, mTLS, a boot epoch, sequence numbers, a channel digest, deadlines, and HMAC-SHA256. The protocol carries no OpenAPPA domain type.
 
-Examples include Label, Trajectory, Authority, Annotator, Sanitizer, Membership Resolver, remedy plan, ReaderId, and effect.
+The adapter receives one immutable generic event. It validates peer identity, Revision, boot epoch, sequence, deadline, event digest, and HMAC. It records a generic replay or delivery entry, then maps the event to one `/hook` request. It maps the runtime response back to one generic host decision.
 
-The OpenAPPA companion owns:
+The adapter binds every `/hook` request to these values:
 
-- Policy loading and `[deployment]` validation.
-- OpenAPPA Engine and runtime calls.
-- Facts, call correlation, consult pins, offers, continuations, and recovery.
-- Annotator, Membership Resolver, Authority, and Sanitizer implementations.
-- OpenAPPA-specific A2A delegation and human-review meaning.
-- Plugin-side durable state and schema migrations.
+- Actor UID and extension ID.
+- Immutable kagent Revision and adapter artifact digest.
+- Runtime policy revision and runtime instance identity.
+- Boot epoch, sequence, event ID, event digest, and deadline.
+- Authenticated channel identity and request HMAC digest.
 
-kagent sees only generic host payloads, phase names, digests, deadlines, decisions, and opaque handles.
+`appa-runtime` verifies this binding before it evaluates a flow. A runtime response binds the same values and its policy revision. The adapter rejects a missing, mismatched, expired, reordered, or duplicate binding. A policy revision change creates a new kagent Revision and follows pin-and-drain.
+
+The adapter does not interpret `permit`, `commit`, `hold`, `interaction`, `event`, or `fail` as policy. It only verifies the runtime response binding and renders the matching neutral host decision.
+
+## Deployment profiles
+
+### Quickstart
+
+Quickstart uses one digest-pinned OpenAPPA companion container with two processes:
+
+```text
++---------------------- OpenAPPA companion container -----------------------+
+| appa-adapter-kagent                  appa runtime --adapter kagent        |
+| kagent UDS gRPC <----adapter----> http://127.0.0.1:8787/hook <----runtime |
+| generic ledger                         policy, Engine, consults, appa.db  |
++---------------------------------------------------------------------------+
+```
+
+`APPA_RUNTIME_URL=http://127.0.0.1:8787` selects the loopback runtime. The runtime listens only on loopback in this profile. Container networking does not expose the runtime port. The adapter has no `appa.db` mount. Only `appa-runtime` mounts the runtime policy, credentials, and durable `appa.db` volume.
+
+### Remote configuration
+
+Remote configuration uses the same `appa-adapter-kagent` image. `APPA_RUNTIME_URL` identifies an authenticated HTTPS runtime gateway or runtime instance.
+
+```text
+kagent host -- private UDS --> appa-adapter-kagent -- mTLS HTTPS --> appa-runtime gateway
+```
+
+The adapter authenticates the remote peer with a pinned CA and workload identity. The remote runtime authenticates the adapter identity and accepts only the configured Actor, extension, and Revision binding. The gateway forwards only to the bound runtime instance. The adapter rejects redirects, unpinned certificates, identity mismatch, and revision mismatch. Runtime policy and `appa.db` remain at the remote runtime.
+
+Both profiles use the same `/hook` request and response binding. Remote configuration changes do not relax the fail-closed rule.
 
 ## OCI companion container
 
-The selected process model is a digest-pinned OCI companion container in the same Substrate Actor.
+The selected process model is a digest-pinned companion container in the same Substrate Actor. The kagent process and adapter communicate through a private Unix-domain socket. A shared memory-backed socket volume carries no durable runtime state.
 
-Substrate already supports [multiple containers with independent readiness probes](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L356). Pinned kagent currently emits [one container](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L32-L91).
+Substrate supports [multiple containers with independent readiness probes](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L356). Pinned kagent currently emits [one container](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L32-L91).
 
-The baseline lacks shared memory sockets, projected config and secrets, per-container identity, filesystem controls, seccomp, and enforced egress.
+The generic fork adds extension containers without an OpenAPPA-specific role. The adapter image runs as a dedicated UID with a read-only root filesystem and no Linux capabilities. Its generic ledger has a separate volume. The kagent container cannot mount it.
 
-Generic Substrate work adds these required features. Extension activation fails when a declared primitive is unavailable.
+Quickstart gives `appa-runtime` a separate private policy and `appa.db` volume. The adapter cannot mount either volume. Remote configuration has no runtime volume in the adapter container.
 
-The generic fork adds extension containers without adding an OpenAPPA-specific sidecar role.
-
-The kagent process and extension communicate over gRPC on a private Unix-domain socket. A shared memory-backed socket volume carries no durable state.
-
-Substrate mints per-activation mTLS identities, a boot epoch, and a message-authentication key.
-
-Every event and decision binds the Actor UID, extension ID, protocol major, boot epoch, sequence, channel digest, deadline, and HMAC.
-
-The extension receives a separate durable state volume. The kagent container cannot mount that volume.
-
-The extension receives opaque configuration and secret mounts. kagent verifies source references and digests but does not parse their content.
-
-The extension image runs as a dedicated UID with a read-only root filesystem and no Linux capabilities.
-
-Resource limits and deny-by-default egress also apply.
-
-Actor-wide CNI policy permits only cluster DNS and an authenticated egress gateway. The gateway enforces per-container destination, TLS identity, redirect, and DNS-rebinding rules.
-
-The kagent process and its in-process tools remain in the trusted computing base. The sidecar isolates OpenAPPA memory and state but cannot sandbox malicious code already running as kagent.
-
-## Established plugin patterns
-
-The protocol borrows established mechanisms rather than using Go shared-library loading.
-
-| Source | Adopted mechanism |
-|---|---|
-| [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin) | Out-of-process RPC, handshake, protocol-major negotiation, health, process isolation, and explicit lifecycle |
-| [Terraform provider protocol](https://developer.hashicorp.com/terraform/plugin/terraform-plugin-protocol) | Artifact version separate from wire compatibility and strict protocol negotiation |
-| [Kubernetes device plugins](https://v1-32.docs.kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) | Serve before registration, Unix-socket gRPC, capability discovery, health, and re-registration |
-| [VS Code extension manifests](https://code.visualstudio.com/api/references/extension-manifest) | Declarative contribution points, compatibility ranges, activation, and reviewable requested capabilities |
-| [Envoy xDS](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol) | Versioned configuration with explicit accept or reject behavior |
-
-The design does not use the Go [`plugin`](https://pkg.go.dev/plugin) package. Its toolchain coupling, platform limits, race-detector limitations, shared address space, and unload restrictions conflict with independently shipped extensions.
+Actor-wide CNI policy permits only cluster DNS and an authenticated egress gateway. The gateway enforces per-container destination, TLS identity, redirect, and DNS-rebinding rules. The kagent process and its in-process tools remain in the trusted computing base.
 
 ## Dynamic extension configuration
 
-A Harness can declare several ordered dynamic extensions. Each declaration is generic:
+A Harness can declare several ordered dynamic extensions. The OpenAPPA declaration names an adapter artifact, not a policy runtime artifact:
 
 ```yaml
 extensions:
   - name: policy-gate
-    image: ghcr.io/archestra-ai/openappa-kagent-plugin@sha256:<digest>
+    image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
     manifestDigest: sha256:<digest>
     protocol: kagent.extension.v1
     required: true
     failureMode: closed
     order: 10
     socket: /run/kagent/extensions/policy-gate.sock
-    config:
-      configMapRef:
-        name: customer-support-policy-v1
-    secrets:
-      - secretRef:
-          name: openappa-plugin-secrets-v1
-    state:
-      durableDir: openappa-plugin-state
+    adapter:
+      runtimeUrlEnv: APPA_RUNTIME_URL
+      runtimeBinding:
+        runtimeId: customer-support-runtime-a
+        policyRevision: customer-support-policy-v1
+        remoteIdentity: spiffe://policy.example/runtime/customer-support-runtime-a
+    ledger:
+      durableDir: policy-gate-delivery-ledger
     egress:
-      - api.policy-provider.example:443
+      - runtime-gateway.policy.example:443
     readiness:
       path: /readyz
       port: 8082
 ```
 
-The generic compiler verifies:
+The generic compiler verifies OCI digest, signature policy, manifest digest, protocol range, references, capability claims, deadlines, limits, socket uniqueness, ledger ownership, egress, and readiness declarations. It treats adapter and runtime configuration as opaque bytes. An immutable Revision binds their digests. Any policy, credential, CA, runtime identity, or remote endpoint change creates a new Revision.
 
-- OCI digest and signature policy.
-- Manifest digest and protocol range.
-- Canonical opaque configuration digest.
-- Secret and volume references without reading plugin semantics.
-- Declared capabilities, exclusive phases, deadlines, limits, and failure mode.
-- Socket, state, egress, readiness, and resource declarations.
+## Negotiation and event relay
 
-The controller resolves opaque ConfigMap and Secret bytes only to hash and copy them.
+The adapter serves the private socket before registration. The host verifies adapter workload identity and per-launch channel secret. It calls `GetExtensionInfo`, sends the complete generic capability and sink inventory, and activates the adapter after it accepts the inventory digest.
 
-It mounts immutable Revision-owned copies and stores no secret bytes in the Revision. Any policy, credential, CA, or secret change creates a new Revision.
+The inventory describes mechanics, not OpenAPPA policy. It includes ADK and provider versions, callback phase ordering, tool and model paths, raw codecs, content-bearing sinks, and snapshot, recovery, and drain capabilities.
 
-The immutable Revision includes these generic values. A plugin revision never changes inside a live scope.
+The adapter sends the inventory activation event to `/hook`. `appa-runtime` validates policy coverage and returns the bound result. The adapter reports ready only after a valid runtime response. The host treats that response as a generic required-extension attestation.
 
-## Neutral protocol negotiation
+Every generic event contains an immutable payload, event ID, digest, Actor UID, Revision, scope, operation, descriptor, sequence, phase, and deadline. The host executes no replacement without a matching `permit`. It publishes no content without a matching `commit` or `event` decision.
 
-The sidecar starts before registration and serves the private socket.
+The adapter ledger makes relays replay-safe. A repeated event ID returns the original bound decision only after the adapter verifies the identical event digest and runtime revision. Runtime recovery remains authoritative. The adapter does not classify semantic outcomes or reconstruct trajectory state.
 
-The host uses this sequence:
+## Lifecycle coverage
 
-1. The host verifies the sidecar workload identity and per-launch socket secret.
-2. The host calls `GetExtensionInfo` for the plugin and protocol identities.
-3. The host sends the complete capability and sink inventory.
-4. The host selects one protocol major and capability set.
-5. The extension accepts the inventory digest and reports its ready state.
-6. The host enables the extension after container and protocol readiness succeed.
+The protected profile uses public ADK interfaces and kagent-owned integration points. It disables any path that bypasses them.
 
-The inventory describes mechanics, not OpenAPPA policy:
-
-- ADK and provider versions.
-- Available callback phases and their ordering.
-- Tool, child, remote, memory, MCP, interaction, event, session, and publication paths.
-- Provider-final descriptor and name-mapping support.
-- Immutable JSON and raw transport codecs.
-- Content-bearing sinks and telemetry surfaces.
-- Snapshot, recovery, and drain capabilities.
-
-The OpenAPPA sidecar validates its own policy against that inventory.
-
-kagent treats the signed ready response as a generic required-extension attestation.
-
-## Existing ADK and kagent surfaces
-
-Current public ADK interfaces cover only part of the required lifecycle.
-
-| Boundary | Existing public surface | kagent-owned integration |
-|---|---|---|
-| Ordinary tool callbacks | `BeforeTool`, `AfterTool`, and tool-error callbacks | Sole content-bearing dynamic proxy |
-| User input | `OnUserMessageCallback` and injected session service | Callback proxy and session append gate |
-| Model request | Injected model interface and kagent-owned provider adapters | Provider-final gate, with opaque upstream providers unavailable |
-| Provider-final tool catalog | Kagent-owned provider adapters | Final descriptors and reversible provider-name map |
-| Raw function-call arguments | Kagent-owned provider decoders | Token preservation before ADK map decoding |
-| Tool execution | Public tool interface and existing tool callbacks | Tool wrapper and sole content-bearing proxy |
-| Model response | Existing model callbacks and injected model wrapper | Standard and supported live-path gates |
-| Session persistence | Injected session service | Exact-byte gate before backing-store append |
-| Runner and task publication | Public Runner output plus kagent-owned A2A code | Barrier before yield, storage, or publication |
-| Child return | Public Agent, Runner, and session interfaces | Child-scope correlation, with unobservable paths unavailable |
-| Memory | Public memory and tool interfaces | Stock preload disabled, kagent-owned gate enabled |
-| MCP | Public tool interface | Kagent-owned no-retry transport |
-| Remote A2A | Existing kagent remote tool | Kagent-owned request and result wrappers |
-| Snapshot, readiness, egress, and drain | Outside ADK | Use the generic kagent and Substrate lifecycle interface |
-
-The protected profile uses only these public interfaces and kagent-owned integration points. It disables any path that can bypass them.
-
-No guarantee in this proposal requires a change to Google ADK source.
-
-No OpenAPPA payload or decision uses a direct kagent API.
-
-All host-side enforcement data crosses only the generic extension protocol. It contains no ADK Go types or OpenAPPA policy types.
-
-## Deterministic extension ordering
-
-The Revision defines one total extension order.
-
-An extension manifest declares each phase as `exclusive`, `transform`, `observe_committed`, or unused.
-
-Only one extension can own an exclusive phase. Revision preparation rejects an ownership conflict.
-
-The OpenAPPA plugin requires exclusive ownership of all uncommitted content phases.
-
-Other extensions can observe metadata or already committed content only after that exclusive gate.
-
-The fixed manifest excludes runtime plugin additions after verification.
-
-## Immutable event envelopes
-
-Every host event has a generic immutable envelope:
-
-```json
-{
-  "protocol": "1.0",
-  "event_id": "opaque-host-id",
-  "event_digest": "sha256:...",
-  "instance_id": "opaque",
-  "scope_id": "opaque",
-  "parent_scope_id": null,
-  "operation_id": "opaque",
-  "descriptor_id": "opaque",
-  "sequence": 42,
-  "phase": "tool.propose",
-  "deadline": "2026-09-01T00:00:00Z",
-  "payload": {
-    "codec": "rfc8785-json",
-    "bytes": "<bounded bytes or blob reference>",
-    "digest": "sha256:..."
-  }
-}
-```
-
-The host IDs are generic and unguessable. They bind instance, Revision, scope, phase, descriptor, operation, expiry, and allowed use.
-
-The sidecar can return an opaque lease for one immediate mechanical next phase.
-
-The host never parses a lease or persists it beyond that delivery lifecycle.
-
-The sidecar resolves held interactions and recovery state from its private store by host event ID.
-
-## Generic decisions
-
-The sidecar returns only generic host decisions:
-
-| Decision | Host behavior |
+| Boundary | kagent-owned integration |
 |---|---|
-| `permit` | Execute the original or replacement immutable payload once |
-| `suppress` | Execute or publish nothing |
-| `hold` | Pause one generic scope without requesting user input |
-| `interaction` | Publish a neutral interaction request and wait for a generic response event |
-| `commit` | Deliver original, replacement, or no result bytes |
-| `event` | Drop, replace, or emit one ADK, session, or A2A event |
-| `fail` | Emit a host-defined content-free failure |
+| Tool callbacks and execution | Sole content-bearing proxy, immutable arguments, execution wrapper, and result gate |
+| User input and sessions | Callback proxy and exact-byte pre-append gate |
+| Model request and catalog | Provider-final request and descriptor gate |
+| Model response and publication | Standard and live-path gates before persistence or yield |
+| Child, memory, MCP, and remote A2A | Generic wrappers with immutable request and terminal-result gates |
+| Snapshot, readiness, egress, and drain | Generic kagent and Substrate lifecycle interface |
 
-A decision binds the event digest, extension revision, deadline, and permitted next phase.
+The adapter relays generic events for every required phase. `appa-runtime` maps those events to policy evaluation, Engine admission, consults, remedies, trajectory transitions, and recovery. The adapter owns no dynamic OpenAPPA tool, response meaning, interaction continuation, delegation state, or audit record.
 
-The host executes no replacement that lacks a matching permit. It publishes no content that lacks a matching commit or event decision.
+## State and recovery
 
-## Mechanical tool lifecycle gate
+| Store | Contents |
+|---|---|
+| kagent | ADK sessions, A2A tasks, and narrow generic host delivery records |
+| `appa-adapter-kagent` | Generic protocol negotiation, HMAC channel state, event digest, replay, delivery, expiry, and lifecycle relay records |
+| `appa-runtime` | Policy identity, `appa.db`, Engine facts, trajectory state, consult pins, remedies, interactions, delegations, audit records, and recovery state |
 
-```text
-ADK proposes a tool call
-  -> host captures final descriptor and immutable arguments
-  -> sidecar: tool.propose
-  <- sidecar: permit(exact payload digest, opaque lease)
-  -> sidecar: execution.begin
-  <- sidecar: acknowledged
-  -> host invokes the tool once with the permitted private payload
-  -> sidecar: tool.complete(raw result or terminal status)
-  <- sidecar: commit(original, replacement, or no bytes)
-  -> host constructs the FunctionResponse from committed bytes only
-```
+The adapter ledger records no OpenAPPA semantic value. The runtime owns all migration of policy and `appa.db`. The adapter artifact can drain independently, but it cannot migrate runtime state.
 
-The extension sees the provider-final descriptor, actual source identity, exact canonical arguments, and generic execution context.
+Before a snapshot, the host stops new work and asks each required adapter to quiesce. The adapter seals its generic ledger and relays lifecycle events to runtime. `appa-runtime` seals and validates its own state generation. A restore remains unready until the host, adapter, and runtime accept the same Actor, extension, adapter artifact, runtime identity, and policy revision bindings.
 
-The host blocks name collisions, descriptor drift, mutable argument reuse, callback bypass, and automatic transport retry before plugin policy runs.
+A crash before adapter acknowledgement of `execution.begin` means the host did not execute the tool. A crash after that acknowledgement and before a terminal result leaves classification to `appa-runtime`. The host freezes the generic scope until the adapter relays a bound runtime `suppress`, `hold`, replayed `commit`, or terminal `fail` decision.
 
-## Model provider request gate
+## Revisions and installation
 
-After all request processors and model callbacks, the host snapshots the exact provider request.
+One adapter artifact, protocol selection, runtime identity, and policy revision remain pinned for each live scope. Existing scopes drain on the prior binding. The host never hot-swaps an adapter or moves a live scope between runtime revisions.
 
-The snapshot includes endpoint, model, catalog, history, instructions, memory, and admitted results.
+Installation has three independently versioned artifacts:
 
-It sends `model.propose` before telemetry or network transmission. Only a matching permit can send that exact request.
+1. A kagent fork with the generic dynamic extension host, public-ADK adapters, and lifecycle points.
+2. The signed `appa-adapter-kagent` image and manifest.
+3. The `appa-runtime` image or binary, policy revision, and runtime identity.
 
-The same gate covers each enabled standard, live, realtime, history, and embedding path.
-
-A live or realtime send uses a kagent-owned wrapper around the public live-session send interface. An unsupported path remains disabled.
-
-## Result and response sink gates
-
-The generic event gate runs before any plugin callback can observe uncommitted event content.
-
-It runs before ADK session append, runner yield, parent return, task state, and A2A conversion.
-
-It also runs before A2A publication, memory insertion, UI publication, content logs, trace attributes, and background storage.
-
-The gate supports `Drop`, `Replace`, and `Emit`. No callback runs between the final event decision and the protected sink.
-
-The first release drops every partial assistant event before persistence and yield.
-
-It emits one terminal text response only. It refuses files, data parts, artifacts, citations, thought content, and multiple terminal responses.
-
-The OpenAPPA plugin maps these generic events to its own admission and `assistant.response` logic internally.
-
-Protected host construction always disables content-bearing telemetry and argument logging before Runner creation.
-
-This immutable kagent workload property does not depend on an extension manifest or decision.
-
-Readiness sends a canary through every model, tool, session, A2A, memory, MCP, and exporter path. Any captured canary content keeps the Actor unready.
-
-## Child, remote agent, and interaction coverage
-
-The host exposes generic child phases:
-
-- `child.propose`
-- `child.started`
-- `child.terminal`
-- `remote_child.state`
-- `remote_child.terminal`
-
-A child starts only after a permit bound to its parent scope and prepared child descriptor.
-
-No child result reaches a parent before a matching commit.
-
-The remote client extension point exposes prepared Agent Card identity, outgoing headers, task state, and terminal content.
-
-The host strips caller credentials and reserved lineage headers.
-
-It sends the complete normalized outbound request through `remote.request` and accepts header or body replacement only through the generic decision envelope.
-
-For human interaction, `interaction` carries a versioned neutral presentation document and host interaction ID.
-
-kagent moves the task to `input_required`, authenticates the responder, and emits `interaction.response` through the ordinary extension phase API.
-
-It does not interpret approve, decline, cancel, Authority, offer, or remedy meaning.
-
-The OpenAPPA plugin owns response meaning, replay protection, expiry, remote-hop state, and resume decisions.
-
-## OpenAPPA semantics in the sidecar
-
-The OpenAPPA sidecar maps generic phases to current Engine and runtime behavior.
-
-It alone compiles the concrete `[deployment]` profile, validates the host inventory, and refuses readiness when coverage is incomplete.
-
-It alone implements:
-
-- Canonical call and result correlation.
-- Annotator routing, mandates, pins, and rewrite semantics.
-- Membership resolution and operation evidence.
-- Authority and Sanitizer consults.
-- `attest-schema` child-return handling.
-- Remedy plans and runtime outcome translation.
-- Label, Value, effect, child, offer, and emission facts.
-- OpenAPPA audit and recovery state.
-
-The kagent fork does not know these concepts.
-
-## Separate state ownership
-
-kagent keeps its ordinary ADK session and A2A task stores.
-
-Its only extension record contains host event ID, digest, extension revision, phase, delivery state, expiry, and optional delivered-payload digest.
-
-The OpenAPPA sidecar keeps all OpenAPPA state in its private volume.
-
-This state includes facts, leases, journals, consult pins, remedies, interactions, delegations, and delivery receipts.
-
-kagent stores no OpenAPPA journal, token, fact, offer, Label, decision, or runtime database.
-
-Generic host event IDs support delivery deduplication. They do not encode plugin meaning.
-
-Before a snapshot, the generic lifecycle host stops new work and asks every required extension to quiesce.
-
-The sidecar returns a signed state-generation manifest. Substrate then checkpoints host-native and extension-owned volumes and attests the encrypted snapshot generation.
-
-A durable fencing epoch accompanies every state write. The host records one atomic snapshot transaction from quiescing through provider completion.
-
-Restore remains blocked until every required extension validates its own generation and accepts the host inventory.
-
-## Conservative crash classification
-
-The selected first-release recovery rule is conservative.
-
-A crash before the sidecar acknowledges `execution.begin` means the host did not execute the tool.
-
-A crash after that acknowledgement and before a terminal result is `Indeterminate` to the OpenAPPA sidecar.
-
-The kagent host does not keep an OpenAPPA-aware execution journal to narrow this window.
-
-The host emits `recovery.reconcile` through the ordinary extension phase API.
-
-The affected generic scope remains frozen until the sidecar returns `suppress`, `hold`, replayed `commit`, or terminal `fail`.
-
-## Pinned revisions and upgrade drain
-
-One plugin artifact and protocol selection remain pinned for each live scope.
-
-The controller durably maps every root, task, context, child, and interaction scope to its ActorTemplate and extension Revision before dispatch.
-
-New roots can use a new plugin revision only after it accepts the new host inventory and reports ready.
-
-Existing scopes drain on the old sidecar revision. The host never hot-swaps a plugin between turns or during a tool lifecycle.
-
-The old workload rejects new roots but remains available for its assigned scopes until terminal or deadline.
-
-The plugin owns any state migration. An incompatible revision requires instance replacement and drain.
-
-## Generic host and plugin installation
-
-Installation has two independently versioned artifacts:
-
-1. A kagent fork with the generic dynamic extension host, public-ADK adapters, and generic lifecycle points.
-2. The OpenAPPA kagent plugin companion image and its signed manifest.
-
-The following commands create immutable policy configuration for the sidecar:
-
-```sh
-kubectl -n kagent create configmap customer-support-policy-v1 \
-  --from-file=appa.toml=./appa.toml \
-  --dry-run=client -o yaml | kubectl apply -f -
-kubectl -n kagent patch configmap customer-support-policy-v1 \
-  --type=merge -p '{"immutable":true}'
-```
-
-The generic Harness references the extension image and opaque configuration. The kagent controller never parses `appa.toml`.
-
-The OpenAPPA plugin reports unready until its policy, state, runtime, host inventory, and required generic phases validate.
-
-A prepared Harness creates a new `AgentInstance`. Existing instances cannot change their pinned extension set.
+The generic Harness references the adapter image. It does not reference `appa.db`. Quickstart provisions the runtime process and private volume in the same companion container. Remote configuration references a gateway identity and policy revision, not a runtime database mount.
 
 ## Architecture
 
 ```text
-+----------------------------- Kubernetes / Substrate Actor ----------------------+
-|                                                                                  |
-|  kagent controller -> immutable Revision -> ActorTemplate                        |
-|                                |                                                 |
-|                 +--------------+----------------+                                |
-|                 |                               |                                |
-|                 v                               v                                |
-|  +-----------------------------+  Unix gRPC  +--------------------------------+  |
-|  | kagent + upstream ADK       |<----------->| dynamic extension sidecar     |  |
-|  |                             | private UDS |                                |  |
-|  | generic extension host      |             | OpenAPPA plugin server        |  |
-|  | public ADK wrappers         |             | appa-runtime + Engine         |  |
-|  | generic execution proxy     |             | policy and consults           |  |
-|  | sessions.db / A2A state     |             | private plugin state          |  |
-|  +-------------+---------------+             +----------------+---------------+  |
-|                |                                                  |              |
-|                v                                                  v              |
-|       model / tools / MCP / A2A                         declared external endpoints|
-|                                                                                  |
-+----------------------------------------------------------------------------------+
-```
++------------------------------ Kubernetes / Substrate Actor ------------------------------+
+| kagent controller -> immutable Revision -> ActorTemplate                                 |
+|                                                                                           |
+| +--------------------------+ private UDS +---------------------------------------------+ |
+| | kagent + upstream ADK    |<----------->| OpenAPPA companion container                 | |
+| | generic extension host   |             | appa-adapter-kagent                          | |
+| | public ADK wrappers      |             | generic negotiation, HMAC, delivery ledger   | |
+| | sessions.db / A2A state  |             |                | APPA_RUNTIME_URL              | |
+| +--------------------------+             |                v                              | |
+|                                           | appa runtime --adapter kagent                | |
+|                                           | policy, Engine, consults, trajectory, appa.db| |
+|                                           +---------------------------------------------+ |
++-------------------------------------------------------------------------------------------+
 
-The Unix socket and generic event protocol are the only enforcement-data interface between kagent and the OpenAPPA component.
+Remote configuration replaces the final loopback hop with authenticated HTTPS to the bound runtime gateway or instance. The runtime port remains loopback-only in quickstart.
 
 ## Incomplete coverage refusal
 
-The protected instance remains unready if a required phase lacks sole, fixed, supported ownership.
+The protected instance remains unready when a required phase lacks sole, fixed, supported ownership. The first release refuses opaque provider paths, stock MCP transport without raw arguments and no-retry execution, unbounded memory preload, mutable catalogs, unverified callbacks, content telemetry, incomplete remote A2A gates, streaming before publication control, mixed revisions, unavailable runtime identity, failed runtime authentication, and any path that needs Google ADK source changes.
 
-The first release refuses:
-
-- Provider-native tools without host dispatch and result boundaries.
-- Stock MCP transport when raw argument injection and no-retry execution are unavailable.
-- Automatic memory preload without the synthetic lifecycle extension.
-- Dynamic tool catalogs that change inside a prepared Revision.
-- Runtime plugins or callbacks appended after manifest verification.
-- Components without a public content-telemetry control.
-- Remote A2A paths without immutable Card, header replacement, state preservation, and terminal gates.
-- Streaming assistant content before the exclusive publication gate.
-- Hot plugin swaps and mixed plugin revisions inside one scope.
-- Any partial capability mode for the required OpenAPPA plugin.
-- Any path that would require patched, vendored, copied, replaced, or internal Google ADK code.
-
-## Existing agent migration
-
-An existing `AgentInstance` cannot add a new dynamic extension set.
-
-The controller creates a replacement protected instance and routes new roots to it.
-
-Existing task and context IDs remain on the old instance until a fixed drain deadline.
-
-At the deadline, cancel remaining old work and suspend the old instance.
-
-The replacement starts new ADK session and OpenAPPA plugin state. It imports neither the old transcript nor old plugin state unless the plugin explicitly validates a migration.
-
-Rollback resumes the old instance and restores routing. It never merges state between plugin revisions.
-
-## Implementation plan
-
-The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the generic protocol, source ownership, public ADK adapters, and kagent-owned barriers.
-
-It also defines sidecar lifecycle, OpenAPPA mapping, and the verification matrix.
+The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the neutral protocol, ownership boundary, deployment profiles, public-ADK integration, and verification matrix.


### PR DESCRIPTION
## Summary
- rename the kagent sidecar to `appa-adapter-kagent`, matching `appa-adapter-claude-code`
- keep `appa-runtime` as a separate process selected by `APPA_RUNTIME_URL`
- document loopback quickstart and remote authenticated runtime configuration

Follow-up to #133. Task: T-1176.

## Validation
- website typecheck passes
- two-process Unix-socket e2e on the GCP VM: adapter posts `/hook` to `appa runtime --adapter kagent`