### PR TITLE
docs: retarget the kagent proposal to stable kagent v0.9.12

### DIFF
--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -1,22 +1,22 @@
 # kagent adapter implementation plan
 
-Source baseline:
+Source baseline — the last stable kagent release:
 
-- kagent commit [`52cc4de2a044a5062d10c4f189d863937c1bb0f9`](https://github.com/kagent-dev/kagent/commit/52cc4de2a044a5062d10c4f189d863937c1bb0f9) (2026-09-01)
-- google-adk 2.8.0, the version kagent's workspace lockfile resolves. The `kagent-adk` package constraint is `google-adk[a2a,db]>=2.6.2,<3` ([pyproject.toml#L26](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/pyproject.toml#L26))
-- Substrate v0.0.20 ([go.mod#L489](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/go.mod#L489))
+- kagent [`v0.9.12`](https://github.com/kagent-dev/kagent/releases/tag/v0.9.12) (2026-07-20). This is the API the public kagent.dev docs describe: `kagent.dev/v1alpha2`, kind `Agent`.
+- kagent-adk 0.3.0 (the workspace package version at that tag)
+- google-adk 1.31.1 — the version the v0.9.12 lock resolves. The package constraint is `google-adk>=1.28.1,<2` ([pyproject.toml#L25](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/pyproject.toml#L25)). Every callback-semantics claim below is verified in the google_adk-1.31.1 wheel, and wheel citations give paths and lines inside it.
 - OpenAPPA `origin/main`: `appa-runtime-api` hook vocabulary (`appa-runtime-api/src/lib.rs`), `appa-runtime` `/hook` endpoint (`appa-runtime/src/main.rs`), and the `appa-adapter-claude-code` codec as the adapter reference.
 
-The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent). ADK citations below give paths and line numbers inside the published `google_adk-2.8.0` wheel.
+The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent). A forward section at the end covers kagent's unreleased `v1alpha3` cutover.
 
 ## Architecture decision
 
 The adapter rides two stock kagent surfaces and changes no kagent or Google ADK source:
 
-1. `Harness.spec.workload.image` — a required, operator-supplied, digest-pinned OCI reference ([harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40)). The adapter ships as that image.
-2. `KAgentApp(plugins=[...])` — a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L65](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L65)), forwarded into ADK's `App(plugins=...)` and its `PluginManager` ([_a2a.py#L136-L139](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L136-L139)). The `AppaHookPlugin` registers there.
+1. Helm `controller.agentImage.{registry,repository,tag,pullPolicy,pullSecret}` — the runtime image for every Declarative agent. The values render into the controller ConfigMap as `IMAGE_*` env ([controller-configmap.yaml#L12-L18](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/templates/controller-configmap.yaml#L12-L18)), which the controller consumes as `--image-*` flags. The adapter ships as that image.
+2. `KAgentApp(plugins=[...])` — a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L63](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L63)), forwarded into ADK's plugin manager ([_a2a.py#L124](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L124)). The `AppaHookPlugin` registers there.
 
-No config-reachable plugin surface exists upstream. The stock entrypoint builds a closed plugin list ([cli.py#L95-L105](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L95-L105)). No CRD field, helm value, env var, or entry point adds to it. The adapter image therefore carries its own entrypoint. That entrypoint calls the same public `kagent-adk` functions as stock `static` and adds one plugin.
+No config-reachable plugin surface exists upstream. The stock entrypoint builds a closed plugin list ([cli.py#L69-L79](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L69-L79)). No CRD field, helm value, env var, or entry point adds to it. The adapter image therefore carries its own entrypoint. That entrypoint calls the same public `kagent-adk` functions as stock `static` and adds one plugin.
 
 The adapter follows the `appa-adapter-claude-code` boundary. It maps harness callbacks to the eight `HookEvent` variants and renders each `HookDecision` back into the harness. It does not link `appa-runtime`, call the Engine, own policy, or open `appa.db`. `appa-runtime` owns policy, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`.
 
@@ -25,9 +25,9 @@ The adapter follows the `appa-adapter-claude-code` boundary. It maps harness cal
 | Artifact | Contents | Owner |
 |---|---|---|
 | `appa-adapter-kagent` Python package | `AppaHookPlugin` (a google-adk `BasePlugin`) and `entrypoint.py` | OpenAPPA repository |
-| `appa-adapter-kagent` OCI image | The published `kagent-adk` image plus the Python package, digest-pinned | OpenAPPA repository |
+| `appa-adapter-kagent` OCI image | The published `kagent-dev/kagent/app` image plus the Python package, digest-pinned base | OpenAPPA repository |
 | `appa-adapter-kagent` Rust crate | The `/hook` codec (`parse`, `render`) for the kagent wire, selected by the runtime's adapter switch | OpenAPPA repository |
-| kagent | Controller, CRDs, compiler, Substrate path, `kagent-adk` library — all stock, no change | Upstream |
+| kagent | Controller, CRDs, translator, helm chart, `kagent-adk` library — all stock, no change | Upstream |
 | Google ADK | Plugin API and dispatch loop — stock dependency, no change | Upstream |
 
 The runtime picks one codec per adapter through a closed enum ([appa-runtime/src/main.rs](../../appa-runtime/src/main.rs), the `Adapter` enum). The kagent deliverable adds one variant beside `ClaudeCode`, mapped to `appa_adapter_kagent::codec()`.
@@ -36,46 +36,48 @@ The plugin holds no policy state. It serializes callback moments into wire event
 
 ## Adapter workload image
 
-Build: `FROM` the published `kagent-adk` image at a pinned digest, add the Python package, set `entrypoint.py` as the container entrypoint. `cli.py` stays in the image unchanged and unused. Equivalent build: a plain Python base plus `pip install kagent-adk` at the locked version.
+Build: `FROM` the published `kagent-dev/kagent/app` image at a pinned digest, add the Python package, set `entrypoint.py` as the container entrypoint. `cli.py` stays in the image unchanged and unused. Equivalent build: a plain Python base plus `pip install kagent-adk==0.3.0`.
+
+Runtime contract the image must keep — the controller sets container args, not the command:
+
+- Accept `--host <bind> --port 8080 --filepath /config` ([deployments.go#L175-L179](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/deployments.go#L175-L179)).
+- Read `config.json` and `agent-card.json` from the per-agent Secret mounted at `/config` ([manifest_builder.go#L243](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L243)).
+- Serve A2A on port 8080 and answer readiness at `/.well-known/agent-card.json` ([manifest_builder.go#L532](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L532)).
 
 Entrypoint steps, in order:
 
-1. Call `materialize_from_env("/config")` — the public `kagent-adk` function that writes `KAGENT_CONFIG_JSON` and `KAGENT_AGENT_CARD_JSON` to config files and expands `__KAGENT_ENV[...]__` credential placeholders ([_config_materialize.py#L55-L69](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_config_materialize.py#L55-L69)). The controller injects both variables into the Actor ([actor_template.go#L43-L44](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L43-L44)).
-2. Parse the raw config JSON with a strict schema. Refuse any field the adapter does not support, and exit unready. Stock `AgentConfig` is a pydantic model that ignores unknown fields ([types.py#L387-L401](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L387-L401)). The adapter must not inherit that silence. See the refusal rules below.
-3. Validate the accepted config with `AgentConfig.model_validate` and build the agent factory over `AgentConfig.to_agent` ([types.py#L403](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L403)).
-4. Rebuild the stock plugin list with the same conditions as `static` (STS integration, `LLMPassthroughPlugin`), then append `AppaHookPlugin(APPA_RUNTIME_URL)`.
-5. Construct `KAgentApp(...)`, call `.build()`, and serve — the same calls as [cli.py#L114-L135](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L114-L135).
+1. Parse the raw `/config/config.json` with a strict schema. Refuse any field the adapter does not support, and exit unready. Stock `AgentConfig` is a pydantic model that ignores unknown fields. The adapter must not inherit that silence.
+2. Validate the accepted config with `AgentConfig.model_validate` and build the agent factory over `AgentConfig.to_agent`.
+3. Rebuild the stock plugin list with the same conditions as `static` (STS token propagation, `LLMPassthroughPlugin`), then append `AppaHookPlugin(APPA_RUNTIME_URL)`.
+4. Construct `KAgentApp(...)`, call `.build()`, and serve on the given host and port — the same calls as [cli.py#L88-L101](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L88-L101).
 
-Refusal rules (fail closed at startup):
+Refusal rules (fail closed at startup): `APPA_RUNTIME_URL` unset or unreachable at the startup probe — unready. Any config field outside the adapter's accepted schema — unready, with the field named in the log.
 
-- `APPA_RUNTIME_URL` unset, or the runtime unreachable at startup probe — unready.
-- Config contains compiled in-process sub-agents (`sub_agents`). The kagent compiler emits them for CRD sub-agent tools ([kagent/compiler.go#L172](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/translator/kagent/compiler.go#L172)), and Python `AgentConfig` drops them silently. The adapter refuses the config instead. Out-of-process (`Dedicated`) sub-agent tools do not reach this path — the compiler rejects them upstream ([compiler.go#L149-L151](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/translator/compiler.go#L149-L151)).
-- Config contains any other field outside the adapter's accepted schema — unready, with the field named in the log.
+`APPA_RUNTIME_URL` delivery: a baked default in the image, overridable per agent through `spec.declarative.deployment.env` ([agent_types.go#L443-L445](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L443-L445)).
 
 ## AppaHookPlugin
 
-The plugin implements google-adk `BasePlugin`. All 14 lifecycle callbacks exist in the 2.8.0 wheel (`google/adk/plugins/base_plugin.py`, lines 114-394). Each gated callback sends one wire event to `POST $APPA_RUNTIME_URL/hook` and enforces the decision that comes back. A transport failure or a non-contract response raises, and ADK aborts the invocation.
+The plugin implements google-adk `BasePlugin`. The 1.31.1 wheel defines 12 lifecycle callbacks (`base_plugin.py` lines 114, 136, 155, 174, 198, 217, 233, 253, 272, 297, 321, 348). Each gated callback sends one wire event to `POST $APPA_RUNTIME_URL/hook` and enforces the decision that comes back. A transport failure or a non-contract response raises, and ADK wraps the exception and aborts the invocation (`plugin_manager.py` 288-305).
 
-| ADK callback | HookEvent | Enforcement at the callback | ADK evidence (2.8.0 wheel) |
+| ADK callback | HookEvent | Enforcement at the callback | 1.31.1 wheel evidence |
 |---|---|---|---|
-| `on_user_message_callback`, first invocation of a fresh session | `SessionStart` | `Refuse` raises before `Prompt` is sent | fires before the session append: `runners.py` 675-700 |
-| `on_user_message_callback` | `Prompt` | `Block` raises pre-append, so the bytes never land in session history | `runners.py` 675-700 |
-| `before_tool_callback` | `ToolCall{spawn}` | `DenyCall{feedback}`: return a dict — ADK skips execution, and the dict becomes the function response the model reads. `Refuse` raises. | `functions.py` 611-641 |
-| `after_tool_callback` | `ToolResult` | `ReplaceOutput{output}`: return a dict — it replaces the result the model sees. `Block` raises. | `functions.py` 652-683 |
-| `on_tool_error_callback` | `ToolResult` with `Failure` outcome | return a dict to convert, or re-raise | `base_plugin.py` 348 |
-| `before_tool_callback` on a sub-agent tool | `ToolCall{spawn:true}` | as `ToolCall`. The plugin holds the `AllowCall{spawn}` binding for the child scope | `functions.py` 611-641 |
-| `before_agent_callback` (child) | `ChildStart` | `Refuse` raises | `base_plugin.py` 198 |
-| `after_agent_callback` (child) | `TurnEnd` (child) | observe | `base_plugin.py` 217 |
-| `after_tool_callback` on the sub-agent return | `SpawnResult` | `ChildReturn{value}` or `ReplaceOutput`: return a dict — the one point where the plugin can substitute the value the parent receives | `functions.py` 652-683 |
-| `after_run_callback` | `TurnEnd` (root) | observe | `base_plugin.py` 174 |
-| `on_run_error_callback` | `TurnEnd` (root, failure) | observe — notification-only, sufficient for an Ack-only event | `base_plugin.py` 394 |
-| `on_agent_error_callback` (child) | `TurnEnd` (child, failure) | observe | `base_plugin.py` 374 |
-| `before_run_callback`, `before_agent_callback` (root) | none | pass through — `Prompt` already gates the same bytes | — |
+| `on_user_message_callback`, first invocation of a fresh session | `SessionStart` | `Refuse` raises before `Prompt` is sent | `runners.py` 1537-1541 |
+| `on_user_message_callback` | `Prompt` | `Block` raises pre-append, so the bytes never land in session history | fires before the append: `runners.py` 1537 then 1550-1556 |
+| `before_tool_callback` | `ToolCall{spawn}` | `DenyCall{feedback}`: return a dict — ADK skips execution, and the dict becomes the function response the model reads. `Refuse` raises. | `functions.py` 509-534, 588-592 |
+| `after_tool_callback` | `ToolResult` | `ReplaceOutput{output}`: return a dict — it replaces the result the model sees. `Block` raises. The plugin recognizes its own deny dicts here (a denied call flows through this callback too) and reports them once. | `functions.py` 547-576 |
+| `on_tool_error_callback` | `ToolResult` with `Failure` outcome | return a dict to convert, or re-raise. Does not fire for a `before_tool_callback` raise — a `Refuse` stays terminal. | `functions.py` 535-545 |
+| `before_tool_callback` on an agent tool | `ToolCall{spawn:true}` | as `ToolCall`. The plugin holds the `AllowCall{spawn}` binding for the child scope | `functions.py` 509-534 |
+| `before_agent_callback` (local sub-agent) | `ChildStart` | a returned `Content` ends the child before its body runs | `base_agent.py` 288-296, 447-452 |
+| `after_tool_callback` on the agent-tool return | `SpawnResult` | `ChildReturn{value}` or `ReplaceOutput`: return a dict — the one point where the plugin can substitute the value the parent receives | `functions.py` 547-576 |
+| `after_run_callback` | `TurnEnd` (root) | observe — also fires after a `before_run` halt | `runners.py` 843-861, 952 |
+| `before_run_callback` | none | pass through — `Prompt` already gates the same bytes | `runners.py` 843-861 |
 | `before_model_callback`, `after_model_callback`, `on_model_error_callback`, `on_event_callback` | none | liveness gates: raise when the `/hook` channel is down, pass otherwise | `base_plugin.py` 233, 253, 272, 155 |
 
 `ChildEnd` is unfed by design. Return substitution is enforceable only where the parent receives the value, so returns cross at `SpawnResult`. The `appa-adapter-claude-code` parse map makes the same choice.
 
-Sub-agent identity: kagent dispatches every declared remote agent as an ordinary ADK tool, `KAgentRemoteA2AToolset` ([types.py#L521](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L521)). The plugin classifies a tool call as a spawn by the tool's type.
+Error-turn gap: google-adk 1.31.1 has no `on_run_error_callback` and no `on_agent_error_callback` (absent from the wheel), and `after_run_callback` is skipped when a run dies on an unhandled error (`runners.py` 949-954, no `finally`). `on_model_error_callback` and `on_tool_error_callback` catch the common failures earlier. For the rest, `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event, and the next `Prompt` fails closed if the runtime is down.
+
+Sub-agent identity: a v1alpha2 agent declares another agent as a tool (`spec.declarative.tools[].type: Agent`), which kagent dispatches as `KAgentRemoteA2ATool` ([_remote_a2a_tool.py#L158-L170](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py#L158-L170)). The plugin classifies a spawn by the tool's type. A successful child reply arrives as `{"result": ...}` for Task replies, and as a bare string for direct Message replies — the plugin handles both shapes. Local ADK sub-agents (BYO-authored) gate through `before_agent_callback`. An `AgentTool` child runs under a fresh child Runner that inherits the parent's plugin list, so coverage continues there.
 
 ### Wire and codec
 
@@ -84,70 +86,48 @@ The plugin emits one JSON event per callback: event kind, trajectory ids, tool n
 ### Trajectory identity
 
 - Root `TrajectoryId`: the ADK session id with a harness prefix, per the `appa-runtime-api` convention.
-- Child classification: the child Actor reads kagent's inbound call metadata. The executor lands that metadata in ADK session state ([_agent_executor.py#L212-L214](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py#L212-L214)). A delegated entry feeds `ChildStart`. A plain external entry feeds `SessionStart` and `Prompt`.
-- Known limits: with `isolate_sessions`, ADK generates the child context id inside `run_async`, so the parent-side `ChildStart` correlation uses the spawn binding, not a pre-known child id. A bare-message A2A return carries no child session id. Both cases resolve at the shared runtime through the `SpawnResult` binding.
+- Child classification: the child pod's plugin reads kagent's inbound call metadata to recognize a delegated entry. A delegated entry feeds `ChildStart`. A plain external entry feeds `SessionStart` and `Prompt`.
+- Parent and child run as separate Deployments, so one trajectory's hooks come from two plugin instances. Both must reach the same `appa-runtime` — a per-pod runtime would split one trajectory into two logs.
 
-## Cross-actor children
-
-A kagent parent and each delegated child run in separate Substrate Actors. The hooks of one trajectory therefore come from two plugin instances:
-
-```text
-parent Actor plugin:  ToolCall{spawn:true} ... SpawnResult
-child Actor plugin:   ChildStart, Prompt-less child turns, TurnEnd (child)
-```
-
-Both must reach the same `appa-runtime`. A per-Actor runtime would split one trajectory into two logs, so the shared-service profile is the default. Verify Substrate egress from Actors to the runtime service in the target cluster before rollout. This is the one open operational item.
-
-## Deployment profiles
-
-### Shared runtime service (default)
-
-One `appa-runtime` per cluster or namespace. `APPA_RUNTIME_URL` in `Harness.spec.env` names it. Only the runtime mounts policy, credentials, and the durable `appa.db` volume. Actors hold no APPA state. Required for any deployment with delegated children.
-
-### Single-actor loopback
-
-The adapter image starts `appa-runtime` as a second process and sets `APPA_RUNTIME_URL=http://127.0.0.1:8787`. The runtime listens on loopback only. Valid only for agents with no delegated children, because each Actor holds a separate trajectory log.
-
-## Harness wiring and rollout
+## Deployment and rollout
 
 ```yaml
-kind: Harness
-spec:
-  kagent: {}
-  workload:
-    image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
-  env:
-    - name: APPA_RUNTIME_URL
-      value: http://appa-runtime.appa-system:8787
-  substrate: { workerPoolRef: {name: <pool>}, snapshotPolicy: {location: <loc>} }
-  allowedAgentTemplates:
-    selector: { matchLabels: { <team labels> } }
+# helm values — the whole kagent-side change
+controller:
+  agentImage:
+    registry: ghcr.io
+    repository: archestra-ai/appa-adapter-kagent
+    tag: "<adapter release>"
 ```
 
-- Pairing: the controller matches each `AgentTemplate` against every same-namespace Harness selector and reconciles one Actor per pair ([collections.go#L85-L102](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/controller/collections.go#L85-L102)).
-- Rollout is "move the label match", never "add a second match". A template matched by two Harnesses runs twice — once gated, once not. Make old and new selectors disjoint.
-- Env budget: the Substrate path caps an Actor at 32 total env vars ([actor_template.go#L50-L52](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L50-L52)). The compiler's own vars count against the cap. The adapter needs one.
-- Prerequisites: helm `controller.substrate.enabled=true`, the `ate-system` install, and a `WorkerPool` — the stock requirements of the Substrate path ([values.yaml#L327-L334](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/helm/kagent/values.yaml#L327-L334)).
+- Rollout is one `helm upgrade`. The controller re-renders every Declarative agent Deployment onto the adapter image, cluster-wide. There is no per-agent opt-in on this lane, and no double-run hazard.
+- Staged rollout, when wanted: `spec.declarative.deployment.imageRegistry` overrides the registry component per agent ([agent_types.go#L392](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L392)) — point pilot agents at a registry that serves the adapter image under the stock repository path.
+- `appa-runtime` deploys as one shared service per cluster or namespace. Only the runtime mounts policy, credentials, and the durable `appa.db` volume. Agent pods hold no APPA state.
 
 ## Known gaps and handling
 
 | Gap | Handling |
 |---|---|
 | No callback at ADK session creation | `SessionStart` synthesizes at first invocation, sent before `Prompt` from the same callback. A never-invoked session emits nothing and flows nothing. |
-| A hard Actor crash emits no `TurnEnd` | `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event. |
-| CRD in-process sub-agents (`sub_agents`) unsupported by Python `AgentConfig` | The adapter refuses the config at startup instead of dropping children. CRD multi-agent topologies stay on `remote_agents`, which compile to gated tools. |
-| Upstream has no plugin config knob | The entrypoint replays `static` behavior through public calls. CI pins `kagent-adk` and google-adk versions and runs an equivalence check on each bump. Propose a `KAGENT_PLUGINS`-style upstream knob to delete the duplication. |
-| Claude and Codex harness variants, non-ADK wrappers, stock-image agents | Out of scope. The Claude harness omits hooks from its supported contract ([config.go#L48-L50](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/harness/claude/config/config.go#L48-L50)). |
+| No error-turn callback in google-adk 1.31.1 | See the error-turn gap above: earlier error callbacks plus `Indeterminate` classification at recovery. |
+| `runtime: go` agents (opt-in) | Out of scope on v0.9.12: no helm value selects the Go runtime image there, and the Go ADK's plugin list is compiled in. The stable default is `python` ([agent_types.go#L175](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L175)), so defaulted fleets are covered. |
+| BYO agents (`spec.byo.deployment.image`) | Per-agent images outside any shared runtime image. Their authors add the one `plugins=[...]` line, or gate at MCP/model boundaries. |
+| `AgentHarness` / `SandboxAgent` sandbox kinds | Different subsystem (Substrate sandboxes), out of scope. |
+| Upstream has no plugin config knob | The entrypoint replays `static` behavior through public calls. CI pins kagent-adk and google-adk versions and runs an equivalence check on each bump. Propose an upstream plugin-loading knob to delete the duplication. |
+
+## Forward lane: the v1alpha3 cutover (unreleased)
+
+kagent's main branch replaces the v1alpha2 Agent controller with a `v1alpha3` `AgentTemplate` × `Harness` model compiled to Substrate Actors (merged to kagent main late August 2026, absent from every release and from public docs). On that lane the same adapter image lands in `Harness.spec.workload.image` (required, digest-pinned, [harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40) at HEAD `52cc4de2`), with agents admitted per `allowedAgentTemplates` label selector and config injected as `KAGENT_CONFIG_JSON` env. The entrypoint already tolerates both config deliveries: `materialize_from_env` is a no-op when the env vars are absent. Two changes to track before that lane is real for users: the 0.10 release candidates flip the Declarative runtime default to `go`, and they add a `controller.goAgentImage` value — pointing it at the adapter image also serves go-declared agents from the Python runtime, except Foundry-model agents, which require the Go binary. Re-verify this section against the first stable 0.10/v1alpha3 release before acting on it.
 
 ## PR sequence
 
 | PR | Change |
 |---|---|
 | 1 | `appa-adapter-kagent` Rust codec crate: wire parse to `HookEvent`, decision render, `Adapter` enum variant, unit tests against recorded wire fixtures |
-| 2 | `appa-adapter-kagent` Python package: `AppaHookPlugin` with the callback table above, fail-closed transport, liveness gates |
-| 3 | Entrypoint: materialize, strict config schema and refusal rules, stock plugin parity, `KAgentApp` assembly |
-| 4 | OCI image build with pinned base digest, SBOM, and provenance, plus the single-actor loopback variant |
-| 5 | End-to-end harness: kind cluster, Substrate path, shared runtime service, cross-actor child scenario |
+| 2 | `appa-adapter-kagent` Python package: `AppaHookPlugin` with the callback table above, fail-closed transport, liveness gates, deny-dict self-recognition |
+| 3 | Entrypoint: strict config schema and refusal rules, stock plugin parity, `KAgentApp` assembly, the `--host/--port/--filepath` args contract |
+| 4 | OCI image build with pinned base digest, SBOM, and provenance |
+| 5 | End-to-end harness: kind cluster with the v0.9.12 chart, `controller.agentImage` swap, parent-and-child scenario against one shared runtime |
 
 No kagent PR and no Google ADK PR is required. The optional upstream contribution (a plugin config knob) is independent and non-blocking.
 
@@ -155,22 +135,23 @@ No kagent PR and no Google ADK PR is required. The optional upstream contributio
 
 Adapter tests:
 
-- Callback-to-event mapping for all rows of the table, including the spawn classification by tool type.
-- Deny path: a `DenyCall` dict skips execution and reaches the model as the function response.
+- Callback-to-event mapping for all rows of the table, including spawn classification by tool type and both child-return shapes (Task dict, bare Message string).
+- Deny path: a `DenyCall` dict skips execution, reaches the model as the function response, and is not double-reported through `after_tool_callback`.
 - Replace path: `ReplaceOutput` and `ChildReturn` substitution at `after_tool_callback`.
 - Pre-append barrier: a blocked `Prompt` leaves no trace in session history.
 - Fail closed: runtime down at each callback blocks the action, and liveness gates hold model and emission callbacks.
-- Startup refusal: missing `APPA_RUNTIME_URL`, `sub_agents` present, unknown config fields.
+- Startup refusal: missing `APPA_RUNTIME_URL`, unknown config fields.
+- Args contract: the entrypoint accepts the controller's `--host/--port/--filepath` args and answers readiness at `/.well-known/agent-card.json`.
 - No link from the codec crate to `appa-runtime` or `appa-engine`, and no policy state in the plugin.
 
 Equivalence tests:
 
-- Entrypoint output matches stock `static` for the same rendered config, minus the added plugin: same agent shape, same stock plugins, same serving surface.
-- Re-run on every `kagent-adk` and google-adk version bump.
+- Entrypoint output matches stock `static` for the same `/config` contents, minus the added plugin: same agent shape, same stock plugins, same serving surface.
+- Re-run on every kagent-adk and google-adk version bump. The callback table re-verifies against the newly locked google-adk.
 
 End-to-end tests:
 
-- Declarative agent on a kind cluster with the Substrate path: gated tool calls, replaced results, blocked prompts.
-- Parent and delegated child in separate Actors against one shared runtime: one trajectory, `ChildStart` and `SpawnResult` correlated.
-- Crash window: kill the Actor between `ToolCall` and `ToolResult`, then make sure the runtime reports the dispatch `Indeterminate`.
-- Double-match rollout guard: the rollout check detects and reports a template matched by two Harnesses.
+- Declarative agent on a kind cluster with the v0.9.12 chart and the `controller.agentImage` swap: gated tool calls, replaced results, blocked prompts.
+- Parent and delegated child in separate pods against one shared runtime: one trajectory, `ChildStart` and `SpawnResult` correlated.
+- Crash window: kill the agent pod between `ToolCall` and `ToolResult`, then make sure the runtime reports the dispatch `Indeterminate`.
+- Error-turn window: force an unhandled model failure and make sure recovery closes the turn at the next admitted event.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -3,7 +3,7 @@ title: kAgent
 nav_title: kAgent
 category: Integrations
 order: 6
-description: Proposal for the OpenAPPA kagent adapter — an ADK plugin delivered in the Harness workload image, with no kagent or Google ADK fork.
+description: Proposal for the OpenAPPA kagent adapter — an ADK plugin delivered through kagent's agent-runtime image setting, with no kagent or Google ADK fork.
 ---
 
 :::proposal
@@ -11,23 +11,23 @@ name: kAgent
 date: 2026-09-01
 :::
 
-[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. Its controller compiles each declarative agent (an `AgentTemplate` resource) into configuration, and runs it on a runtime image that the operator names in a `Harness` resource. This proposal gates kagent agents with OpenAPPA through those stock surfaces. It does not fork, patch, or vendor kagent or Google ADK.
+[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. Its public API is `kagent.dev/v1alpha2`: the operator creates `Agent` resources (type `Declarative` or `BYO`), and the controller runs each Declarative agent as a Deployment on a shared runtime image. This proposal gates those agents with OpenAPPA through stock configuration. It does not fork, patch, or vendor kagent or Google ADK.
 
-`appa-adapter-kagent` is the adapter. Its workload image extends the published `kagent-adk` image with two files: a small entrypoint and one Google ADK plugin. The plugin maps ADK callbacks to the eight `appa-runtime` `/hook` events and enforces the returned decisions inside the ADK dispatch loop. `appa-runtime` stays a separate process. It owns policy, the Engine, consults, remedy plans, trajectory state, and `appa.db`. Policy semantics stay in [How it works](/how-it-works) and [Policy contracts](/contracts).
+`appa-adapter-kagent` is the adapter. Its image extends the published `kagent-adk` runtime image with two files: a small entrypoint and one Google ADK plugin. The plugin maps ADK callbacks to the eight `appa-runtime` `/hook` events and enforces the returned decisions inside the ADK dispatch loop. `appa-runtime` stays a separate process. It owns policy, the Engine, consults, remedy plans, trajectory state, and `appa.db`. Policy semantics stay in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
-Two upstream surfaces carry the whole integration:
+Two stock surfaces carry the whole integration:
 
-- `Harness.spec.workload.image` is a required, operator-supplied, digest-pinned image reference ([harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40)). Every kagent install names a runtime image there. Naming the adapter image is ordinary configuration.
-- `KAgentApp(plugins=[...])` is a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L65](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L65)). kagent registers its own plugins through the same parameter ([cli.py#L95-L105](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L95-L105)).
+- Helm value `controller.agentImage.{registry,repository,tag}` selects the runtime image for every Declarative agent ([values.yaml#L179-L183](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/values.yaml#L179-L183) → controller ConfigMap `IMAGE_*` env ([controller-configmap.yaml#L12-L18](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/templates/controller-configmap.yaml#L12-L18)) → controller `--image-*` flags). Naming the adapter image there is ordinary install configuration.
+- `KAgentApp(plugins=[...])` is a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L63](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L63)). kagent registers its own plugins through the same parameter ([cli.py#L69-L79](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L69-L79)).
 
-Source baseline: kagent commit [`52cc4de2`](https://github.com/kagent-dev/kagent/commit/52cc4de2a044a5062d10c4f189d863937c1bb0f9) (2026-09-01), google-adk 2.8.0 (kagent's lockfile resolution), Substrate v0.0.20 ([go.mod#L489](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/go.mod#L489)).
+Source baseline — the last stable release: kagent [`v0.9.12`](https://github.com/kagent-dev/kagent/releases/tag/v0.9.12) (2026-07-20, the API the public docs describe), kagent-adk 0.3.0, google-adk 1.31.1 (the workspace lock). Every enforcement claim below is re-verified against the google-adk 1.31.1 wheel, not carried over from newer versions.
 
 ## Overview
 
-- The platform operator edits one `Harness`: point `spec.workload.image` at the adapter image, and set `APPA_RUNTIME_URL` in `spec.env`.
-- The Harness label selector chooses which `AgentTemplate` resources run gated ([harness_types.go#L114-L117](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L114-L117), [collections.go#L85-L102](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/controller/collections.go#L85-L102)). Agent developers change nothing.
-- Inside each agent Actor, the adapter entrypoint rebuilds the compiled agent from `KAGENT_CONFIG_JSON` — the same steps as stock `kagent-adk static` — and registers `AppaHookPlugin`.
-- Each gated ADK callback becomes one `/hook` request to `appa-runtime`. The plugin enforces the returned `HookDecision` where the callback fires: it can deny a tool call with feedback the model reads, replace a tool result, or substitute a child's return.
+- The platform operator sets three helm values: `controller.agentImage.{registry,repository,tag}` name the adapter image. Every Declarative `runtime: python` agent — and `python` is the CRD default ([agent_types.go#L175](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L175)) — rolls onto it. No CRD edits, no agent changes.
+- `APPA_RUNTIME_URL` arrives as a baked image default, or per agent via `spec.declarative.deployment.env` ([agent_types.go#L443-L445](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L443-L445)).
+- Inside each agent pod, the adapter entrypoint rebuilds the compiled agent from the Secret-mounted `/config` — the same steps as stock `kagent-adk static` — and registers `AppaHookPlugin`.
+- Each gated ADK callback becomes one `/hook` request to the shared `appa-runtime`. The plugin enforces the returned `HookDecision` where the callback fires: it can deny a tool call with feedback the model reads, replace a tool result, or substitute a child's return.
 - Hooks fail closed. When the runtime is unreachable or answers outside the contract, the gated action does not run.
 
 ## Highlights
@@ -37,16 +37,17 @@ Source baseline: kagent commit [`52cc4de2`](https://github.com/kagent-dev/kagent
 ```text
 Kubernetes cluster
 +---------------------------------------------------------------------------+
-| kagent controller-v2 (stock)                                              |
-|   watches AgentTemplate, Harness, ModelConfig, RemoteMCPServer            |
-|   pairs   Harness.spec.allowedAgentTemplates selector -> AgentTemplates   |
-|   renders one immutable Revision per (AgentTemplate, Harness) pair        |
+| kagent controller (stock, v0.9.12)                                        |
+|   watches kagent.dev/v1alpha2 Agent resources                             |
+|   runtime image for Declarative agents = helm controller.agentImage       |
+|   renders per agent: Deployment + Service + config Secret                 |
 +------------------------------------+--------------------------------------+
-                                     | runs each Revision as a Substrate Actor
+                                     | one Deployment per Agent
                                      v
-+--------------------- Substrate Actor (one per agent) ---------------------+
-| image: Harness.spec.workload.image = appa-adapter-kagent (digest-pinned)  |
-| env:   KAGENT_CONFIG_JSON (the compiled agent), APPA_RUNTIME_URL, ...     |
++---------------------- agent pod (one per Agent) --------------------------+
+| image: controller.agentImage = appa-adapter-kagent                        |
+| /config (Secret): config.json (the compiled agent), agent-card.json      |
+| args: --host <bind> --port 8080 --filepath /config                        |
 |                                                                           |
 | adapter entrypoint -> KAgentApp(plugins=[.., AppaHookPlugin]) -> A2A :8080|
 +-----------------------------+---------------------------------------------+
@@ -57,9 +58,9 @@ Kubernetes cluster
 +---------------------------------------------------------------------------+
 ```
 
-The controller injects the compiled agent as environment variables into the Actor ([actor_template.go#L43-L44](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L43-L44)). The agent exists in the pod only as that data. No developer code and no per-agent image exists there, so one generic adapter image serves every admitted `AgentTemplate`.
+The controller writes the compiled agent into a per-agent Secret mounted at `/config` ([manifest_builder.go#L243](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L243)) and passes `--host/--port/--filepath` as container args ([deployments.go#L175-L179](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/deployments.go#L175-L179)). The agent exists in the pod only as that data. No developer code and no per-agent image exists there, so one generic adapter image serves every Declarative agent.
 
-All gated Actors of one deployment report to one shared `appa-runtime`. A parent and its delegated children run in separate Actors, and their hooks must reach the same runtime to correlate into one trajectory.
+All gated pods of one deployment report to one shared `appa-runtime`. A parent and each agent it calls run as separate workloads, and their hooks must reach the same runtime to correlate into one trajectory.
 
 ### One image wraps kagent-adk
 
@@ -68,30 +69,31 @@ appa-adapter-kagent image
 +-------------------------------------------------------------+
 | OpenAPPA layer (two files)                                  |
 |   entrypoint.py       replays the `kagent-adk static` steps |
+|                       and accepts the same --host/--port/   |
+|                       --filepath args the controller sends  |
 |   appa_hook_plugin.py ADK BasePlugin -> POST /hook          |
 +-------------------------------------------------------------+
-| base: published kagent-adk image, unmodified                |
-|   kagent-adk package  (cli.py present, not used as PID 1)   |
-|   google-adk 2.8.0    (BasePlugin is its official API)      |
+| base: published kagent-adk (kagent/app) image, unmodified   |
+|   kagent-adk 0.3.0    (cli.py present, not used as PID 1)   |
+|   google-adk 1.31.1   (BasePlugin is its official API)      |
 +-------------------------------------------------------------+
 
 entrypoint flow — the same public calls as stock `static`, one delta:
-  materialize_from_env("/config")                  # env -> config files
-  cfg = AgentConfig.model_validate(config)         # refuse unsupported fields
+  cfg = AgentConfig.model_validate(/config/config.json)  # refuse unknown fields
   plugins = [<stock STS / passthrough plugins>]
-  plugins.append(AppaHookPlugin(APPA_RUNTIME_URL)) # <-- the delta
-  KAgentApp(lambda: cfg.to_agent(name), card, url, name,
-            plugins=plugins).build()
+  plugins.append(AppaHookPlugin(APPA_RUNTIME_URL))       # <-- the delta
+  KAgentApp(root_agent, card, url, name,
+            plugins=plugins).build()                     # serve A2A on :8080
 ```
 
-Stock `kagent-adk static` performs the identical sequence with a closed plugin list ([cli.py#L76-L135](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L76-L135)). The steps are materialize ([_config_materialize.py#L55-L69](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_config_materialize.py#L55-L69)), then validate and rebuild the agent ([types.py#L387-L403](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L387-L403)), then serve ([_a2a.py#L126-L149](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L126-L149)). The plugin list handed to ADK's `App(plugins=...)` becomes ADK's `PluginManager`, so one registration covers the root agent, every sub-agent, and every tool. Google ADK stays an unmodified dependency.
+Stock `static` performs the identical sequence with a closed plugin list ([cli.py#L54-L101](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L54-L101)). The plugin list handed to ADK becomes its plugin manager, so one registration covers the root agent, every sub-agent, and every tool. The image must keep the stock runtime contract: serve A2A on port 8080 and answer readiness at `/.well-known/agent-card.json` ([manifest_builder.go#L532](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L532)). Google ADK stays an unmodified dependency.
 
 ### Callback-to-hook mapping
 
-The runtime's hook vocabulary is the eight `HookEvent` variants in `appa-runtime-api/src/lib.rs`. The plugin maps each gated ADK callback onto exactly one event, and callbacks with no event either pass through or hold as liveness gates.
+The runtime's hook vocabulary is the eight `HookEvent` variants in `appa-runtime-api/src/lib.rs`. The plugin maps each gated ADK callback onto exactly one event. google-adk 1.31.1 defines 12 plugin callbacks (`google/adk/plugins/base_plugin.py`, lines 114-348 in the wheel). Callbacks with no event either pass through or hold as liveness gates.
 
 ```text
-   ADK CALLBACK (google-adk 2.8.0, unmodified)           APPA RUNTIME /hook — the 8 HookEvents
+   ADK CALLBACK (google-adk 1.31.1, unmodified)          APPA RUNTIME /hook — the 8 HookEvents
    time flows top→bottom within one turn                 and the decisions each one answers
    ─────────────────────────────────────────             ─────────────────────────────────────
 
@@ -99,9 +101,9 @@ session  first invocation of a fresh ADK session ──────▶ [1] Sessi
   │        detected in on_user_message_callback;             root TrajectoryId derived
   ▼        no callback exists at session creation            from the ADK session id
 prompt   on_user_message_callback ─────────────────────▶ [2] Prompt            ◀ Ack | Block
-  │        fires BEFORE the session append, so a
-  │        Block keeps the exact bytes out of
-  │        stored session history
+  │        fires BEFORE the session append
+  │        (runners.py 1537 then 1550), so a Block
+  │        keeps the exact bytes out of history
   │      before_run_callback ───────x no event  (Prompt already gates the same bytes)
   │      before_agent_cb (root) ────x no event  (root entry IS Prompt)
   ▼
@@ -113,16 +115,17 @@ model    before_model_callback ─────x no event ┐ no model-layer Hook
 tool     before_tool_callback ═════════════════════════▶ [3] ToolCall{spawn:F} ◀ AllowCall | DenyCall
 loop        deny: the returned dict SKIPS execution                              | Refuse
   │         and becomes the function response the
-  │         model reads
+  │         model reads (functions.py 509-534)
   │      after_tool_callback ══════════════════════════▶ [4] ToolResult        ◀ Ack | ReplaceOutput
   │      on_tool_error_callback ───────────────────────▶ [4] ToolResult{Failure} | Block
   ▼
-child    before_tool_cb (sub-agent tool) ──────────────▶ [3] ToolCall{spawn:T} ◀ AllowCall{binding}
-deleg.     │ child scope opens:
-           │  before_agent_cb (child) ─────────────────▶ [5] ChildStart        ◀ Ack
+child    before_tool_cb (agent tool) ──────────────────▶ [3] ToolCall{spawn:T} ◀ AllowCall{binding}
+deleg.     │ child scope opens (its own pod):
+           │  child-side plugin classifies the
+           │  delegated entry ─────────────────────────▶ [5] ChildStart        ◀ Ack
            │      … child runs its own [3]/[4] loop …
-           │  after_agent_cb (child) ──────────────────▶ [6] TurnEnd (child)   ◀ Ack
-           └ after_tool_cb (sub-agent return) ─────────▶ [7] SpawnResult       ◀ Ack | ChildReturn{value}
+           │  child-side after_run_callback ───────────▶ [6] TurnEnd (child)   ◀ Ack
+           └ after_tool_cb (agent tool return) ────────▶ [7] SpawnResult       ◀ Ack | ChildReturn{value}
                the ONE point where the value the                                 | ReplaceOutput | Block
                parent receives can be substituted
   │
@@ -131,8 +134,9 @@ emit     on_event_callback ─────────x no event  (no emission H
   │                                              held as a liveness gate)
   ▼
 turn     after_run_callback ───────────────────────────▶ [6] TurnEnd (root)    ◀ Ack —
-end      on_run_error_callback ────────────────────────▶ [6] TurnEnd (root,      closes tool dispatches
-         on_agent_error_cb (child) ────────────────────▶ [6] TurnEnd  failure)   the turn abandoned
+end        fires on normal completion and after a          closes tool dispatches
+           before_run halt; google-adk 1.31.1 has NO       the turn abandoned
+           error-turn callback — see fail-closed rule 4
 
                                                          [8] ChildEnd — unfed BY DESIGN:
                                                              return substitution is enforceable
@@ -141,31 +145,30 @@ end      on_run_error_callback ────────────────�
                                                              adapter makes the same choice.
 ```
 
-The enforcement mechanics come from ADK's own plugin contract, verified in the 2.8.0 wheel:
+The enforcement mechanics come from ADK's own plugin contract, re-verified in the 1.31.1 wheel:
 
-- All 14 callbacks above exist on `BasePlugin` (`google/adk/plugins/base_plugin.py`, lines 114-394 in the 2.8.0 wheel).
-- A dict returned from `before_tool_callback` skips execution and becomes the function response the model reads — `DenyCall` with feedback (`google/adk/flows/llm_flows/functions.py`, lines 611-641).
-- A dict returned from `after_tool_callback` replaces the result the model sees — `ReplaceOutput` (`functions.py`, lines 652-683).
-- `on_user_message_callback` fires before the runner appends the message to session history (`google/adk/runners.py`, lines 675-700), so a `Block` on `Prompt` is a pre-append barrier.
-- kagent dispatches every declared remote sub-agent as an ordinary ADK tool, `KAgentRemoteA2AToolset` ([types.py#L521](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/types.py#L521)), so the tool-call gate is also the spawn gate.
+- A dict returned from `before_tool_callback` skips execution and becomes the function response the model reads — `DenyCall` with feedback (`functions.py`, lines 509-534 and 588-592). The deny dict also flows through `after_tool_callback`, so the plugin recognizes its own deny payload and does not report it twice.
+- A non-None return from `after_tool_callback` replaces the result the model sees — `ReplaceOutput` (`functions.py`, lines 547-576).
+- `on_user_message_callback` fires before the runner appends the message to session history (`runners.py`, lines 1537-1556), so a `Block` on `Prompt` is a pre-append barrier.
+- A v1alpha2 agent declares another agent as a tool (`spec.declarative.tools[].type: Agent`), and kagent dispatches it as an ordinary ADK tool, `KAgentRemoteA2ATool` ([_remote_a2a_tool.py#L158-L170](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py#L158-L170)) — so the tool-call gate is also the spawn gate.
 
-kagent children run in separate Actors. The child Actor's own plugin recognizes the delegated entry from kagent's inbound metadata ([_agent_executor.py#L212-L214](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py#L212-L214)). It feeds `ChildStart` and the child `TurnEnd`, while the parent's plugin feeds the spawn `ToolCall` and `SpawnResult`. Both report to the one shared runtime.
+Each called agent runs in its own pod with its own plugin instance. The child side classifies the delegated entry and feeds `ChildStart` and the child `TurnEnd`. The parent side feeds the spawn `ToolCall` and `SpawnResult`. Both report to the one shared runtime.
 
 ### Fail-closed rules
 
-1. An unreachable `/hook` endpoint, or a response outside the contract, blocks the gated action. The plugin raises, and ADK aborts the invocation.
-2. A rendered config with a field the entrypoint does not support refuses to start, and the Actor stays unready. In-process `sub_agents` compiled from CRD sub-agent tools are the known case: stock `kagent-adk` drops them silently, and the adapter refuses instead.
+1. An unreachable `/hook` endpoint, or a response outside the contract, blocks the gated action. The plugin raises, ADK wraps the exception, and the invocation aborts (`plugin_manager.py`, lines 288-305 in the wheel).
+2. A `/config/config.json` with a field the entrypoint does not support refuses to start, and the pod stays unready. Stock `AgentConfig` ignores unknown fields — the adapter must not inherit that silence.
 3. The model and emission callbacks feed no event, but they still hold the action when the `/hook` channel is down.
-4. A hard Actor crash emits nothing. `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event.
+4. google-adk 1.31.1 has no error-turn callback (`on_run_error_callback` and `on_agent_error_callback` do not exist in this version), so a turn that dies on an unhandled error emits no `TurnEnd`. `on_model_error_callback` and `on_tool_error_callback` catch the common failures earlier. For the rest, `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event, and the next `Prompt` fails closed if the runtime is down.
 
 ### Scope and limits
 
-- Covered: declarative `AgentTemplate` agents on the kagent (Python ADK) harness variant, run from this workload image on the Substrate path (helm `controller.substrate.enabled`).
-- Not covered: the Claude harness, which omits hooks, permission mode, memory, and inline MCP from its supported contract ([config.go#L48-L50](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/harness/claude/config/config.go#L48-L50)).
-- Also not covered: the Codex harness, the non-ADK framework wrappers, and agents on kagent's stock image, whose plugin list is closed ([cli.py#L95-L105](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/cli.py#L95-L105)).
+- Covered: `kagent.dev/v1alpha2` `Agent` resources with `type: Declarative` and `runtime: python` — the CRD default — on stable kagent v0.9.12.
+- Not covered: `runtime: go` agents (opt-in — v0.9.12 has no helm value for the Go runtime image, and the Go ADK's plugin list is compiled in), BYO agents (per-agent images whose authors add the one plugin line themselves), and the `AgentHarness`/`SandboxAgent` sandbox kinds.
 - `SessionStart` is a first-invocation proxy. A session that is created but never invoked emits nothing, and also flows nothing.
 - The entrypoint replays the behavior of `kagent-adk static` instead of calling it, because upstream has no plugin configuration knob. Each `kagent-adk` release therefore costs one small equivalence re-check. A one-field upstream contribution would remove the duplication.
+- Forward path: kagent's main branch is mid-cutover to a `v1alpha3` `AgentTemplate` × `Harness` model on Substrate Actors, unreleased and publicly undocumented. The 0.10 release candidates also flip the runtime default to `go` and add a `controller.goAgentImage` value. The same adapter image moves to `Harness.spec.workload.image` there. The [implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) carries the details.
 
 ## Implementation plan
 
-The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the artifacts, the entrypoint and plugin specification, the runtime-side codec, deployment profiles, trajectory identity, and the verification matrix.
+The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the artifacts, the entrypoint and plugin specification, the runtime-side codec, deployment and rollout, trajectory identity, the forward (v1alpha3) lane, and the verification matrix.


### PR DESCRIPTION
Re-researches the kagent integration against the last stable release and retargets both documents, since public kagent.dev docs describe `kagent.dev/v1alpha2` — not the v1alpha3 model at kagent HEAD.

**What the re-research established** (two adversarially verified multi-agent passes over the v0.9.12 and v0.10.0-rc4 tags, kagent HEAD, the kagent.dev docs, and the google-adk 1.31.1 wheel):
- Released kagent runs every documented v1alpha2 `Agent` as a plain Deployment + Service; the v1alpha3 `AgentTemplate`×`Harness`/Substrate model exists only at unreleased HEAD (mid-cutover).
- The stable-lane delivery is helm `controller.agentImage.{registry,repository,tag}` — it swaps the runtime image for every Declarative `runtime: python` agent, and `python` is the v0.9.12 CRD default. Zero agent changes.
- The callback-to-hook mapping holds on google-adk 1.31.1 (v0.9.12's lock) with one real difference: `on_run_error_callback`/`on_agent_error_callback` do not exist there, so the error-turn `TurnEnd` gap routes through appa-runtime recovery.

**Changes**
- `website/content/docs/kagent.md`: baseline v0.9.12 + kagent-adk 0.3.0 + google-adk 1.31.1; Deployment topology diagram; args/readiness image contract; 1.31.1-accurate mapping diagram; go/BYO/sandbox scope exclusions; the v1alpha3 lane as a scope-labeled forward path.
- `integrations/kagent/IMPLEMENTATION.md`: v0.9.12 runtime contract, entrypoint refusal rules, the 12-callback table with wheel-verified evidence, helm rollout with per-agent staging, error-turn gap handling, condensed HEAD-only forward section, updated PR sequence and verification matrix.

Every load-bearing claim links a v0.9.12 permalink or a google-adk 1.31.1 wheel path. Golden files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)