### PR TITLE
fix(runtime): name APPA in the outstanding-call refusal

### DIFF
--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -140,7 +140,7 @@ pub enum OpenError {
 /// as a deny.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum EventError {
-    #[error("a call is already outstanding; propose one call at a time")]
+    #[error("[appa] a call is already outstanding; propose one call at a time")]
     CallOutstanding,
     #[error(
         "the substituted {tool} call did not run and is now closed; propose your call again (a substituted call needs a fresh offer)"


### PR DESCRIPTION
`CallOutstanding` reached the model with no `[appa]` prefix, unlike every other refusal APPA renders. It is folded straight from the `EventError` Display string (`hooks.rs` `fold` → `error.to_string()`), and the prefix is written at individual message sites in `engine.rs` and `hooks.rs`, so this variant never got one.

The refusal therefore arrived bare — no prefix, no reason, no offer id — which is exactly the shape a session uses to tell an APPA answer from a harness error.

## Why it matters

A session interrupted a released `Bash` call. No outcome hook fired, so the dispatch stayed open and the next six proposals were refused with `a call is already outstanding; propose one call at a time`. Having seen real `[appa]` denials earlier in the same trajectory, the session read this one as a harness fault, spent five calls and about ninety seconds on the wrong cause, and drafted a bug report against the wrong component. The trajectory recovered at the turn end, as #15 intends.

## Change

One line. `appa-runtime/src/api/mod.rs:143`:

```rust
#[error("[appa] a call is already outstanding; propose one call at a time")]
CallOutstanding,
```

The prefix has to go on the `#[error(...)]` string; there is no intermediate render site for this variant.

Scope is this variant only. The other `EventError` messages are still unprefixed — a separate question, not addressed here.

## Validation
- `cargo test -p appa`: 22 suites, 334 passed, 0 failed
- reproduced the refusal against a live runtime by posting hook events to `127.0.0.1:8787/hook`: a second `PreToolUse` with no outcome reported for the first is denied, and a `Stop` clears it