### PR TITLE
fix(init): automate matching plugin installs and runtime recovery

### DIFF
--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -16,19 +16,6 @@ on:
         description: SHA-256 of the plugin artifact these binaries must accept
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      release_ref:
-        description: Immutable release tag to build and stamp into the binaries
-        required: true
-        type: string
-      plugin_sha256:
-        description: >-
-          SHA-256 of the plugin artifact these binaries must accept, as the
-          release workflow's plugin-artifact job computes it.
-        required: true
-        type: string
-
 permissions: {}
 
 concurrency:

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -82,9 +82,28 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.release_ref }}
+          # A workflow input may name the release, but never selects code to
+          # execute in the default-branch cache scope. The caller's commit is
+          # the trusted source; the next step proves the tag names that commit.
+          ref: ${{ github.sha }}
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Verify release tag targets the source commit
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
+        run: |
+          if [[ ! "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::release_ref must be a version tag"
+            exit 1
+          fi
+          git fetch --no-tags origin \
+            "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
+          tag_commit=$(git rev-parse "${RELEASE_REF}^{commit}")
+          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+            echo "::error::${RELEASE_REF} targets ${tag_commit}, not source commit ${GITHUB_SHA}"
+            exit 1
+          fi
 
       # The binary accepts only the plugin artifact whose digest it is built
       # with. Baking it in at compile time is what makes a shipped binary

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -3,8 +3,8 @@ name: Build appa binaries
 on:
   workflow_call:
     inputs:
-      source_ref:
-        description: Branch, tag, or commit SHA to build
+      release_ref:
+        description: Immutable release tag to build and stamp into the binaries
         required: true
         type: string
       expected_version:
@@ -18,24 +18,21 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      source_ref:
-        description: Branch, tag, or commit SHA to build
+      release_ref:
+        description: Immutable release tag to build and stamp into the binaries
         required: true
-        default: main
         type: string
       plugin_sha256:
         description: >-
           SHA-256 of the plugin artifact these binaries must accept, as the
-          release workflow's plugin-artifact job computes it. Required: a binary
-          built here without one refuses every init that does not pass an
-          explicit --plugin-source, and the package smoke test rejects it.
+          release workflow's plugin-artifact job computes it.
         required: true
         type: string
 
 permissions: {}
 
 concurrency:
-  group: build-appa-runtime-${{ inputs.source_ref }}
+  group: build-appa-runtime-${{ inputs.release_ref }}
   cancel-in-progress: false
 
 jobs:
@@ -98,7 +95,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.release_ref }}
           persist-credentials: false
           fetch-depth: 1
 
@@ -108,6 +105,10 @@ jobs:
       - name: Build binary
         env:
           APPA_PLUGIN_SHA256: ${{ inputs.plugin_sha256 }}
+          # The tag/ref is compiled in beside the digest. Runtime init never
+          # guesses it from the Cargo version, which may also describe later
+          # development commits before the next release.
+          APPA_RELEASE_REF: ${{ inputs.release_ref }}
           RUSTFLAGS: ${{ runner.os == 'Windows' && '-C target-feature=+crt-static' || '' }}
           TARGET: ${{ matrix.target }}
         run: cargo build --release --locked --package appa --target "$TARGET"
@@ -186,6 +187,7 @@ jobs:
           # them could be pointed at another release's plugin.
           hostile=$(APPA_PLUGIN_SHA256=$(printf 'a%.0s' {1..64}) \
             APPA_RELEASE_BASE_URL=http://127.0.0.1:9 \
+            APPA_SOURCE_ARCHIVE_BASE_URL=http://127.0.0.1:9 \
             APPA_ENDPOINT=http://127.0.0.1:9999 \
             ./appa init claude-code 2>&1 || true)
           case "$hostile" in
@@ -269,10 +271,12 @@ jobs:
             # it at another release's plugin.
             $env:APPA_PLUGIN_SHA256 = "a" * 64
             $env:APPA_RELEASE_BASE_URL = "http://127.0.0.1:9"
+            $env:APPA_SOURCE_ARCHIVE_BASE_URL = "http://127.0.0.1:9"
             $env:APPA_ENDPOINT = "http://127.0.0.1:9999"
             $hostile = (& $cli init claude-code 2>&1 | Out-String)
             $env:APPA_PLUGIN_SHA256 = $null
             $env:APPA_RELEASE_BASE_URL = $null
+            $env:APPA_SOURCE_ARCHIVE_BASE_URL = $null
             $env:APPA_ENDPOINT = $null
             if ($hostile -match "development build" -or $hostile -match "127\.0\.0\.1:9") {
               throw "the released binary honoured a debug-only seam: $hostile"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
       - release-please
       - plugin-artifact
     permissions:
-      contents: read # Required by the reusable workflow to check out the release tag.
+      contents: read # Required to check out the source commit and verify its release tag.
     uses: ./.github/workflows/build-appa-runtime-binaries.yml
     with:
       release_ref: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
       contents: read # Required by the reusable workflow to check out the release tag.
     uses: ./.github/workflows/build-appa-runtime-binaries.yml
     with:
-      source_ref: ${{ needs.release-please.outputs.tag_name }}
+      release_ref: ${{ needs.release-please.outputs.tag_name }}
       expected_version: ${{ needs.release-please.outputs.version }}
       plugin_sha256: ${{ needs.plugin-artifact.outputs.sha256 }}
 

--- a/README.md
+++ b/README.md
@@ -65,20 +65,21 @@ fastest way to watch a policy make a decision on real work:
 
 ```sh
 cargo install --path appa-runtime --force
-plugin=$(mktemp -d)/bundle
-sh scripts/appa-stage-plugin-bundle.sh "$plugin"
-appa init claude-code --plugin-source "$plugin"
+appa init claude-code
 ```
 
-A release binary carries the digest of its own release's plugin and needs no
-`--plugin-source`; a build from a checkout has no such digest, so it is given
-the bundle staged from that same checkout.
+A release binary resolves the plugin from its baked release tag and digest. A
+clean checkout build resolves the plugin from its baked Git commit and verifies
+the canonical plugin-tree digest; a dirty plugin build uses that exact checkout
+only while its bytes still match the build.
 
 The native `appa` command installs the plugin, the runtime deployment,
 statusline, and `clappa` launcher. It replaces an existing APPA plugin instead
 of stacking a second copy and preserves an existing policy or custom
-statusline. Start `clappa`, then run `/appa-guide init` to bring the
-session's MCP servers into the policy. Plain `claude` sessions stay untouched.
+statusline. Fresh policies use a fail-closed Claude annotator as a compatibility
+net for MCP tools they do not yet name. Start `clappa`, then run
+`/appa-guide init` to replace that fallback with exact connector contracts.
+Plain `claude` sessions stay untouched.
 
 ![A protected Claude Code session refuses to post content from a private meeting recording to a public GitHub repo, and explains why](website/public/images/claude-code-blocked-flow.png)
 

--- a/appa-runtime/Cargo.toml
+++ b/appa-runtime/Cargo.toml
@@ -54,6 +54,10 @@ rig-agent = { version = "0.42", default-features = false }
 # Depended on only to name the crypto provider; see the workspace manifest.
 rustls = { workspace = true }
 
+[build-dependencies]
+sha2 = { workspace = true }
+tar = "0.4"
+
 [dev-dependencies]
 # The fail points the orchestration tests drive. A dev-dependency, so they are
 # absent from the binary.

--- a/appa-runtime/README.md
+++ b/appa-runtime/README.md
@@ -24,14 +24,12 @@ install -m 755 appa ~/.local/bin/
 appa init claude-code
 ```
 
-A build from a checkout has no such digest, refuses to download, and requires an
-explicit source:
+A build from a checkout carries its exact Git commit and plugin-tree digest, so
+the same command works there too:
 
 ```sh
 cargo install --path appa-runtime --force
-plugin=$(mktemp -d)/bundle
-sh scripts/appa-stage-plugin-bundle.sh "$plugin"
-appa init claude-code --plugin-source "$plugin"
+appa init claude-code
 ```
 
 The result does not depend on the working directory. It replaces an existing APPA plugin instead of stacking

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -120,6 +120,10 @@ fn export_committed_repository(repository: &Path, destination: &Path) -> std::io
         }
         let target = destination.join(&relative);
         match entry.header().entry_type() {
+            // BSD tar (and therefore `git archive` on macOS) may prepend PAX
+            // metadata records. They describe following entries and are not
+            // files in the repository export.
+            tar::EntryType::XHeader | tar::EntryType::XGlobalHeader => {}
             tar::EntryType::Directory => fs::create_dir_all(&target)?,
             tar::EntryType::Regular => {
                 if let Some(parent) = target.parent() {

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -1,0 +1,237 @@
+#[path = "src/plugin_layout.rs"]
+mod plugin_layout;
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=APPA_PLUGIN_SHA256");
+    println!("cargo:rerun-if-env-changed=APPA_RELEASE_REF");
+
+    let crate_root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Cargo sets CARGO_MANIFEST_DIR"));
+    let repository = crate_root.parent().expect("appa-runtime is inside the repository");
+    for (source, _) in plugin_layout::REPOSITORY_MAPPINGS {
+        println!("cargo:rerun-if-changed={}", repository.join(source).display());
+    }
+    watch_git_identity(repository);
+
+    let release = env::var("APPA_RELEASE_REF").ok();
+    let commit = git(repository, &["rev-parse", "HEAD"]);
+    let dirty = plugin_is_dirty(repository);
+    if release.is_some() {
+        assert!(
+            commit.is_some() && !dirty,
+            "a release build requires a clean Git checkout"
+        );
+    }
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"));
+    let staged = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR")).join("plugin-build-source");
+    if staged.exists() {
+        fs::remove_dir_all(&staged).expect("remove the previous staged plugin identity");
+    }
+    let committed = out_dir.join("plugin-build-repository");
+    if committed.exists() {
+        fs::remove_dir_all(&committed).expect("remove the previous committed plugin source");
+    }
+    let identity_source = if commit.is_some() && !dirty {
+        export_committed_repository(repository, &committed).expect("export the committed plugin source");
+        committed.as_path()
+    } else {
+        repository
+    };
+    plugin_layout::stage_repository(identity_source, &staged).expect("stage the plugin source for build identity");
+    let digest = canonical_tree_digest(&staged).expect("digest the staged plugin source");
+    println!("cargo:rustc-env=APPA_PLUGIN_TREE_SHA256={}", hex(&digest));
+
+    if let Some(reference) = release {
+        assert!(!reference.trim().is_empty(), "APPA_RELEASE_REF must not be empty");
+        println!("cargo:rustc-env=APPA_RELEASE_REF={reference}");
+        println!("cargo:rustc-env=APPA_PLUGIN_SOURCE_KIND=release");
+        return;
+    }
+
+    match (commit, dirty) {
+        (Some(commit), false) => {
+            println!("cargo:rustc-env=APPA_BUILD_COMMIT={commit}");
+            println!("cargo:rustc-env=APPA_PLUGIN_SOURCE_KIND=commit");
+        }
+        _ => {
+            println!("cargo:rustc-env=APPA_PLUGIN_SOURCE_KIND=local");
+            println!("cargo:rustc-env=APPA_PLUGIN_SOURCE_ROOT={}", repository.display());
+        }
+    }
+}
+
+fn plugin_is_dirty(repository: &Path) -> bool {
+    git(
+        repository,
+        &[
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--",
+            "integrations/claude-code/.claude-plugin",
+            "integrations/claude-code/plugin",
+            "integrations/claude-code/examples",
+            "batteries",
+            "integrations/claude-code/README.md",
+            "integrations/claude-code/live-gate-check.py",
+            "website/content/docs/contracts.md",
+        ],
+    )
+    .is_none_or(|output| !output.trim().is_empty())
+}
+
+fn export_committed_repository(repository: &Path, destination: &Path) -> std::io::Result<()> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(repository)
+        .args(["archive", "--format=tar", "HEAD", "--"]);
+    for (source, _) in plugin_layout::REPOSITORY_MAPPINGS {
+        command.arg(source);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(
+            String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        ));
+    }
+    fs::create_dir_all(destination)?;
+    let mut archive = tar::Archive::new(std::io::Cursor::new(output.stdout));
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let relative = entry.path()?.into_owned();
+        if relative
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Git archived an unsafe path: {}", relative.display()),
+            ));
+        }
+        let target = destination.join(&relative);
+        match entry.header().entry_type() {
+            tar::EntryType::Directory => fs::create_dir_all(&target)?,
+            tar::EntryType::Regular => {
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let mut file = fs::File::create(target)?;
+                std::io::copy(&mut entry, &mut file)?;
+            }
+            kind => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Git archived {} as unsupported {kind:?}", relative.display()),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn git(repository: &Path, arguments: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(arguments)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn watch_git_identity(repository: &Path) {
+    let mut git_paths = vec!["HEAD".to_owned()];
+    if let Some(reference) = git(repository, &["symbolic-ref", "-q", "HEAD"]) {
+        git_paths.push(reference);
+    }
+    for git_path in git_paths {
+        if let Some(path) = git(repository, &["rev-parse", "--git-path", &git_path]) {
+            let path = PathBuf::from(path);
+            let path = if path.is_absolute() {
+                path
+            } else {
+                repository.join(path)
+            };
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn canonical_tree_digest(root: &Path) -> std::io::Result<[u8; 32]> {
+    let mut entries = BTreeMap::<String, Option<PathBuf>>::new();
+    collect(root, root, &mut entries)?;
+    let mut hasher = Sha256::new();
+    for (relative, absolute) in entries {
+        absorb(&mut hasher, relative.as_bytes());
+        match absolute {
+            None => {
+                hasher.update(*b"d");
+                absorb(&mut hasher, &[]);
+            }
+            Some(path) => {
+                hasher.update(*b"f");
+                let mut file = fs::File::open(path)?;
+                let length = file.metadata()?.len();
+                hasher.update(length.to_be_bytes());
+                let mut buffer = [0u8; 64 * 1024];
+                loop {
+                    let read = file.read(&mut buffer)?;
+                    if read == 0 {
+                        break;
+                    }
+                    hasher.update(&buffer[..read]);
+                }
+            }
+        }
+    }
+    Ok(hasher.finalize().into())
+}
+
+fn absorb(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+fn collect(root: &Path, directory: &Path, entries: &mut BTreeMap<String, Option<PathBuf>>) -> std::io::Result<()> {
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let absolute = entry.path();
+        let relative = absolute.strip_prefix(root).map_err(std::io::Error::other)?;
+        let portable = relative
+            .components()
+            .map(|component| component.as_os_str().to_str())
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "plugin path is not UTF-8"))?
+            .join("/");
+        let kind = entry.file_type()?;
+        if kind.is_dir() {
+            entries.insert(portable, None);
+            collect(root, &absolute, entries)?;
+        } else if kind.is_file() {
+            entries.insert(portable, Some(absolute));
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{} is neither a regular file nor a directory", absolute.display()),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -178,8 +178,12 @@ pub(crate) enum EventError {
     PolicyUnavailable(String),
     #[error("engine invariant breach: {0}")]
     EngineInvariant(String),
-    #[error("annotator={annotator} error={reason}")]
-    AnnotationRefused { annotator: String, reason: String },
+    #[error("annotator={annotator} error={reason}{next_action}")]
+    AnnotationRefused {
+        annotator: String,
+        reason: String,
+        next_action: &'static str,
+    },
     #[error("tool {tool} is not declared in this policy and no wildcard covers it; the call is refused before it runs")]
     UndeclaredTool { tool: String },
     #[error("storage failure: {0}")]
@@ -187,6 +191,19 @@ pub(crate) enum EventError {
 }
 
 impl EventError {
+    fn annotation_refused(annotator: String, reason: String) -> Self {
+        let next_action = if annotator == "claude-code.undeclared-tool" {
+            "; this tool has no exact policy contract; run /appa-guide init to sync installed MCP tools"
+        } else {
+            ""
+        };
+        Self::AnnotationRefused {
+            annotator,
+            reason,
+            next_action,
+        }
+    }
+
     /// Whether this failure is the deployment's problem rather than
     /// something the model or the harness can act on. An operational
     /// failure refuses wherever it happens, so the harness fails closed
@@ -992,6 +1009,19 @@ mod deployment_tests {
 
     use super::*;
     use crate::config::{AnnotatorImplementation, Endpoint, ExternalBindings, LlmBinding, LlmProvider};
+
+    #[test]
+    fn the_undeclared_tool_fallback_refusal_names_the_recovery_action() {
+        let fallback = EventError::annotation_refused(
+            "claude-code.undeclared-tool".to_string(),
+            "non_success status=1".to_string(),
+        )
+        .to_string();
+        assert!(fallback.contains("run /appa-guide init"), "{fallback}");
+
+        let exact = EventError::annotation_refused("bash-classifier".to_string(), "timeout".to_string()).to_string();
+        assert!(!exact.contains("/appa-guide init"), "{exact}");
+    }
 
     /// A deployment with no `[externals.annotators]` bindings: the policy under test names
     /// `builtin = "claude-code"` on the declarations it wants answered by Claude Code.

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -836,10 +836,7 @@ impl Session {
                             }
                             _ => tracing::debug!(annotator, ?reason, "an annotation consult produced no answer"),
                         }
-                        return Err(EventError::AnnotationRefused {
-                            annotator: annotator.clone(),
-                            reason: reason.diagnostic(),
-                        });
+                        return Err(EventError::annotation_refused(annotator.clone(), reason.diagnostic()));
                     }
                 };
                 ExternalEvidence::Annotation {

--- a/appa-runtime/src/bin/appa.rs
+++ b/appa-runtime/src/bin/appa.rs
@@ -57,10 +57,8 @@ impl Adapter {
 enum Harness {
     /// Install this build's Claude Code plugin and initialize its local deployment.
     ClaudeCode {
-        /// Development override: a marketplace root to deploy instead of this
-        /// build's own release plugin. Without it, init installs only the
-        /// plugin artifact whose digest this binary was built with.
-        #[arg(long)]
+        /// Developer override: a staged marketplace root to deploy.
+        #[arg(long, hide = true)]
         plugin_source: Option<String>,
     },
 }

--- a/appa-runtime/src/builtins.rs
+++ b/appa-runtime/src/builtins.rs
@@ -508,35 +508,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn a_claude_nonzero_exit_keeps_its_status() {
-        use std::os::unix::fs::PermissionsExt as _;
-
-        let dir = tempfile::tempdir().expect("a temp dir");
-        let fake = dir.path().join("fake-claude");
-        std::fs::write(&fake, "#!/bin/sh\ncat > /dev/null\nexit 7\n").expect("the fake writes");
-        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).expect("the fake is executable");
-        let backend = ClaudeCodeBackend {
-            command: fake,
-            model: "m".to_string(),
-            timeout: std::time::Duration::from_secs(5),
-            max_body_bytes: 65_536,
-        };
-        let prompt = ModelPrompt {
-            system: "rule".to_string(),
-            input: "{}".to_string(),
-            schema: serde_json::json!({"type": "object"}),
-        };
-
-        assert_eq!(
-            backend
-                .consult(&prompt, tokio::time::Instant::now() + std::time::Duration::from_secs(5))
-                .await,
-            Err(NoAnswerReason::NonSuccess { status: 7 })
-        );
-    }
-
     /// A helper the CLI leaves running — here a backgrounded `sleep` that keeps the
     /// CLI's stdout open, whose pid the fake records — neither stalls the answer nor
     /// survives the consult that started it.

--- a/appa-runtime/src/builtins.rs
+++ b/appa-runtime/src/builtins.rs
@@ -419,13 +419,7 @@ pub(crate) async fn run_claude_code(
         .stderr(Stdio::null())
         .kill_on_drop(true);
     command.as_std_mut().process_group(0);
-    // No APPA secret or wiring variable reaches the model: the child needs its own
-    // credentials and HOME, never this runtime's bearer tokens.
-    for (key, _) in std::env::vars_os() {
-        if key.to_string_lossy().starts_with("APPA_") {
-            command.env_remove(key);
-        }
-    }
+    isolate_claude_environment(&mut command);
     tracing::debug!("claude consult starts");
     let child = command.spawn().map_err(|_| {
         tracing::warn!(command = %backend.command.display(), "the claude executable did not start");
@@ -460,10 +454,28 @@ pub(crate) async fn run_claude_code(
     let status = process.terminate_and_reap().await?;
     if !status.success() {
         tracing::debug!(code = ?status.code(), "claude exited without an answer");
-        return Err(NoAnswerReason::Transport);
+        return Err(NoAnswerReason::NonSuccess {
+            status: status.code().and_then(|code| u16::try_from(code).ok()).unwrap_or(0),
+        });
     }
     let envelope: ClaudeResultEnvelope = serde_json::from_slice(&output).map_err(|_| NoAnswerReason::Malformed)?;
     envelope.structured_output.ok_or(NoAnswerReason::Malformed)
+}
+
+#[cfg(unix)]
+fn isolate_claude_environment(command: &mut tokio::process::Command) {
+    // Claude Code marks its own process tree and refuses to start a nested CLI
+    // while that marker is present. This consult is deliberately isolated,
+    // tool-less, and non-persistent, so it is safe and necessary to clear the
+    // harness marker before launching it.
+    command.env_remove("CLAUDECODE");
+    // No APPA secret or wiring variable reaches the model: the child needs its own
+    // credentials and HOME, never this runtime's bearer tokens.
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("APPA_") {
+            command.env_remove(key);
+        }
+    }
 }
 
 /// The builtin is a local process under a process group this platform lacks; the
@@ -480,6 +492,50 @@ pub(crate) async fn run_claude_code(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn a_claude_consult_clears_the_parent_session_marker() {
+        let mut command = tokio::process::Command::new("claude");
+        command.env("CLAUDECODE", "1");
+        isolate_claude_environment(&mut command);
+        assert!(
+            command
+                .as_std()
+                .get_envs()
+                .any(|(name, value)| name == "CLAUDECODE" && value.is_none()),
+            "the nested-session marker is explicitly removed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_claude_nonzero_exit_keeps_its_status() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let fake = dir.path().join("fake-claude");
+        std::fs::write(&fake, "#!/bin/sh\ncat > /dev/null\nexit 7\n").expect("the fake writes");
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).expect("the fake is executable");
+        let backend = ClaudeCodeBackend {
+            command: fake,
+            model: "m".to_string(),
+            timeout: std::time::Duration::from_secs(5),
+            max_body_bytes: 65_536,
+        };
+        let prompt = ModelPrompt {
+            system: "rule".to_string(),
+            input: "{}".to_string(),
+            schema: serde_json::json!({"type": "object"}),
+        };
+
+        assert_eq!(
+            backend
+                .consult(&prompt, tokio::time::Instant::now() + std::time::Duration::from_secs(5))
+                .await,
+            Err(NoAnswerReason::NonSuccess { status: 7 })
+        );
+    }
 
     /// A helper the CLI leaves running — here a backgrounded `sleep` that keeps the
     /// CLI's stdout open, whose pid the fake records — neither stalls the answer nor

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -1524,7 +1524,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         // shell can take over a second to start, and that is not the failure under test.
         assert_eq!(
             run(fake_claude(dir.path(), "exit 7"), 5000, 1024).await,
-            Err(NoAnswerReason::Transport)
+            Err(NoAnswerReason::NonSuccess { status: 7 })
         );
         assert_eq!(
             run(fake_claude(dir.path(), "sleep 1"), 20, 1024).await,

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1417,22 +1417,50 @@ fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
 }
 
 #[cfg(windows)]
+const WINDOWS_APPA_IDENTITY_SCRIPT: &str = r#"
+$appaPid = [int]$env:APPA_STALE_PID
+$appaProcess = Get-Process -Id $appaPid -ErrorAction SilentlyContinue
+$appaState = 'missing'
+if ($null -ne $appaProcess) {
+    $appaState = 'foreign'
+    $appaCim = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $appaPid" -ErrorAction SilentlyContinue
+    $appaOwner = if ($null -ne $appaCim) {
+        Invoke-CimMethod -InputObject $appaCim -MethodName GetOwnerSid -ErrorAction SilentlyContinue
+    } else {
+        $null
+    }
+    $appaCallerSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    if ($appaProcess.ProcessName -ieq 'appa' -and
+        $null -ne $appaCim -and $appaCim.Name -ieq 'appa.exe' -and
+        $null -ne $appaOwner -and $appaOwner.ReturnValue -eq 0 -and
+        $appaOwner.Sid -eq $appaCallerSid) {
+        $appaState = 'owned'
+    }
+}
+"#;
+
+#[cfg(windows)]
 fn is_owned_appa_runtime(pid: i32) -> Result<bool, InitError> {
-    let answer = powershell(
-        "$p = Get-Process -Id ([int]$env:APPA_STALE_PID) -ErrorAction SilentlyContinue; \
-         if ($null -ne $p) { $p.ProcessName }",
-        [("APPA_STALE_PID", pid.to_string())],
-    )?;
-    Ok(answer.trim().eq_ignore_ascii_case("appa"))
+    let command = format!("{WINDOWS_APPA_IDENTITY_SCRIPT}\n$appaState");
+    let answer = powershell(&command, [("APPA_STALE_PID", pid.to_string())])?;
+    Ok(answer.trim() == "owned")
 }
 
 #[cfg(windows)]
 fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
-    powershell(
-        "Stop-Process -Id ([int]$env:APPA_STALE_PID) -Force -ErrorAction Stop",
-        [("APPA_STALE_PID", pid.to_string())],
-    )
-    .map(drop)
+    // Resolve the process object first and stop that object, not a freshly
+    // looked-up PID. The SID/name checks are repeated in this same PowerShell
+    // invocation so an elevated init never turns a forged health answer into
+    // authority to terminate another user's process.
+    let command = format!(
+        "{WINDOWS_APPA_IDENTITY_SCRIPT}\n\
+         if ($appaState -eq 'missing') {{ exit 0 }}\n\
+         if ($appaState -ne 'owned') {{ throw 'pid is not this user''s appa runtime' }}\n\
+         if (-not $appaProcess.HasExited) {{ \
+             Stop-Process -InputObject $appaProcess -Force -ErrorAction Stop \
+         }}"
+    );
+    powershell(&command, [("APPA_STALE_PID", pid.to_string())]).map(drop)
 }
 
 fn endpoint_owner(binary: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -131,15 +131,29 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     };
     let deployment = match &source {
         PluginSource::Explicit(path) => deploy(Population::Tree(path))?,
-        PluginSource::Release(digest) => {
+        PluginSource::Release { reference, digest } => {
             let archive = plugin_bundle::ensure_archive(
                 *digest,
+                reference,
                 env!("CARGO_PKG_VERSION"),
                 &paths.data_dir.join("cache").join("plugin"),
                 &plugin_bundle::release_base_url(),
             )?;
             deploy(Population::Archive(&archive))?
         }
+        PluginSource::Commit { commit, digest } => {
+            let archive = plugin_bundle::ensure_commit_archive(
+                commit,
+                *digest,
+                &paths.data_dir.join("cache").join("plugin"),
+                &plugin_bundle::source_archive_base_url(),
+            )?;
+            deploy(Population::Archive(&archive))?
+        }
+        PluginSource::Local { root, digest } => deploy(Population::Repository {
+            root,
+            expected: *digest,
+        })?,
     };
 
     // 4. Clear the endpoint before anything is mutated. A verified runtime at a
@@ -147,6 +161,10 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     //    leaving a new plugin registered against an old runtime that a rerun
     //    cannot dislodge.
     clear_retired_runtime(&paths)?;
+    //    A previous install may have been unlinked before init ran. Its process
+    //    still owns the endpoint, and its authenticated health answer names the
+    //    stale pid even though no pathname remains for the retired-path scan.
+    clear_stale_endpoint(&endpoint)?;
     //    Whatever still answers must be the build this init installs. A foreign
     //    responder cannot be stopped from here, so it is refused now, while
     //    Claude and the launcher are still untouched.
@@ -203,7 +221,9 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
 fn source_label(source: &PluginSource, deployment: &Deployment) -> String {
     let origin = match source {
         PluginSource::Explicit(path) => format!("{} (development source)", friendly_path(path)),
-        PluginSource::Release(_) => format!("appa {} release plugin", env!("CARGO_PKG_VERSION")),
+        PluginSource::Release { reference, .. } => format!("appa {reference} release plugin"),
+        PluginSource::Commit { commit, .. } => format!("OpenAPPA commit {}", &commit[..commit.len().min(12)]),
+        PluginSource::Local { root, .. } => format!("{} (dirty development source)", friendly_path(root)),
     };
     format!("{origin} -> {}", friendly_path(&deployment.root))
 }
@@ -457,13 +477,12 @@ fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
 /// Stop any runtime executing the retired install path before anything is
 /// mutated.
 ///
-/// The stop set is exact: `<install_dir>/appa`, the path an init with the
-/// environment resolving as it does now would have deployed to. Managed
-/// stopping and default-endpoint ownership are bounded to that. A runtime left
-/// by an init run under a different `APPA_INSTALL_DIR` or `APPA_DATA_DIR`
-/// executes a path this init never computes, so it is not in the stop set;
-/// `verify_runtime_binary` reports it as a foreign responder and leaves it
-/// running.
+/// The pathname stop set is exact: `<install_dir>/appa`, the path an init with
+/// the environment resolving as it does now would have deployed to. A runtime
+/// whose executable was already unlinked cannot match that path; the subsequent
+/// endpoint check reclaims it only when `/health` explicitly answers
+/// `stale <pid>` and the pid passes the starter's ownership/name check. A
+/// healthy runtime from another install remains foreign and is never stopped.
 ///
 /// A verified target that survives termination aborts init, because the
 /// fingerprint backstop runs after the Claude switch: proceeding would register
@@ -1242,9 +1261,9 @@ fn start_runtime(plugin_root: &Path, runtime: &Path, endpoint: &Endpoint) -> Res
 
 /// Who is answering the endpoint, as far as one probe can establish.
 ///
-/// Managed stopping covers only the paths this environment resolves to, so a
-/// runtime left by an init run under a different `APPA_INSTALL_DIR` or
-/// `APPA_DATA_DIR` is foreign: named, never killed.
+/// A healthy runtime left by an init under a different `APPA_INSTALL_DIR` or
+/// `APPA_DATA_DIR` is foreign: named, never killed. Stale runtimes are cleared
+/// before this classification through their separate health protocol.
 enum EndpointOwner {
     /// Nothing answered, or what answered serves no fingerprint. Before the
     /// start this is the ordinary case; after it, it is a failure.
@@ -1253,6 +1272,154 @@ enum EndpointOwner {
     Deployment,
     /// A different build.
     Foreign,
+}
+
+fn endpoint_health(endpoint: &Endpoint) -> Result<Option<String>, InitError> {
+    let output = Command::new("curl")
+        .args(["--fail", "--silent", "--max-time", "2"])
+        .arg(endpoint.join("/health"))
+        .output()
+        .map_err(|error| InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(String::from_utf8_lossy(&output.stdout).trim().to_owned()))
+}
+
+fn stale_pid(answer: &str) -> Option<i32> {
+    let pid = answer.strip_prefix("stale ")?;
+    if pid.is_empty() || pid.starts_with('0') || !pid.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    pid.parse().ok()
+}
+
+/// Stop the exact stale APPA runtime named by the endpoint before classifying
+/// any remaining responder as foreign.
+///
+/// This covers an unlinked Unix executable: pathname identity is unavailable,
+/// but the runtime's own health protocol still names its pid. The pid is not
+/// trusted by itself; init applies the same same-user/process-name check as the
+/// shipped starter before sending a signal. An `ok`, malformed, or absent
+/// health answer never grants shutdown authority.
+fn clear_stale_endpoint(endpoint: &Endpoint) -> Result<(), InitError> {
+    let Some(answer) = endpoint_health(endpoint)? else {
+        return Ok(());
+    };
+    let Some(pid) = stale_pid(&answer) else {
+        return Ok(());
+    };
+    if !is_owned_appa_runtime(pid)? {
+        return Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: format!(
+                "the endpoint names stale pid {pid}, but it is not this user's appa runtime; not stopping it"
+            ),
+        });
+    }
+    // Close the validation-to-signal race: the process must still be the one
+    // answering with the same stale pid immediately before it is terminated.
+    match endpoint_health(endpoint)? {
+        None => return Ok(()),
+        Some(ref current) if current == "ok" => return Ok(()),
+        Some(ref current) if stale_pid(current) == Some(pid) => {}
+        Some(_) => {
+            return Err(InitError::RuntimeIdentity {
+                endpoint: endpoint.url().to_owned(),
+                message: format!("the endpoint changed ownership before stale pid {pid} could be stopped"),
+            });
+        }
+    }
+    terminate_stale_pid(pid)?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        match endpoint_health(endpoint)? {
+            None => return Ok(()),
+            Some(ref current) if current == "ok" => return Ok(()),
+            Some(ref current) if stale_pid(current) == Some(pid) => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Some(_) => {
+                return Err(InitError::RuntimeIdentity {
+                    endpoint: endpoint.url().to_owned(),
+                    message: format!("the endpoint changed ownership while stale pid {pid} was stopping"),
+                });
+            }
+        }
+    }
+    #[cfg(unix)]
+    let path = executable_of(pid).unwrap_or_else(|| PathBuf::from(format!("pid {pid} at {}", endpoint.url())));
+    #[cfg(windows)]
+    let path = PathBuf::from(format!("pid {pid} at {}", endpoint.url()));
+    Err(InitError::RuntimeSurvived { pid, path })
+}
+
+#[cfg(unix)]
+fn is_owned_appa_runtime(pid: i32) -> Result<bool, InitError> {
+    if pid == std::process::id() as i32 {
+        return Ok(false);
+    }
+    let query = |field: &str| -> Option<String> {
+        let output = Command::new("ps")
+            .args(["-o", field, "-p", &pid.to_string()])
+            .output()
+            .ok()?;
+        output
+            .status
+            .success()
+            .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    };
+    let Some(uid) = query("uid=").and_then(|uid| uid.parse::<u32>().ok()) else {
+        return Ok(false);
+    };
+    if uid != unsafe { libc::geteuid() } {
+        return Ok(false);
+    }
+    let Some(command_name) = query("comm=") else {
+        return Ok(false);
+    };
+    if Path::new(&command_name).file_name().and_then(OsStr::to_str) != Some("appa") {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+#[cfg(unix)]
+fn terminate_stale_pid(pid: i32) -> Result<(), InitError> {
+    if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
+        return Ok(());
+    }
+    let source = std::io::Error::last_os_error();
+    if source.kind() == std::io::ErrorKind::NotFound {
+        return Ok(());
+    }
+    Err(InitError::InstallRuntime {
+        path: executable_of(pid).unwrap_or_else(|| PathBuf::from(format!("pid {pid}"))),
+        source,
+    })
+}
+
+#[cfg(windows)]
+fn is_owned_appa_runtime(pid: i32) -> Result<bool, InitError> {
+    let answer = powershell(
+        "$p = Get-Process -Id ([int]$env:APPA_STALE_PID) -ErrorAction SilentlyContinue; \
+         if ($null -ne $p) { $p.ProcessName }",
+        [("APPA_STALE_PID", pid.to_string())],
+    )?;
+    Ok(answer.trim().eq_ignore_ascii_case("appa"))
+}
+
+#[cfg(windows)]
+fn terminate_stale_pid(pid: i32) -> Result<(), InitError> {
+    powershell(
+        "Stop-Process -Id ([int]$env:APPA_STALE_PID) -Force -ErrorAction Stop",
+        [("APPA_STALE_PID", pid.to_string())],
+    )
+    .map(drop)
 }
 
 fn endpoint_owner(binary: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {
@@ -1381,6 +1548,80 @@ mod tests {
     fn still_running(pid: i32) -> bool {
         std::thread::sleep(std::time::Duration::from_millis(300));
         unsafe { libc::kill(pid, 0) == 0 }
+    }
+
+    #[cfg(unix)]
+    fn health_answers(answers: Vec<String>) -> Endpoint {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("a loopback health fixture binds");
+        let endpoint = Endpoint::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        std::thread::spawn(move || {
+            for answer in answers {
+                let (mut connection, _) = listener.accept().expect("the health probe connects");
+                let mut request = [0u8; 2048];
+                let _ = connection.read(&mut request);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{answer}",
+                    answer.len()
+                );
+                connection
+                    .write_all(response.as_bytes())
+                    .expect("the health answer writes");
+            }
+        });
+        endpoint
+    }
+
+    #[test]
+    fn only_canonical_stale_health_answers_grant_a_pid() {
+        assert_eq!(stale_pid("stale 42"), Some(42));
+        for answer in [
+            "",
+            "ok",
+            "stale",
+            "stale ",
+            "stale 0",
+            "stale 01",
+            "stale -1",
+            "stale 42 extra",
+        ] {
+            assert_eq!(stale_pid(answer), None, "accepted {answer:?}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_reclaims_an_unlinked_runtime_named_by_its_stale_health_answer() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let retired = directory.path().join("bin/appa");
+        let Some(pid) = process_executing(&retired, false, RUNTIME_ARGUMENTS) else {
+            return;
+        };
+        fs::remove_file(&retired).expect("the installed binary is unlinked while its runtime remains");
+        let endpoint = health_answers(vec![format!("stale {pid}"), format!("stale {pid}")]);
+
+        clear_stale_endpoint(&endpoint).expect("init stops its stale unlinked runtime");
+
+        assert!(!still_running(pid), "the stale runtime still owns its process");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_spoofed_stale_pid_does_not_grant_process_shutdown() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let other = directory.path().join("bin/not-appa");
+        let Some(pid) = process_executing(&other, false, RUNTIME_ARGUMENTS) else {
+            return;
+        };
+        let endpoint = health_answers(vec![format!("stale {pid}")]);
+
+        let refused = clear_stale_endpoint(&endpoint);
+
+        assert!(matches!(refused, Err(InitError::RuntimeIdentity { .. })));
+        assert!(still_running(pid), "a non-appa process was terminated");
+        unsafe { libc::kill(pid, libc::SIGKILL) };
     }
 
     #[cfg(unix)]

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::ffi::OsStr;
 use std::fs::{self, OpenOptions};
-use std::io::{IsTerminal, Write};
+use std::io::{BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -95,6 +95,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     let endpoint = Endpoint::resolve()?;
 
     // 1. Resolve and verify the source. Nothing outside a temp file has changed.
+    progress("resolving the matching plugin");
     let source = PluginSource::resolve(explicit_source)?;
     let paths = deployment_paths()?;
     let installations = installed_plugin_installations(&paths.claude_dir)?;
@@ -118,6 +119,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     let config_created = create_default_config(&config)?;
 
     // 3. Materialize the deployment, or validate and reuse an existing one.
+    progress("preparing the plugin bundle");
     let deployments = paths.data_dir.join("deployments");
     let deploy = |population| {
         plugin_bundle::materialize(
@@ -160,15 +162,15 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     //    retired install path that will not stop aborts init here, rather than
     //    leaving a new plugin registered against an old runtime that a rerun
     //    cannot dislodge.
+    progress("checking the runtime endpoint");
     clear_retired_runtime(&paths)?;
     //    A previous install may have been unlinked before init ran. Its process
     //    still owns the endpoint, and its authenticated health answer names the
     //    stale pid even though no pathname remains for the retired-path scan.
     clear_stale_endpoint(&endpoint)?;
-    //    Whatever still answers must be the build this init installs. A foreign
-    //    responder cannot be stopped from here, so it is refused now, while
-    //    Claude and the launcher are still untouched.
-    refuse_foreign_endpoint(&appa, &endpoint)?;
+    //    A healthy runtime from another build is stopped only after an explicit
+    //    confirmation and only when it identifies a same-user appa pid.
+    clear_foreign_endpoint(&appa, &endpoint)?;
 
     // 5. Snapshot for recovery and disarm the launcher.
     let launcher_dir = appa.parent().unwrap_or(&paths.install_dir);
@@ -181,12 +183,14 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     //    bound to: one transaction. Verification is inside it, because a plugin
     //    left registered against a runtime that failed verification is exactly
     //    the skew this bundle exists to prevent.
+    progress("updating the Claude Code plugin");
     let switch = replace_plugin(&deployment.root, &marketplaces, &installations)
         .and_then(|()| install_runtime(&appa, &deployed_appa))
         .and_then(|()| remove_legacy_runtime(&appa, &paths))
         .and_then(|()| installed_plugin_root(&paths.claude_dir))
         .and_then(|plugin_root| {
             install_statusline(&plugin_root, &paths)?;
+            progress("starting the runtime");
             start_runtime(&plugin_root, &deployed_appa, &endpoint)
         });
     if let Err(operation) = switch {
@@ -216,6 +220,10 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         stale_path_copy.as_deref(),
         std::io::stdout().is_terminal() && env::var_os("NO_COLOR").is_none(),
     ))
+}
+
+fn progress(message: &str) {
+    eprintln!("appa init: {message}...");
 }
 
 fn source_label(source: &PluginSource, deployment: &Deployment) -> String {
@@ -1264,14 +1272,16 @@ fn start_runtime(plugin_root: &Path, runtime: &Path, endpoint: &Endpoint) -> Res
 /// A healthy runtime left by an init under a different `APPA_INSTALL_DIR` or
 /// `APPA_DATA_DIR` is foreign: named, never killed. Stale runtimes are cleared
 /// before this classification through their separate health protocol.
+#[derive(Debug, PartialEq, Eq)]
 enum EndpointOwner {
     /// Nothing answered, or what answered serves no fingerprint. Before the
     /// start this is the ordinary case; after it, it is a failure.
     Unidentified,
     /// The binary whose bytes were offered for comparison.
     Deployment,
-    /// A different build.
-    Foreign,
+    /// A different build. New runtimes name their pid; an older runtime may
+    /// return only its digest and remains ineligible for automatic stopping.
+    Foreign { pid: Option<i32> },
 }
 
 fn endpoint_health(endpoint: &Endpoint) -> Result<Option<String>, InitError> {
@@ -1289,12 +1299,15 @@ fn endpoint_health(endpoint: &Endpoint) -> Result<Option<String>, InitError> {
     Ok(Some(String::from_utf8_lossy(&output.stdout).trim().to_owned()))
 }
 
-fn stale_pid(answer: &str) -> Option<i32> {
-    let pid = answer.strip_prefix("stale ")?;
+fn positive_pid(pid: &str) -> Option<i32> {
     if pid.is_empty() || pid.starts_with('0') || !pid.bytes().all(|byte| byte.is_ascii_digit()) {
         return None;
     }
     pid.parse().ok()
+}
+
+fn stale_pid(answer: &str) -> Option<i32> {
+    positive_pid(answer.strip_prefix("stale ")?)
 }
 
 /// Stop the exact stale APPA runtime named by the endpoint before classifying
@@ -1333,7 +1346,7 @@ fn clear_stale_endpoint(endpoint: &Endpoint) -> Result<(), InitError> {
             });
         }
     }
-    terminate_stale_pid(pid)?;
+    terminate_appa_pid(pid)?;
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while std::time::Instant::now() < deadline {
@@ -1389,7 +1402,7 @@ fn is_owned_appa_runtime(pid: i32) -> Result<bool, InitError> {
 }
 
 #[cfg(unix)]
-fn terminate_stale_pid(pid: i32) -> Result<(), InitError> {
+fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
     if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
         return Ok(());
     }
@@ -1414,7 +1427,7 @@ fn is_owned_appa_runtime(pid: i32) -> Result<bool, InitError> {
 }
 
 #[cfg(windows)]
-fn terminate_stale_pid(pid: i32) -> Result<(), InitError> {
+fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
     powershell(
         "Stop-Process -Id ([int]$env:APPA_STALE_PID) -Force -ErrorAction Stop",
         [("APPA_STALE_PID", pid.to_string())],
@@ -1439,26 +1452,128 @@ fn endpoint_owner(binary: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, I
     if !output.status.success() {
         return Ok(EndpointOwner::Unidentified);
     }
-    let actual = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    Ok(if actual == expected {
-        EndpointOwner::Deployment
-    } else {
-        EndpointOwner::Foreign
-    })
+    let answer = String::from_utf8_lossy(&output.stdout);
+    Ok(classify_endpoint_owner(&expected, &answer))
 }
 
-/// Refuse a foreign owner while Claude and the launcher are still untouched.
+fn classify_endpoint_owner(expected: &str, answer: &str) -> EndpointOwner {
+    let mut fields = answer.split_whitespace();
+    let actual = fields.next().unwrap_or_default();
+    let pid = fields.next().and_then(positive_pid);
+    if actual == expected {
+        EndpointOwner::Deployment
+    } else {
+        EndpointOwner::Foreign { pid }
+    }
+}
+
+fn confirm_stop(pid: i32, endpoint: &Endpoint) -> Result<bool, InitError> {
+    let stdin = std::io::stdin();
+    let stderr = std::io::stderr();
+    confirm_stop_with(pid, endpoint, &mut stdin.lock(), &mut stderr.lock())
+}
+
+fn confirm_stop_with(
+    pid: i32,
+    endpoint: &Endpoint,
+    input: &mut impl BufRead,
+    output: &mut impl Write,
+) -> Result<bool, InitError> {
+    write!(
+        output,
+        "appa: a different appa build (pid {pid}) owns {}. Stop it and continue? [Y/n] ",
+        endpoint.url()
+    )
+    .and_then(|()| output.flush())
+    .map_err(|source| InitError::RuntimeIdentity {
+        endpoint: endpoint.url().to_owned(),
+        message: format!("cannot ask permission to stop pid {pid}: {source}"),
+    })?;
+    let mut answer = String::new();
+    if input
+        .read_line(&mut answer)
+        .map_err(|source| InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: format!("cannot read permission to stop pid {pid}: {source}"),
+        })?
+        == 0
+    {
+        return Ok(false);
+    }
+    Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes"))
+}
+
+/// Clear a foreign owner while Claude and the launcher are still untouched.
 ///
-/// Silence is not refused here: nothing answering is what a first install looks
-/// like, and the backstop after the start is what proves the runtime is ours.
-fn refuse_foreign_endpoint(binary: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+/// Silence is accepted because that is a first install. A foreign process is
+/// eligible only when the APPA identity response names a same-user `appa`
+/// process and the user confirms the stop. The identity is checked again
+/// immediately before signalling to close the prompt-to-kill race.
+fn clear_foreign_endpoint(binary: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     match endpoint_owner(binary, endpoint)? {
         EndpointOwner::Deployment | EndpointOwner::Unidentified => Ok(()),
-        EndpointOwner::Foreign => Err(InitError::RuntimeIdentity {
+        EndpointOwner::Foreign { pid: None } => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
-            message: "a different appa build already owns this endpoint; stop that process and rerun init".to_owned(),
+            message: "a different appa build owns this endpoint, but this older runtime does not identify its pid; stop it and rerun init"
+                .to_owned(),
         }),
+        EndpointOwner::Foreign { pid: Some(pid) } => {
+            clear_confirmed_foreign_with(binary, endpoint, pid, confirm_stop)
+        }
     }
+}
+
+fn clear_confirmed_foreign_with(
+    binary: &Path,
+    endpoint: &Endpoint,
+    pid: i32,
+    confirm: impl FnOnce(i32, &Endpoint) -> Result<bool, InitError>,
+) -> Result<(), InitError> {
+    if !is_owned_appa_runtime(pid)? {
+        return Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: format!(
+                "a different build names pid {pid}, but it is not this user's appa runtime; not stopping it"
+            ),
+        });
+    }
+    if !confirm(pid, endpoint)? {
+        return Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: format!("a different appa build (pid {pid}) still owns this endpoint; init cancelled"),
+        });
+    }
+    match endpoint_owner(binary, endpoint)? {
+        EndpointOwner::Unidentified => return Ok(()),
+        EndpointOwner::Deployment => return Ok(()),
+        EndpointOwner::Foreign { pid: Some(current) } if current == pid => {}
+        EndpointOwner::Foreign { .. } => {
+            return Err(InitError::RuntimeIdentity {
+                endpoint: endpoint.url().to_owned(),
+                message: "the endpoint changed ownership after approval; not stopping either process".to_owned(),
+            });
+        }
+    }
+    if !is_owned_appa_runtime(pid)? {
+        return Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: format!("pid {pid} changed identity after approval; not stopping it"),
+        });
+    }
+    terminate_appa_pid(pid)?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        match endpoint_health(endpoint)? {
+            None => return Ok(()),
+            Some(_) => std::thread::sleep(std::time::Duration::from_millis(50)),
+        }
+    }
+    #[cfg(unix)]
+    let path = executable_of(pid).unwrap_or_else(|| PathBuf::from(format!("pid {pid} at {}", endpoint.url())));
+    #[cfg(windows)]
+    let path = PathBuf::from(format!("pid {pid} at {}", endpoint.url()));
+    Err(InitError::RuntimeSurvived { pid, path })
 }
 
 fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
@@ -1468,7 +1583,7 @@ fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), Init
             endpoint: endpoint.url().to_owned(),
             message: "the answering process exposes no binary fingerprint; stop it and rerun init".to_owned(),
         }),
-        EndpointOwner::Foreign => Err(InitError::RuntimeIdentity {
+        EndpointOwner::Foreign { .. } => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
             message: "a different appa build is answering; stop that process and rerun init".to_owned(),
         }),
@@ -1589,6 +1704,63 @@ mod tests {
         ] {
             assert_eq!(stale_pid(answer), None, "accepted {answer:?}");
         }
+    }
+
+    #[test]
+    fn runtime_identity_accepts_old_answers_but_only_new_answers_name_a_process() {
+        assert_eq!(classify_endpoint_owner("same", "same 42"), EndpointOwner::Deployment);
+        assert_eq!(
+            classify_endpoint_owner("same", "different 42"),
+            EndpointOwner::Foreign { pid: Some(42) }
+        );
+        assert_eq!(
+            classify_endpoint_owner("same", "different"),
+            EndpointOwner::Foreign { pid: None }
+        );
+    }
+
+    #[test]
+    fn stopping_a_foreign_runtime_requires_a_y_or_default_yes_answer() {
+        let endpoint = Endpoint::parse("http://127.0.0.1:8787").expect("the endpoint parses");
+        for answer in ["y\n", "YES\n", "\n"] {
+            let mut output = Vec::new();
+            assert!(
+                confirm_stop_with(42, &endpoint, &mut answer.as_bytes(), &mut output).expect("the answer reads"),
+                "{answer:?} approves"
+            );
+            assert!(
+                String::from_utf8(output)
+                    .unwrap()
+                    .contains("Stop it and continue? [Y/n]")
+            );
+        }
+        for answer in ["n\n", "no\n", "anything else\n", ""] {
+            assert!(
+                !confirm_stop_with(42, &endpoint, &mut answer.as_bytes(), &mut Vec::new()).expect("the answer reads"),
+                "{answer:?} refuses"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_approved_foreign_appa_runtime_is_stopped() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let foreign = directory.path().join("foreign/appa");
+        let Some(pid) = process_executing(&foreign, false, RUNTIME_ARGUMENTS) else {
+            return;
+        };
+        let candidate = directory.path().join("candidate-appa");
+        fs::write(&candidate, "a different candidate build").expect("the candidate binary exists");
+        let endpoint = health_answers(vec![format!("different-fingerprint {pid}")]);
+
+        clear_confirmed_foreign_with(&candidate, &endpoint, pid, |approved_pid, _| {
+            assert_eq!(approved_pid, pid);
+            Ok(true)
+        })
+        .expect("the approved foreign runtime stops");
+
+        assert!(!still_running(pid), "the approved runtime still owns its process");
     }
 
     #[cfg(unix)]

--- a/appa-runtime/src/lib.rs
+++ b/appa-runtime/src/lib.rs
@@ -18,3 +18,4 @@ mod elicit;
 mod engine;
 mod external;
 mod llm;
+mod plugin_layout;

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -217,8 +217,12 @@ async fn binary_fingerprint(State(state): State<AppState>) -> Result<String, axu
     state
         .executable
         .as_ref()
-        .map(|executable| executable.digest.clone())
+        .map(|executable| binary_fingerprint_answer(&executable.digest, std::process::id()))
         .ok_or(axum::http::StatusCode::NOT_FOUND)
+}
+
+fn binary_fingerprint_answer(digest: &str, pid: u32) -> String {
+    format!("{digest} {pid}")
 }
 
 fn health_answer(stale: bool, pid: u32) -> String {
@@ -440,6 +444,11 @@ mod tests {
 
         fs::remove_file(&path).expect("the executable is removed");
         assert!(replaced(&path));
+    }
+
+    #[test]
+    fn the_binary_fingerprint_names_the_process_that_serves_it() {
+        assert_eq!(binary_fingerprint_answer("abc123", 41), "abc123 41");
     }
 
     #[test]

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -362,6 +362,12 @@ mod tests {
             DEFAULT_CONFIG
         );
         Config::load(&path).expect("the embedded default config validates");
+        assert!(
+            DEFAULT_CONFIG.contains("name = \"claude-code.undeclared-tool\"")
+                && DEFAULT_CONFIG.contains("name = \"*\"")
+                && DEFAULT_CONFIG.contains("annotator = \"claude-code.undeclared-tool\""),
+            "a fresh Claude Code deployment carries its explicit compatibility fallback"
+        );
 
         fs::write(&path, "existing deployment").expect("existing config is replaced by the test");
         assert!(!ensure_default_config(&path).expect("existing config is preserved"));

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -839,6 +839,14 @@ fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundl
             )));
         }
 
+        let kind = entry.header().entry_type();
+        // GitHub source archives may contain POSIX PAX metadata records. They
+        // describe following entries and do not materialize in the plugin
+        // tree; the following entry's resolved path is still checked below.
+        if matches!(kind, tar::EntryType::XHeader | tar::EntryType::XGlobalHeader) {
+            continue;
+        }
+
         let path = entry
             .path()
             .map_err(|error| malformed(format!("unreadable entry path: {error}")))?
@@ -857,7 +865,7 @@ fn extract_archive(archive: &Path, destination: &Path) -> Result<(), PluginBundl
             source,
         };
 
-        match entry.header().entry_type() {
+        match kind {
             tar::EntryType::Directory => fs::create_dir_all(&target).map_err(write)?,
             tar::EntryType::Regular => {
                 if let Some(parent) = target.parent() {
@@ -1626,6 +1634,17 @@ mod tests {
         {
             let encoder = flate2::write::GzEncoder::new(&mut bytes, flate2::Compression::fast());
             let mut archive = tar::Builder::new(encoder);
+
+            // GitHub source archives can begin with this POSIX PAX metadata
+            // entry. It is transport metadata, not part of the source tree.
+            let metadata = b"27 comment=GitHub archive\n";
+            let mut header = tar::Header::new_ustar();
+            header.set_path("pax_global_header").unwrap();
+            header.set_size(metadata.len() as u64);
+            header.set_entry_type(tar::EntryType::XGlobalHeader);
+            header.set_cksum();
+            archive.append(&header, metadata.as_slice()).unwrap();
+
             for (source, _) in crate::plugin_layout::REPOSITORY_MAPPINGS {
                 let path = repository.join(source);
                 let archived = Path::new("OpenAPPA-test").join(source);

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -1,10 +1,11 @@
 //! The Claude plugin bundle belonging to this binary's own release.
 //!
-//! A binary is built knowing the SHA-256 of its release's plugin artifact and
-//! accepts no other bytes. That digest is the whole compatibility rule: there is
-//! no version field inside the artifact and no commit to compare, because the
-//! digest already pins the exact bytes. A development build has no digest, so it
-//! refuses to download and requires `--plugin-source`.
+//! A release binary is built knowing its release tag and the SHA-256 of that
+//! tag's plugin artifact. A clean source build knows its Git commit and the
+//! canonical SHA-256 of the plugin tree built beside it. In both cases init
+//! resolves immutable remote bytes automatically and verifies them before any
+//! installed state changes. A dirty source build uses the exact local checkout
+//! only while it still matches the tree digest baked at compile time.
 
 use std::env;
 use std::fmt;
@@ -49,8 +50,12 @@ pub enum TreeShape {
 
 #[derive(Debug, Error)]
 pub enum PluginBundleError {
-    #[error("appa {version} is a development build with no plugin artifact digest; pass --plugin-source <checkout>")]
-    NoBakedDigest { version: &'static str },
+    #[error("this appa build has no usable plugin source identity; rebuild it from a Git checkout or a release tag")]
+    MissingBuildIdentity,
+    #[error("this appa build carries a release plugin digest but no release tag")]
+    MissingReleaseRef,
+    #[error("this appa build carries an invalid plugin tree digest: {value}")]
+    MalformedBuildDigest { value: String },
     #[error("{value} is not a SHA-256 digest")]
     MalformedDigest { value: String },
     #[error("the plugin source at {path} is not a marketplace root: {reason}")]
@@ -79,6 +84,14 @@ pub enum PluginBundleError {
         expected: PluginDigest,
         actual: PluginDigest,
     },
+    #[error("the plugin at {origin} is not the twin of this appa build: expected tree {expected}, got {actual}")]
+    SourceDigestMismatch {
+        origin: String,
+        expected: PluginDigest,
+        actual: PluginDigest,
+    },
+    #[error("cannot stage the plugin from the OpenAPPA source at {path}: {reason}")]
+    StageRepository { path: PathBuf, reason: String },
 }
 
 /// The SHA-256 of a plugin artifact: what a binary was built with, and what a
@@ -131,48 +144,92 @@ impl fmt::Debug for PluginDigest {
     }
 }
 
-/// The digest of the plugin artifact this build belongs to.
-///
-/// Release builds carry it as a compile-time constant, so a shipped binary
-/// cannot be pointed at other bytes by its environment. `[profile.release]` pins
-/// `debug-assertions = false`, which is what closes the debug branch there.
-pub fn expected_plugin_digest() -> Option<PluginDigest> {
-    let raw = if cfg!(debug_assertions) {
-        env::var("APPA_PLUGIN_SHA256").ok()
-    } else {
-        option_env!("APPA_PLUGIN_SHA256").map(str::to_owned)
-    };
-    raw.as_deref().and_then(|value| PluginDigest::parse(value).ok())
+#[derive(Debug, Clone, Copy)]
+struct BuildIdentity<'a> {
+    pub release_digest: Option<PluginDigest>,
+    pub release_ref: Option<&'a str>,
+    pub commit: Option<&'a str>,
+    pub tree_digest: Option<PluginDigest>,
+    pub local_root: Option<&'a str>,
+    pub source_kind: Option<&'a str>,
 }
 
-/// Where a deployment's bytes come from. `Explicit` is the development override;
-/// everything else resolves to this binary's own release artifact.
+impl BuildIdentity<'static> {
+    fn compiled() -> Result<Self, PluginBundleError> {
+        // Both digests are compile-time constants. Runtime environment changes
+        // cannot redirect a shipped binary to different plugin bytes.
+        let release_digest = option_env!("APPA_PLUGIN_SHA256")
+            .map(PluginDigest::parse)
+            .transpose()
+            .map_err(|_| PluginBundleError::MalformedBuildDigest {
+                value: option_env!("APPA_PLUGIN_SHA256").unwrap_or_default().to_owned(),
+            })?;
+        let raw_tree = option_env!("APPA_PLUGIN_TREE_SHA256").ok_or(PluginBundleError::MissingBuildIdentity)?;
+        let tree_digest = PluginDigest::parse(raw_tree).map_err(|_| PluginBundleError::MalformedBuildDigest {
+            value: raw_tree.to_owned(),
+        })?;
+        Ok(Self {
+            release_digest,
+            release_ref: option_env!("APPA_RELEASE_REF"),
+            commit: option_env!("APPA_BUILD_COMMIT"),
+            tree_digest: Some(tree_digest),
+            local_root: option_env!("APPA_PLUGIN_SOURCE_ROOT"),
+            source_kind: option_env!("APPA_PLUGIN_SOURCE_KIND"),
+        })
+    }
+}
+
+/// Where a deployment's bytes come from. `Explicit` is the semi-hidden
+/// development override; normal init resolves the identity baked into this
+/// binary without consulting PATH, the working directory, or mutable refs.
 #[derive(Debug, Clone)]
 pub enum PluginSource {
     Explicit(PathBuf),
-    Release(PluginDigest),
+    Release { reference: String, digest: PluginDigest },
+    Commit { commit: String, digest: PluginDigest },
+    Local { root: PathBuf, digest: PluginDigest },
 }
 
 impl PluginSource {
-    /// `--plugin-source` when given, otherwise this build's release artifact.
-    /// A development build with neither refuses rather than guessing.
+    /// `--plugin-source` when given, otherwise this build's immutable twin.
     pub fn resolve(explicit: Option<&str>) -> Result<Self, PluginBundleError> {
-        Self::decide(explicit, expected_plugin_digest())
+        Self::decide(explicit, BuildIdentity::compiled()?)
     }
 
-    /// The decision itself, with this build's digest supplied rather than read,
-    /// so it is testable without touching the process environment.
-    pub fn decide(explicit: Option<&str>, baked: Option<PluginDigest>) -> Result<Self, PluginBundleError> {
-        match explicit {
-            Some(path) => Ok(Self::Explicit(canonical_source(Path::new(path))?)),
-            None => baked.map(Self::Release).ok_or(PluginBundleError::NoBakedDigest {
-                version: env!("CARGO_PKG_VERSION"),
-            }),
+    /// The decision itself with metadata supplied explicitly for unit tests.
+    fn decide(explicit: Option<&str>, build: BuildIdentity<'_>) -> Result<Self, PluginBundleError> {
+        if let Some(path) = explicit {
+            return Ok(Self::Explicit(canonical_source(Path::new(path))?));
+        }
+        if let Some(digest) = build.release_digest {
+            let reference = build.release_ref.ok_or(PluginBundleError::MissingReleaseRef)?;
+            return Ok(Self::Release {
+                reference: reference.to_owned(),
+                digest,
+            });
+        }
+        let digest = build.tree_digest.ok_or(PluginBundleError::MissingBuildIdentity)?;
+        match build.source_kind {
+            Some("commit") => {
+                let commit = build.commit.ok_or(PluginBundleError::MissingBuildIdentity)?;
+                Ok(Self::Commit {
+                    commit: commit.to_owned(),
+                    digest,
+                })
+            }
+            Some("local") => {
+                let root = build.local_root.ok_or(PluginBundleError::MissingBuildIdentity)?;
+                Ok(Self::Local {
+                    root: PathBuf::from(root),
+                    digest,
+                })
+            }
+            _ => Err(PluginBundleError::MissingBuildIdentity),
         }
     }
 }
 
-/// Resolve the user's `--plugin-source` argument like any other path argument.
+/// Resolve the developer's `--plugin-source` override like any other path argument.
 ///
 /// Windows keeps the existing carve-out: Claude rejects a `\\?\` marketplace
 /// path, so the extended-length prefix is stripped after canonicalization.
@@ -197,7 +254,7 @@ fn strip_extended_prefix(path: &Path) -> PathBuf {
     }
 }
 
-/// Structural validation, applied identically to a `--plugin-source` checkout, a
+/// Structural validation, applied identically to a `--plugin-source` tree, a
 /// freshly extracted archive, and an existing deployment considered for reuse.
 ///
 /// This checks shape, not content: a tree whose `batteries/` files were edited in
@@ -345,7 +402,7 @@ type StagedEntry = (String, u8, PathBuf);
 ///
 /// Computed over the staged tree after staging and **before** rendering, so it
 /// never depends on the paths being rendered into it. Without this, editing a
-/// file in a `--plugin-source` checkout and re-running init would reuse the
+/// file in a `--plugin-source` tree and re-running init would reuse the
 /// existing deployment and never reach Claude.
 pub fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundleError> {
     let entries = walk(root)?;
@@ -516,9 +573,13 @@ const WINDOWS_HOOKS: &str = "plugin/hooks/hooks.windows.json";
 const PATHS_PS1: &str = "plugin/hooks/appa-paths.ps1";
 
 /// Where a deployment's bytes come from at materialization time.
+#[derive(Clone, Copy)]
 pub enum Population<'a> {
-    /// A `--plugin-source` checkout, copied.
+    /// A staged `--plugin-source` marketplace root, copied.
     Tree(&'a Path),
+    /// The repository that produced a dirty source build, staged through the
+    /// same repository-to-marketplace mapping used at compile time.
+    Repository { root: &'a Path, expected: PluginDigest },
     /// A verified release archive, extracted.
     Archive(&'a Path),
 }
@@ -561,12 +622,29 @@ pub fn materialize(
                 walk(source)?;
                 copy_tree(source, &incoming)?
             }
+            Population::Repository { root, .. } => {
+                crate::plugin_layout::stage_repository(root, &incoming).map_err(|error| {
+                    PluginBundleError::StageRepository {
+                        path: root.to_path_buf(),
+                        reason: error.to_string(),
+                    }
+                })?;
+            }
             Population::Archive(archive) => extract_archive(archive, &incoming)?,
         }
         validate_tree(&incoming, TreeShape::Source)?;
         // After staging, before rendering: the source identity must not depend
         // on the paths about to be rendered into it.
         let source_digest = canonical_source_digest(&incoming)?;
+        if let Population::Repository { root, expected } = population
+            && source_digest != expected
+        {
+            return Err(PluginBundleError::SourceDigestMismatch {
+                origin: root.display().to_string(),
+                expected,
+                actual: source_digest,
+            });
+        }
         let plan = DeploymentPlan {
             source_digest,
             binary_path: binary_path.to_path_buf(),
@@ -968,6 +1046,7 @@ fn ps_literal(value: &str) -> String {
 // ---------------------------------------------------------------------------
 
 const RELEASE_BASE_URL: &str = "https://github.com/archestra-ai/OpenAPPA/releases/download";
+const SOURCE_ARCHIVE_BASE_URL: &str = "https://github.com/archestra-ai/OpenAPPA/archive";
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_REDIRECTS: usize = 5;
@@ -996,6 +1075,17 @@ pub fn release_base_url() -> String {
     configured.unwrap_or_else(|| RELEASE_BASE_URL.to_owned())
 }
 
+/// The immutable GitHub source-archive base. Like the release test seam, the
+/// override exists only in debug builds and cannot redirect a shipped binary.
+pub fn source_archive_base_url() -> String {
+    let configured = if cfg!(debug_assertions) {
+        env::var("APPA_SOURCE_ARCHIVE_BASE_URL").ok()
+    } else {
+        None
+    };
+    configured.unwrap_or_else(|| SOURCE_ARCHIVE_BASE_URL.to_owned())
+}
+
 /// The verified archive for this build's release, from the cache when it is
 /// already there and from the release otherwise.
 ///
@@ -1003,6 +1093,7 @@ pub fn release_base_url() -> String {
 /// with, so the cache cannot be used to bypass a refusal.
 pub fn ensure_archive(
     digest: PluginDigest,
+    reference: &str,
     version: &str,
     cache_dir: &Path,
     base_url: &str,
@@ -1024,7 +1115,7 @@ pub fn ensure_archive(
         source,
     })?;
 
-    let url = format!("{base_url}/v{version}/{}", artifact_name(version));
+    let url = format!("{base_url}/{reference}/{}", artifact_name(version));
     let incoming = tempfile::NamedTempFile::new_in(cache_dir).map_err(|source| PluginBundleError::WriteDeployment {
         path: cache_dir.to_path_buf(),
         source,
@@ -1049,6 +1140,142 @@ pub fn ensure_archive(
             source: error.error,
         })?;
     Ok(cached)
+}
+
+fn commit_archive_name(commit: &str, digest: PluginDigest) -> String {
+    format!("appa-plugin-{commit}-{digest}.tar.gz")
+}
+
+/// Resolve a clean source build's plugin from its immutable Git commit.
+///
+/// GitHub's repository archive is transport only. It is staged into the same
+/// marketplace shape as a release and checked against the canonical tree
+/// digest baked into the binary before entering the cache.
+pub fn ensure_commit_archive(
+    commit: &str,
+    expected: PluginDigest,
+    cache_dir: &Path,
+    base_url: &str,
+) -> Result<PathBuf, PluginBundleError> {
+    fs::create_dir_all(cache_dir).map_err(|source| PluginBundleError::WriteDeployment {
+        path: cache_dir.to_path_buf(),
+        source,
+    })?;
+    let cached = cache_dir.join(commit_archive_name(commit, expected));
+    if cached.is_file() {
+        match bundle_archive_digest(&cached) {
+            Ok(actual) if actual == expected => return Ok(cached),
+            Ok(_) | Err(_) => {
+                tracing::debug!(path = %cached.display(), "re-fetching a commit bundle that no longer matches its tree digest");
+            }
+        }
+    }
+
+    let source = tempfile::NamedTempFile::new_in(cache_dir).map_err(|error| PluginBundleError::WriteDeployment {
+        path: cache_dir.to_path_buf(),
+        source: error,
+    })?;
+    let url = format!("{base_url}/{commit}.tar.gz");
+    download(&url, source.path())?;
+
+    let workspace = tempfile::tempdir_in(cache_dir).map_err(|error| PluginBundleError::WriteDeployment {
+        path: cache_dir.to_path_buf(),
+        source: error,
+    })?;
+    let repository_container = workspace.path().join("repository");
+    fs::create_dir(&repository_container).map_err(|source| PluginBundleError::WriteDeployment {
+        path: repository_container.clone(),
+        source,
+    })?;
+    extract_archive(source.path(), &repository_container)?;
+    let repository = single_directory(&repository_container)?;
+    let bundle = workspace.path().join("bundle");
+    crate::plugin_layout::stage_repository(&repository, &bundle).map_err(|error| {
+        PluginBundleError::StageRepository {
+            path: repository.clone(),
+            reason: error.to_string(),
+        }
+    })?;
+    validate_tree(&bundle, TreeShape::Source)?;
+    let actual = canonical_source_digest(&bundle)?;
+    if actual != expected {
+        return Err(PluginBundleError::SourceDigestMismatch {
+            origin: format!("commit {commit} fetched from {url}"),
+            expected,
+            actual,
+        });
+    }
+
+    let incoming = tempfile::NamedTempFile::new_in(cache_dir).map_err(|error| PluginBundleError::WriteDeployment {
+        path: cache_dir.to_path_buf(),
+        source: error,
+    })?;
+    pack_bundle(&bundle, incoming.path())?;
+    incoming
+        .persist(&cached)
+        .map_err(|error| PluginBundleError::WriteDeployment {
+            path: cached.clone(),
+            source: error.error,
+        })?;
+    Ok(cached)
+}
+
+fn single_directory(container: &Path) -> Result<PathBuf, PluginBundleError> {
+    let mut entries = fs::read_dir(container).map_err(|source| PluginBundleError::ReadSource {
+        path: container.to_path_buf(),
+        source,
+    })?;
+    let first = entries
+        .next()
+        .transpose()
+        .map_err(|source| PluginBundleError::ReadSource {
+            path: container.to_path_buf(),
+            source,
+        })?
+        .ok_or_else(|| PluginBundleError::MalformedArchive {
+            path: container.to_path_buf(),
+            reason: "it contains no repository root".to_owned(),
+        })?;
+    if entries.next().is_some() || !first.path().is_dir() {
+        return Err(PluginBundleError::MalformedArchive {
+            path: container.to_path_buf(),
+            reason: "it does not contain exactly one repository root".to_owned(),
+        });
+    }
+    Ok(first.path())
+}
+
+fn pack_bundle(source: &Path, destination: &Path) -> Result<(), PluginBundleError> {
+    let file = fs::File::create(destination).map_err(|source| PluginBundleError::WriteDeployment {
+        path: destination.to_path_buf(),
+        source,
+    })?;
+    let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+    let mut archive = tar::Builder::new(encoder);
+    archive
+        .append_dir_all(".", source)
+        .map_err(|source| PluginBundleError::WriteDeployment {
+            path: destination.to_path_buf(),
+            source,
+        })?;
+    archive
+        .into_inner()
+        .and_then(flate2::write::GzEncoder::finish)
+        .map_err(|source| PluginBundleError::WriteDeployment {
+            path: destination.to_path_buf(),
+            source,
+        })?;
+    Ok(())
+}
+
+fn bundle_archive_digest(archive: &Path) -> Result<PluginDigest, PluginBundleError> {
+    let staged = tempfile::tempdir().map_err(|source| PluginBundleError::WriteDeployment {
+        path: archive.to_path_buf(),
+        source,
+    })?;
+    extract_archive(archive, staged.path())?;
+    validate_tree(staged.path(), TreeShape::Source)?;
+    canonical_source_digest(staged.path())
 }
 
 fn digest_of_file(path: &Path) -> Result<PluginDigest, PluginBundleError> {
@@ -1393,6 +1620,82 @@ mod tests {
         (base, stop)
     }
 
+    fn repository_archive() -> Vec<u8> {
+        let repository = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let mut bytes = Vec::new();
+        {
+            let encoder = flate2::write::GzEncoder::new(&mut bytes, flate2::Compression::fast());
+            let mut archive = tar::Builder::new(encoder);
+            for (source, _) in crate::plugin_layout::REPOSITORY_MAPPINGS {
+                let path = repository.join(source);
+                let archived = Path::new("OpenAPPA-test").join(source);
+                if path.is_dir() {
+                    archive.append_dir_all(archived, path).unwrap();
+                } else {
+                    archive.append_path_with_name(path, archived).unwrap();
+                }
+            }
+            archive.into_inner().unwrap().finish().unwrap();
+        }
+        bytes
+    }
+
+    #[test]
+    fn build_time_and_runtime_repository_staging_have_one_tree_identity() {
+        let repository = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let staged = tempfile::tempdir().unwrap();
+        crate::plugin_layout::stage_repository(repository, staged.path()).unwrap();
+
+        let runtime = canonical_source_digest(staged.path()).unwrap();
+        let compiled = PluginDigest::parse(env!("APPA_PLUGIN_TREE_SHA256")).unwrap();
+        assert_eq!(runtime, compiled);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_release_script_and_runtime_mapping_stage_identical_trees() {
+        let repository = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let scripted = directory.path().join("scripted");
+        let mapped = directory.path().join("mapped");
+        let status = std::process::Command::new("sh")
+            .arg(repository.join("scripts/appa-stage-plugin-bundle.sh"))
+            .arg(&scripted)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        crate::plugin_layout::stage_repository(repository, &mapped).unwrap();
+
+        assert_eq!(
+            canonical_source_digest(&scripted).unwrap(),
+            canonical_source_digest(&mapped).unwrap()
+        );
+    }
+
+    #[test]
+    fn a_commit_source_archive_is_staged_verified_and_cached() {
+        let expected = PluginDigest::parse(env!("APPA_PLUGIN_TREE_SHA256")).unwrap();
+        let (base, _stop) = serve(repository_archive());
+        let cache = tempfile::tempdir().unwrap();
+
+        let archive = ensure_commit_archive("71b5080", expected, cache.path(), &base).unwrap();
+
+        assert_eq!(bundle_archive_digest(&archive).unwrap(), expected);
+        assert!(archive.file_name().unwrap().to_string_lossy().contains("71b5080"));
+    }
+
+    #[test]
+    fn a_commit_whose_plugin_tree_is_not_the_build_twin_is_refused() {
+        let (base, _stop) = serve(repository_archive());
+        let cache = tempfile::tempdir().unwrap();
+        let expected = PluginDigest::of(b"not this repository tree");
+
+        let refused = ensure_commit_archive("71b5080", expected, cache.path(), &base);
+
+        assert!(matches!(refused, Err(PluginBundleError::SourceDigestMismatch { .. })));
+        assert_eq!(fs::read_dir(cache.path()).unwrap().count(), 0);
+    }
+
     #[test]
     fn a_verified_download_lands_in_the_cache() {
         let cache = tempfile::tempdir().unwrap();
@@ -1400,7 +1703,7 @@ mod tests {
         let digest = PluginDigest::of(&body);
         let (base, _stop) = serve(body);
 
-        let archive = ensure_archive(digest, "9.9.9", cache.path(), &base).unwrap();
+        let archive = ensure_archive(digest, "v9.9.9", "9.9.9", cache.path(), &base).unwrap();
 
         assert_eq!(digest_of_file(&archive).unwrap(), digest);
         assert!(
@@ -1419,7 +1722,7 @@ mod tests {
         let (base, _stop) = serve(b"someone else's bytes".to_vec());
         let expected = PluginDigest::of(b"what this build accepts");
 
-        let refused = ensure_archive(expected, "9.9.9", cache.path(), &base);
+        let refused = ensure_archive(expected, "v9.9.9", "9.9.9", cache.path(), &base);
 
         assert!(matches!(refused, Err(PluginBundleError::DigestMismatch { .. })));
         let leftovers: Vec<_> = fs::read_dir(cache.path())
@@ -1438,7 +1741,7 @@ mod tests {
         fs::write(cached_archive_path(cache.path(), "9.9.9", digest), &body).unwrap();
 
         // Nothing is listening here, so any request would fail.
-        let archive = ensure_archive(digest, "9.9.9", cache.path(), "http://127.0.0.1:1").unwrap();
+        let archive = ensure_archive(digest, "v9.9.9", "9.9.9", cache.path(), "http://127.0.0.1:1").unwrap();
 
         assert_eq!(fs::read(archive).unwrap(), body);
     }
@@ -1452,17 +1755,76 @@ mod tests {
         fs::write(&path, b"corrupted").unwrap();
 
         let (base, _stop) = serve(body.clone());
-        let archive = ensure_archive(digest, "9.9.9", cache.path(), &base).unwrap();
+        let archive = ensure_archive(digest, "v9.9.9", "9.9.9", cache.path(), &base).unwrap();
 
         assert_eq!(fs::read(archive).unwrap(), body);
     }
 
     #[test]
-    fn a_development_build_refuses_to_download() {
+    fn a_clean_source_build_resolves_its_commit_twin() {
+        let digest = PluginDigest::of(b"tree");
+        let source = PluginSource::decide(
+            None,
+            BuildIdentity {
+                release_digest: None,
+                release_ref: None,
+                commit: Some("71b5080ad2a49e21493887c5bf71a45c620e924f"),
+                tree_digest: Some(digest),
+                local_root: None,
+                source_kind: Some("commit"),
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(source, PluginSource::Commit { commit, digest: actual } if commit == "71b5080ad2a49e21493887c5bf71a45c620e924f" && actual == digest)
+        );
+    }
+
+    #[test]
+    fn the_compiled_binary_always_has_an_automatic_plugin_source() {
         assert!(matches!(
-            PluginSource::decide(None, None),
-            Err(PluginBundleError::NoBakedDigest { .. })
+            PluginSource::resolve(None).unwrap(),
+            PluginSource::Release { .. } | PluginSource::Commit { .. } | PluginSource::Local { .. }
         ));
+    }
+
+    #[test]
+    fn a_release_build_resolves_the_stamped_tag_not_the_cargo_version() {
+        let release = PluginDigest::of(b"release archive");
+        let source = PluginSource::decide(
+            None,
+            BuildIdentity {
+                release_digest: Some(release),
+                release_ref: Some("v7.8.9"),
+                commit: Some("ignored"),
+                tree_digest: Some(PluginDigest::of(b"tree")),
+                local_root: None,
+                source_kind: Some("release"),
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(source, PluginSource::Release { reference, digest } if reference == "v7.8.9" && digest == release)
+        );
+    }
+
+    #[test]
+    fn the_explicit_development_source_wins_over_build_metadata() {
+        let source = tempfile::tempdir().unwrap();
+        sample_tree(source.path());
+        let selected = PluginSource::decide(
+            source.path().to_str(),
+            BuildIdentity {
+                release_digest: None,
+                release_ref: None,
+                commit: None,
+                tree_digest: None,
+                local_root: None,
+                source_kind: None,
+            },
+        )
+        .unwrap();
+        assert!(matches!(selected, PluginSource::Explicit(path) if path == source.path().canonicalize().unwrap()));
     }
 
     #[test]

--- a/appa-runtime/src/plugin_layout.rs
+++ b/appa-runtime/src/plugin_layout.rs
@@ -1,0 +1,68 @@
+//! The repository paths that make up the distributable Claude Code plugin.
+//!
+//! This module is also compiled by `build.rs`, so keep it limited to `std`.
+//! One mapping drives build-time identity and runtime staging from a GitHub
+//! source archive.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+pub const REPOSITORY_MAPPINGS: [(&str, &str); 7] = [
+    ("integrations/claude-code/.claude-plugin", ".claude-plugin"),
+    ("integrations/claude-code/plugin", "plugin"),
+    ("integrations/claude-code/examples", "examples"),
+    ("batteries", "batteries"),
+    ("integrations/claude-code/README.md", "README.md"),
+    ("integrations/claude-code/live-gate-check.py", "live-gate-check.py"),
+    ("website/content/docs/contracts.md", "website/content/docs/contracts.md"),
+];
+
+/// Stage the plugin marketplace tree from an OpenAPPA repository checkout.
+pub fn stage_repository(repository: &Path, destination: &Path) -> io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for (source, target) in REPOSITORY_MAPPINGS {
+        let source = repository.join(source);
+        let target = destination.join(target);
+        copy_entry(&source, &target)?;
+    }
+    Ok(())
+}
+
+fn copy_entry(source: &Path, destination: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{} is a symlink", source.display()),
+        ));
+    }
+    if metadata.is_dir() {
+        fs::create_dir_all(destination)?;
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            if ignored_generated_entry(&name) {
+                continue;
+            }
+            copy_entry(&entry.path(), &destination.join(name))?;
+        }
+        return Ok(());
+    }
+    if metadata.is_file() {
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source, destination)?;
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("{} is neither a regular file nor a directory", source.display()),
+    ))
+}
+
+fn ignored_generated_entry(name: &std::ffi::OsStr) -> bool {
+    let name = name.to_string_lossy();
+    name == "__pycache__" || name.ends_with(".pyc") || name.ends_with(".pyo")
+}

--- a/appa-runtime/tests/claude_code_subagent.rs
+++ b/appa-runtime/tests/claude_code_subagent.rs
@@ -48,8 +48,13 @@ fn deployment(policy_extra: &str, externals_extra: &str) -> Runtime {
     let (before_deployment, after_deployment) = policy
         .split_once(deployment)
         .expect("the example carries the context-controlling deployment");
+    // These tests exercise trajectory binding, not the default's model-backed
+    // compatibility fallback. Keep their recorded Bash and Read calls
+    // deterministic.
+    let tools = "[[policy.tool]]\nname = \"Bash\"\ndelta = {}\n\
+                 [[policy.tool]]\nname = \"Read\"\ndelta = {}\n";
     let text = format!(
-        "{before_deployment}{deployment}{policy_extra}\n{after_deployment}[externals]{externals}\n{externals_extra}"
+        "{before_deployment}{deployment}{policy_extra}\n{tools}{after_deployment}[externals]{externals}\n{externals_extra}"
     );
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let path = dir.path().join("appa.toml");

--- a/appa-runtime/tests/examples_load.rs
+++ b/appa-runtime/tests/examples_load.rs
@@ -42,3 +42,49 @@ fn every_shipped_example_opens() {
 fn the_complete_battery_example_opens() {
     opens(&repo_root().join("examples/claude-code-battery/appa.toml"));
 }
+
+#[cfg(unix)]
+#[test]
+fn the_initialized_default_composes_with_the_claude_code_battery() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let battery_dir = dir.path().join("batteries/claude-code");
+    std::fs::create_dir_all(&battery_dir).expect("the battery directory is created");
+
+    let repository = repo_root();
+    let default = std::fs::read_to_string(repository.join("integrations/claude-code/examples/claude-code.appa.toml"))
+        .expect("the initialized default is readable");
+    for file in ["appa.toml", "read-sensitivity.py"] {
+        std::fs::copy(
+            repository.join("batteries/claude-code").join(file),
+            battery_dir.join(file),
+        )
+        .expect("the battery file is copied");
+    }
+
+    let root = dir.path().join("appa.toml");
+    std::fs::write(
+        &root,
+        format!("include = [\"batteries/claude-code/appa.toml\"]\n\n{default}"),
+    )
+    .expect("the initialized config includes the battery");
+
+    let config = Config::load(&root).expect("the initialized config and battery compose");
+    let tools = config.policy_file().value()["tool"]
+        .as_array()
+        .expect("the composed tools are an array");
+    for (name, annotator) in [
+        ("Bash", "claude-code.bash-requirements"),
+        ("Read", "claude-code.read-sensitivity"),
+        ("*", "claude-code.undeclared-tool"),
+    ] {
+        let matches = tools
+            .iter()
+            .filter(|tool| tool["name"].as_str() == Some(name))
+            .collect::<Vec<_>>();
+        assert_eq!(matches.len(), 1, "{name} has exactly one composed rule");
+        assert_eq!(matches[0]["annotator"].as_str(), Some(annotator));
+    }
+
+    let database = dir.path().join("appa.db");
+    Runtime::open(config, database, None).expect("the composed deployment opens");
+}

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -5,6 +5,13 @@
 # differing is how a foreign runtime arriving mid-install is reproduced.
 set -eu
 
+case "$*" in
+  *"/health"*)
+    printf 'ok\n'
+    exit 0
+    ;;
+esac
+
 if [ -n "${FAKE_CURL_CALLS:-}" ]; then
   count=$(( $(cat "$FAKE_CURL_CALLS" 2>/dev/null || echo 0) + 1 ))
   printf '%s' "$count" >"$FAKE_CURL_CALLS"

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -44,6 +44,16 @@ fn deployed_binary(data: &Path) -> std::path::PathBuf {
 }
 
 #[test]
+fn the_plugin_source_override_is_hidden_from_normal_help() {
+    let output = Command::new(env!("CARGO_BIN_EXE_appa"))
+        .args(["init", "claude-code", "--help"])
+        .output()
+        .expect("appa help runs");
+    assert!(output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("plugin-source"));
+}
+
+#[test]
 fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let bin = directory.path().join("bin");

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -112,6 +112,19 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
 
     let first = run(&fingerprint, None);
     assert!(first.status.success(), "{}", String::from_utf8_lossy(&first.stderr));
+    let first_stderr = String::from_utf8_lossy(&first.stderr);
+    for phase in [
+        "resolving the matching plugin",
+        "preparing the plugin bundle",
+        "checking the runtime endpoint",
+        "updating the Claude Code plugin",
+        "starting the runtime",
+    ] {
+        assert!(
+            first_stderr.contains(phase),
+            "missing progress phase {phase:?}: {first_stderr}"
+        );
+    }
     let first_stdout = String::from_utf8(first.stdout).expect("UTF-8 output");
     assert!(first_stdout.starts_with("OpenAPPA initialized for Claude Code"));
     assert!(first_stdout.contains("development source"));

--- a/batteries/README.md
+++ b/batteries/README.md
@@ -8,7 +8,7 @@ it.
 
 | Battery | Covers | Externals |
 | --- | --- | --- |
-| `claude-code/` | `Bash`, `Read`, and every tool the policy does not name in a Claude Code session | The Claude Code model annotates Bash calls and every tool the wildcard covers; `read-sensitivity.py` labels file contents |
+| `claude-code/` | `Bash` and `Read` in a Claude Code session | The Claude Code model annotates Bash calls; `read-sensitivity.py` labels file contents |
 | `slack/` | the claude.ai Slack connector, all 19 tools: read, search, send, canvases | none |
 | `github/` | the GitHub MCP server's default tool sets: profile, repositories, issues, pull requests, users (44 tools) | none |
 | `grain/` | the Grain MCP server: meetings, transcripts, notes, deals, clips, stories, collections, workspace admin (49 tools) | none |

--- a/batteries/claude-code/README.md
+++ b/batteries/claude-code/README.md
@@ -3,8 +3,7 @@
 Use this battery for Claude Code sessions that need policy-aware shell commands
 and automatic privacy labels for local file reads.
 
-It covers two built-in tools, and its wildcard covers every tool the policy
-does not name:
+It covers two built-in tools:
 
 - **Bash** — Before a command runs, the Claude Code model decides what trust,
   audience, and fresh attention the command requires. It also labels the
@@ -14,11 +13,10 @@ does not name:
   Hidden paths, credential files, private keys, system-secret locations, and
   sensitive symlink targets produce private content. Other paths produce public
   content. The resolver does not block the read or lower its trust.
-- **Every other tool** — The wildcard rule sends a tool with no policy entry,
-  such as an MCP server's tool, to the Claude Code model for a per-call
-  contract before it runs. The annotator can hold an unknown tool's output to
-  suspicious trust and a private audience, or clear one it recognizes. Name a tool exactly, or add a
-  root rule, when it needs its own contract.
+
+The default config created by `appa init claude-code` separately provides the
+wildcard fallback for tools it does not name. Keeping that fallback in the root
+lets this battery compose without declaring a second wildcard or annotator.
 
 ## Add it to a deployment
 

--- a/batteries/claude-code/appa.toml
+++ b/batteries/claude-code/appa.toml
@@ -28,24 +28,5 @@ name = "Read"
 description = "Reads a file and returns its contents."
 annotator = "claude-code.read-sensitivity"
 
-# The wildcard covers every tool this policy does not name — an MCP server's
-# tool, for one. Each covered call is annotated by the stock model before it
-# runs: the mandate admits both trust ranks, and "private" is the one literal
-# reader an annotation may name ("public" is always admissible), so it can
-# hold an unknown tool's output to suspicious trust and a private audience,
-# or clear one it recognizes. Name a tool exactly, or add a root rule, when
-# it needs its own contract.
-[[policy.annotator]]
-name = "claude-code.undeclared-tool"
-builtin = "claude-code"
-ranks = ["suspicious", "trusted"]
-audiences = ["private"]
-marks = ["hitl"]
-effects = []
-
-[[policy.tool]]
-name = "*"
-annotator = "claude-code.undeclared-tool"
-
 [externals.annotators."claude-code.read-sensitivity"]
 command = ["python3", "./read-sensitivity.py"]

--- a/batteries/claude-code/appa.toml
+++ b/batteries/claude-code/appa.toml
@@ -40,6 +40,8 @@ name = "claude-code.undeclared-tool"
 builtin = "claude-code"
 ranks = ["suspicious", "trusted"]
 audiences = ["private"]
+marks = ["hitl"]
+effects = []
 
 [[policy.tool]]
 name = "*"

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -62,6 +62,11 @@ cargo install --path appa-runtime --force
 appa init claude-code
 ```
 
+Init reports each slow phase on stderr. If another installed APPA build owns
+the runtime endpoint, init identifies its process and asks `Stop it and
+continue? [Y/n]` before sending any signal. It never offers to stop an
+unidentified listener or another user's process.
+
 Init installs `clappa` beside `appa` so the short command works in later examples.
 
 Init uninstalls an existing user-scoped APPA plugin and replaces its marketplace

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -39,10 +39,10 @@ receives it, in the `Agent` tool's result.
 
 This flow needs the `claude` command, `curl`, and Cargo when building from a checkout.
 
-`appa init` installs one bundle: the plugin belonging to the running binary's
-own release, and that binary. Each build knows the SHA-256 of its release's
-plugin artifact and accepts no other bytes, so version X can never install
-version Y's plugin. The result does not depend on the working directory.
+`appa init` installs one bundle: the plugin belonging to the running binary and
+that binary. Release builds carry an immutable tag and artifact digest; clean
+checkout builds carry an immutable commit and plugin-tree digest. The result
+does not depend on the working directory.
 
 From a release binary, that digest is baked in. The artifact is downloaded once,
 verified against the digest before anything outside a temporary file changes,
@@ -52,15 +52,14 @@ and cached, so a later init needs no network:
 appa init claude-code
 ```
 
-A build from a checkout has no baked-in digest, because the digest exists only
-once a release has published the artifact. Such a build refuses to download and
-requires an explicit source: stage the bundle from the same checkout and name it.
+A clean checkout build downloads the source archive for its exact commit,
+stages the marketplace tree, and verifies the digest baked at compilation. A
+build with local plugin changes uses that exact checkout and verifies that it
+has not changed since compilation.
 
 ```sh
 cargo install --path appa-runtime --force
-plugin=$(mktemp -d)/bundle
-sh scripts/appa-stage-plugin-bundle.sh "$plugin"
-appa init claude-code --plugin-source "$plugin"
+appa init claude-code
 ```
 
 Init installs `clappa` beside `appa` so the short command works in later examples.
@@ -151,12 +150,14 @@ was installed again after this runtime started; the next protected
 session start replaces the process, and so does running the starter
 by hand.
 
-The default policy names only Claude Code's built-in tools. APPA blocks every
-installed MCP tool until the policy names it. Start `clappa` and run
-`/appa-guide init` from that protected session. It inventories MCP
-servers, proposes one policy entry per tool, and marks which tools read data
-that must stay in the session or send data outward. It asks once about servers
-it cannot judge. You review the complete proposal before it writes anything.
+The default policy names Claude Code's built-in tools and sends every other
+tool through a bounded, fail-closed Claude annotator. That compatibility net
+keeps a newly installed MCP tool usable, but it is not a substitute for a
+reviewed connector contract. Start `clappa` and run `/appa-guide init` from
+that protected session. It inventories MCP servers, proposes exact policy
+entries or maintained batteries, and marks which tools read data that must
+stay in the session or send data outward. It asks once about servers it cannot
+judge. You review the complete proposal before it writes anything.
 
 For development from a source checkout, run the runtime on its own port
 so an installed runtime on 8787 is untouched, and point a session at it

--- a/integrations/claude-code/examples/claude-code.appa.toml
+++ b/integrations/claude-code/examples/claude-code.appa.toml
@@ -1,9 +1,11 @@
 # Example deployment for protecting a Claude Code session.
 #
-# Every built-in tool of the harness is named: a tool the policy does
-# not name is refused before it runs. A named tool without a `delta` key restricts
-# nothing, the same statement as `delta = {}`: the result's label is the
-# combination of its sources, unchanged.
+# Every built-in tool of the harness is named. A tool the policy does not name
+# reaches the bounded Claude fallback at the end of this file, so a newly
+# installed MCP tool still gets a per-call contract until `/appa-guide init`
+# gives it an exact one. A named tool without a `delta` key restricts nothing,
+# the same statement as `delta = {}`: the result's label is the combination of
+# its sources, unchanged.
 #
 # Tools that bring outside content into the session — the web tools —
 # carry `delta = { trust = "suspicious" }` instead: their results
@@ -206,6 +208,22 @@ delta = { trust = "suspicious" }
 [[policy.tool]]
 name = "WebSearch"
 delta = { trust = "suspicious" }
+
+# Compatibility net for tools installed after this policy was generated. Exact
+# declarations always win over the wildcard, including declarations supplied by
+# connector batteries. The mandate is deliberately closed to this deployment's
+# two trust ranks, its one private audience, HITL, and no effects.
+[[policy.annotator]]
+name = "claude-code.undeclared-tool"
+builtin = "claude-code"
+ranks = ["suspicious", "trusted"]
+audiences = ["private"]
+marks = ["hitl"]
+effects = []
+
+[[policy.tool]]
+name = "*"
+annotator = "claude-code.undeclared-tool"
 
 # The deployment controls what a subagent starts from: the harness gives
 # every subagent exactly the prompt the parent's spawn call carried, and

--- a/integrations/claude-code/examples/claude-code.appa.toml
+++ b/integrations/claude-code/examples/claude-code.appa.toml
@@ -1,11 +1,12 @@
 # Example deployment for protecting a Claude Code session.
 #
-# Every built-in tool of the harness is named. A tool the policy does not name
-# reaches the bounded Claude fallback at the end of this file, so a newly
-# installed MCP tool still gets a per-call contract until `/appa-guide init`
-# gives it an exact one. A named tool without a `delta` key restricts nothing,
-# the same statement as `delta = {}`: the result's label is the combination of
-# its sources, unchanged.
+# The stable built-in tools of the harness are named. Bash and Read deliberately
+# reach the bounded Claude fallback at the end of this file unless the optional
+# Claude Code battery supplies their exact annotators. Any other tool the policy
+# does not name gets the same per-call fallback until `/appa-guide init` gives it
+# an exact contract. A named tool without a `delta` key restricts nothing, the
+# same statement as `delta = {}`: the result's label is the combination of its
+# sources, unchanged.
 #
 # Tools that bring outside content into the session — the web tools —
 # carry `delta = { trust = "suspicious" }` instead: their results
@@ -38,10 +39,6 @@ delta = {}
 
 [[policy.tool]]
 name = "Artifact"
-delta = {}
-
-[[policy.tool]]
-name = "Bash"
 delta = {}
 
 [[policy.tool]]
@@ -114,10 +111,6 @@ delta = {}
 
 [[policy.tool]]
 name = "PushNotification"
-delta = {}
-
-[[policy.tool]]
-name = "Read"
 delta = {}
 
 [[policy.tool]]

--- a/scripts/appa-stage-plugin-bundle.sh
+++ b/scripts/appa-stage-plugin-bundle.sh
@@ -45,6 +45,12 @@ cp -- "$repo/integrations/claude-code/live-gate-check.py" ./live-gate-check.py
 mkdir -p -- ./website/content/docs
 cp -- "$repo/website/content/docs/contracts.md" ./website/content/docs/contracts.md
 
+# Generated Python caches are not plugin source. A developer may have them in a
+# checkout, while a GitHub source archive and a clean release runner never do;
+# excluding them keeps all three staging paths byte-identical.
+find . -type d -name __pycache__ -prune -exec rm -rf -- {} +
+find . -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+
 # Modes are applied by init when it materializes a deployment; these are for
 # anyone who unpacks the archive by hand.
 find . -type d -exec chmod 755 {} +

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -13,21 +13,18 @@ You need Cargo, Claude Code, and `curl`.
 
 ```sh
 cargo install --path appa-runtime --force
-plugin=$(mktemp -d)/bundle
-sh scripts/appa-stage-plugin-bundle.sh "$plugin"
-appa init claude-code --plugin-source "$plugin"
+appa init claude-code
 ```
 
 Initialization installs `clappa` beside `appa` so the short command works below.
 
 The native `appa` command installs the runtime, the matching Claude Code
-plugin, the statusline, and `clappa`, a protected way to start Claude Code. Each
-build accepts exactly one plugin artifact: a release binary knows the digest of
-its own release's artifact and downloads it, and a build from a checkout has no
-such digest and is given the bundle staged from that checkout. Init replaces an
-existing APPA installation instead of stacking another hook set. It preserves an
-existing policy and custom statusline. It does not replace `claude` or change how
-ordinary sessions start.
+plugin, the statusline, and `clappa`, a protected way to start Claude Code. A
+release binary resolves its plugin from its baked tag and artifact digest; a
+checkout build resolves it from its baked commit and plugin-tree digest. Init
+replaces an existing APPA installation instead of stacking another hook set. It
+preserves an existing policy and custom statusline. It does not replace `claude`
+or change how ordinary sessions start.
 
 ## 1. Teach OpenAPPA about your tools
 
@@ -44,6 +41,8 @@ clappa
 ```
 
 The skill inspects the MCP servers and tools available to Claude Code. It uses their declared purpose to identify what they read and which actions can send data outside the session. When a data boundary is unclear, it asks you one focused question.
+
+Before this sync, a fresh installation routes unnamed tools through a bounded Claude annotator. The fallback fails closed and keeps newly installed tools from becoming an immediate configuration outage; exact contracts and maintained batteries produced by the skill take precedence over it.
 
 It begins with `appa describe`, which reports the current config,
 included batteries, policy tools, referenced groups, and membership wiring.

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -16,6 +16,11 @@ cargo install --path appa-runtime --force
 appa init claude-code
 ```
 
+Initialization prints progress while it resolves the matching plugin, updates
+Claude Code, and starts the runtime. If a different APPA build already owns the
+runtime endpoint, it asks before stopping that process; an unidentified
+listener is never stopped automatically.
+
 Initialization installs `clappa` beside `appa` so the short command works below.
 
 The native `appa` command installs the runtime, the matching Claude Code


### PR DESCRIPTION
## What changed

- Make every `appa` binary resolve and verify its matching Claude Code plugin automatically:
  - release builds use their release tag and artifact digest
  - clean source builds use their Git commit and plugin-tree digest
  - dirty source builds use their checkout while its plugin tree still matches
- Keep `--plugin-source` as a hidden development escape hatch.
- Reclaim stale runtime state automatically. If a healthy runtime belongs to a different APPA build, identify its process and ask before stopping it.
- Print progress for the slow init phases: resolving, bundling, checking the runtime, updating Claude Code, and starting the runtime.
- Give fresh Claude Code policies a fail-closed Claude fallback for newly installed MCP tools, while exact connector batteries retain precedence.
- Make the fallback reliable inside Claude Code by clearing `CLAUDECODE`, preserving non-zero exit status, and returning an actionable `/appa-guide init` hint.

## Why

Source-built binaries still required users to manually locate and stage a matching plugin. Init could also stop at an opaque runtime-ownership error, or fail with `claude-code.undeclared-tool` when a newly installed MCP tool had no exact annotator.

The normal path is now simply:

```sh
appa init claude-code
```

The plugin bytes remain cryptographically tied to the binary that installs them.

## Runtime conflict UX

When another APPA build owns the endpoint, init now offers:

```text
appa: a different appa build (pid 1234) owns http://127.0.0.1:8787. Stop it and continue? [Y/n]
```

Only a same-user process that still identifies as `appa` is eligible. Init rechecks both endpoint ownership and process identity after approval before sending `SIGTERM`. Unknown listeners, changed processes, non-interactive EOF, and older runtimes without a PID are never killed automatically.

## Verification

- `cargo test -p appa`
- `cargo clippy -p appa --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
