### PR TITLE
docs: finalize the kagent proposal on the no-fork ADK plugin lane

### DIFF
--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -1,291 +1,176 @@
-# kagent dynamic adapter implementation plan
+# kagent adapter implementation plan
 
 Source baseline:
 
-- kagent commit `9e246fd3797457b18fc277680be1629a0f57fce0`
-- Google ADK Go `v2.2.0` at `b264039aaec43baedc123e5b9a0cf87681d0bbca`
-- Substrate `v0.0.20`
-- OpenAPPA `origin/main` at `d87d6f822fdde2968d607b05f2be4c6140b67342`
+- kagent commit [`52cc4de2a044a5062d10c4f189d863937c1bb0f9`](https://github.com/kagent-dev/kagent/commit/52cc4de2a044a5062d10c4f189d863937c1bb0f9) (2026-09-01)
+- google-adk 2.8.0, the version kagent's workspace lockfile resolves. The `kagent-adk` package constraint is `google-adk[a2a,db]>=2.6.2,<3` ([pyproject.toml#L26](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/pyproject.toml#L26))
+- Substrate v0.0.20 ([go.mod#L489](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/go.mod#L489))
+- OpenAPPA `origin/main`: `appa-runtime-api` hook vocabulary (`appa-runtime-api/src/lib.rs`), `appa-runtime` `/hook` endpoint (`appa-runtime/src/main.rs`), and the `appa-adapter-claude-code` codec as the adapter reference.
 
-The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent).
+The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent). ADK citations below give paths and line numbers inside the published `google_adk-2.8.0` wheel.
 
 ## Architecture decision
 
-`appa-adapter-kagent` is the OpenAPPA kagent adapter. It maps generic kagent harness events to the existing `appa-runtime` `/hook` HTTP interface.
+The adapter rides two stock kagent surfaces and changes no kagent or Google ADK source:
 
-The adapter follows the `appa-adapter-claude-code` boundary. It depends on `appa-runtime-api` for hook wire types and codecs. It does not link `appa-runtime`, call the Engine, own policy, or open `appa.db`.
+1. `Harness.spec.workload.image` — a required, operator-supplied, digest-pinned OCI reference ([harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40)). The adapter ships as that image.
+2. `KAgentApp(plugins=[...])` — a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L65](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L65)), forwarded into ADK's `App(plugins=...)` and its `PluginManager` ([_a2a.py#L136-L139](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L136-L139)). The `AppaHookPlugin` registers there.
 
-`appa-runtime` is a separate logical process. It owns policy loading, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`. The adapter sends a bound `/hook` request and maps its bound response to the generic kagent decision wire.
+No config-reachable plugin surface exists upstream. The stock entrypoint builds a closed plugin list ([cli.py#L95-L105](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L95-L105)). No CRD field, helm value, env var, or entry point adds to it. The adapter image therefore carries its own entrypoint. That entrypoint calls the same public `kagent-adk` functions as stock `static` and adds one plugin.
 
-The adapter fails closed when `APPA_RUNTIME_URL` is unavailable, unauthenticated, expired, mismatched, or unreachable. A runtime response without the required identity and revision binding fails closed.
+The adapter follows the `appa-adapter-claude-code` boundary. It maps harness callbacks to the eight `HookEvent` variants and renders each `HookDecision` back into the harness. It does not link `appa-runtime`, call the Engine, own policy, or open `appa.db`. `appa-runtime` owns policy, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`.
 
-Google ADK Go remains an unmodified upstream dependency. The implementation has no fork, vendored or copied source, patch, module replacement, or `internal` import.
+## Artifacts and ownership
 
-## Ownership and forbidden dependencies
+| Artifact | Contents | Owner |
+|---|---|---|
+| `appa-adapter-kagent` Python package | `AppaHookPlugin` (a google-adk `BasePlugin`) and `entrypoint.py` | OpenAPPA repository |
+| `appa-adapter-kagent` OCI image | The published `kagent-adk` image plus the Python package, digest-pinned | OpenAPPA repository |
+| `appa-adapter-kagent` Rust crate | The `/hook` codec (`parse`, `render`) for the kagent wire, selected by the runtime's adapter switch | OpenAPPA repository |
+| kagent | Controller, CRDs, compiler, Substrate path, `kagent-adk` library — all stock, no change | Upstream |
+| Google ADK | Plugin API and dispatch loop — stock dependency, no change | Upstream |
 
-| Owner | Responsibilities |
-|---|---|
-| kagent fork | Neutral extension API, manifest and Revision validation, sidecar rendering, public-ADK wrappers, payload snapshots, generic decisions, host sink barriers, and host-native session and A2A state |
-| `appa-adapter-kagent` | Generic protocol negotiation, mTLS and HMAC channel state, event replay and delivery ledger, lifecycle relay, and kagent wire to `/hook` codec |
-| `appa-runtime` | Runtime API, policy, Engine, consults, remedies, trajectory state, recovery, audit, policy configuration, and `appa.db` |
+The runtime picks one codec per adapter through a closed enum ([appa-runtime/src/main.rs](../../appa-runtime/src/main.rs), the `Adapter` enum). The kagent deliverable adds one variant beside `ClaudeCode`, mapped to `appa_adapter_kagent::codec()`.
 
-`appa-adapter-kagent` has no OpenAPPA policy parser, `[deployment]` validation, Engine dependency, Engine call, consult backend, remedy planner, trajectory store, recovery classifier, dynamic policy tool, policy schema migration, or `appa.db` path.
+The plugin holds no policy state. It serializes callback moments into wire events, sends them to `APPA_RUNTIME_URL`, and enforces the answered decision. Every semantic judgment stays in `appa-runtime`.
 
-The adapter ledger contains only generic protocol values: event ID and digest, actor and extension IDs, adapter artifact digest, runtime identity, policy revision, boot epoch, channel digest, sequence, expiry, delivery status, and response digest. It contains no Label, Value, fact, offer, continuation, dispatch identifier, policy decision, consult evidence, or runtime database record.
+## Adapter workload image
 
-The kagent fork has no OpenAPPA named package, field, enum, callback, table, error code, tool route, policy type, or database migration. CI scans the generic-host packages for the maintained forbidden set.
+Build: `FROM` the published `kagent-adk` image at a pinned digest, add the Python package, set `entrypoint.py` as the container entrypoint. `cli.py` stays in the image unchanged and unused. Equivalent build: a plain Python base plus `pip install kagent-adk` at the locked version.
+
+Entrypoint steps, in order:
+
+1. Call `materialize_from_env("/config")` — the public `kagent-adk` function that writes `KAGENT_CONFIG_JSON` and `KAGENT_AGENT_CARD_JSON` to config files and expands `__KAGENT_ENV[...]__` credential placeholders ([_config_materialize.py#L55-L69](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_config_materialize.py#L55-L69)). The controller injects both variables into the Actor ([actor_template.go#L43-L44](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L43-L44)).
+2. Parse the raw config JSON with a strict schema. Refuse any field the adapter does not support, and exit unready. Stock `AgentConfig` is a pydantic model that ignores unknown fields ([types.py#L387-L401](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L387-L401)). The adapter must not inherit that silence. See the refusal rules below.
+3. Validate the accepted config with `AgentConfig.model_validate` and build the agent factory over `AgentConfig.to_agent` ([types.py#L403](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L403)).
+4. Rebuild the stock plugin list with the same conditions as `static` (STS integration, `LLMPassthroughPlugin`), then append `AppaHookPlugin(APPA_RUNTIME_URL)`.
+5. Construct `KAgentApp(...)`, call `.build()`, and serve — the same calls as [cli.py#L114-L135](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L114-L135).
+
+Refusal rules (fail closed at startup):
+
+- `APPA_RUNTIME_URL` unset, or the runtime unreachable at startup probe — unready.
+- Config contains compiled in-process sub-agents (`sub_agents`). The kagent compiler emits them for CRD sub-agent tools ([kagent/compiler.go#L172](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/translator/kagent/compiler.go#L172)), and Python `AgentConfig` drops them silently. The adapter refuses the config instead. Out-of-process (`Dedicated`) sub-agent tools do not reach this path — the compiler rejects them upstream ([compiler.go#L149-L151](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/translator/compiler.go#L149-L151)).
+- Config contains any other field outside the adapter's accepted schema — unready, with the field named in the log.
+
+## AppaHookPlugin
+
+The plugin implements google-adk `BasePlugin`. All 14 lifecycle callbacks exist in the 2.8.0 wheel (`google/adk/plugins/base_plugin.py`, lines 114-394). Each gated callback sends one wire event to `POST $APPA_RUNTIME_URL/hook` and enforces the decision that comes back. A transport failure or a non-contract response raises, and ADK aborts the invocation.
+
+| ADK callback | HookEvent | Enforcement at the callback | ADK evidence (2.8.0 wheel) |
+|---|---|---|---|
+| `on_user_message_callback`, first invocation of a fresh session | `SessionStart` | `Refuse` raises before `Prompt` is sent | fires before the session append: `runners.py` 675-700 |
+| `on_user_message_callback` | `Prompt` | `Block` raises pre-append, so the bytes never land in session history | `runners.py` 675-700 |
+| `before_tool_callback` | `ToolCall{spawn}` | `DenyCall{feedback}`: return a dict — ADK skips execution, and the dict becomes the function response the model reads. `Refuse` raises. | `functions.py` 611-641 |
+| `after_tool_callback` | `ToolResult` | `ReplaceOutput{output}`: return a dict — it replaces the result the model sees. `Block` raises. | `functions.py` 652-683 |
+| `on_tool_error_callback` | `ToolResult` with `Failure` outcome | return a dict to convert, or re-raise | `base_plugin.py` 348 |
+| `before_tool_callback` on a sub-agent tool | `ToolCall{spawn:true}` | as `ToolCall`. The plugin holds the `AllowCall{spawn}` binding for the child scope | `functions.py` 611-641 |
+| `before_agent_callback` (child) | `ChildStart` | `Refuse` raises | `base_plugin.py` 198 |
+| `after_agent_callback` (child) | `TurnEnd` (child) | observe | `base_plugin.py` 217 |
+| `after_tool_callback` on the sub-agent return | `SpawnResult` | `ChildReturn{value}` or `ReplaceOutput`: return a dict — the one point where the plugin can substitute the value the parent receives | `functions.py` 652-683 |
+| `after_run_callback` | `TurnEnd` (root) | observe | `base_plugin.py` 174 |
+| `on_run_error_callback` | `TurnEnd` (root, failure) | observe — notification-only, sufficient for an Ack-only event | `base_plugin.py` 394 |
+| `on_agent_error_callback` (child) | `TurnEnd` (child, failure) | observe | `base_plugin.py` 374 |
+| `before_run_callback`, `before_agent_callback` (root) | none | pass through — `Prompt` already gates the same bytes | — |
+| `before_model_callback`, `after_model_callback`, `on_model_error_callback`, `on_event_callback` | none | liveness gates: raise when the `/hook` channel is down, pass otherwise | `base_plugin.py` 233, 253, 272, 155 |
+
+`ChildEnd` is unfed by design. Return substitution is enforceable only where the parent receives the value, so returns cross at `SpawnResult`. The `appa-adapter-claude-code` parse map makes the same choice.
+
+Sub-agent identity: kagent dispatches every declared remote agent as an ordinary ADK tool, `KAgentRemoteA2AToolset` ([types.py#L521](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L521)). The plugin classifies a tool call as a spawn by the tool's type.
+
+### Wire and codec
+
+The plugin emits one JSON event per callback: event kind, trajectory ids, tool name, raw argument bytes, outcome, and value fields — the data the matching `HookEvent` variant needs. The `appa-adapter-kagent` Rust crate parses this wire into `HookEvent` and renders each `HookDecision` into the response the plugin enforces, through the `Codec` contract of `appa-runtime-api` (`parse`, `render` — `appa-runtime-api/src/lib.rs`). The wire carries no policy meaning. Raw tool arguments cross as spelled, and the Engine canonicalizes them.
+
+### Trajectory identity
+
+- Root `TrajectoryId`: the ADK session id with a harness prefix, per the `appa-runtime-api` convention.
+- Child classification: the child Actor reads kagent's inbound call metadata. The executor lands that metadata in ADK session state ([_agent_executor.py#L212-L214](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py#L212-L214)). A delegated entry feeds `ChildStart`. A plain external entry feeds `SessionStart` and `Prompt`.
+- Known limits: with `isolate_sessions`, ADK generates the child context id inside `run_async`, so the parent-side `ChildStart` correlation uses the spawn binding, not a pre-known child id. A bare-message A2A return carries no child session id. Both cases resolve at the shared runtime through the `SpawnResult` binding.
+
+## Cross-actor children
+
+A kagent parent and each delegated child run in separate Substrate Actors. The hooks of one trajectory therefore come from two plugin instances:
+
+```text
+parent Actor plugin:  ToolCall{spawn:true} ... SpawnResult
+child Actor plugin:   ChildStart, Prompt-less child turns, TurnEnd (child)
+```
+
+Both must reach the same `appa-runtime`. A per-Actor runtime would split one trajectory into two logs, so the shared-service profile is the default. Verify Substrate egress from Actors to the runtime service in the target cluster before rollout. This is the one open operational item.
 
 ## Deployment profiles
 
-### Quickstart profile
+### Shared runtime service (default)
 
-Quickstart has one digest-pinned OpenAPPA companion container and two processes:
+One `appa-runtime` per cluster or namespace. `APPA_RUNTIME_URL` in `Harness.spec.env` names it. Only the runtime mounts policy, credentials, and the durable `appa.db` volume. Actors hold no APPA state. Required for any deployment with delegated children.
 
-```text
-+---------------------------- OpenAPPA companion container ----------------------------+
-| appa-adapter-kagent                                                          :8082   |
-| private kagent UDS gRPC -> neutral event -> /hook request                            |
-|                                      | APPA_RUNTIME_URL=http://127.0.0.1:8787         |
-| appa runtime --adapter kagent        | policy, Engine, consults, remedies, appa.db   |
-| HTTP listener: 127.0.0.1:8787 only   |                                                |
-+---------------------------------------------------------------------------------------+
-```
+### Single-actor loopback
 
-The runtime port has loopback binding only. The container has no service, ingress, or network-policy exception for this port. Only `appa-runtime` mounts the policy, credentials, and `appa.db` volume. The adapter mounts only its generic delivery ledger and connection material.
+The adapter image starts `appa-runtime` as a second process and sets `APPA_RUNTIME_URL=http://127.0.0.1:8787`. The runtime listens on loopback only. Valid only for agents with no delegated children, because each Actor holds a separate trajectory log.
 
-### Remote configuration profile
-
-Remote configuration uses the same adapter artifact. `APPA_RUNTIME_URL` identifies an authenticated HTTPS gateway or runtime instance.
-
-```text
-kagent host -> private UDS -> appa-adapter-kagent -> mTLS HTTPS -> bound runtime gateway -> appa-runtime
-```
-
-The adapter trusts a configured CA and remote workload identity. The remote gateway authenticates the adapter workload identity. It forwards only to the runtime identity bound by the immutable Revision. The runtime verifies Actor UID, extension ID, adapter artifact digest, runtime identity, policy revision, boot epoch, sequence, event digest, and request channel digest.
-
-The runtime response binds the same values and its accepted policy revision. Redirects, certificate mismatch, identity mismatch, endpoint mismatch, policy revision mismatch, unknown runtime identity, and expired bindings fail closed. Remote configuration gives the adapter no runtime policy mount or `appa.db` volume.
-
-## Repository deliverables
-
-| Owner | Component |
-|---|---|
-| OpenAPPA repository | `appa-adapter-kagent` crate and binary |
-| OpenAPPA repository | `appa-adapter-kagent-protocol` crate for neutral kagent wire bindings |
-| OpenAPPA repository | `appa-runtime-api` hook types and codecs shared by the runtime and adapters |
-| OpenAPPA repository | `appa-runtime` `/hook` binding validation, runtime mapping, policy, Engine, and `appa.db` ownership |
-| OCI packaging | `appa-adapter-kagent` image, quickstart companion image, manifests, SBOM, and provenance |
-| kagent private fork | Generic host and public-ADK integration changes |
-
-The adapter binary is `appa-adapter-kagent`. The quickstart runtime process is `appa runtime --adapter kagent`. The adapter image is `ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>`. The quickstart companion image contains this adapter and the runtime binary.
-
-## Generic Harness API
-
-The generic Harness declaration contains an ordered adapter list:
+## Harness wiring and rollout
 
 ```yaml
-workload:
-  image: ghcr.io/private-kagent/kagent-go-adk@sha256:<digest>
-  extensions:
-    - name: policy-gate
-      image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
-      manifestDigest: sha256:<digest>
-      signaturePolicyRef: required-extension-signers-v1
-      required: true
-      failureMode: closed
-      order: 10
-      protocol:
-        minMajor: 1
-        maxMajor: 1
-      socket:
-        path: /run/kagent/extensions/policy-gate.sock
-      adapter:
-        runtimeUrlEnv: APPA_RUNTIME_URL
-        runtimeBinding:
-          runtimeId: customer-support-runtime-a
-          policyRevision: customer-support-policy-v1
-          remoteIdentity: spiffe://policy.example/runtime/customer-support-runtime-a
-          caConfigMapRef: runtime-gateway-ca-v1
-      ledger:
-        volumeName: policy-gate-delivery-ledger
-        mountPath: /var/lib/appa-adapter-kagent
-      egress:
-        - host: runtime-gateway.policy.example
-          port: 443
-      readiness:
-        path: /readyz
-        port: 8082
+kind: Harness
+spec:
+  kagent: {}
+  workload:
+    image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
+  env:
+    - name: APPA_RUNTIME_URL
+      value: http://appa-runtime.appa-system:8787
+  substrate: { workerPoolRef: {name: <pool>}, snapshotPolicy: {location: <loc>} }
+  allowedAgentTemplates:
+    selector: { matchLabels: { <team labels> } }
 ```
 
-The generic compiler validates image and manifest digests, signatures, references, protocol ranges, socket uniqueness, ledger ownership, resource limits, egress shape, and ordering. It treats adapter and runtime configuration as opaque. The immutable Revision stores only their digests and generated references.
+- Pairing: the controller matches each `AgentTemplate` against every same-namespace Harness selector and reconciles one Actor per pair ([collections.go#L85-L102](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/controller/collections.go#L85-L102)).
+- Rollout is "move the label match", never "add a second match". A template matched by two Harnesses runs twice — once gated, once not. Make old and new selectors disjoint.
+- Env budget: the Substrate path caps an Actor at 32 total env vars ([actor_template.go#L50-L52](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L50-L52)). The compiler's own vars count against the cap. The adapter needs one.
+- Prerequisites: helm `controller.substrate.enabled=true`, the `ate-system` install, and a `WorkerPool` — the stock requirements of the Substrate path ([values.yaml#L327-L334](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/helm/kagent/values.yaml#L327-L334)).
 
-The quickstart manifest adds a runtime process and mounts to the companion container. Its runtime listener remains `127.0.0.1`. The remote manifest adds no runtime volume.
+## Known gaps and handling
 
-## Neutral protocol
-
-The `kagent.extension.v1` protocol defines these generic RPCs:
-
-| RPC | Purpose |
+| Gap | Handling |
 |---|---|
-| `GetExtensionInfo` | Return adapter artifact, protocol, manifest, and ledger schema identity |
-| `Negotiate` | Select protocol and capabilities for one host inventory |
-| `Activate` | Accept the immutable Revision and host inventory digest |
-| `InvokePhase` | Relay one immutable generic host or lifecycle event |
-| `Quiesce` | Seal adapter delivery state and relay lifecycle quiescence |
-| `ValidateRestore` | Validate restored host, adapter, and runtime bindings |
-| `Shutdown` | Drain and terminate cleanly |
-
-The protocol contains neutral types only. It contains no Google ADK Go types, OpenAPPA policy types, or runtime types.
-
-The launcher creates one ephemeral Actor CA, host certificate, adapter certificate, boot epoch, and message-authentication key per activation. The Unix socket uses mTLS. Certificate SANs bind Actor UID, Revision, container identity, extension ID, and boot epoch.
-
-Every event and decision carries protocol major, actor, extension, boot epoch, channel binding digest, event ID, event digest, Revision, scope, sequence, deadline, and HMAC-SHA256 over deterministic protobuf bytes. The adapter verifies peer identity, HMAC, deadline, sequence, and binding before it sends `/hook`.
-
-## Hook relay and revision binding
-
-The adapter converts a neutral phase event to the existing hook request codec. It adds a transport binding outside the policy payload:
-
-```json
-{
-  "runtime_id": "customer-support-runtime-a",
-  "policy_revision": "customer-support-policy-v1",
-  "actor_uid": "actor-opaque-id",
-  "extension_id": "policy-gate",
-  "adapter_artifact_digest": "sha256:...",
-  "kagent_revision": "revision-opaque-id",
-  "boot_epoch": "epoch-opaque-id",
-  "sequence": 42,
-  "event_id": "event-opaque-id",
-  "event_digest": "sha256:...",
-  "channel_binding_digest": "sha256:...",
-  "deadline": "2026-09-01T00:00:00Z"
-}
-```
-
-The runtime authenticates and validates this binding before it admits the hook event. Its response contains the same binding, the accepted runtime identity, the accepted policy revision, response digest, and terminal hook decision.
-
-The adapter maps only a fully matched runtime response to `permit`, `suppress`, `hold`, `interaction`, `commit`, `event`, or `fail`. It does not derive a fallback decision. An unavailable runtime produces the generic content-free failure or scope freeze required by the phase.
-
-The adapter ledger returns the original response only for an identical event digest and complete binding. Runtime recovery remains authoritative for any unresolved or semantically indeterminate event.
-
-## kagent integration points
-
-The kagent fork uses public Google ADK interfaces and kagent-owned code only:
-
-| Boundary | Generic integration |
-|---|---|
-| Public callbacks | One content-bearing out-of-process proxy |
-| Provider-final catalog and request | Kagent-owned adapter before telemetry and network transmission |
-| Tool call | Immutable raw argument snapshot, execution wrapper, and terminal result relay |
-| Model response and event | Gate before dispatch, persistence, yield, or publication |
-| Session and A2A | Exact-byte pre-append and pre-publication barriers |
-| Child, memory, MCP, remote A2A | Public-interface wrappers and generic lifecycle phases |
-| Snapshot, readiness, egress, drain | Generic kagent and Substrate lifecycle interface |
-
-An unavailable required boundary rejects activation. Protected workloads disable opaque provider paths, direct content callbacks, automatic memory preload, unbounded tool catalogs, unverified MCP transport, content-bearing telemetry, unpinned remote A2A paths, and streaming before the publication gate.
-
-The generic host executes only a matching immutable `permit` payload. Raw output reaches no protected sink before a matching `commit`. Generic extension ordering and phase ownership remain immutable for one Revision.
-
-## Runtime mapping
-
-`appa-runtime` receives the adapter's `/hook` event. It validates the bound runtime identity and policy revision. It maps the event to runtime admission and owns all OpenAPPA behavior:
-
-- Policy parsing and `[deployment]` validation.
-- Engine decisions, Value and Label handling, and trajectory state.
-- Annotator, Membership Resolver, Authority, and Sanitizer consults.
-- Canonical call and result correlation, remedy plans, and interactions.
-- Child, remote delegation, assistant response, audit, and recovery behavior.
-- `appa.db`, policy migrations, and runtime state generations.
-
-The adapter has no policy-specific dynamic tool. A runtime remedy or interaction remains runtime state until its bound hook result crosses the adapter. The host receives only a neutral interaction or terminal decision.
-
-## State, recovery, and snapshots
-
-| Store | State |
-|---|---|
-| kagent host | ADK sessions, A2A tasks, generic host event IDs, and host outbox records |
-| `appa-adapter-kagent` | Negotiation, channel HMAC state, event digest, replay status, delivery status, lifecycle relay status, and expiry |
-| `appa-runtime` | Policy identity, `appa.db`, Engine facts, trajectory state, consult evidence, remedies, interactions, delegation, audit, and recovery |
-
-The adapter ledger cannot become a policy cache. It never persists a semantic decision or continuation.
-
-During recovery, kagent reconstructs host-native work and sends unresolved generic events to the adapter. The adapter re-establishes the pinned runtime binding and relays each event to `/hook`. `appa-runtime` resolves replay and indeterminate outcomes. The adapter maps the bound result back to the generic decision wire.
-
-During snapshots, the host stops new work and calls `Quiesce`. The adapter seals its generic ledger and relays the lifecycle event. The runtime seals and validates `appa.db` and its trajectory generation. Restore readiness requires matching host, adapter, runtime, and policy-revision bindings. The adapter has no authority to accept an `appa.db` generation.
-
-## Security and network boundary
-
-Admission requires signed OCI image and manifest artifacts, an SBOM, and provenance. The generic trust policy pins the allowed registry, signer identity, and minimum provenance level. Tag-only images, mismatched referrers, unsigned manifests, and Revision overrides fail admission.
-
-The adapter uses a dedicated non-root UID, read-only root filesystem, `allowPrivilegeEscalation: false`, no Linux capabilities, and RuntimeDefault seccomp. The adapter ledger uses single-writer fencing. The runtime volume uses separate fencing and belongs only to runtime.
-
-Default-deny CNI egress permits cluster DNS and the authenticated egress gateway. Remote profile egress permits only the bound HTTPS runtime gateway. The gateway enforces workload identity, destination, TLS identity, redirect, IP-range, and DNS-rebinding policy.
-
-Quickstart does not use network egress to reach the runtime. Its `APPA_RUNTIME_URL` is loopback only. This profile does not weaken loopback binding.
-
-## Revision drain
-
-Every live scope pins the adapter artifact, adapter manifest, generic protocol, runtime identity, policy revision, and runtime authentication binding. A change creates a new Revision.
-
-New roots use the new binding after its adapter and runtime report ready. Existing scopes remain on the previous binding through terminal state or drain deadline. No between-turn hot swap exists. A rollback is another new-root routing transition. It does not move a live scope or merge runtime state.
+| No callback at ADK session creation | `SessionStart` synthesizes at first invocation, sent before `Prompt` from the same callback. A never-invoked session emits nothing and flows nothing. |
+| A hard Actor crash emits no `TurnEnd` | `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event. |
+| CRD in-process sub-agents (`sub_agents`) unsupported by Python `AgentConfig` | The adapter refuses the config at startup instead of dropping children. CRD multi-agent topologies stay on `remote_agents`, which compile to gated tools. |
+| Upstream has no plugin config knob | The entrypoint replays `static` behavior through public calls. CI pins `kagent-adk` and google-adk versions and runs an equivalence check on each bump. Propose a `KAGENT_PLUGINS`-style upstream knob to delete the duplication. |
+| Claude and Codex harness variants, non-ADK wrappers, stock-image agents | Out of scope. The Claude harness omits hooks from its supported contract ([config.go#L48-L50](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/harness/claude/config/config.go#L48-L50)). |
 
 ## PR sequence
 
-### Generic kagent fork
-
 | PR | Change |
 |---|---|
-| 1 | Generic Harness API, adapter manifests, Revision data, and signature policy |
-| 2 | Adapter containers, private sockets, adapter-ledger volumes, egress, and readiness |
-| 3 | Neutral protocol, negotiation, health, HMAC, and generic extension host |
-| 4 | Provider-final request and catalog gates in kagent-owned adapters |
-| 5 | Sole content-bearing callback proxy and kagent-owned tool wrappers |
-| 6 | Model response gates, session barriers, A2A publication barriers, and content-free telemetry |
-| 7 | Agent, Runner, memory, remote, MCP, interaction, snapshot, recovery, and drain wrappers |
+| 1 | `appa-adapter-kagent` Rust codec crate: wire parse to `HookEvent`, decision render, `Adapter` enum variant, unit tests against recorded wire fixtures |
+| 2 | `appa-adapter-kagent` Python package: `AppaHookPlugin` with the callback table above, fail-closed transport, liveness gates |
+| 3 | Entrypoint: materialize, strict config schema and refusal rules, stock plugin parity, `KAgentApp` assembly |
+| 4 | OCI image build with pinned base digest, SBOM, and provenance, plus the single-actor loopback variant |
+| 5 | End-to-end harness: kind cluster, Substrate path, shared runtime service, cross-actor child scenario |
 
-Each generic PR uses neutral fake adapters. Production packages have no OpenAPPA import or name. No PR changes Google ADK source or imports an ADK `internal` package.
-
-### OpenAPPA repository
-
-| PR | Change |
-|---|---|
-| 1 | `appa-adapter-kagent-protocol`, `appa-adapter-kagent`, UDS handshake, HMAC, and neutral inventory relay |
-| 2 | `/hook` request and response binding, `APPA_RUNTIME_URL`, fail-closed transport, and runtime identity validation |
-| 3 | Generic event relay, replay and delivery ledger, lifecycle relay, and quickstart companion image |
-| 4 | Remote HTTPS gateway authentication, CA pinning, runtime identity, policy-revision binding, manifest, SBOM, and provenance |
-| 5 | Runtime `/hook` mappings for tool, model, event, child, memory, MCP, remote, interaction, recovery, and snapshot phases |
-
-The runtime PRs retain exclusive ownership of policy, Engine, consults, remedies, trajectory state, recovery semantics, and `appa.db`.
+No kagent PR and no Google ADK PR is required. The optional upstream contribution (a plugin config knob) is independent and non-blocking.
 
 ## Verification matrix
 
-### Generic host tests
+Adapter tests:
 
-- Manifest signature, adapter digest, protocol range, capability, and ordering validation.
-- Socket identity, launch-secret, mTLS, HMAC, event digest, deadline, sequence, and channel-binding validation.
-- Immutable payload, permit, commit, event, hold, interaction, and fail decision validation.
-- Required adapter health, activation, pin-and-drain, and incomplete-coverage refusal.
-- No Google ADK fork, vendor tree, source copy, patch, module replacement, or `internal` import.
+- Callback-to-event mapping for all rows of the table, including the spawn classification by tool type.
+- Deny path: a `DenyCall` dict skips execution and reaches the model as the function response.
+- Replace path: `ReplaceOutput` and `ChildReturn` substitution at `after_tool_callback`.
+- Pre-append barrier: a blocked `Prompt` leaves no trace in session history.
+- Fail closed: runtime down at each callback blocks the action, and liveness gates hold model and emission callbacks.
+- Startup refusal: missing `APPA_RUNTIME_URL`, `sub_agents` present, unknown config fields.
+- No link from the codec crate to `appa-runtime` or `appa-engine`, and no policy state in the plugin.
 
-### Adapter tests
+Equivalence tests:
 
-- No link dependency from `appa-adapter-kagent` to `appa-runtime` or `appa-engine`.
-- No adapter policy parser, Engine call, policy schema migration, or `appa.db` path.
-- Harness event to `/hook` wire mapping and response-to-neutral-decision mapping.
-- Quickstart loopback URL, loopback-only runtime listener, and unavailable runtime fail-closed behavior.
-- Remote HTTPS CA pinning, workload authentication, runtime identity, Actor, extension, artifact, and policy-revision binding.
-- Rejected redirect, invalid certificate, stale epoch, duplicate event, changed event digest, changed runtime identity, and changed policy revision.
-- Generic ledger replay and delivery behavior without policy or trajectory records.
-- Quiesce, restore, shutdown, and drain lifecycle relay behavior.
+- Entrypoint output matches stock `static` for the same rendered config, minus the added plugin: same agent shape, same stock plugins, same serving surface.
+- Re-run on every `kagent-adk` and google-adk version bump.
 
-### Runtime and end-to-end tests
+End-to-end tests:
 
-- Runtime ownership of policy, Engine, consults, remedies, trajectory state, recovery, and `appa.db`.
-- Tool allow, replacement, suppression, terminal failure, timeout, and crash-window behavior through the adapter.
-- Model, session, child, A2A, memory, MCP, remote, interaction, and assistant-response gate coverage.
-- Replay of terminal runtime decisions and runtime handling of indeterminate execution.
-- Separate kagent host, adapter, and runtime state inspection.
-- Quickstart two-process companion acceptance with runtime loopback binding.
-- Remote gateway acceptance with authenticated HTTPS and revision-pinned runtime routing.
-- Prohibited-content checks across logs, traces, adapter ledger, host state, A2A output, and snapshots.
-
-The proof of completion requires every required capability to pass. No partial-capability mode reports ready.
+- Declarative agent on a kind cluster with the Substrate path: gated tool calls, replaced results, blocked prompts.
+- Parent and delegated child in separate Actors against one shared runtime: one trajectory, `ChildStart` and `SpawnResult` correlated.
+- Crash window: kill the Actor between `ToolCall` and `ToolResult`, then make sure the runtime reports the dispatch `Indeterminate`.
+- Double-match rollout guard: the rollout check detects and reports a template matched by two Harnesses.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -3,222 +3,169 @@ title: kAgent
 nav_title: kAgent
 category: Integrations
 order: 6
-description: Proposal for an OpenAPPA adapter for kagent without forking Google ADK.
+description: Proposal for the OpenAPPA kagent adapter — an ADK plugin delivered in the Harness workload image, with no kagent or Google ADK fork.
 ---
 
 :::proposal
 name: kAgent
-date: 2026-08-27
+date: 2026-09-01
 :::
 
-This proposal adds a generic out-of-process extension host to the kagent Go fork.
+[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. Its controller compiles each declarative agent (an `AgentTemplate` resource) into configuration, and runs it on a runtime image that the operator names in a `Harness` resource. This proposal gates kagent agents with OpenAPPA through those stock surfaces. It does not fork, patch, or vendor kagent or Google ADK.
 
-OpenAPPA uses `appa-adapter-kagent` as the kagent extension. The adapter maps the generic kagent harness wire to the existing `appa-runtime` `/hook` HTTP interface. The adapter does not link `appa-runtime`, own policy, call the Engine, or own `appa.db`.
+`appa-adapter-kagent` is the adapter. Its workload image extends the published `kagent-adk` image with two files: a small entrypoint and one Google ADK plugin. The plugin maps ADK callbacks to the eight `appa-runtime` `/hook` events and enforces the returned decisions inside the ADK dispatch loop. `appa-runtime` stays a separate process. It owns policy, the Engine, consults, remedy plans, trajectory state, and `appa.db`. Policy semantics stay in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
-`appa-runtime` is a separate logical process. It owns policy loading, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`. The adapter fails closed when `APPA_RUNTIME_URL` is unavailable or rejects a bound request.
+Two upstream surfaces carry the whole integration:
 
-The kagent fork contains no OpenAPPA policy, Label, trajectory, remedy, consult, runtime, or persistence logic. Google ADK remains an unmodified upstream dependency. The design does not fork, vendor, copy, patch, replace, or import internal Google ADK packages.
+- `Harness.spec.workload.image` is a required, operator-supplied, digest-pinned image reference ([harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40)). Every kagent install names a runtime image there. Naming the adapter image is ordinary configuration.
+- `KAgentApp(plugins=[...])` is a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L65](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L65)). kagent registers its own plugins through the same parameter ([cli.py#L95-L105](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L95-L105)).
 
-This proposal uses [kagent commit `9e246fd37`](https://github.com/kagent-dev/kagent/commit/9e246fd3797457b18fc277680be1629a0f57fce0) as its source baseline. It also uses Google ADK Go 2.2.0 and Substrate 0.0.20.
+Source baseline: kagent commit [`52cc4de2`](https://github.com/kagent-dev/kagent/commit/52cc4de2a044a5062d10c4f189d863937c1bb0f9) (2026-09-01), google-adk 2.8.0 (kagent's lockfile resolution), Substrate v0.0.20 ([go.mod#L489](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/go.mod#L489)).
 
-OpenAPPA policy semantics remain in [How it works](/how-it-works) and [Policy contracts](/contracts).
+## Overview
 
-## Ownership
+- The platform operator edits one `Harness`: point `spec.workload.image` at the adapter image, and set `APPA_RUNTIME_URL` in `spec.env`.
+- The Harness label selector chooses which `AgentTemplate` resources run gated ([harness_types.go#L114-L117](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L114-L117), [collections.go#L85-L102](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/controller/collections.go#L85-L102)). Agent developers change nothing.
+- Inside each agent Actor, the adapter entrypoint rebuilds the compiled agent from `KAGENT_CONFIG_JSON` — the same steps as stock `kagent-adk static` — and registers `AppaHookPlugin`.
+- Each gated ADK callback becomes one `/hook` request to `appa-runtime`. The plugin enforces the returned `HookDecision` where the callback fires: it can deny a tool call with feedback the model reads, replace a tool result, or substitute a child's return.
+- Hooks fail closed. When the runtime is unreachable or answers outside the contract, the gated action does not run.
 
-| Component | Ownership |
-|---|---|
-| kagent fork | Neutral extension protocol, Harness Revision, public-ADK wrappers, immutable payload snapshots, host sink barriers, and host-native session and A2A state |
-| `appa-adapter-kagent` | Generic kagent protocol negotiation, channel HMAC state, replay and delivery ledger, lifecycle relay, and harness-wire to `/hook` mapping |
-| `appa-runtime` | Policy, Engine, consults, remedy plans, trajectory state, recovery semantics, runtime API, and `appa.db` |
+## Highlights
 
-The adapter has no OpenAPPA semantic state. Its replay and delivery ledger contains only generic event and delivery bindings. It contains no policy decision, Label, trajectory fact, consult result, remedy, continuation, dispatch identifier, or `appa.db` data.
-
-The kagent fork sees only generic host payloads, phase names, digests, deadlines, decisions, and opaque handles. It does not parse OpenAPPA configuration or response meaning.
-
-## Generic kagent changes
-
-The fork implements generic extension infrastructure only:
-
-- Dynamic extension configuration and artifact verification.
-- Version and capability negotiation.
-- Dynamic proxies for existing public ADK callbacks.
-- Generic wrappers around public ADK model, tool, session, memory, and Runner interfaces.
-- Generic barriers in kagent-owned provider, tool, A2A, publication, and lifecycle code.
-- Generic execution, event, interaction, and lifecycle decisions.
-- Generic sidecar readiness, egress, volume, snapshot, and drain handling.
-
-The fork has no OpenAPPA crate, Go package, protobuf package, policy schema, wire enum, generated type, special tool route, or database migration. A missing public ADK boundary makes its generic capability unavailable. A required adapter then rejects activation.
-
-The protected instance enforces four contracts:
-
-1. The host executes only the immutable payload permitted by the required extension.
-2. Raw tool and child results remain withheld until the extension commits a delivery payload.
-3. Every enabled model, session, A2A, memory, UI, log, telemetry, and storage path crosses an exclusive extension gate.
-4. The instance remains unready when its generic inventory cannot satisfy every required adapter capability.
-
-## Adapter and runtime boundary
-
-The kagent extension protocol remains neutral. It uses private Unix-domain-socket gRPC, mTLS, a boot epoch, sequence numbers, a channel digest, deadlines, and HMAC-SHA256. The protocol carries no OpenAPPA domain type.
-
-The adapter receives one immutable generic event. It validates peer identity, Revision, boot epoch, sequence, deadline, event digest, and HMAC. It records a generic replay or delivery entry, then maps the event to one `/hook` request. It maps the runtime response back to one generic host decision.
-
-The adapter binds every `/hook` request to these values:
-
-- Actor UID and extension ID.
-- Immutable kagent Revision and adapter artifact digest.
-- Runtime policy revision and runtime instance identity.
-- Boot epoch, sequence, event ID, event digest, and deadline.
-- Authenticated channel identity and request HMAC digest.
-
-`appa-runtime` verifies this binding before it evaluates a flow. A runtime response binds the same values and its policy revision. The adapter rejects a missing, mismatched, expired, reordered, or duplicate binding. A policy revision change creates a new kagent Revision and follows pin-and-drain.
-
-The adapter does not interpret `permit`, `commit`, `hold`, `interaction`, `event`, or `fail` as policy. It only verifies the runtime response binding and renders the matching neutral host decision.
-
-## Deployment profiles
-
-### Quickstart
-
-Quickstart uses one digest-pinned OpenAPPA companion container with two processes:
+### Gated agents on Kubernetes
 
 ```text
-+---------------------- OpenAPPA companion container -----------------------+
-| appa-adapter-kagent                  appa runtime --adapter kagent        |
-| kagent UDS gRPC <----adapter----> http://127.0.0.1:8787/hook <----runtime |
-| generic ledger                         policy, Engine, consults, appa.db  |
+Kubernetes cluster
++---------------------------------------------------------------------------+
+| kagent controller-v2 (stock)                                              |
+|   watches AgentTemplate, Harness, ModelConfig, RemoteMCPServer            |
+|   pairs   Harness.spec.allowedAgentTemplates selector -> AgentTemplates   |
+|   renders one immutable Revision per (AgentTemplate, Harness) pair        |
++------------------------------------+--------------------------------------+
+                                     | runs each Revision as a Substrate Actor
+                                     v
++--------------------- Substrate Actor (one per agent) ---------------------+
+| image: Harness.spec.workload.image = appa-adapter-kagent (digest-pinned)  |
+| env:   KAGENT_CONFIG_JSON (the compiled agent), APPA_RUNTIME_URL, ...     |
+|                                                                           |
+| adapter entrypoint -> KAgentApp(plugins=[.., AppaHookPlugin]) -> A2A :8080|
++-----------------------------+---------------------------------------------+
+                              | POST /hook  (fail closed)
+                              v
++------------------- appa-runtime (one shared service) ---------------------+
+| policy, Engine, consults, remedy plans, trajectory state, appa.db         |
 +---------------------------------------------------------------------------+
 ```
 
-`APPA_RUNTIME_URL=http://127.0.0.1:8787` selects the loopback runtime. The runtime listens only on loopback in this profile. Container networking does not expose the runtime port. The adapter has no `appa.db` mount. Only `appa-runtime` mounts the runtime policy, credentials, and durable `appa.db` volume.
+The controller injects the compiled agent as environment variables into the Actor ([actor_template.go#L43-L44](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L43-L44)). The agent exists in the pod only as that data. No developer code and no per-agent image exists there, so one generic adapter image serves every admitted `AgentTemplate`.
 
-### Remote configuration
+All gated Actors of one deployment report to one shared `appa-runtime`. A parent and its delegated children run in separate Actors, and their hooks must reach the same runtime to correlate into one trajectory.
 
-Remote configuration uses the same `appa-adapter-kagent` image. `APPA_RUNTIME_URL` identifies an authenticated HTTPS runtime gateway or runtime instance.
-
-```text
-kagent host -- private UDS --> appa-adapter-kagent -- mTLS HTTPS --> appa-runtime gateway
-```
-
-The adapter authenticates the remote peer with a pinned CA and workload identity. The remote runtime authenticates the adapter identity and accepts only the configured Actor, extension, and Revision binding. The gateway forwards only to the bound runtime instance. The adapter rejects redirects, unpinned certificates, identity mismatch, and revision mismatch. Runtime policy and `appa.db` remain at the remote runtime.
-
-Both profiles use the same `/hook` request and response binding. Remote configuration changes do not relax the fail-closed rule.
-
-## OCI companion container
-
-The selected process model is a digest-pinned companion container in the same Substrate Actor. The kagent process and adapter communicate through a private Unix-domain socket. A shared memory-backed socket volume carries no durable runtime state.
-
-Substrate supports [multiple containers with independent readiness probes](https://github.com/kagent-dev/substrate/blob/v0.0.20/pkg/api/v1alpha1/actortemplate_types.go#L243-L356). Pinned kagent currently emits [one container](https://github.com/kagent-dev/kagent/blob/9e246fd3797457b18fc277680be1629a0f57fce0/go/core/v2/substrate/actor_template.go#L32-L91).
-
-The generic fork adds extension containers without an OpenAPPA-specific role. The adapter image runs as a dedicated UID with a read-only root filesystem and no Linux capabilities. Its generic ledger has a separate volume. The kagent container cannot mount it.
-
-Quickstart gives `appa-runtime` a separate private policy and `appa.db` volume. The adapter cannot mount either volume. Remote configuration has no runtime volume in the adapter container.
-
-Actor-wide CNI policy permits only cluster DNS and an authenticated egress gateway. The gateway enforces per-container destination, TLS identity, redirect, and DNS-rebinding rules. The kagent process and its in-process tools remain in the trusted computing base.
-
-## Dynamic extension configuration
-
-A Harness can declare several ordered dynamic extensions. The OpenAPPA declaration names an adapter artifact, not a policy runtime artifact:
-
-```yaml
-extensions:
-  - name: policy-gate
-    image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
-    manifestDigest: sha256:<digest>
-    protocol: kagent.extension.v1
-    required: true
-    failureMode: closed
-    order: 10
-    socket: /run/kagent/extensions/policy-gate.sock
-    adapter:
-      runtimeUrlEnv: APPA_RUNTIME_URL
-      runtimeBinding:
-        runtimeId: customer-support-runtime-a
-        policyRevision: customer-support-policy-v1
-        remoteIdentity: spiffe://policy.example/runtime/customer-support-runtime-a
-    ledger:
-      durableDir: policy-gate-delivery-ledger
-    egress:
-      - runtime-gateway.policy.example:443
-    readiness:
-      path: /readyz
-      port: 8082
-```
-
-The generic compiler verifies OCI digest, signature policy, manifest digest, protocol range, references, capability claims, deadlines, limits, socket uniqueness, ledger ownership, egress, and readiness declarations. It treats adapter and runtime configuration as opaque bytes. An immutable Revision binds their digests. Any policy, credential, CA, runtime identity, or remote endpoint change creates a new Revision.
-
-## Negotiation and event relay
-
-The adapter serves the private socket before registration. The host verifies adapter workload identity and per-launch channel secret. It calls `GetExtensionInfo`, sends the complete generic capability and sink inventory, and activates the adapter after it accepts the inventory digest.
-
-The inventory describes mechanics, not OpenAPPA policy. It includes ADK and provider versions, callback phase ordering, tool and model paths, raw codecs, content-bearing sinks, and snapshot, recovery, and drain capabilities.
-
-The adapter sends the inventory activation event to `/hook`. `appa-runtime` validates policy coverage and returns the bound result. The adapter reports ready only after a valid runtime response. The host treats that response as a generic required-extension attestation.
-
-Every generic event contains an immutable payload, event ID, digest, Actor UID, Revision, scope, operation, descriptor, sequence, phase, and deadline. The host executes no replacement without a matching `permit`. It publishes no content without a matching `commit` or `event` decision.
-
-The adapter ledger makes relays replay-safe. A repeated event ID returns the original bound decision only after the adapter verifies the identical event digest and runtime revision. Runtime recovery remains authoritative. The adapter does not classify semantic outcomes or reconstruct trajectory state.
-
-## Lifecycle coverage
-
-The protected profile uses public ADK interfaces and kagent-owned integration points. It disables any path that bypasses them.
-
-| Boundary | kagent-owned integration |
-|---|---|
-| Tool callbacks and execution | Sole content-bearing proxy, immutable arguments, execution wrapper, and result gate |
-| User input and sessions | Callback proxy and exact-byte pre-append gate |
-| Model request and catalog | Provider-final request and descriptor gate |
-| Model response and publication | Standard and live-path gates before persistence or yield |
-| Child, memory, MCP, and remote A2A | Generic wrappers with immutable request and terminal-result gates |
-| Snapshot, readiness, egress, and drain | Generic kagent and Substrate lifecycle interface |
-
-The adapter relays generic events for every required phase. `appa-runtime` maps those events to policy evaluation, Engine admission, consults, remedies, trajectory transitions, and recovery. The adapter owns no dynamic OpenAPPA tool, response meaning, interaction continuation, delegation state, or audit record.
-
-## State and recovery
-
-| Store | Contents |
-|---|---|
-| kagent | ADK sessions, A2A tasks, and narrow generic host delivery records |
-| `appa-adapter-kagent` | Generic protocol negotiation, HMAC channel state, event digest, replay, delivery, expiry, and lifecycle relay records |
-| `appa-runtime` | Policy identity, `appa.db`, Engine facts, trajectory state, consult pins, remedies, interactions, delegations, audit records, and recovery state |
-
-The adapter ledger records no OpenAPPA semantic value. The runtime owns all migration of policy and `appa.db`. The adapter artifact can drain independently, but it cannot migrate runtime state.
-
-Before a snapshot, the host stops new work and asks each required adapter to quiesce. The adapter seals its generic ledger and relays lifecycle events to runtime. `appa-runtime` seals and validates its own state generation. A restore remains unready until the host, adapter, and runtime accept the same Actor, extension, adapter artifact, runtime identity, and policy revision bindings.
-
-A crash before adapter acknowledgement of `execution.begin` means the host did not execute the tool. A crash after that acknowledgement and before a terminal result leaves classification to `appa-runtime`. The host freezes the generic scope until the adapter relays a bound runtime `suppress`, `hold`, replayed `commit`, or terminal `fail` decision.
-
-## Revisions and installation
-
-One adapter artifact, protocol selection, runtime identity, and policy revision remain pinned for each live scope. Existing scopes drain on the prior binding. The host never hot-swaps an adapter or moves a live scope between runtime revisions.
-
-Installation has three independently versioned artifacts:
-
-1. A kagent fork with the generic dynamic extension host, public-ADK adapters, and lifecycle points.
-2. The signed `appa-adapter-kagent` image and manifest.
-3. The `appa-runtime` image or binary, policy revision, and runtime identity.
-
-The generic Harness references the adapter image. It does not reference `appa.db`. Quickstart provisions the runtime process and private volume in the same companion container. Remote configuration references a gateway identity and policy revision, not a runtime database mount.
-
-## Architecture
+### One image wraps kagent-adk
 
 ```text
-+------------------------------ Kubernetes / Substrate Actor ------------------------------+
-| kagent controller -> immutable Revision -> ActorTemplate                                 |
-|                                                                                           |
-| +--------------------------+ private UDS +---------------------------------------------+ |
-| | kagent + upstream ADK    |<----------->| OpenAPPA companion container                 | |
-| | generic extension host   |             | appa-adapter-kagent                          | |
-| | public ADK wrappers      |             | generic negotiation, HMAC, delivery ledger   | |
-| | sessions.db / A2A state  |             |                | APPA_RUNTIME_URL              | |
-| +--------------------------+             |                v                              | |
-|                                           | appa runtime --adapter kagent                | |
-|                                           | policy, Engine, consults, trajectory, appa.db| |
-|                                           +---------------------------------------------+ |
-+-------------------------------------------------------------------------------------------+
+appa-adapter-kagent image
++-------------------------------------------------------------+
+| OpenAPPA layer (two files)                                  |
+|   entrypoint.py       replays the `kagent-adk static` steps |
+|   appa_hook_plugin.py ADK BasePlugin -> POST /hook          |
++-------------------------------------------------------------+
+| base: published kagent-adk image, unmodified                |
+|   kagent-adk package  (cli.py present, not used as PID 1)   |
+|   google-adk 2.8.0    (BasePlugin is its official API)      |
++-------------------------------------------------------------+
 
-Remote configuration replaces the final loopback hop with authenticated HTTPS to the bound runtime gateway or instance. The runtime port remains loopback-only in quickstart.
+entrypoint flow — the same public calls as stock `static`, one delta:
+  materialize_from_env("/config")                  # env -> config files
+  cfg = AgentConfig.model_validate(config)         # refuse unsupported fields
+  plugins = [<stock STS / passthrough plugins>]
+  plugins.append(AppaHookPlugin(APPA_RUNTIME_URL)) # <-- the delta
+  KAgentApp(lambda: cfg.to_agent(name), card, url, name,
+            plugins=plugins).build()
+```
 
-## Incomplete coverage refusal
+Stock `kagent-adk static` performs the identical sequence with a closed plugin list ([cli.py#L76-L135](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L76-L135)). The steps are materialize ([_config_materialize.py#L55-L69](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_config_materialize.py#L55-L69)), then validate and rebuild the agent ([types.py#L387-L403](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L387-L403)), then serve ([_a2a.py#L126-L149](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L126-L149)). The plugin list handed to ADK's `App(plugins=...)` becomes ADK's `PluginManager`, so one registration covers the root agent, every sub-agent, and every tool. Google ADK stays an unmodified dependency.
 
-The protected instance remains unready when a required phase lacks sole, fixed, supported ownership. The first release refuses opaque provider paths, stock MCP transport without raw arguments and no-retry execution, unbounded memory preload, mutable catalogs, unverified callbacks, content telemetry, incomplete remote A2A gates, streaming before publication control, mixed revisions, unavailable runtime identity, failed runtime authentication, and any path that needs Google ADK source changes.
+### Callback-to-hook mapping
 
-The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the neutral protocol, ownership boundary, deployment profiles, public-ADK integration, and verification matrix.
+The runtime's hook vocabulary is the eight `HookEvent` variants in `appa-runtime-api/src/lib.rs`. The plugin maps each gated ADK callback onto exactly one event, and callbacks with no event either pass through or hold as liveness gates.
+
+```text
+   ADK CALLBACK (google-adk 2.8.0, unmodified)           APPA RUNTIME /hook — the 8 HookEvents
+   time flows top→bottom within one turn                 and the decisions each one answers
+   ─────────────────────────────────────────             ─────────────────────────────────────
+
+session  first invocation of a fresh ADK session ──────▶ [1] SessionStart      ◀ Ack
+  │        detected in on_user_message_callback;             root TrajectoryId derived
+  ▼        no callback exists at session creation            from the ADK session id
+prompt   on_user_message_callback ─────────────────────▶ [2] Prompt            ◀ Ack | Block
+  │        fires BEFORE the session append, so a
+  │        Block keeps the exact bytes out of
+  │        stored session history
+  │      before_run_callback ───────x no event  (Prompt already gates the same bytes)
+  │      before_agent_cb (root) ────x no event  (root entry IS Prompt)
+  ▼
+model    before_model_callback ─────x no event ┐ no model-layer HookEvent exists;
+         after_model_callback ──────x no event │ the plugin holds these callbacks as
+         on_model_error_callback ───x no event ┘ liveness gates: /hook down ⇒ refuse
+  │
+  ▼
+tool     before_tool_callback ═════════════════════════▶ [3] ToolCall{spawn:F} ◀ AllowCall | DenyCall
+loop        deny: the returned dict SKIPS execution                              | Refuse
+  │         and becomes the function response the
+  │         model reads
+  │      after_tool_callback ══════════════════════════▶ [4] ToolResult        ◀ Ack | ReplaceOutput
+  │      on_tool_error_callback ───────────────────────▶ [4] ToolResult{Failure} | Block
+  ▼
+child    before_tool_cb (sub-agent tool) ──────────────▶ [3] ToolCall{spawn:T} ◀ AllowCall{binding}
+deleg.     │ child scope opens:
+           │  before_agent_cb (child) ─────────────────▶ [5] ChildStart        ◀ Ack
+           │      … child runs its own [3]/[4] loop …
+           │  after_agent_cb (child) ──────────────────▶ [6] TurnEnd (child)   ◀ Ack
+           └ after_tool_cb (sub-agent return) ─────────▶ [7] SpawnResult       ◀ Ack | ChildReturn{value}
+               the ONE point where the value the                                 | ReplaceOutput | Block
+               parent receives can be substituted
+  │
+  ▼
+emit     on_event_callback ─────────x no event  (no emission HookEvent;
+  │                                              held as a liveness gate)
+  ▼
+turn     after_run_callback ───────────────────────────▶ [6] TurnEnd (root)    ◀ Ack —
+end      on_run_error_callback ────────────────────────▶ [6] TurnEnd (root,      closes tool dispatches
+         on_agent_error_cb (child) ────────────────────▶ [6] TurnEnd  failure)   the turn abandoned
+
+                                                         [8] ChildEnd — unfed BY DESIGN:
+                                                             return substitution is enforceable
+                                                             only parent-side, so returns cross
+                                                             at [7] SpawnResult. The Claude Code
+                                                             adapter makes the same choice.
+```
+
+The enforcement mechanics come from ADK's own plugin contract, verified in the 2.8.0 wheel:
+
+- All 14 callbacks above exist on `BasePlugin` (`google/adk/plugins/base_plugin.py`, lines 114-394 in the 2.8.0 wheel).
+- A dict returned from `before_tool_callback` skips execution and becomes the function response the model reads — `DenyCall` with feedback (`google/adk/flows/llm_flows/functions.py`, lines 611-641).
+- A dict returned from `after_tool_callback` replaces the result the model sees — `ReplaceOutput` (`functions.py`, lines 652-683).
+- `on_user_message_callback` fires before the runner appends the message to session history (`google/adk/runners.py`, lines 675-700), so a `Block` on `Prompt` is a pre-append barrier.
+- kagent dispatches every declared remote sub-agent as an ordinary ADK tool, `KAgentRemoteA2AToolset` ([types.py#L521](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L521)), so the tool-call gate is also the spawn gate.
+
+kagent children run in separate Actors. The child Actor's own plugin recognizes the delegated entry from kagent's inbound metadata ([_agent_executor.py#L212-L214](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py#L212-L214)). It feeds `ChildStart` and the child `TurnEnd`, while the parent's plugin feeds the spawn `ToolCall` and `SpawnResult`. Both report to the one shared runtime.
+
+### Fail-closed rules
+
+1. An unreachable `/hook` endpoint, or a response outside the contract, blocks the gated action. The plugin raises, and ADK aborts the invocation.
+2. A rendered config with a field the entrypoint does not support refuses to start, and the Actor stays unready. In-process `sub_agents` compiled from CRD sub-agent tools are the known case: stock `kagent-adk` drops them silently, and the adapter refuses instead.
+3. The model and emission callbacks feed no event, but they still hold the action when the `/hook` channel is down.
+4. A hard Actor crash emits nothing. `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event.
+
+### Scope and limits
+
+- Covered: declarative `AgentTemplate` agents on the kagent (Python ADK) harness variant, run from this workload image on the Substrate path (helm `controller.substrate.enabled`).
+- Not covered: the Claude harness, which omits hooks, permission mode, memory, and inline MCP from its supported contract ([config.go#L48-L50](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/harness/claude/config/config.go#L48-L50)).
+- Also not covered: the Codex harness, the non-ADK framework wrappers, and agents on kagent's stock image, whose plugin list is closed ([cli.py#L95-L105](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L95-L105)).
+- `SessionStart` is a first-invocation proxy. A session that is created but never invoked emits nothing, and also flows nothing.
+- The entrypoint replays the behavior of `kagent-adk static` instead of calling it, because upstream has no plugin configuration knob. Each `kagent-adk` release therefore costs one small equivalence re-check. A one-field upstream contribution would remove the duplication.
+
+## Implementation plan
+
+The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the artifacts, the entrypoint and plugin specification, the runtime-side codec, deployment profiles, trajectory identity, and the verification matrix.


### PR DESCRIPTION
Finalizes the kagent integration proposal on the decision that upstream kagent carries the whole adapter with no fork or patch of kagent or Google ADK.

**Proposal** (`website/content/docs/kagent.md`) — now a short intro/overview plus diagram highlights:
- Kubernetes topology: controller-v2 pairs `AgentTemplate`s to the Harness by label selector; each pair runs as a Substrate Actor from `Harness.spec.workload.image`, reporting to one shared `appa-runtime`.
- The adapter image wraps the published `kagent-adk` image: a ~30-line entrypoint replays `kagent-adk static` through public calls and appends `AppaHookPlugin` via the public `KAgentApp(plugins=[...])` parameter.
- The full ADK callback-to-hook mapping for all eight `HookEvent`s, with fail-closed rules and scope limits.

**Implementation plan** (`integrations/kagent/IMPLEMENTATION.md`) — rewritten for the plugin lane: artifacts (Python package, OCI image, runtime-side codec crate), entrypoint and startup refusal rules, the 14-callback enforcement table, trajectory identity and cross-actor children, deployment profiles, Harness wiring/rollout, known gaps, PR sequence, and verification matrix.

Every load-bearing claim links kagent commit `52cc4de2` permalinks or google-adk 2.8.0 wheel paths. Golden files are untouched. Both documents follow ASD-STE100 flavored mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)