### PR TITLE
docs: redraw the kagent diagrams and split the plan by lane and runtime

### DIFF
--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -1,61 +1,95 @@
 # kagent adapter implementation plan
 
-Source baseline — the last stable kagent release:
+The adapter family follows the `appa-adapter-claude-code` conventions: one adapter name, the `appa` prefix on every OpenAPPA-owned artifact, a runtime-side codec crate selected by the runtime's adapter switch, and no policy state outside `appa-runtime`.
 
-- kagent [`v0.9.12`](https://github.com/kagent-dev/kagent/releases/tag/v0.9.12) (2026-07-20). This is the API the public kagent.dev docs describe: `kagent.dev/v1alpha2`, kind `Agent`.
-- kagent-adk 0.3.0 (the workspace package version at that tag)
-- google-adk 1.31.1 — the version the v0.9.12 lock resolves. The package constraint is `google-adk>=1.28.1,<2` ([pyproject.toml#L25](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/pyproject.toml#L25)). Every callback-semantics claim below is verified in the google_adk-1.31.1 wheel, and wheel citations give paths and lines inside it.
-- OpenAPPA `origin/main`: `appa-runtime-api` hook vocabulary (`appa-runtime-api/src/lib.rs`), `appa-runtime` `/hook` endpoint (`appa-runtime/src/main.rs`), and the `appa-adapter-claude-code` codec as the adapter reference.
+## Naming
 
-The reader-facing proposal is at [openappa.com/kagent](https://www.openappa.com/kagent). A forward section at the end covers kagent's unreleased `v1alpha3` cutover.
+| Artifact | Name | Mirrors |
+|---|---|---|
+| Rust codec crate | `appa-adapter-kagent` | `appa-adapter-claude-code` |
+| Python package (plugin + entrypoint) | `appa-adapter-kagent` | one adapter, one name |
+| Python runtime OCI image | `ghcr.io/archestra-ai/appa-adapter-kagent` | — |
+| Go runtime OCI image | `ghcr.io/archestra-ai/appa-adapter-kagent-go` | — |
+| Go module (plugin + runtime main) | `appa-adapter-kagent-go` | — |
+| Runtime env var | `APPA_RUNTIME_URL` | Claude Code integration |
+| Policy examples | `integrations/kagent/examples/*.appa.toml` | `integrations/claude-code/examples` |
+
+Both runtime images emit the same adapter wire, and the one codec crate parses it. The runtime selects the codec through its closed `Adapter` enum ([appa-runtime/src/main.rs](../../appa-runtime/src/main.rs)) — one new variant beside `ClaudeCode`, mapped to `appa_adapter_kagent::codec()`.
+
+## Source baselines
+
+Stable release — the lane users install today:
+
+- kagent [`v0.9.12`](https://github.com/kagent-dev/kagent/releases/tag/v0.9.12) (2026-07-20), the `kagent.dev/v1alpha2` API the public docs describe.
+- kagent-adk 0.3.0. google-adk 1.31.1 — the lock resolution. The constraint is `google-adk>=1.28.1,<2` ([pyproject.toml#L25](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/pyproject.toml#L25)). Python-side callback claims below are verified in the google_adk-1.31.1 wheel (wheel citations give paths and lines inside it).
+- Go ADK: `google.golang.org/adk v1.4.0` ([go.mod#L50](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/go.mod#L50)) — the v1 line, before the v2 plugin API.
+
+Release-candidate line — mid-cutover, in two observed states:
+
+- Tag [`v0.10.0-rc4`](https://github.com/kagent-dev/kagent/releases/tag/v0.10.0-rc4) (`af84a618`, 2026-08-26): still the v1alpha2 `Agent` → Deployment controller, plus the `controller.goAgentImage` value. Go ADK: `google.golang.org/adk/v2 v2.1.0` ([go.mod#L50](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/go/go.mod#L50)). The workspace lock resolves google-adk 2.8.0.
+- Main at [`52cc4de2`](https://github.com/kagent-dev/kagent/commit/52cc4de2a044a5062d10c4f189d863937c1bb0f9) (2026-09-01): the v1alpha2 Agent controller is deleted, and agents are `v1alpha3` `AgentTemplate` × `Harness` pairs compiled to Substrate Actors. Go ADK: `google.golang.org/adk/v2 v2.2.0`.
+
+OpenAPPA: `appa-runtime-api` hook vocabulary (`appa-runtime-api/src/lib.rs`) and the `appa-runtime` `/hook` endpoint (`appa-runtime/src/main.rs`).
 
 ## Architecture decision
 
-The adapter rides two stock kagent surfaces and changes no kagent or Google ADK source:
+No kagent fork and no Google ADK fork, in either runtime:
 
-1. Helm `controller.agentImage.{registry,repository,tag,pullPolicy,pullSecret}` — the runtime image for every Declarative agent. The values render into the controller ConfigMap as `IMAGE_*` env ([controller-configmap.yaml#L12-L18](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/templates/controller-configmap.yaml#L12-L18)), which the controller consumes as `--image-*` flags. The adapter ships as that image.
-2. `KAgentApp(plugins=[...])` — a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L63](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L63)), forwarded into ADK's plugin manager ([_a2a.py#L124](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L124)). The `AppaHookPlugin` registers there.
+- **Python runtime**: `KAgentApp(plugins=[...])` is a public constructor parameter of the published `kagent-adk` package ([v0.9.12 _a2a.py#L63](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L63)), forwarded into ADK's plugin manager. kagent registers its own plugins through it ([cli.py#L69-L79](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L69-L79)). The stock entrypoint's plugin list is closed and no config adds to it, so the adapter image carries its own entrypoint that makes the same public calls and appends one plugin.
+- **Go runtime**: kagent's Go runtime is Google's official Go ADK. On the release-candidate line it registers plugins through the ADK v2 plugin API — kagent's own runner adapter passes `runner.PluginConfig{Plugins: ...}` ([v0.10.0-rc4 go/adk/pkg/runner/adapter.go#L93-L111](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/go/adk/pkg/runner/adapter.go#L93-L111)) — but the list is compiled in, with no config knob. The Go adapter is therefore a replacement runtime main built on kagent's public `go/adk` packages that registers `AppaHookPlugin` (Go) in that list.
+- Delivery is always an image reference the operator already controls. The lanes below name the knob per tree.
 
-No config-reachable plugin surface exists upstream. The stock entrypoint builds a closed plugin list ([cli.py#L69-L79](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L69-L79)). No CRD field, helm value, env var, or entry point adds to it. The adapter image therefore carries its own entrypoint. That entrypoint calls the same public `kagent-adk` functions as stock `static` and adds one plugin.
+Both plugins hold no policy state. They serialize callback moments into wire events, send them to `APPA_RUNTIME_URL`, and enforce the answered `HookDecision`. `appa-runtime` owns policy, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`.
 
-The adapter follows the `appa-adapter-claude-code` boundary. It maps harness callbacks to the eight `HookEvent` variants and renders each `HookDecision` back into the harness. It does not link `appa-runtime`, call the Engine, own policy, or open `appa.db`. `appa-runtime` owns policy, the Engine, consults, remedy plans, trajectory state, recovery semantics, and `appa.db`.
+## Delivery lanes
 
-## Artifacts and ownership
+### Lane A — stable release (v1alpha2 `Agent` → Deployment)
 
-| Artifact | Contents | Owner |
-|---|---|---|
-| `appa-adapter-kagent` Python package | `AppaHookPlugin` (a google-adk `BasePlugin`) and `entrypoint.py` | OpenAPPA repository |
-| `appa-adapter-kagent` OCI image | The published `kagent-dev/kagent/app` image plus the Python package, digest-pinned base | OpenAPPA repository |
-| `appa-adapter-kagent` Rust crate | The `/hook` codec (`parse`, `render`) for the kagent wire, selected by the runtime's adapter switch | OpenAPPA repository |
-| kagent | Controller, CRDs, translator, helm chart, `kagent-adk` library — all stock, no change | Upstream |
-| Google ADK | Plugin API and dispatch loop — stock dependency, no change | Upstream |
+The shipped controller reconciles every `Agent` into a plain Deployment + Service. The declarative runtime image is install configuration:
 
-The runtime picks one codec per adapter through a closed enum ([appa-runtime/src/main.rs](../../appa-runtime/src/main.rs), the `Adapter` enum). The kagent deliverable adds one variant beside `ClaudeCode`, mapped to `appa_adapter_kagent::codec()`.
+- **Python (the stable default runtime)**: `spec.declarative.runtime` defaults to `python` in the shipped CRD ([agent_types.go#L175](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L175)). Helm `controller.agentImage.{registry,repository,tag}` flows into the controller ConfigMap as `IMAGE_*` ([controller-configmap.yaml#L12-L18](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/templates/controller-configmap.yaml#L12-L18)) and lands as the agent Deployment's image. Pointing it at `appa-adapter-kagent` gates every python-runtime agent with zero agent changes.
+- **Go**: v0.9.12 has no Go-image value and no Go-image controller flag, and its Go ADK is the v1 line without the v2 plugin API. Go-runtime agents are opt-in there. To gate one on stable, set `runtime: python` on that Agent (one field) — or move to lane B, which carries the Go adapter.
 
-The plugin holds no policy state. It serializes callback moments into wire events, sends them to `APPA_RUNTIME_URL`, and enforces the answered decision. Every semantic judgment stays in `appa-runtime`.
-
-## Adapter workload image
-
-Build: `FROM` the published `kagent-dev/kagent/app` image at a pinned digest, add the Python package, set `entrypoint.py` as the container entrypoint. `cli.py` stays in the image unchanged and unused. Equivalent build: a plain Python base plus `pip install kagent-adk==0.3.0`.
-
-Runtime contract the image must keep — the controller sets container args, not the command:
+Runtime contract the python image must keep — the controller sets container args, not the command:
 
 - Accept `--host <bind> --port 8080 --filepath /config` ([deployments.go#L175-L179](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/deployments.go#L175-L179)).
 - Read `config.json` and `agent-card.json` from the per-agent Secret mounted at `/config` ([manifest_builder.go#L243](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L243)).
 - Serve A2A on port 8080 and answer readiness at `/.well-known/agent-card.json` ([manifest_builder.go#L532](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L532)).
 
-Entrypoint steps, in order:
+Rollout: one `helm upgrade` re-renders every declarative python agent onto the adapter image, cluster-wide, with no double-run hazard. Staged rollout: `spec.declarative.deployment.imageRegistry` overrides the registry component per agent ([agent_types.go#L392](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L392)) — point pilot agents at a registry that serves the adapter image under the stock repository path. `APPA_RUNTIME_URL` arrives as a baked image default or per agent via `spec.declarative.deployment.env` ([agent_types.go#L443-L445](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L443-L445)).
 
-1. Parse the raw `/config/config.json` with a strict schema. Refuse any field the adapter does not support, and exit unready. Stock `AgentConfig` is a pydantic model that ignores unknown fields. The adapter must not inherit that silence.
-2. Validate the accepted config with `AgentConfig.model_validate` and build the agent factory over `AgentConfig.to_agent`.
-3. Rebuild the stock plugin list with the same conditions as `static` (STS token propagation, `LLMPassthroughPlugin`), then append `AppaHookPlugin(APPA_RUNTIME_URL)`.
-4. Construct `KAgentApp(...)`, call `.build()`, and serve on the given host and port — the same calls as [cli.py#L88-L101](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L88-L101).
+### Lane B — release-candidate line
 
-Refusal rules (fail closed at startup): `APPA_RUNTIME_URL` unset or unreachable at the startup probe — unready. Any config field outside the adapter's accepted schema — unready, with the field named in the log.
+Two observed states, one adapter story:
 
-`APPA_RUNTIME_URL` delivery: a baked default in the image, overridable per agent through `spec.declarative.deployment.env` ([agent_types.go#L443-L445](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L443-L445)).
+**B1 — the current release candidates (v1alpha2 `Agent` → Deployment, both image knobs).** Same Deployment path as lane A, with three differences. The runtime default flips to `go` ([rc4 agent_types.go#L235-L241](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/go/api/v1alpha2/agent_types.go#L235-L241)). `controller.goAgentImage.{registry,repository,tag}` exists beside `controller.agentImage` ([rc4 controller-configmap.yaml#L28](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/helm/kagent/templates/controller-configmap.yaml#L28), [app.go#L226](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/go/core/pkg/app/app.go#L226)). And agents with skills or `executeCodeBlocks` resolve a `<tag>-full` Go-image variant, so the Go adapter publishes both tags. Point both values at the matching adapter images and every declarative agent is gated — python agents by `appa-adapter-kagent`, go agents by `appa-adapter-kagent-go`. Foundry-model agents require the Go runtime by compiler validation ([rc4 compiler.go#L224-L227](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/go/core/internal/controller/translator/agent/compiler.go#L224-L227)). The Go adapter covers them, because it is a Go ADK runtime.
 
-## AppaHookPlugin
+**B2 — main (v1alpha3 `AgentTemplate` × `Harness` → Substrate Actor).** The Harness names the runtime image directly and selects which templates it runs:
+
+```yaml
+kind: Harness
+spec:
+  kagent: {}
+  workload:
+    image: ghcr.io/archestra-ai/appa-adapter-kagent@sha256:<digest>
+  env:
+    - name: APPA_RUNTIME_URL
+      value: http://appa-runtime.appa-system:8787
+  substrate: { workerPoolRef: {name: <pool>}, snapshotPolicy: {location: <loc>} }
+  allowedAgentTemplates:
+    selector: { matchLabels: { <team labels> } }
+```
+
+- `workload.image` is required and digest-pinned ([harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40)). `spec.env` carries `APPA_RUNTIME_URL`, with Secret refs available.
+- Pairing: the controller matches each `AgentTemplate` against every same-namespace Harness selector and reconciles one Actor per pair ([collections.go#L85-L102](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/controller/collections.go#L85-L102)). Rollout is "move the label match", never "add a second match" — a template matched by two Harnesses runs twice. Make old and new selectors disjoint.
+- Config arrives as `KAGENT_CONFIG_JSON` / `KAGENT_AGENT_CARD_JSON` env ([actor_template.go#L43-L44](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L43-L44)). The python entrypoint's `materialize_from_env` handles both deliveries and is a no-op on the Deployment path. The Substrate path caps an Actor at 32 total env vars ([actor_template.go#L50-L52](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/substrate/actor_template.go#L50-L52)), and the adapter needs one.
+- Prerequisites: helm `controller.substrate.enabled=true`, the `ate-system` install, and a `WorkerPool` — the stock Substrate-path requirements.
+- Templates whose compiled config carries in-process `sub_agents` ([kagent/compiler.go#L172](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/translator/kagent/compiler.go#L172)) refuse at the python entrypoint (stock parsing drops them silently — the adapter must not). Out-of-process (`Dedicated`) sub-agent tools are rejected upstream ([compiler.go#L149-L151](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/core/v2/translator/compiler.go#L149-L151)). The Go adapter consumes the Go-shaped config natively and carries these topologies once its mapping verifies.
+- Re-verify this sub-lane against the first release that ships v1alpha3 before acting on it.
+
+## Runtime adapters
+
+### Python — `AppaHookPlugin` on google-adk (verified)
 
 The plugin implements google-adk `BasePlugin`. The 1.31.1 wheel defines 12 lifecycle callbacks (`base_plugin.py` lines 114, 136, 155, 174, 198, 217, 233, 253, 272, 297, 321, 348). Each gated callback sends one wire event to `POST $APPA_RUNTIME_URL/hook` and enforces the decision that comes back. A transport failure or a non-contract response raises, and ADK wraps the exception and aborts the invocation (`plugin_manager.py` 288-305).
 
@@ -75,83 +109,85 @@ The plugin implements google-adk `BasePlugin`. The 1.31.1 wheel defines 12 lifec
 
 `ChildEnd` is unfed by design. Return substitution is enforceable only where the parent receives the value, so returns cross at `SpawnResult`. The `appa-adapter-claude-code` parse map makes the same choice.
 
-Error-turn gap: google-adk 1.31.1 has no `on_run_error_callback` and no `on_agent_error_callback` (absent from the wheel), and `after_run_callback` is skipped when a run dies on an unhandled error (`runners.py` 949-954, no `finally`). `on_model_error_callback` and `on_tool_error_callback` catch the common failures earlier. For the rest, `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event, and the next `Prompt` fails closed if the runtime is down.
+Per-ADK differences the plugin handles:
 
-Sub-agent identity: a v1alpha2 agent declares another agent as a tool (`spec.declarative.tools[].type: Agent`), which kagent dispatches as `KAgentRemoteA2ATool` ([_remote_a2a_tool.py#L158-L170](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py#L158-L170)). The plugin classifies a spawn by the tool's type. A successful child reply arrives as `{"result": ...}` for Task replies, and as a bare string for direct Message replies — the plugin handles both shapes. Local ADK sub-agents (BYO-authored) gate through `before_agent_callback`. An `AgentTool` child runs under a fresh child Runner that inherits the parent's plugin list, so coverage continues there.
+- **google-adk 1.31.1 (stable lane)**: no `on_run_error_callback` and no `on_agent_error_callback` (absent from the wheel), and `after_run_callback` is skipped when a run dies on an unhandled error (`runners.py` 949-954, no `finally`). The model-error and tool-error callbacks catch the common failures earlier. For the rest, `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event. An `AgentTool` child runs under a fresh child Runner that inherits the parent's plugin list, so coverage continues there.
+- **google-adk 2.8.0 (release-candidate lane lock)**: both error callbacks exist — the plugin feeds `TurnEnd` (root failure) from `on_run_error_callback` and `TurnEnd` (child failure) from `on_agent_error_callback`, closing the error-turn gap on that lane. Sub-agents re-enter `run_async`, so `before/after_agent_callback` fire per child directly.
 
-### Wire and codec
+Entrypoint (python image), in order:
 
-The plugin emits one JSON event per callback: event kind, trajectory ids, tool name, raw argument bytes, outcome, and value fields — the data the matching `HookEvent` variant needs. The `appa-adapter-kagent` Rust crate parses this wire into `HookEvent` and renders each `HookDecision` into the response the plugin enforces, through the `Codec` contract of `appa-runtime-api` (`parse`, `render` — `appa-runtime-api/src/lib.rs`). The wire carries no policy meaning. Raw tool arguments cross as spelled, and the Engine canonicalizes them.
+1. Parse the mounted or env-delivered config with a strict schema, and refuse unknown fields with an unready exit.
+2. Validate with `AgentConfig.model_validate` and build the factory over `to_agent`.
+3. Rebuild the stock plugin list with the stock conditions (STS token propagation, LLM passthrough), then append `AppaHookPlugin(APPA_RUNTIME_URL)`.
+4. Construct `KAgentApp(...)`, call `.build()`, and serve on the controller-given host and port — the same calls as [cli.py#L88-L101](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L88-L101).
 
-### Trajectory identity
+### Go — `AppaHookPlugin` on the Go ADK (design, verification pending)
+
+The Go adapter is a small runtime main, module `appa-adapter-kagent-go`, that imports kagent's public `go/adk` packages, constructs the same agent the stock Go runtime builds from the rendered config, and registers the Go `AppaHookPlugin` through the ADK v2 plugin API — the registration point kagent itself uses ([rc4 adapter.go#L93-L111](https://github.com/kagent-dev/kagent/blob/v0.10.0-rc4/go/adk/pkg/runner/adapter.go#L93-L111)). It emits the same adapter wire as the python plugin.
+
+Verification status, stated plainly: the callback-to-hook mapping above is proven for the python plugin against its pinned google-adk versions. The Go mapping must be proven the same way against `google.golang.org/adk/v2` at the locked version (v2.1.0 on rc4, v2.2.0 on main) before the Go image ships: which plugin callbacks exist, whether a before-tool return skips execution and reaches the model as the function response, whether an after-tool return replaces the result, and where the user message crosses into session state. The Go runtime also serves Foundry-model agents, which the compiler ties to the Go runtime. Deliverables: both tags (`<tag>` and `<tag>-full`, the variant kagent resolves for agents with skills or `executeCodeBlocks`).
+
+## Wire and codec
+
+Each plugin emits one JSON event per callback: event kind, trajectory ids, tool name, raw argument bytes, outcome, and value fields — the data the matching `HookEvent` variant needs. The `appa-adapter-kagent` Rust crate parses this wire into `HookEvent` and renders each `HookDecision` into the response the plugins enforce, through the `Codec` contract of `appa-runtime-api` (`parse`, `render`). The wire carries no policy meaning. Raw tool arguments cross as spelled, and the Engine canonicalizes them. One wire and one codec serve both runtime images.
+
+## Trajectory identity
 
 - Root `TrajectoryId`: the ADK session id with a harness prefix, per the `appa-runtime-api` convention.
-- Child classification: the child pod's plugin reads kagent's inbound call metadata to recognize a delegated entry. A delegated entry feeds `ChildStart`. A plain external entry feeds `SessionStart` and `Prompt`.
-- Parent and child run as separate Deployments, so one trajectory's hooks come from two plugin instances. Both must reach the same `appa-runtime` — a per-pod runtime would split one trajectory into two logs.
-
-## Deployment and rollout
-
-```yaml
-# helm values — the whole kagent-side change
-controller:
-  agentImage:
-    registry: ghcr.io
-    repository: archestra-ai/appa-adapter-kagent
-    tag: "<adapter release>"
-```
-
-- Rollout is one `helm upgrade`. The controller re-renders every Declarative agent Deployment onto the adapter image, cluster-wide. There is no per-agent opt-in on this lane, and no double-run hazard.
-- Staged rollout, when wanted: `spec.declarative.deployment.imageRegistry` overrides the registry component per agent ([agent_types.go#L392](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L392)) — point pilot agents at a registry that serves the adapter image under the stock repository path.
-- `appa-runtime` deploys as one shared service per cluster or namespace. Only the runtime mounts policy, credentials, and the durable `appa.db` volume. Agent pods hold no APPA state.
+- Child classification: the child pod's plugin reads kagent's inbound call metadata to recognize a delegated entry (on the v1alpha3 lane the executor lands it in session state — [_agent_executor.py#L212-L214](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/python/packages/kagent-adk/src/kagent/adk/_agent_executor.py#L212-L214)). A delegated entry feeds `ChildStart`. A plain external entry feeds `SessionStart` and `Prompt`.
+- A successful child reply arrives as `{"result": ...}` for Task replies and as a bare string for direct Message replies — the plugins handle both shapes.
+- Parent and child run as separate workloads (Deployments on lane A/B1, Substrate Actors on B2), so one trajectory's hooks come from two plugin instances. Both must reach the same `appa-runtime` — a per-pod runtime would split one trajectory into two logs.
 
 ## Known gaps and handling
 
-| Gap | Handling |
-|---|---|
-| No callback at ADK session creation | `SessionStart` synthesizes at first invocation, sent before `Prompt` from the same callback. A never-invoked session emits nothing and flows nothing. |
-| No error-turn callback in google-adk 1.31.1 | See the error-turn gap above: earlier error callbacks plus `Indeterminate` classification at recovery. |
-| `runtime: go` agents (opt-in) | Out of scope on v0.9.12: no helm value selects the Go runtime image there, and the Go ADK's plugin list is compiled in. The stable default is `python` ([agent_types.go#L175](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L175)), so defaulted fleets are covered. |
-| BYO agents (`spec.byo.deployment.image`) | Per-agent images outside any shared runtime image. Their authors add the one `plugins=[...]` line, or gate at MCP/model boundaries. |
-| `AgentHarness` / `SandboxAgent` sandbox kinds | Different subsystem (Substrate sandboxes), out of scope. |
-| Upstream has no plugin config knob | The entrypoint replays `static` behavior through public calls. CI pins kagent-adk and google-adk versions and runs an equivalence check on each bump. Propose an upstream plugin-loading knob to delete the duplication. |
-
-## Forward lane: the v1alpha3 cutover (unreleased)
-
-kagent's main branch replaces the v1alpha2 Agent controller with a `v1alpha3` `AgentTemplate` × `Harness` model compiled to Substrate Actors (merged to kagent main late August 2026, absent from every release and from public docs). On that lane the same adapter image lands in `Harness.spec.workload.image` (required, digest-pinned, [harness_types.go#L34-L40](https://github.com/kagent-dev/kagent/blob/52cc4de2a044a5062d10c4f189d863937c1bb0f9/go/api/v1alpha3/harness_types.go#L34-L40) at HEAD `52cc4de2`), with agents admitted per `allowedAgentTemplates` label selector and config injected as `KAGENT_CONFIG_JSON` env. The entrypoint already tolerates both config deliveries: `materialize_from_env` is a no-op when the env vars are absent. Two changes to track before that lane is real for users: the 0.10 release candidates flip the Declarative runtime default to `go`, and they add a `controller.goAgentImage` value — pointing it at the adapter image also serves go-declared agents from the Python runtime, except Foundry-model agents, which require the Go binary. Re-verify this section against the first stable 0.10/v1alpha3 release before acting on it.
+| Gap | Lane / runtime | Handling |
+|---|---|---|
+| No callback at ADK session creation | all | `SessionStart` synthesizes at first invocation, sent before `Prompt`. A never-invoked session emits nothing and flows nothing. |
+| No error-turn callback in google-adk 1.31.1 | A / python | Earlier error callbacks plus `Indeterminate` classification at recovery. Closed on lane B by google-adk 2.8.0's error callbacks. |
+| Go-runtime agents on stable | A / go | No Go-image knob and a v1 Go ADK in v0.9.12: flip those agents to `runtime: python` (one field), or adopt lane B. |
+| Go mapping unproven | B / go | Verify against the locked `adk/v2` before shipping the Go image. Until then the Go lane is design, not a claim. |
+| CRD in-process `sub_agents` on the python runtime | B2 / python | The entrypoint refuses the config instead of dropping children. The Go adapter consumes them natively once verified. |
+| BYO agents | all | Per-agent images outside any shared runtime image. Their authors add the one plugin line, in either language. |
+| Sandbox kinds (`AgentHarness`, `SandboxAgent`) | all | Different subsystem, out of scope. |
+| Upstream has no plugin config knob | all | The entrypoints replay stock behavior through public calls. CI pins kagent and ADK versions per lane and re-runs the equivalence checks on each bump. Propose an upstream plugin-loading knob to delete the duplication. |
 
 ## PR sequence
 
 | PR | Change |
 |---|---|
 | 1 | `appa-adapter-kagent` Rust codec crate: wire parse to `HookEvent`, decision render, `Adapter` enum variant, unit tests against recorded wire fixtures |
-| 2 | `appa-adapter-kagent` Python package: `AppaHookPlugin` with the callback table above, fail-closed transport, liveness gates, deny-dict self-recognition |
-| 3 | Entrypoint: strict config schema and refusal rules, stock plugin parity, `KAgentApp` assembly, the `--host/--port/--filepath` args contract |
-| 4 | OCI image build with pinned base digest, SBOM, and provenance |
-| 5 | End-to-end harness: kind cluster with the v0.9.12 chart, `controller.agentImage` swap, parent-and-child scenario against one shared runtime |
+| 2 | `appa-adapter-kagent` Python package: `AppaHookPlugin` with the callback table, per-ADK deltas, fail-closed transport, liveness gates, deny-dict self-recognition |
+| 3 | Python entrypoint: strict config schema and refusal rules, stock plugin parity, both config deliveries, the controller args contract |
+| 4 | Python OCI image with pinned base digest, SBOM, and provenance |
+| 5 | Lane A end-to-end: kind cluster with the stable chart, `controller.agentImage` swap, parent-and-child scenario against one shared runtime |
+| 6 | `appa-adapter-kagent-go`: adk/v2 mapping verification, the Go plugin and runtime main, both image tags |
+| 7 | Lane B end-to-end: the B1 dual-knob swap on the release-candidate chart, and B2 Harness × AgentTemplate on the Substrate path |
 
 No kagent PR and no Google ADK PR is required. The optional upstream contribution (a plugin config knob) is independent and non-blocking.
 
 ## Verification matrix
 
-Adapter tests:
+Adapter tests (per runtime):
 
-- Callback-to-event mapping for all rows of the table, including spawn classification by tool type and both child-return shapes (Task dict, bare Message string).
-- Deny path: a `DenyCall` dict skips execution, reaches the model as the function response, and is not double-reported through `after_tool_callback`.
-- Replace path: `ReplaceOutput` and `ChildReturn` substitution at `after_tool_callback`.
+- Callback-to-event mapping for every table row, including spawn classification by tool type and both child-return shapes.
+- Deny path: a `DenyCall` skips execution, reaches the model as the function response, and is not double-reported.
+- Replace path: `ReplaceOutput` and `ChildReturn` substitution at the after-tool point.
 - Pre-append barrier: a blocked `Prompt` leaves no trace in session history.
 - Fail closed: runtime down at each callback blocks the action, and liveness gates hold model and emission callbacks.
-- Startup refusal: missing `APPA_RUNTIME_URL`, unknown config fields.
-- Args contract: the entrypoint accepts the controller's `--host/--port/--filepath` args and answers readiness at `/.well-known/agent-card.json`.
-- No link from the codec crate to `appa-runtime` or `appa-engine`, and no policy state in the plugin.
+- Startup refusal: missing `APPA_RUNTIME_URL`, unknown config fields, `sub_agents` on the python runtime.
+- Args contract: the entrypoints accept the controller's args and answer readiness at the stock endpoint.
+- No link from the codec crate to `appa-runtime` or `appa-engine`, and no policy state in either plugin.
 
 Equivalence tests:
 
-- Entrypoint output matches stock `static` for the same `/config` contents, minus the added plugin: same agent shape, same stock plugins, same serving surface.
-- Re-run on every kagent-adk and google-adk version bump. The callback table re-verifies against the newly locked google-adk.
+- Each entrypoint's output matches its stock counterpart for the same rendered config, minus the added plugin.
+- Re-run on every kagent and ADK version bump, per lane. The callback tables re-verify against the newly locked ADK.
 
 End-to-end tests:
 
-- Declarative agent on a kind cluster with the v0.9.12 chart and the `controller.agentImage` swap: gated tool calls, replaced results, blocked prompts.
-- Parent and delegated child in separate pods against one shared runtime: one trajectory, `ChildStart` and `SpawnResult` correlated.
-- Crash window: kill the agent pod between `ToolCall` and `ToolResult`, then make sure the runtime reports the dispatch `Indeterminate`.
-- Error-turn window: force an unhandled model failure and make sure recovery closes the turn at the next admitted event.
+- Lane A: declarative python agent on a kind cluster with the stable chart and the `controller.agentImage` swap — gated tool calls, replaced results, blocked prompts.
+- Lane B1: both image knobs swapped on the release-candidate chart — a python agent and a go agent gated side by side.
+- Lane B2: `AgentTemplate` × `Harness` on the Substrate path — admission by selector, `KAGENT_CONFIG_JSON` delivery, the env-var cap respected.
+- Cross-workload trajectory: parent and delegated child against one shared runtime — one trajectory, `ChildStart` and `SpawnResult` correlated.
+- Crash window: kill the agent workload between `ToolCall` and `ToolResult`, then make sure the runtime reports the dispatch `Indeterminate`.
+- Error-turn window per lane: on lane A, force an unhandled model failure and make sure recovery closes the turn at the next admitted event. On lane B, make sure the error callbacks feed the failure `TurnEnd`s.

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -828,6 +828,19 @@ samp {
   color: inherit;
 }
 
+/* ```text blocks are box-drawing diagrams. The Plex Mono webfont ships
+   a latin subset with no U+2500 box-drawing glyphs, so their rails fall
+   back to a font with different metrics, and the default 1.6 leading
+   opens gaps between the │ glyphs. Diagrams get the system mono stack —
+   whose box glyphs span the full line box — and tighter leading;
+   command snippets keep the site font and the roomier default. */
+.prose pre code.language-text {
+  display: block;
+  font-family: ui-monospace, "Cascadia Mono", Menlo, Consolas,
+    "DejaVu Sans Mono", monospace;
+  line-height: 1.15;
+}
+
 .battery-figure {
   width: 100%;
   max-width: 45rem;

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -11,22 +11,22 @@ name: kAgent
 date: 2026-09-01
 :::
 
-[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. Its public API is `kagent.dev/v1alpha2`: the operator creates `Agent` resources (type `Declarative` or `BYO`), and the controller runs each Declarative agent as a Deployment on a shared runtime image. This proposal gates those agents with OpenAPPA through stock configuration. It does not fork, patch, or vendor kagent or Google ADK.
+[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. The operator creates `Agent` resources, and the kagent controller runs each declarative agent on a shared runtime image that the install configuration selects. This proposal gates those agents with OpenAPPA through that stock configuration. It does not fork, patch, or vendor kagent or Google ADK.
 
-`appa-adapter-kagent` is the adapter. Its image extends the published `kagent-adk` runtime image with two files: a small entrypoint and one Google ADK plugin. The plugin maps ADK callbacks to the eight `appa-runtime` `/hook` events and enforces the returned decisions inside the ADK dispatch loop. `appa-runtime` stays a separate process. It owns policy, the Engine, consults, remedy plans, trajectory state, and `appa.db`. Policy semantics stay in [How it works](/how-it-works) and [Policy contracts](/contracts).
+`appa-adapter-kagent` is the adapter. Its image extends kagent's published agent-runtime image with two files: a small entrypoint and one Google ADK plugin. The plugin maps ADK callbacks to the eight `appa-runtime` `/hook` events and enforces the returned decisions inside the ADK dispatch loop. `appa-runtime` stays a separate process. It owns policy, the Engine, consults, remedy plans, trajectory state, and `appa.db`. Policy semantics stay in [How it works](/how-it-works) and [Policy contracts](/contracts).
 
 Two stock surfaces carry the whole integration:
 
-- Helm value `controller.agentImage.{registry,repository,tag}` selects the runtime image for every Declarative agent ([values.yaml#L179-L183](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/values.yaml#L179-L183) → controller ConfigMap `IMAGE_*` env ([controller-configmap.yaml#L12-L18](https://github.com/kagent-dev/kagent/blob/v0.9.12/helm/kagent/templates/controller-configmap.yaml#L12-L18)) → controller `--image-*` flags). Naming the adapter image there is ordinary install configuration.
-- `KAgentApp(plugins=[...])` is a public constructor parameter of the published `kagent-adk` package ([_a2a.py#L63](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_a2a.py#L63)). kagent registers its own plugins through the same parameter ([cli.py#L69-L79](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L69-L79)).
+- The helm value `controller.agentImage` selects the runtime image for every declarative agent. Naming the adapter image there is ordinary install configuration.
+- `KAgentApp(plugins=[...])` is a public constructor parameter of kagent's published runtime library. kagent registers its own plugins through the same parameter, and the adapter plugin registers beside them.
 
-Source baseline — the last stable release: kagent [`v0.9.12`](https://github.com/kagent-dev/kagent/releases/tag/v0.9.12) (2026-07-20, the API the public docs describe), kagent-adk 0.3.0, google-adk 1.31.1 (the workspace lock). Every enforcement claim below is re-verified against the google-adk 1.31.1 wheel, not carried over from newer versions.
+The [implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) pins the exact source baselines and backs every claim on this page with code evidence.
 
 ## Overview
 
-- The platform operator sets three helm values: `controller.agentImage.{registry,repository,tag}` name the adapter image. Every Declarative `runtime: python` agent — and `python` is the CRD default ([agent_types.go#L175](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L175)) — rolls onto it. No CRD edits, no agent changes.
-- `APPA_RUNTIME_URL` arrives as a baked image default, or per agent via `spec.declarative.deployment.env` ([agent_types.go#L443-L445](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/api/v1alpha2/agent_types.go#L443-L445)).
-- Inside each agent pod, the adapter entrypoint rebuilds the compiled agent from the Secret-mounted `/config` — the same steps as stock `kagent-adk static` — and registers `AppaHookPlugin`.
+- The platform operator points `controller.agentImage` at the adapter image. Every declarative python-runtime agent — the default runtime — rolls onto it. No CRD edits, no agent changes.
+- `APPA_RUNTIME_URL` arrives as a baked image default, or per agent through the agent's deployment env.
+- Inside each agent pod, the adapter entrypoint rebuilds the compiled agent from the mounted config — the same steps as the stock entrypoint — and registers `AppaHookPlugin`.
 - Each gated ADK callback becomes one `/hook` request to the shared `appa-runtime`. The plugin enforces the returned `HookDecision` where the callback fires: it can deny a tool call with feedback the model reads, replace a tool result, or substitute a child's return.
 - Hooks fail closed. When the runtime is unreachable or answers outside the contract, the gated action does not run.
 
@@ -35,140 +35,159 @@ Source baseline — the last stable release: kagent [`v0.9.12`](https://github.c
 ### Gated agents on Kubernetes
 
 ```text
-Kubernetes cluster
-+---------------------------------------------------------------------------+
-| kagent controller (stock, v0.9.12)                                        |
-|   watches kagent.dev/v1alpha2 Agent resources                             |
-|   runtime image for Declarative agents = helm controller.agentImage       |
-|   renders per agent: Deployment + Service + config Secret                 |
-+------------------------------------+--------------------------------------+
-                                     | one Deployment per Agent
-                                     v
-+---------------------- agent pod (one per Agent) --------------------------+
-| image: controller.agentImage = appa-adapter-kagent                        |
-| /config (Secret): config.json (the compiled agent), agent-card.json      |
-| args: --host <bind> --port 8080 --filepath /config                        |
-|                                                                           |
-| adapter entrypoint -> KAgentApp(plugins=[.., AppaHookPlugin]) -> A2A :8080|
-+-----------------------------+---------------------------------------------+
-                              | POST /hook  (fail closed)
-                              v
-+------------------- appa-runtime (one shared service) ---------------------+
-| policy, Engine, consults, remedy plans, trajectory state, appa.db         |
-+---------------------------------------------------------------------------+
+kagent controller — stock, unmodified
+  watches the operator's Agent resources
+  runtime image = helm controller.agentImage  ◀── the knob
+        │
+        │  renders per Agent:
+        │  Deployment + Service + config Secret
+        ▼
+┌─ agent pod · one per Agent ───────────────────────────┐
+│                                                       │
+│  image    controller.agentImage = appa-adapter-kagent │
+│  /config  the compiled agent, mounted as data:        │
+│           config.json + agent-card.json               │
+│                                                       │
+│  entrypoint ─▶ KAgentApp(plugins=[ ..stock..,         │
+│                AppaHookPlugin ]) ─▶ serve A2A         │
+└──────────────────────────┬────────────────────────────┘
+                           │  POST /hook · fail closed
+                           ▼
+┌─ appa-runtime · one shared service ───────────────────┐
+│  policy · Engine · consults · remedy plans ·          │
+│  trajectory state · appa.db                           │
+└───────────────────────────────────────────────────────┘
 ```
 
-The controller writes the compiled agent into a per-agent Secret mounted at `/config` ([manifest_builder.go#L243](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L243)) and passes `--host/--port/--filepath` as container args ([deployments.go#L175-L179](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/deployments.go#L175-L179)). The agent exists in the pod only as that data. No developer code and no per-agent image exists there, so one generic adapter image serves every Declarative agent.
+The agent exists in the pod only as mounted configuration. No developer code and no per-agent image exists there, so one generic adapter image serves every declarative agent.
 
 All gated pods of one deployment report to one shared `appa-runtime`. A parent and each agent it calls run as separate workloads, and their hooks must reach the same runtime to correlate into one trajectory.
 
-### One image wraps kagent-adk
+### One image wraps the stock runtime
 
 ```text
-appa-adapter-kagent image
-+-------------------------------------------------------------+
-| OpenAPPA layer (two files)                                  |
-|   entrypoint.py       replays the `kagent-adk static` steps |
-|                       and accepts the same --host/--port/   |
-|                       --filepath args the controller sends  |
-|   appa_hook_plugin.py ADK BasePlugin -> POST /hook          |
-+-------------------------------------------------------------+
-| base: published kagent-adk (kagent/app) image, unmodified   |
-|   kagent-adk 0.3.0    (cli.py present, not used as PID 1)   |
-|   google-adk 1.31.1   (BasePlugin is its official API)      |
-+-------------------------------------------------------------+
+┌─ appa-adapter-kagent image ───────────────────────────┐
+│                                                       │
+│  OpenAPPA layer — two files                           │
+│    entrypoint.py        replays the stock entrypoint  │
+│                         steps and accepts the same    │
+│                         args the controller sends     │
+│    appa_hook_plugin.py  ADK BasePlugin ─▶ POST /hook  │
+│                                                       │
+├─ base: kagent's published runtime image · unmodified ─┤
+│    kagent runtime lib   its CLI present, not PID 1    │
+│    google-adk           BasePlugin is its official    │
+│                         plugin API                    │
+└───────────────────────────────────────────────────────┘
 
-entrypoint flow — the same public calls as stock `static`, one delta:
-  cfg = AgentConfig.model_validate(/config/config.json)  # refuse unknown fields
-  plugins = [<stock STS / passthrough plugins>]
-  plugins.append(AppaHookPlugin(APPA_RUNTIME_URL))       # <-- the delta
+entrypoint flow — the stock calls, one delta:
+
+  cfg = AgentConfig.model_validate(config.json)
+                             # refuse unknown fields
+  plugins  = [ ..stock plugins.. ]
+  plugins += [ AppaHookPlugin(APPA_RUNTIME_URL) ]  ◀ delta
   KAgentApp(root_agent, card, url, name,
-            plugins=plugins).build()                     # serve A2A on :8080
+            plugins=plugins).build()   ─▶ serve A2A
 ```
 
-Stock `static` performs the identical sequence with a closed plugin list ([cli.py#L54-L101](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/cli.py#L54-L101)). The plugin list handed to ADK becomes its plugin manager, so one registration covers the root agent, every sub-agent, and every tool. The image must keep the stock runtime contract: serve A2A on port 8080 and answer readiness at `/.well-known/agent-card.json` ([manifest_builder.go#L532](https://github.com/kagent-dev/kagent/blob/v0.9.12/go/core/internal/controller/translator/agent/manifest_builder.go#L532)). Google ADK stays an unmodified dependency.
+The stock entrypoint performs the identical sequence with a closed plugin list. The plugin list handed to ADK becomes its plugin manager, so one registration covers the root agent, every sub-agent, and every tool. Google ADK stays an unmodified dependency, and the image keeps the stock runtime contract: the same args, the same serving port, the same readiness endpoint.
 
 ### Callback-to-hook mapping
 
-The runtime's hook vocabulary is the eight `HookEvent` variants in `appa-runtime-api/src/lib.rs`. The plugin maps each gated ADK callback onto exactly one event. google-adk 1.31.1 defines 12 plugin callbacks (`google/adk/plugins/base_plugin.py`, lines 114-348 in the wheel). Callbacks with no event either pass through or hold as liveness gates.
+The runtime's hook vocabulary is the eight `HookEvent` variants of `appa-runtime-api`. The plugin maps each gated ADK callback onto exactly one event. Callbacks with no event either pass through or hold as liveness gates.
 
 ```text
-   ADK CALLBACK (google-adk 1.31.1, unmodified)          APPA RUNTIME /hook — the 8 HookEvents
-   time flows top→bottom within one turn                 and the decisions each one answers
-   ─────────────────────────────────────────             ─────────────────────────────────────
+ADK plugin callback                     ─▶ feeds /hook event
+time flows top→bottom within one turn   ◀  decisions answered
+─────────────────────────────────────────────────────────────
 
-session  first invocation of a fresh ADK session ──────▶ [1] SessionStart      ◀ Ack
-  │        detected in on_user_message_callback;             root TrajectoryId derived
-  ▼        no callback exists at session creation            from the ADK session id
-prompt   on_user_message_callback ─────────────────────▶ [2] Prompt            ◀ Ack | Block
-  │        fires BEFORE the session append
-  │        (runners.py 1537 then 1550), so a Block
-  │        keeps the exact bytes out of history
-  │      before_run_callback ───────x no event  (Prompt already gates the same bytes)
-  │      before_agent_cb (root) ────x no event  (root entry IS Prompt)
-  ▼
-model    before_model_callback ─────x no event ┐ no model-layer HookEvent exists;
-         after_model_callback ──────x no event │ the plugin holds these callbacks as
-         on_model_error_callback ───x no event ┘ liveness gates: /hook down ⇒ refuse
-  │
-  ▼
-tool     before_tool_callback ═════════════════════════▶ [3] ToolCall{spawn:F} ◀ AllowCall | DenyCall
-loop        deny: the returned dict SKIPS execution                              | Refuse
-  │         and becomes the function response the
-  │         model reads (functions.py 509-534)
-  │      after_tool_callback ══════════════════════════▶ [4] ToolResult        ◀ Ack | ReplaceOutput
-  │      on_tool_error_callback ───────────────────────▶ [4] ToolResult{Failure} | Block
-  ▼
-child    before_tool_cb (agent tool) ──────────────────▶ [3] ToolCall{spawn:T} ◀ AllowCall{binding}
-deleg.     │ child scope opens (its own pod):
-           │  child-side plugin classifies the
-           │  delegated entry ─────────────────────────▶ [5] ChildStart        ◀ Ack
-           │      … child runs its own [3]/[4] loop …
-           │  child-side after_run_callback ───────────▶ [6] TurnEnd (child)   ◀ Ack
-           └ after_tool_cb (agent tool return) ────────▶ [7] SpawnResult       ◀ Ack | ChildReturn{value}
-               the ONE point where the value the                                 | ReplaceOutput | Block
-               parent receives can be substituted
-  │
-  ▼
-emit     on_event_callback ─────────x no event  (no emission HookEvent;
-  │                                              held as a liveness gate)
-  ▼
-turn     after_run_callback ───────────────────────────▶ [6] TurnEnd (root)    ◀ Ack —
-end        fires on normal completion and after a          closes tool dispatches
-           before_run halt; google-adk 1.31.1 has NO       the turn abandoned
-           error-turn callback — see fail-closed rule 4
+session   first invocation of a fresh ADK session,
+│         detected in on_user_message_callback
+│         (no callback exists at session creation)
+│           ─▶ [1] SessionStart   ◀ Ack
+│              root TrajectoryId = the ADK session id
+▼
+prompt    on_user_message_callback — fires BEFORE the
+│         session append, so a Block keeps the exact
+│         bytes out of stored history
+│           ═▶ [2] Prompt         ◀ Ack | Block
+│         before_run_callback · before_agent_cb (root)
+│           ─x no event: Prompt gates the same bytes
+▼
+model     before_model · after_model · on_model_error
+│           ─x no event: held as liveness gates —
+│              /hook channel down ⇒ refuse
+▼
+tool      before_tool_callback — a deny dict SKIPS
+loop      execution and becomes the function response
+│         the model reads
+│           ═▶ [3] ToolCall{spawn:false}
+│              ◀ AllowCall | DenyCall | Refuse
+│         after_tool_callback — a returned dict
+│         replaces what the model sees
+│           ═▶ [4] ToolResult
+│              ◀ Ack | ReplaceOutput | Block
+│         on_tool_error_callback
+│           ─▶ [4] ToolResult{Failure}
+▼
+child     before_tool_cb on the agent tool
+deleg.    │ ═▶ [3] ToolCall{spawn:true}
+│         │    ◀ AllowCall{binding}
+│         │ child scope opens, in its own pod:
+│         │   the child plugin classifies the
+│         │   delegated entry
+│         │     ─▶ [5] ChildStart        ◀ Ack
+│         │   … the child runs its own [3]/[4] loop …
+│         │   child-side after_run_callback
+│         │     ─▶ [6] TurnEnd (child)   ◀ Ack
+│         └ after_tool_cb on the agent-tool return —
+│           the ONE point where the value the parent
+│           receives can be substituted
+│             ═▶ [7] SpawnResult
+│                ◀ Ack | ChildReturn | ReplaceOutput
+│                  | Block
+▼
+emit      on_event_callback
+│           ─x no event: held as a liveness gate
+▼
+turn      after_run_callback — fires on normal
+end       completion and after a pre-run halt; the
+          pinned google-adk has no error-turn callback
+          (fail-closed rule 4)
+            ─▶ [6] TurnEnd (root)  ◀ Ack
+               closes tool dispatches the turn abandoned
 
-                                                         [8] ChildEnd — unfed BY DESIGN:
-                                                             return substitution is enforceable
-                                                             only parent-side, so returns cross
-                                                             at [7] SpawnResult. The Claude Code
-                                                             adapter makes the same choice.
+          [8] ChildEnd — unfed BY DESIGN: return
+              substitution is enforceable only on the
+              parent side, so returns cross at
+              [7] SpawnResult. The Claude Code adapter
+              makes the same choice.
 ```
 
-The enforcement mechanics come from ADK's own plugin contract, re-verified in the 1.31.1 wheel:
+The enforcement comes from ADK's own plugin contract, verified in the pinned google-adk sources:
 
-- A dict returned from `before_tool_callback` skips execution and becomes the function response the model reads — `DenyCall` with feedback (`functions.py`, lines 509-534 and 588-592). The deny dict also flows through `after_tool_callback`, so the plugin recognizes its own deny payload and does not report it twice.
-- A non-None return from `after_tool_callback` replaces the result the model sees — `ReplaceOutput` (`functions.py`, lines 547-576).
-- `on_user_message_callback` fires before the runner appends the message to session history (`runners.py`, lines 1537-1556), so a `Block` on `Prompt` is a pre-append barrier.
-- A v1alpha2 agent declares another agent as a tool (`spec.declarative.tools[].type: Agent`), and kagent dispatches it as an ordinary ADK tool, `KAgentRemoteA2ATool` ([_remote_a2a_tool.py#L158-L170](https://github.com/kagent-dev/kagent/blob/v0.9.12/python/packages/kagent-adk/src/kagent/adk/_remote_a2a_tool.py#L158-L170)) — so the tool-call gate is also the spawn gate.
+- A dict returned from `before_tool_callback` skips execution and becomes the function response the model reads — `DenyCall` with feedback. The deny dict also flows through `after_tool_callback`, so the plugin recognizes its own deny payload and does not report it twice.
+- A non-None return from `after_tool_callback` replaces the result the model sees — `ReplaceOutput`.
+- `on_user_message_callback` fires before the runner appends the message to session history, so a `Block` on `Prompt` is a pre-append barrier.
+- An agent declares another agent as a tool, and kagent dispatches it as an ordinary ADK tool — so the tool-call gate is also the spawn gate.
 
 Each called agent runs in its own pod with its own plugin instance. The child side classifies the delegated entry and feeds `ChildStart` and the child `TurnEnd`. The parent side feeds the spawn `ToolCall` and `SpawnResult`. Both report to the one shared runtime.
 
 ### Fail-closed rules
 
-1. An unreachable `/hook` endpoint, or a response outside the contract, blocks the gated action. The plugin raises, ADK wraps the exception, and the invocation aborts (`plugin_manager.py`, lines 288-305 in the wheel).
-2. A `/config/config.json` with a field the entrypoint does not support refuses to start, and the pod stays unready. Stock `AgentConfig` ignores unknown fields — the adapter must not inherit that silence.
+1. An unreachable `/hook` endpoint, or a response outside the contract, blocks the gated action. The plugin raises, and ADK aborts the invocation.
+2. A mounted config with a field the entrypoint does not support refuses to start, and the pod stays unready. The stock config parser ignores unknown fields — the adapter must not inherit that silence.
 3. The model and emission callbacks feed no event, but they still hold the action when the `/hook` channel is down.
-4. google-adk 1.31.1 has no error-turn callback (`on_run_error_callback` and `on_agent_error_callback` do not exist in this version), so a turn that dies on an unhandled error emits no `TurnEnd`. `on_model_error_callback` and `on_tool_error_callback` catch the common failures earlier. For the rest, `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event, and the next `Prompt` fails closed if the runtime is down.
+4. The pinned google-adk defines no error-turn callback, so a turn that dies on an unhandled error emits no `TurnEnd`. The model-error and tool-error callbacks catch the common failures earlier. For the rest, `appa-runtime` recovery classifies the open dispatch as `Indeterminate` at the next admitted event, and the next `Prompt` fails closed if the runtime is down.
 
 ### Scope and limits
 
-- Covered: `kagent.dev/v1alpha2` `Agent` resources with `type: Declarative` and `runtime: python` — the CRD default — on stable kagent v0.9.12.
-- Not covered: `runtime: go` agents (opt-in — v0.9.12 has no helm value for the Go runtime image, and the Go ADK's plugin list is compiled in), BYO agents (per-agent images whose authors add the one plugin line themselves), and the `AgentHarness`/`SandboxAgent` sandbox kinds.
+- Covered: declarative agents on the python runtime — the default — in the current stable kagent release.
+- Not covered: go-runtime agents (opt-in, and the Go ADK's plugin list is compiled in), BYO agents (per-agent images whose authors add the one plugin line themselves), and kagent's sandbox kinds.
 - `SessionStart` is a first-invocation proxy. A session that is created but never invoked emits nothing, and also flows nothing.
-- The entrypoint replays the behavior of `kagent-adk static` instead of calling it, because upstream has no plugin configuration knob. Each `kagent-adk` release therefore costs one small equivalence re-check. A one-field upstream contribution would remove the duplication.
-- Forward path: kagent's main branch is mid-cutover to a `v1alpha3` `AgentTemplate` × `Harness` model on Substrate Actors, unreleased and publicly undocumented. The 0.10 release candidates also flip the runtime default to `go` and add a `controller.goAgentImage` value. The same adapter image moves to `Harness.spec.workload.image` there. The [implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) carries the details.
+- The entrypoint replays the stock entrypoint's behavior instead of calling it, because upstream has no plugin configuration knob. Each upstream release therefore costs one small equivalence re-check. A one-field upstream contribution would remove the duplication.
+- Forward path: kagent's release-candidate line replaces the Agent controller with a `Harness` × `AgentTemplate` model, where the same adapter image lands in the Harness's required workload-image field. The implementation plan covers both lanes in full.
 
 ## Implementation plan
 
-The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) defines the artifacts, the entrypoint and plugin specification, the runtime-side codec, deployment and rollout, trajectory identity, the forward (v1alpha3) lane, and the verification matrix.
+The [kagent implementation plan](../../../integrations/kagent/IMPLEMENTATION.md) pins the source baselines, defines the artifacts, the entrypoint and plugin specification, the runtime-side codec, both delivery lanes with their rollout procedures, trajectory identity, and the verification matrix — with code evidence for every claim.


### PR DESCRIPTION
Polishes the kagent proposal's diagrams and finalizes the document split, verified with headless Chromium against the live docs dev server.

**Diagrams** (`website/content/docs/kagent.md`): one box-drawing style across all three, within the 66-column budget the docs page renders without horizontal scroll (was 3/3 overflowing on desktop, now 0/3, all ≤61 cols). A scoped CSS rule (`website/app/globals.css`) fixes the broken rails: the Plex Mono latin subset has no box-drawing glyphs, so `code.language-text` blocks now use the system mono stack with tighter leading — command snippets keep the site font.

**Proposal page**: drops all code references and version numbers — those are implementation details, now only in the plan, which the page links.

**Implementation plan** (`integrations/kagent/IMPLEMENTATION.md`): expanded to cover both delivery lanes — the stable release (v1alpha2 `Agent` → Deployment via `controller.agentImage`) and the release-candidate line (dual image knobs, then the v1alpha3 `AgentTemplate` × `Harness` model) — and both runtime adapters: python google-adk (mapping verified per pinned version) and the Go ADK twin (`appa-adapter-kagent-go`, design marked pending verification), all under the `appa-adapter-claude-code` naming conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)