### PR TITLE
fix!: bind a command external's credential to that command

### DIFF
--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -190,8 +190,11 @@ pub enum EvidenceRefusal {
 /// One operation-wide claim per provider id, folded across every occurrence the evidence
 /// carries. A collection that reports a member and a viewer that reports the same member
 /// with its verified address describe one reader, not a contradiction: a silent occurrence
-/// makes no counter-claim and defers to the verified one. Two different verified addresses
-/// for one id have no resolution and refuse. Every consumer resolves an occurrence through
+/// makes no counter-claim and defers to the verified one. Two verified addresses conflict
+/// when they name different principals, not when they are spelled differently: the same
+/// address under two domain cases is one claim, because that is the reader both resolve to.
+/// Addresses that do differ have no resolution and refuse. Every consumer resolves an
+/// occurrence through
 /// this table, so one id seats exactly one principal in an operation — the engine when it
 /// canonicalizes, and the runtime when it asks a custom implementation.
 pub fn folded_claims(evidence: &AudienceEvidence) -> Result<BTreeMap<String, MemberClaims>, EvidenceRefusal> {
@@ -208,7 +211,9 @@ pub fn folded_claims(evidence: &AudienceEvidence) -> Result<BTreeMap<String, Mem
             }
             std::collections::btree_map::Entry::Occupied(mut held) => {
                 match (&held.get().verified_email, &claims.verified_email) {
-                    (Some(standing), Some(offered)) if standing != offered => {
+                    (Some(_), Some(_))
+                        if verified_email_principal(held.get())? != verified_email_principal(claims)? =>
+                    {
                         return Err(EvidenceRefusal::ConflictingClaims { id: claims.id.clone() });
                     }
                     (None, Some(_)) => {
@@ -1201,6 +1206,28 @@ mod tests {
             members("full-members"),
             BTreeSet::from([ReaderId::new("a@corp.com"), ReaderId::new("slack:U2")]),
             "the folded claim seats one principal for the id everywhere it occurs"
+        );
+
+        // Two claims conflict when they name different readers, not when two sources spell
+        // one address with different domain case: both resolve to the same principal.
+        let spelled_twice = AudienceEvidence {
+            sources: vec![
+                SourceClaims {
+                    provider: "slack".into(),
+                    selector: "viewer".into(),
+                    members: vec![member("slack:U1", Some("Alice@CORP.com"))],
+                },
+                SourceClaims {
+                    provider: "slack".into(),
+                    selector: "full-members".into(),
+                    members: vec![member("slack:U1", Some("Alice@corp.com"))],
+                },
+            ],
+            ..AudienceEvidence::default()
+        };
+        assert!(
+            registry.expansions(&spelled_twice).is_ok(),
+            "one address under two domain cases is one claim"
         );
 
         // A lookup's claims must be for the member asked — a source may not canonicalize a

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -46,8 +46,18 @@ impl Trust {
 /// `@` (a group reference). The constructor cannot enforce that, so the rule is
 /// [`is_literal`](ReaderId::is_literal), applied on every ingress that builds a reader set:
 /// registry declarations at load, annotation answers, and membership answers.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct ReaderId(String);
+
+/// Every reader that arrives as data — a persisted event at replay, an external's answer,
+/// an API payload — carries the same one spelling per identity as a constructed one.
+/// Deserializing straight into the field would let `alice@CORP.com` off the wire compare
+/// as a second reader.
+impl<'de> Deserialize<'de> for ReaderId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<ReaderId, D::Error> {
+        Ok(ReaderId::new(String::deserialize(deserializer)?))
+    }
+}
 
 impl ReaderId {
     /// Build a reader, normalized so that one identity has one spelling: an address keeps
@@ -1195,6 +1205,26 @@ mod tests {
         assert!(ReaderId::new("alice@corp.com").is_literal());
         assert!(ReaderId::new("slack:U012345").is_literal());
         assert!(ReaderId::new("Self").is_literal(), "reserved spellings are exact");
+    }
+
+    #[test]
+    fn a_reader_off_the_wire_normalizes_like_a_constructed_one() {
+        let wire: ReaderId = serde_json::from_str("\"Alice@CORP.com\"").expect("a reader deserializes from a string");
+        assert_eq!(wire, ReaderId::new("Alice@corp.com"));
+        assert_eq!(
+            wire.as_str(),
+            "Alice@corp.com",
+            "the local part survives the domain fold"
+        );
+        assert_eq!(
+            serde_json::to_string(&wire).expect("a reader serializes"),
+            "\"Alice@corp.com\"",
+            "a replayed record round-trips to the spelling every comparison uses"
+        );
+
+        // A reader that is no address keeps every byte, provider prefixes included.
+        let qualified: ReaderId = serde_json::from_str("\"slack:U012345\"").expect("a reader deserializes");
+        assert_eq!(qualified.as_str(), "slack:U012345");
     }
 
     fn context_free() -> (WithinAssertions, BTreeSet<String>, Expansions) {

--- a/appa-runtime/src/builtins.rs
+++ b/appa-runtime/src/builtins.rs
@@ -469,10 +469,14 @@ fn isolate_claude_environment(command: &mut tokio::process::Command) {
     // tool-less, and non-persistent, so it is safe and necessary to clear the
     // harness marker before launching it.
     command.env_remove("CLAUDECODE");
-    // No APPA secret or wiring variable reaches the model: the child needs its own
-    // credentials and HOME, never this runtime's bearer tokens.
+    // No APPA variable of any kind reaches the model: the child needs its own credentials
+    // and HOME, never this runtime's bearer tokens — and not the provider credential a
+    // `command` external inherits either, which this consult never reads.
     for (key, _) in std::env::vars_os() {
-        if key.to_string_lossy().starts_with("APPA_") {
+        if key
+            .to_string_lossy()
+            .starts_with(crate::config::RUNTIME_VARIABLE_PREFIX)
+        {
             command.env_remove(key);
         }
     }

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -20,18 +20,13 @@ pub struct Config {
 /// consult both stay in this process.
 pub(crate) const RUNTIME_VARIABLE_PREFIX: &str = "APPA_";
 
-/// The one part of the runtime's namespace that survives into a child: the credential a
-/// `command` external reads for itself — a battery's provider token, which the runtime
-/// never reads and never sends. `token_env` may not name one, so the passthrough cannot
+/// The namespace a `command` external's own credential lives in — a battery's provider
+/// token, which the runtime never reads and never sends. A child inherits nothing of the
+/// runtime's namespace by default; the one variable its binding names is put back, and only
+/// from this namespace, so a credential reaches the one command that reads it and no other.
+/// A `url` binding's `token_env` may not name a variable here, so the passthrough cannot
 /// become a way to hand a subprocess a secret this runtime holds.
 pub(crate) const PROVIDER_CREDENTIAL_PREFIX: &str = "APPA_PROVIDER_";
-
-/// Whether a variable of this process must be removed from a `command` external's
-/// environment. The `claude-code` consult is stricter still and keeps nothing of the
-/// namespace, carve-out included: it reads no provider credential.
-pub(crate) fn withheld_from_child(key: &str) -> bool {
-    key.starts_with(RUNTIME_VARIABLE_PREFIX) && !key.starts_with(PROVIDER_CREDENTIAL_PREFIX)
-}
 
 /// The effective policy file: deterministic TOML bytes after includes
 /// compose, and the policy value parsed from those bytes. The stored
@@ -99,8 +94,15 @@ impl ExternalBindings {
 /// declared it — an embedded host supplies an absolute one itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Binding {
-    Url { url: String, token_env: Option<String> },
-    Command { argv: Vec<String>, cwd: PathBuf },
+    Url {
+        url: String,
+        token_env: Option<String>,
+    },
+    Command {
+        argv: Vec<String>,
+        cwd: PathBuf,
+        token_env: Option<String>,
+    },
     Builtin(String),
 }
 
@@ -243,11 +245,14 @@ pub enum AnnotatorImplementation {
     Command(ResolverCommand),
 }
 
-/// A command binding's argv and the directory of the config that declared it.
+/// A command binding's argv, the directory of the config that declared it, and the one
+/// `APPA_PROVIDER_*` variable its child inherits. The name is carried, never the value: the
+/// runtime forwards the variable at spawn and never reads the credential itself.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolverCommand {
     pub argv: Vec<String>,
     pub cwd: PathBuf,
+    pub token_env: Option<String>,
 }
 
 pub const CLAUDE_CODE_BUILTIN: &str = "claude-code";
@@ -365,9 +370,16 @@ pub enum ConfigError {
         var: String,
     },
     #[error(
-        "the {section} endpoint {name:?} names {var}, which reaches command children: a token this runtime sends itself needs a variable outside {prefix}"
+        "the {section} endpoint {name:?} names {var}, which a command child can inherit: a token this runtime sends itself needs a variable outside {prefix}"
     )]
     ChildCredentialVariable {
+        section: &'static str,
+        name: String,
+        var: String,
+        prefix: &'static str,
+    },
+    #[error("the {section} command {name:?} names {var}, and only a {prefix} variable reaches its child")]
+    CommandCredentialVariable {
         section: &'static str,
         name: String,
         var: String,
@@ -868,7 +880,7 @@ fn embedded_binding(
             entry
         }
         Binding::Builtin(builtin) => vec![("builtin", toml::Value::String(builtin.clone()))],
-        Binding::Command { argv, cwd } => {
+        Binding::Command { argv, cwd, token_env } => {
             if !cwd.is_absolute() {
                 return Err(ConfigError::RelativeCommandCwd {
                     section: section.name(),
@@ -879,10 +891,14 @@ fn embedded_binding(
                 field: "externals command cwd",
             })?;
             command_cwds.insert(section.origin_key(name), toml::Value::String(cwd.to_string()));
-            vec![(
+            let mut entry = vec![(
                 "command",
                 toml::Value::Array(argv.iter().cloned().map(toml::Value::String).collect()),
-            )]
+            )];
+            if let Some(token_env) = token_env {
+                entry.push(("token_env", toml::Value::String(token_env.clone())));
+            }
+            entry
         }
     };
     Ok(toml::Value::Table(
@@ -1137,7 +1153,7 @@ fn resolve_binding(
             }
             Ok(Implementation::Builtin(builtin))
         }
-        (None, None, Some(argv)) if token_env.is_none() => resolve_command(section, name, argv, origins),
+        (None, None, Some(argv)) => resolve_command(section, name, argv, token_env, origins),
         _ => Err(ConfigError::ImplementationChoice {
             section: section.name(),
             name: name.to_string(),
@@ -1145,10 +1161,16 @@ fn resolve_binding(
     }
 }
 
+/// A command's `token_env` is the opposite of a URL's: the runtime sends nothing, it
+/// forwards one variable to the child that reads it, and only from the passthrough
+/// namespace. Presence is deliberately not checked here — the runtime never reads the
+/// value, so a policy stays loadable and describable on a machine that holds no provider
+/// credential, and a missing one surfaces as the child's own refusal to answer.
 fn resolve_command(
     section: Section,
     name: &str,
     argv: Vec<String>,
+    token_env: Option<String>,
     origins: &BTreeMap<String, PathBuf>,
 ) -> Result<Implementation, ConfigError> {
     if argv.is_empty() || argv.iter().any(String::is_empty) {
@@ -1157,9 +1179,20 @@ fn resolve_command(
             name: name.to_string(),
         });
     }
+    if let Some(var) = token_env
+        .as_ref()
+        .filter(|var| !var.starts_with(PROVIDER_CREDENTIAL_PREFIX))
+    {
+        return Err(ConfigError::CommandCredentialVariable {
+            section: section.name(),
+            name: name.to_string(),
+            var: var.clone(),
+            prefix: PROVIDER_CREDENTIAL_PREFIX,
+        });
+    }
     #[cfg(not(unix))]
     {
-        let _ = (argv, origins);
+        let _ = (argv, origins, token_env);
         return Err(ConfigError::UnsupportedCommandPlatform {
             section: section.name(),
             name: name.to_string(),
@@ -1173,6 +1206,7 @@ fn resolve_command(
                 .get(&section.origin_key(name))
                 .expect("every composed command binding records its source")
                 .clone(),
+            token_env,
         }))
     }
 }
@@ -1442,6 +1476,46 @@ mod tests {
             parse_with(&empty, |_| Some(String::new())),
             Err(ConfigError::MissingSecret { .. }),
         ));
+    }
+
+    /// A command's `token_env` is the mirror of a URL's: nothing is sent, one variable is
+    /// forwarded to the child that reads it, and only from the passthrough namespace.
+    #[cfg(unix)]
+    #[test]
+    fn a_command_forwards_one_credential_and_only_from_the_passthrough_namespace() {
+        let with = |token_env: &str| {
+            format!(
+                "{MINIMAL}\n[externals.audience.slack]\ncommand = [\"python3\", \"source.py\"]\ntoken_env = \"{token_env}\"\n"
+            )
+        };
+        let set = |var: &str| (var == "APPA_PROVIDER_SLACK_TOKEN").then(|| "xoxb-fixture".to_string());
+
+        assert!(
+            matches!(
+                parse_with(&with("APPA_SLACK_TOKEN"), set),
+                Err(ConfigError::CommandCredentialVariable { .. })
+            ),
+            "the runtime's own namespace never reaches a child, so a command cannot name it"
+        );
+        assert!(matches!(
+            parse_with(&with("SLACK_TOKEN"), set),
+            Err(ConfigError::CommandCredentialVariable { .. }),
+        ));
+        assert!(
+            parse_with(&with("APPA_PROVIDER_GITHUB_TOKEN"), set).is_ok(),
+            "the runtime never reads the value, so a policy stays loadable and describable \
+             without the credential on the machine"
+        );
+
+        let config = parse_with(&with("APPA_PROVIDER_SLACK_TOKEN"), set).expect("the bound credential validates");
+        let Some(Implementation::Command(command)) = config.externals.audience.get("slack") else {
+            panic!("the slack audience source is a command")
+        };
+        assert_eq!(command.token_env.as_deref(), Some("APPA_PROVIDER_SLACK_TOKEN"));
+        assert!(
+            !format!("{command:?}").contains("xoxb-fixture"),
+            "the binding carries the variable name, never the credential"
+        );
     }
 
     #[test]
@@ -1845,6 +1919,7 @@ mod tests {
                 Binding::Command {
                     argv: vec!["python3".to_string(), argument.to_string()],
                     cwd: std::fs::canonicalize(cwd).expect("canonical command directory"),
+                    token_env: None,
                 },
             );
             embedded(bindings).expect("embedded command config loads")
@@ -1872,6 +1947,7 @@ mod tests {
             Binding::Command {
                 argv: vec!["python3".to_string()],
                 cwd: PathBuf::from("battery"),
+                token_env: None,
             },
         );
         assert!(matches!(

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -14,6 +14,25 @@ pub struct Config {
     pub externals: Externals,
 }
 
+/// The runtime's own environment namespace: its wiring (`APPA_CONFIG`, `APPA_DB`,
+/// `APPA_GATE`, …) and every secret a `token_env` names. Nothing in it reaches a child
+/// process, so a bearer token this runtime sends and a gate variable that would recurse a
+/// consult both stay in this process.
+pub(crate) const RUNTIME_VARIABLE_PREFIX: &str = "APPA_";
+
+/// The one part of the runtime's namespace that survives into a child: the credential a
+/// `command` external reads for itself — a battery's provider token, which the runtime
+/// never reads and never sends. `token_env` may not name one, so the passthrough cannot
+/// become a way to hand a subprocess a secret this runtime holds.
+pub(crate) const PROVIDER_CREDENTIAL_PREFIX: &str = "APPA_PROVIDER_";
+
+/// Whether a variable of this process must be removed from a `command` external's
+/// environment. The `claude-code` consult is stricter still and keeps nothing of the
+/// namespace, carve-out included: it reads no provider credential.
+pub(crate) fn withheld_from_child(key: &str) -> bool {
+    key.starts_with(RUNTIME_VARIABLE_PREFIX) && !key.starts_with(PROVIDER_CREDENTIAL_PREFIX)
+}
+
 /// The effective policy file: deterministic TOML bytes after includes
 /// compose, and the policy value parsed from those bytes. The stored
 /// value and bytes always describe the same deployment.
@@ -344,6 +363,15 @@ pub enum ConfigError {
         section: &'static str,
         name: String,
         var: String,
+    },
+    #[error(
+        "the {section} endpoint {name:?} names {var}, which reaches command children: a token this runtime sends itself needs a variable outside {prefix}"
+    )]
+    ChildCredentialVariable {
+        section: &'static str,
+        name: String,
+        var: String,
+        prefix: &'static str,
     },
     #[error("the {section} endpoint {name:?} names {var}, which is not set")]
     MissingSecret {
@@ -1244,11 +1272,19 @@ fn resolve_token(
     let Some(var) = token_env else {
         return Ok(None);
     };
-    if !var.starts_with("APPA_") {
+    if !var.starts_with(RUNTIME_VARIABLE_PREFIX) {
         return Err(ConfigError::ForeignSecretVariable {
             section,
             name: name.to_string(),
             var,
+        });
+    }
+    if var.starts_with(PROVIDER_CREDENTIAL_PREFIX) {
+        return Err(ConfigError::ChildCredentialVariable {
+            section,
+            name: name.to_string(),
+            var,
+            prefix: PROVIDER_CREDENTIAL_PREFIX,
         });
     }
     match lookup(&var) {
@@ -1388,6 +1424,16 @@ mod tests {
             "{MINIMAL}\n[externals.authorities.security]\nurl = \"https://authority.internal\"\ntoken_env = \"APPA_AUTHORITY_TOKEN\"\n"
         );
         assert!(matches!(parse(&unset), Err(ConfigError::MissingSecret { .. })));
+
+        // The passthrough namespace reaches command children, so a token this runtime sends
+        // may not live there — the refusal comes before the variable is even read.
+        let passthrough = format!(
+            "{MINIMAL}\n[externals.authorities.security]\nurl = \"https://authority.internal\"\ntoken_env = \"APPA_PROVIDER_AUTHORITY_TOKEN\"\n"
+        );
+        assert!(matches!(
+            parse(&passthrough),
+            Err(ConfigError::ChildCredentialVariable { .. }),
+        ));
 
         let empty = format!(
             "{MINIMAL}\n[externals.authorities.security]\nurl = \"https://authority.internal\"\ntoken_env = \"APPA_AUTHORITY_TOKEN\"\n"

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -715,12 +715,22 @@ async fn run_command_process(
         .kill_on_drop(true);
     configured.as_std_mut().process_group(0);
     // The runtime's own namespace stops here: no bearer token it sends, and no wiring
-    // variable, reaches the child. A command's own provider credential is the exception the
-    // namespace carves out, because the child is the only thing that reads it.
+    // variable, reaches the child. The binding's own provider credential is put back
+    // afterwards, so a command inherits the one variable it reads and no other's.
     for (key, _) in std::env::vars_os() {
-        if crate::config::withheld_from_child(&key.to_string_lossy()) {
+        if key
+            .to_string_lossy()
+            .starts_with(crate::config::RUNTIME_VARIABLE_PREFIX)
+        {
             configured.env_remove(key);
         }
+    }
+    if let Some((var, credential)) = command
+        .token_env
+        .as_ref()
+        .and_then(|var| std::env::var_os(var).map(|credential| (var, credential)))
+    {
+        configured.env(var, credential);
     }
 
     let child = configured.spawn().map_err(|_| NoAnswerReason::Unreachable)?;
@@ -1103,6 +1113,7 @@ mod tests {
                 "one argument".to_string(),
             ],
             cwd: dir.to_path_buf(),
+            token_env: Some("APPA_PROVIDER_TEST_TOKEN".to_string()),
         };
         config
             .annotators
@@ -1161,6 +1172,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("a fixture directory is created");
         unsafe { std::env::set_var("APPA_COMMAND_TEST_SECRET", "must-not-leak") };
         unsafe { std::env::set_var("APPA_PROVIDER_TEST_TOKEN", "provider-credential") };
+        // Another battery's credential: in the same namespace, named by no binding here.
+        unsafe { std::env::set_var("APPA_PROVIDER_OTHER_TOKEN", "must-not-leak") };
         let services = command_services(
             dir.path(),
             r#"cat > request.json
@@ -1174,6 +1187,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         let outcome = resolve_command(&services).await;
         unsafe { std::env::remove_var("APPA_COMMAND_TEST_SECRET") };
         unsafe { std::env::remove_var("APPA_PROVIDER_TEST_TOKEN") };
+        unsafe { std::env::remove_var("APPA_PROVIDER_OTHER_TOKEN") };
 
         assert_eq!(
             outcome,
@@ -1197,8 +1211,8 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         assert_eq!(
             std::fs::read_to_string(dir.path().join("appa-env.txt")).unwrap(),
             "APPA_PROVIDER_TEST_TOKEN=provider-credential\n",
-            "a command inherits the provider credential it reads for itself, and nothing else of \
-             the runtime's namespace"
+            "a command inherits the one credential its binding names — not the runtime's own \
+             variables, and not another binding's credential in the same namespace"
         );
 
         // The same command serves an authority: the transport is kind-agnostic.
@@ -1294,6 +1308,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
             AnnotatorImplementation::Command(ResolverCommand {
                 argv: vec!["/definitely/missing/resolver".to_string()],
                 cwd: dir.path().to_path_buf(),
+                token_env: None,
             }),
         );
         assert_eq!(

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -714,8 +714,11 @@ async fn run_command_process(
         .stderr(Stdio::null())
         .kill_on_drop(true);
     configured.as_std_mut().process_group(0);
+    // The runtime's own namespace stops here: no bearer token it sends, and no wiring
+    // variable, reaches the child. A command's own provider credential is the exception the
+    // namespace carves out, because the child is the only thing that reads it.
     for (key, _) in std::env::vars_os() {
-        if key.to_string_lossy().starts_with("APPA_") {
+        if crate::config::withheld_from_child(&key.to_string_lossy()) {
             configured.env_remove(key);
         }
     }
@@ -1157,6 +1160,7 @@ mod tests {
     async fn a_command_receives_one_envelope_in_its_directory_and_answers_for_any_kind() {
         let dir = tempfile::tempdir().expect("a fixture directory is created");
         unsafe { std::env::set_var("APPA_COMMAND_TEST_SECRET", "must-not-leak") };
+        unsafe { std::env::set_var("APPA_PROVIDER_TEST_TOKEN", "provider-credential") };
         let services = command_services(
             dir.path(),
             r#"cat > request.json
@@ -1169,6 +1173,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         );
         let outcome = resolve_command(&services).await;
         unsafe { std::env::remove_var("APPA_COMMAND_TEST_SECRET") };
+        unsafe { std::env::remove_var("APPA_PROVIDER_TEST_TOKEN") };
 
         assert_eq!(
             outcome,
@@ -1191,8 +1196,9 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         );
         assert_eq!(
             std::fs::read_to_string(dir.path().join("appa-env.txt")).unwrap(),
-            "",
-            "no APPA_* variable reaches a resolver command"
+            "APPA_PROVIDER_TEST_TOKEN=provider-credential\n",
+            "a command inherits the provider credential it reads for itself, and nothing else of \
+             the runtime's namespace"
         );
 
         // The same command serves an authority: the transport is kind-agnostic.
@@ -1478,6 +1484,8 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         let command = fake_claude(capture.path(), &script);
         // The runtime's own wiring and secrets must not reach the child.
         unsafe { std::env::set_var("APPA_TEST_SECRET_TOKEN", "leaky") };
+        // Not even the credential a `command` external inherits: this consult reads none.
+        unsafe { std::env::set_var("APPA_PROVIDER_TEST_TOKEN", "leaky") };
         let raw = run_claude_code(
             &claude_backend(command, 2000, 65_536),
             &prompt,
@@ -1486,6 +1494,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
         .await
         .expect("the fake Claude process returns structured output");
         unsafe { std::env::remove_var("APPA_TEST_SECRET_TOKEN") };
+        unsafe { std::env::remove_var("APPA_PROVIDER_TEST_TOKEN") };
         assert_eq!(raw["delta"]["trust"], "suspicious");
 
         let sent: serde_json::Value =

--- a/batteries/github/README.md
+++ b/batteries/github/README.md
@@ -63,17 +63,18 @@ from = ["github:org/archestra-ai/team/finance"]
 
 [externals.audience.github]
 command = ["python3", "batteries/github/audience-source.py"]
+token_env = "APPA_PROVIDER_GITHUB_TOKEN"
 ```
 
 A command path is resolved against the directory of the config file
 that names it, so write the path as your root config sees the battery.
 
-The script reads its token from `APPA_PROVIDER_GITHUB_TOKEN`. The token needs
-the `read:org` and `user:email` scopes. The runtime keeps its own
-`APPA_*` variables — its wiring and every `token_env` secret — out of a
-command it runs, and passes through only the `APPA_PROVIDER_*`
-namespace, which holds credentials a command reads for itself and the
-runtime never sends. Any GitHub error or missing answer stops the operation without
+The script reads its token from `APPA_PROVIDER_GITHUB_TOKEN`, which the
+binding's `token_env` forwards. The token needs the `read:org` and
+`user:email` scopes. A command inherits none of the runtime's `APPA_*`
+namespace — not its wiring, not a bearer token it sends, not another
+command's credential — only the one `APPA_PROVIDER_*` variable its own
+binding names. Any GitHub error or missing answer stops the operation without
 recording a decision; nothing is guessed.
 
 **`test_audience_source.py`** — fixture tests over recorded GitHub REST

--- a/batteries/github/README.md
+++ b/batteries/github/README.md
@@ -68,11 +68,12 @@ command = ["python3", "batteries/github/audience-source.py"]
 A command path is resolved against the directory of the config file
 that names it, so write the path as your root config sees the battery.
 
-The script reads its token from `OPENAPPA_GITHUB_TOKEN`. The token needs
-the `read:org` and `user:email` scopes. The runtime strips every
-`APPA_*` variable from a command it runs — its own credentials never
-reach an external — so a source's token must be named outside that
-prefix. Any GitHub error or missing answer stops the operation without
+The script reads its token from `APPA_PROVIDER_GITHUB_TOKEN`. The token needs
+the `read:org` and `user:email` scopes. The runtime keeps its own
+`APPA_*` variables — its wiring and every `token_env` secret — out of a
+command it runs, and passes through only the `APPA_PROVIDER_*`
+namespace, which holds credentials a command reads for itself and the
+runtime never sends. Any GitHub error or missing answer stops the operation without
 recording a decision; nothing is guessed.
 
 **`test_audience_source.py`** — fixture tests over recorded GitHub REST

--- a/batteries/github/audience-source.py
+++ b/batteries/github/audience-source.py
@@ -13,7 +13,7 @@ owner's addresses through /user/emails, while a profile's public email
 is whatever its owner typed, so every other member keeps the bare
 `github:<login>` identity and distinct identities never merge by guess.
 
-Credentials come from OPENAPPA_GITHUB_TOKEN (read:org and user:email
+Credentials come from APPA_PROVIDER_GITHUB_TOKEN (read:org and user:email
 scopes). Any GitHub error or missing answer exits nonzero: the runtime
 treats that as no answer and refuses the operation, so an API hiccup
 never becomes a policy decision.
@@ -28,7 +28,7 @@ import urllib.request
 
 
 API_ROOT = "https://api.github.com"
-TOKEN_VAR = "OPENAPPA_GITHUB_TOKEN"
+TOKEN_VAR = "APPA_PROVIDER_GITHUB_TOKEN"
 TIMEOUT_SECONDS = 30
 PAGE_SIZE = 100
 

--- a/batteries/github/test_audience_source.py
+++ b/batteries/github/test_audience_source.py
@@ -160,7 +160,7 @@ class EnvelopeTests(unittest.TestCase):
         }
 
     def test_a_foreign_envelope_is_refused(self):
-        env = {"PATH": "/usr/bin:/bin", "OPENAPPA_GITHUB_TOKEN": "ghp-fixture"}
+        env = {"PATH": "/usr/bin:/bin", "APPA_PROVIDER_GITHUB_TOKEN": "ghp-fixture"}
         for request in [
             self.envelope(version=2),
             self.envelope(kind="annotation"),
@@ -173,7 +173,7 @@ class EnvelopeTests(unittest.TestCase):
     def test_a_missing_token_is_a_failure_before_any_network(self):
         result = self.run_script(self.envelope(), {"PATH": "/usr/bin:/bin"})
         self.assertEqual(result.returncode, 1, result.stderr)
-        self.assertIn("OPENAPPA_GITHUB_TOKEN", result.stderr)
+        self.assertIn("APPA_PROVIDER_GITHUB_TOKEN", result.stderr)
 
 
 if __name__ == "__main__":

--- a/batteries/google-workspace/README.md
+++ b/batteries/google-workspace/README.md
@@ -45,23 +45,26 @@ from = ["google-workspace:group/finance@corp.com"]
 
 [externals.audience.google-workspace]
 command = ["python3", "batteries/google-workspace/audience-source.py"]
+token_env = "APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN"
 ```
 
 A command path is resolved against the directory of the config file
 that names it, so write the path as your root config sees the battery.
 
-The script reads its token from `APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN`: an
-OAuth2 access token with the `admin.directory.user.readonly` and
+The script reads its token from `APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN`,
+which the binding's `token_env` forwards: an OAuth2 access token with the
+`admin.directory.user.readonly` and
 `admin.directory.group.member.readonly` scopes plus `openid email`.
-The runtime keeps its own `APPA_*` variables — its wiring and every
-`token_env` secret — out of a command it runs, and passes through only
-the `APPA_PROVIDER_*` namespace, which holds credentials a command reads
-for itself and the runtime never sends. Any API error or missing answer stops the
+A command inherits none of the runtime's `APPA_*` namespace — not its
+wiring, not a bearer token it sends, not another command's credential —
+only the one `APPA_PROVIDER_*` variable its own binding names. Any API error or missing answer stops the
 operation without recording a decision; nothing is guessed.
 
-Reads are directory-wide: `full-members` pages through every account.
-Size `externals.timeout_ms` and `externals.max_body_bytes` for your
-Workspace, not for a single annotation.
+Reads are directory-wide: `full-members` pages through every account, and
+a non-empty `group/<address>` adds one directory pass after the traversal
+to decide which member addresses this Workspace administers. Size
+`externals.timeout_ms` and `externals.max_body_bytes` for your Workspace,
+not for a single annotation.
 
 **`test_audience_source.py`** — fixture tests over recorded Google API
 payloads, no network. Run with `python3 test_audience_source.py`.

--- a/batteries/google-workspace/README.md
+++ b/batteries/google-workspace/README.md
@@ -50,12 +50,13 @@ command = ["python3", "batteries/google-workspace/audience-source.py"]
 A command path is resolved against the directory of the config file
 that names it, so write the path as your root config sees the battery.
 
-The script reads its token from `OPENAPPA_GOOGLE_WORKSPACE_TOKEN`: an
+The script reads its token from `APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN`: an
 OAuth2 access token with the `admin.directory.user.readonly` and
 `admin.directory.group.member.readonly` scopes plus `openid email`.
-The runtime strips every `APPA_*` variable from a command it runs — its
-own credentials never reach an external — so a source's token must be
-named outside that prefix. Any API error or missing answer stops the
+The runtime keeps its own `APPA_*` variables — its wiring and every
+`token_env` secret — out of a command it runs, and passes through only
+the `APPA_PROVIDER_*` namespace, which holds credentials a command reads
+for itself and the runtime never sends. Any API error or missing answer stops the
 operation without recording a decision; nothing is guessed.
 
 Reads are directory-wide: `full-members` pages through every account.

--- a/batteries/google-workspace/audience-source.py
+++ b/batteries/google-workspace/audience-source.py
@@ -20,7 +20,7 @@ group member outside the directory belongs to the group like any other
 its qualified identity, because the Workspace administers no account
 for that address and attests nothing about it.
 
-Credentials come from OPENAPPA_GOOGLE_WORKSPACE_TOKEN: an OAuth2 access
+Credentials come from APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN: an OAuth2 access
 token with the admin.directory.user.readonly and
 admin.directory.group.member.readonly scopes plus openid email. Any
 API error or missing answer exits nonzero: the runtime treats that as
@@ -38,7 +38,7 @@ import urllib.request
 
 USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
 DIRECTORY_ROOT = "https://admin.googleapis.com/admin/directory/v1"
-TOKEN_VAR = "OPENAPPA_GOOGLE_WORKSPACE_TOKEN"
+TOKEN_VAR = "APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN"
 TIMEOUT_SECONDS = 30
 
 

--- a/batteries/google-workspace/audience-source.py
+++ b/batteries/google-workspace/audience-source.py
@@ -89,27 +89,26 @@ def viewer_members(call):
     return [claims]
 
 
-def directory_users(call):
-    """Every account the Workspace itself administers, live and reachable."""
-    return [
-        user
-        for user in paginated(call, f"{DIRECTORY_ROOT}/users", "users", customer="my_customer", maxResults=500)
-        if not user.get("suspended") and not user.get("archived")
-    ]
+def directory_users(call, active_only):
+    """Every account this Workspace administers.
+
+    `active_only` separates two different questions. Who belongs to the
+    workspace right now excludes a suspended or archived account. Whether the
+    Workspace administers an address does not: it still owns that identity, and
+    a direct member lookup attests it, so a group expansion must agree.
+    """
+    users = paginated(call, f"{DIRECTORY_ROOT}/users", "users", customer="my_customer", maxResults=500)
+    if not active_only:
+        return list(users)
+    return [user for user in users if not user.get("suspended") and not user.get("archived")]
 
 
 def full_members(call):
-    return [claims_of(user["primaryEmail"]) for user in directory_users(call)]
+    return [claims_of(user["primaryEmail"]) for user in directory_users(call, active_only=True)]
 
 
 def group_members(call, address):
-    # Membership proves that someone belongs to the group. Only a directory
-    # account proves that this Workspace administers their email identity, and
-    # the API's own member `type` does not draw that line: its EXTERNAL value
-    # is documented as unused, so an outside auditor arrives as an ordinary
-    # USER. One directory pass answers the question the type cannot.
-    administered = {user["primaryEmail"] for user in directory_users(call)}
-    members = []
+    addresses = []
     visited = {address}
     queue = [address]
     while queue:
@@ -120,13 +119,8 @@ def group_members(call, address):
                     pass
                 case "USER" | "EXTERNAL":
                     email = member["email"]
-                    # A member the directory does not administer belongs to the
-                    # group like any other, but the Workspace attests nothing
-                    # about their address: they keep their qualified identity
-                    # and merge with no other provider's reader.
-                    members.append(
-                        claims_of(email) if email in administered else {"id": f"google-workspace:{email}"}
-                    )
+                    if email not in addresses:
+                        addresses.append(email)
                 case "GROUP":
                     nested = member["email"]
                     if nested not in visited:
@@ -136,11 +130,21 @@ def group_members(call, address):
                     # A CUSTOMER member stands for the whole domain; an
                     # unexpandable entry must fail, never under-report.
                     raise RuntimeError(f"group {address} holds an unexpandable {other} member")
-    unique = []
-    for claims in members:
-        if claims not in unique:
-            unique.append(claims)
-    return unique
+    if not addresses:
+        return []
+    # Membership proves that someone belongs to the group. Only a directory
+    # account proves that this Workspace administers their email identity, and
+    # the API's own member `type` does not draw that line: its EXTERNAL value
+    # is documented as unused, so an outside auditor arrives as an ordinary
+    # USER. One directory pass answers the question the type cannot — after the
+    # traversal, so an empty or unexpandable group never pays for it. A member
+    # the directory does not administer belongs to the group like any other,
+    # but the Workspace attests nothing about their address: they keep their
+    # qualified identity and merge with no other provider's reader.
+    administered = {user["primaryEmail"] for user in directory_users(call, active_only=False)}
+    return [
+        claims_of(email) if email in administered else {"id": f"google-workspace:{email}"} for email in addresses
+    ]
 
 
 def member_claims(call, member):

--- a/batteries/google-workspace/test_audience_source.py
+++ b/batteries/google-workspace/test_audience_source.py
@@ -159,22 +159,44 @@ class SelectorTests(unittest.TestCase):
             {"members": [{"id": "google-workspace:alice@corp.com", "verified_email": "alice@corp.com"}]},
         )
 
-    def test_an_unexpandable_group_member_is_a_failure_not_an_under_report(self):
-        url = f"{DIRECTORY}/groups/everyone%40corp.com/members"
+    def test_a_group_member_the_directory_administers_is_attested_however_the_account_stands(self):
+        # Suspended memberships leave the group, but an archived account is one
+        # the Workspace still administers: a direct member lookup attests that
+        # address, so the group expansion must not disagree with itself.
+        url = f"{DIRECTORY}/groups/finance%40corp.com/members"
         call = fixture_api(
             [
-                empty_directory(),
-                (url, {"maxResults": 200}, {"members": [{"type": "CUSTOMER", "id": "C123"}]}),
+                (
+                    f"{DIRECTORY}/users",
+                    {"customer": "my_customer", "maxResults": 500},
+                    {"users": [{"primaryEmail": "old@corp.com", "archived": True}]},
+                ),
+                (url, {"maxResults": 200}, {"members": [{"type": "USER", "email": "old@corp.com"}]}),
             ]
         )
+        self.assertEqual(
+            AUDIENCE_SOURCE.answer(call, {"selector": "group/finance@corp.com"}),
+            {"members": [{"id": "google-workspace:old@corp.com", "verified_email": "old@corp.com"}]},
+        )
+
+    def test_an_unexpandable_group_member_is_a_failure_not_an_under_report(self):
+        # No directory fixture: the traversal fails before anything needs
+        # attesting, so the tenant-wide pass is never paid for.
+        url = f"{DIRECTORY}/groups/everyone%40corp.com/members"
+        call = fixture_api([(url, {"maxResults": 200}, {"members": [{"type": "CUSTOMER", "id": "C123"}]})])
         with self.assertRaises(RuntimeError):
             AUDIENCE_SOURCE.answer(call, {"selector": "group/everyone@corp.com"})
 
     def test_an_unknown_group_is_a_failure_not_an_empty_answer(self):
         url = f"{DIRECTORY}/groups/typo%40corp.com/members"
-        call = fixture_api([empty_directory(), (url, {"maxResults": 200}, AUDIENCE_SOURCE.NotFound(url))])
+        call = fixture_api([(url, {"maxResults": 200}, AUDIENCE_SOURCE.NotFound(url))])
         with self.assertRaises(AUDIENCE_SOURCE.NotFound):
             AUDIENCE_SOURCE.answer(call, {"selector": "group/typo@corp.com"})
+
+    def test_an_empty_group_answers_without_a_directory_pass(self):
+        url = f"{DIRECTORY}/groups/empty%40corp.com/members"
+        call = fixture_api([(url, {"maxResults": 200}, {"members": []})])
+        self.assertEqual(AUDIENCE_SOURCE.answer(call, {"selector": "group/empty@corp.com"}), {"members": []})
 
     def test_an_unserved_selector_is_refused(self):
         call = fixture_api([])

--- a/batteries/google-workspace/test_audience_source.py
+++ b/batteries/google-workspace/test_audience_source.py
@@ -228,7 +228,7 @@ class EnvelopeTests(unittest.TestCase):
         }
 
     def test_a_foreign_envelope_is_refused(self):
-        env = {"PATH": "/usr/bin:/bin", "OPENAPPA_GOOGLE_WORKSPACE_TOKEN": "ya29-fixture"}
+        env = {"PATH": "/usr/bin:/bin", "APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN": "ya29-fixture"}
         for request in [
             self.envelope(version=2),
             self.envelope(kind="annotation"),
@@ -241,7 +241,7 @@ class EnvelopeTests(unittest.TestCase):
     def test_a_missing_token_is_a_failure_before_any_network(self):
         result = self.run_script(self.envelope(), {"PATH": "/usr/bin:/bin"})
         self.assertEqual(result.returncode, 1, result.stderr)
-        self.assertIn("OPENAPPA_GOOGLE_WORKSPACE_TOKEN", result.stderr)
+        self.assertIn("APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN", result.stderr)
 
 
 if __name__ == "__main__":

--- a/batteries/slack/README.md
+++ b/batteries/slack/README.md
@@ -58,17 +58,18 @@ from = ["slack:user-group/finance"]
 
 [externals.audience.slack]
 command = ["python3", "batteries/slack/audience-source.py"]
+token_env = "APPA_PROVIDER_SLACK_TOKEN"
 ```
 
 A command path is resolved against the directory of the config file
 that names it, so write the path as your root config sees the battery.
 
-The script reads its token from `APPA_PROVIDER_SLACK_TOKEN`. The token needs the
-`users:read`, `users:read.email`, and `usergroups:read` scopes. The
-runtime keeps its own `APPA_*` variables — its wiring and every
-`token_env` secret — out of a command it runs, and passes through only
-the `APPA_PROVIDER_*` namespace, which holds credentials a command reads
-for itself and the runtime never sends. Any Slack error or missing answer stops the
+The script reads its token from `APPA_PROVIDER_SLACK_TOKEN`, which the
+binding's `token_env` forwards. The token needs the `users:read`,
+`users:read.email`, and `usergroups:read` scopes. A command inherits
+none of the runtime's `APPA_*` namespace — not its wiring, not a bearer
+token it sends, not another command's credential — only the one
+`APPA_PROVIDER_*` variable its own binding names. Any Slack error or missing answer stops the
 operation without recording a decision; nothing is guessed.
 
 Reads are workspace-wide: `full-members` and `user-group/<handle>` page

--- a/batteries/slack/README.md
+++ b/batteries/slack/README.md
@@ -63,11 +63,12 @@ command = ["python3", "batteries/slack/audience-source.py"]
 A command path is resolved against the directory of the config file
 that names it, so write the path as your root config sees the battery.
 
-The script reads its token from `OPENAPPA_SLACK_TOKEN`. The token needs the
+The script reads its token from `APPA_PROVIDER_SLACK_TOKEN`. The token needs the
 `users:read`, `users:read.email`, and `usergroups:read` scopes. The
-runtime strips every `APPA_*` variable from a command it runs — its own
-credentials never reach an external — so a source's token must be named
-outside that prefix. Any Slack error or missing answer stops the
+runtime keeps its own `APPA_*` variables — its wiring and every
+`token_env` secret — out of a command it runs, and passes through only
+the `APPA_PROVIDER_*` namespace, which holds credentials a command reads
+for itself and the runtime never sends. Any Slack error or missing answer stops the
 operation without recording a decision; nothing is guessed.
 
 Reads are workspace-wide: `full-members` and `user-group/<handle>` page

--- a/batteries/slack/audience-source.py
+++ b/batteries/slack/audience-source.py
@@ -10,7 +10,7 @@ Serves the stock `slack` selector catalog over the Slack Web API:
 
 and the member lookup that canonicalizes one `slack:U...` reader.
 
-Credentials come from OPENAPPA_SLACK_TOKEN (a bot or user token with
+Credentials come from APPA_PROVIDER_SLACK_TOKEN (a bot or user token with
 users:read, users:read.email, and usergroups:read). Any Slack error,
 missing answer, or malformed response exits nonzero: the runtime treats
 that as no answer and refuses the operation, so a directory hiccup never
@@ -25,7 +25,7 @@ import urllib.request
 
 
 API_ROOT = "https://slack.com/api/"
-TOKEN_VAR = "OPENAPPA_SLACK_TOKEN"
+TOKEN_VAR = "APPA_PROVIDER_SLACK_TOKEN"
 TIMEOUT_SECONDS = 30
 
 

--- a/batteries/slack/test_audience_source.py
+++ b/batteries/slack/test_audience_source.py
@@ -232,7 +232,7 @@ class EnvelopeTests(unittest.TestCase):
         }
 
     def test_a_foreign_envelope_is_refused(self):
-        env = {"PATH": "/usr/bin:/bin", "OPENAPPA_SLACK_TOKEN": "xoxb-fixture"}
+        env = {"PATH": "/usr/bin:/bin", "APPA_PROVIDER_SLACK_TOKEN": "xoxb-fixture"}
         for request in [
             self.envelope(version=2),
             self.envelope(kind="annotation"),
@@ -245,7 +245,7 @@ class EnvelopeTests(unittest.TestCase):
     def test_a_missing_token_is_a_failure_before_any_network(self):
         result = self.run_script(self.envelope(), {"PATH": "/usr/bin:/bin"})
         self.assertEqual(result.returncode, 1, result.stderr)
-        self.assertIn("OPENAPPA_SLACK_TOKEN", result.stderr)
+        self.assertIn("APPA_PROVIDER_SLACK_TOKEN", result.stderr)
 
 
 if __name__ == "__main__":

--- a/examples/claude-code-battery/appa.toml
+++ b/examples/claude-code-battery/appa.toml
@@ -40,6 +40,7 @@ builtin = "hitl"
 
 [externals.audience.slack]
 command = ["python3", "../../batteries/slack/audience-source.py"]
+token_env = "APPA_PROVIDER_SLACK_TOKEN"   # the one variable this command inherits
 
 # Root contracts run before every included battery. This local rule bypasses
 # the shipped Bash classifier for `cargo test` and adds a fresh approval step.

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -559,14 +559,16 @@ An entry is `[externals.<kind>.<name>]`, with `<kind>` one of `authorities`, `sa
 
 | Binding | Serves | Notes |
 |---|---|---|
-| `url = "…"` | every kind | HTTPS anywhere; cleartext `http` only on loopback; no credentials in the URL. `token_env` names an `APPA_*` variable whose value is sent as a bearer token. |
-| `command = ["…", …]` | every kind | Unix only. One JSON consult on standard input, one JSON answer on standard output; no shell; the working folder is that of the file that declares it; bounded by `timeout_ms` and `max_body_bytes`. At most eight run at once per runtime. |
+| `url = "…"` | every kind | HTTPS anywhere; cleartext `http` only on loopback; no credentials in the URL. `token_env` names an `APPA_*` variable whose value is sent as a bearer token, and never an `APPA_PROVIDER_*` one. |
+| `command = ["…", …]` | every kind | Unix only. One JSON consult on standard input, one JSON answer on standard output; no shell; the working folder is that of the file that declares it; bounded by `timeout_ms` and `max_body_bytes`. At most eight run at once per runtime. The child inherits no `APPA_*` variable except the `APPA_PROVIDER_*` namespace. |
 | `builtin = "hitl"` | authorities | The harness asks a person. |
 | `builtin = "approve"` | authorities | Approves within `permits`. |
 | `builtin = "redact-email"` | sanitizers | Replaces email addresses with a placeholder. |
 | `builtin = "claude-code"` | authorities, sanitizers; an annotator names it on its declaration | Unix only. One isolated `claude -p` process per consult, tuned in `[externals.claude_code]`. |
 | `builtin = "llm"` | authorities, sanitizers; an annotator names it on its declaration | The API-key profile in `[externals.llm]`. |
 | `builtin = "<module>"` | authorities, sanitizers | A deployer module from `--modules-dir`, called in-process. |
+
+`APPA_*` is the runtime's own environment namespace: its wiring and every secret a `token_env` names. A `command` child inherits none of it. The one exception is `APPA_PROVIDER_*`, the namespace for a credential the command reads for itself — a battery's Slack or GitHub token, which the runtime never reads and never sends. `token_env` may not name a variable there, so the passthrough cannot carry a secret this runtime holds. A `claude-code` consult inherits nothing of the namespace at all, `APPA_PROVIDER_*` included.
 
 ### The consult
 

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -560,7 +560,7 @@ An entry is `[externals.<kind>.<name>]`, with `<kind>` one of `authorities`, `sa
 | Binding | Serves | Notes |
 |---|---|---|
 | `url = "…"` | every kind | HTTPS anywhere; cleartext `http` only on loopback; no credentials in the URL. `token_env` names an `APPA_*` variable whose value is sent as a bearer token, and never an `APPA_PROVIDER_*` one. |
-| `command = ["…", …]` | every kind | Unix only. One JSON consult on standard input, one JSON answer on standard output; no shell; the working folder is that of the file that declares it; bounded by `timeout_ms` and `max_body_bytes`. At most eight run at once per runtime. The child inherits no `APPA_*` variable except the `APPA_PROVIDER_*` namespace. |
+| `command = ["…", …]` | every kind | Unix only. One JSON consult on standard input, one JSON answer on standard output; no shell; the working folder is that of the file that declares it; bounded by `timeout_ms` and `max_body_bytes`. At most eight run at once per runtime. The child inherits no `APPA_*` variable except the one `APPA_PROVIDER_*` credential its own `token_env` names. |
 | `builtin = "hitl"` | authorities | The harness asks a person. |
 | `builtin = "approve"` | authorities | Approves within `permits`. |
 | `builtin = "redact-email"` | sanitizers | Replaces email addresses with a placeholder. |
@@ -568,7 +568,9 @@ An entry is `[externals.<kind>.<name>]`, with `<kind>` one of `authorities`, `sa
 | `builtin = "llm"` | authorities, sanitizers; an annotator names it on its declaration | The API-key profile in `[externals.llm]`. |
 | `builtin = "<module>"` | authorities, sanitizers | A deployer module from `--modules-dir`, called in-process. |
 
-`APPA_*` is the runtime's own environment namespace: its wiring and every secret a `token_env` names. A `command` child inherits none of it. The one exception is `APPA_PROVIDER_*`, the namespace for a credential the command reads for itself — a battery's Slack or GitHub token, which the runtime never reads and never sends. `token_env` may not name a variable there, so the passthrough cannot carry a secret this runtime holds. A `claude-code` consult inherits nothing of the namespace at all, `APPA_PROVIDER_*` included.
+`APPA_*` is the runtime's own environment namespace: its wiring and every secret a `url` binding's `token_env` names. A child process inherits none of it.
+
+A `command` binding takes a `token_env` of its own, and it means the opposite of a URL's: the runtime sends nothing, it forwards that one variable to the child that reads it. The variable must be in the `APPA_PROVIDER_*` namespace — a credential belonging to the provider, such as a battery's Slack or GitHub token, which the runtime never reads. A `url` binding's `token_env` may not name a variable there, so the forwarding cannot carry a secret this runtime holds, and a command receives only the credential its own binding names, never another command's. The value is not read when the policy loads, so a policy stays loadable and describable on a machine that holds no provider credential; a missing one surfaces as the source's own refusal to answer. A `claude-code` consult inherits nothing of the namespace at all.
 
 ### The consult
 


### PR DESCRIPTION
Follow-up to #134: the review round on its last three commits landed after the merge, and the environment-namespace commit never reached the branch. This carries both.

## A command's credential is bound to that command

The runtime strips its own `APPA_*` namespace — its wiring and every `token_env` secret — from any child it spawns, so a battery's provider token had nowhere to live under the project prefix and the audience sources read `OPENAPPA_*_TOKEN`.

A `command` binding now takes a `token_env` of its own, meaning the mirror of a `url` binding's: the runtime sends nothing and forwards that one variable to the child that reads it. The variable must be `APPA_PROVIDER_*`; a `url` binding's `token_env` may not be, so forwarding cannot carry a secret the runtime holds, and a command receives only the credential its own binding names — never another command's. The binding carries the variable name, never the value, and the value is not read at load, so a policy stays loadable and describable without provider credentials. A `claude-code` consult inherits nothing of the namespace.

## Review fixes on merged code

- `ReaderId` derived `Deserialize`, so a reader arriving as data — a persisted event, an external's answer, an API payload — kept a spelling that construction would have normalized, and `alice@CORP.com` compared as a second reader.
- `folded_claims` compared verified addresses as raw strings, so one address that two sources spell with different domain case refused the act, though both resolve to the same principal. The comparison runs through the principal.
- A Workspace group attested only members the directory reports as live, while a direct member lookup attests an archived account: one person canonicalized two ways depending on the path. Administration, not activity, is what a verified claim asserts — `full-members` keeps the active filter, group expansion does not.
- The tenant-wide directory pass ran before the group traversal, so an empty, unknown or unexpandable group paid for it and got nothing.

## Breaking

An audience source's token moves from `OPENAPPA_<PROVIDER>_TOKEN` to `APPA_PROVIDER_<PROVIDER>_TOKEN`, and the binding must name it:

```toml
[externals.audience.slack]
command = ["python3", "batteries/slack/audience-source.py"]
token_env = "APPA_PROVIDER_SLACK_TOKEN"
```

BREAKING CHANGE: an audience source's token moves to `APPA_PROVIDER_<PROVIDER>_TOKEN` and its `command` binding must name it in `token_env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MYhtvfj9vSESxiA8nAgq8
