### PR TITLE
fix(runtime): consult budgets and policy reconciliation on init

### DIFF
--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -436,7 +436,7 @@ impl Runtime {
     /// against the key of the configuration it just validated: a process that kept
     /// running across the install serves the policy it loaded at startup, and only a
     /// difference here is worth reloading.
-    pub fn serving_policy_key(&self) -> String {
+    pub(crate) fn serving_policy_key(&self) -> String {
         let serving = self
             .inner
             .deployment
@@ -1391,6 +1391,28 @@ delta = { audience = { resolver = "directory", argument = "customer" } }
             retired_len(&runtime),
             0,
             "the cache does not carry compiled engines across a reload"
+        );
+    }
+
+    #[test]
+    fn the_serving_policy_key_names_the_deployment_answering_now() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime =
+            Runtime::open(versioned_policy("first"), dir.path().join("appa.db"), None).expect("the deployment opens");
+        let before = runtime.serving_policy_key();
+
+        let reloaded = runtime
+            .reload(versioned_policy("second"))
+            .expect("the second deployment loads");
+        assert_eq!(
+            runtime.serving_policy_key(),
+            reloaded.policy_key,
+            "the key answers for the deployment the reload installed"
+        );
+        assert_ne!(
+            runtime.serving_policy_key(),
+            before,
+            "a different policy answers under a different key, which is what makes the key a divergence signal"
         );
     }
 

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -432,6 +432,19 @@ impl Runtime {
         })
     }
 
+    /// The policy file key the serving deployment answers under. An install compares it
+    /// against the key of the configuration it just validated: a process that kept
+    /// running across the install serves the policy it loaded at startup, and only a
+    /// difference here is worth reloading.
+    pub fn serving_policy_key(&self) -> String {
+        let serving = self
+            .inner
+            .deployment
+            .read()
+            .expect("the deployment lock is never poisoned: no panic runs while it is held");
+        crate::engine::policy_file_key(serving.config.policy_file().bytes())
+    }
+
     /// Replace the serving deployment with the one this configuration
     /// declares, without stopping the process (
     /// reloading a policy). The caller reads the file; the runtime never

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -190,24 +190,30 @@ impl Externals {
 
 /// How this deployment runs the stock `claude-code` builtin. `command` overrides the
 /// executable (a service environment often strips `PATH`); `model` pins the model the
-/// consult runs on; `timeout` bounds one consult on its own budget instead of the shared
-/// machine-consult `timeout`.
+/// consult runs on; `timeout` bounds one consult.
+///
+/// A model consult runs for tens of seconds, so it owns its budget. `externals.timeout_ms`
+/// bounds an HTTP round trip and never applies here: a deployment that names no
+/// `timeout_ms` gets [`DEFAULT_CLAUDE_CODE_TIMEOUT`], not the shared one.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClaudeCode {
     pub command: PathBuf,
     pub model: String,
-    pub timeout: Option<Duration>,
+    pub timeout: Duration,
 }
+
+/// The budget one `claude-code` consult gets when the deployment names none.
+pub const DEFAULT_CLAUDE_CODE_TIMEOUT: Duration = Duration::from_secs(60);
 
 impl Default for ClaudeCode {
     /// The usable defaults every construction path shares — an embedded host building
-    /// its bindings by hand gets the same `claude` on `PATH` and `sonnet` alias the file
-    /// loader fills in, never an empty command.
+    /// its bindings by hand gets the same `claude` on `PATH`, `sonnet` alias, and consult
+    /// budget the file loader fills in, never an empty command.
     fn default() -> ClaudeCode {
         ClaudeCode {
             command: "claude".into(),
             model: "sonnet".to_string(),
-            timeout: None,
+            timeout: DEFAULT_CLAUDE_CODE_TIMEOUT,
         }
     }
 }
@@ -806,12 +812,13 @@ fn embedded_document(policy: toml::Value, bindings: &ExternalBindings) -> Result
             "model".to_string(),
             toml::Value::String(bindings.claude_code.model.clone()),
         );
-        if let Some(timeout) = bindings.claude_code.timeout {
-            claude_code.insert(
-                "timeout_ms".to_string(),
-                embedded_integer("externals.claude_code.timeout_ms", timeout.as_millis())?,
-            );
-        }
+        claude_code.insert(
+            "timeout_ms".to_string(),
+            embedded_integer(
+                "externals.claude_code.timeout_ms",
+                bindings.claude_code.timeout.as_millis(),
+            )?,
+        );
         external_table.insert("claude_code".to_string(), toml::Value::Table(claude_code));
     }
 
@@ -1212,8 +1219,8 @@ fn resolve_command(
 }
 
 /// The `[externals.claude_code]` table with its defaults filled: bare `claude` on `PATH`,
-/// the `sonnet` alias, and the shared machine-consult timeout. A zero `timeout_ms` is a
-/// refusal like the shared one.
+/// the `sonnet` alias, and the model-consult budget. A zero `timeout_ms` is a refusal like
+/// the shared one.
 fn resolve_claude_code(raw: Option<RawClaudeCode>) -> Result<ClaudeCode, ConfigError> {
     let raw = raw.unwrap_or(RawClaudeCode {
         command: None,
@@ -1226,7 +1233,9 @@ fn resolve_claude_code(raw: Option<RawClaudeCode>) -> Result<ClaudeCode, ConfigE
     Ok(ClaudeCode {
         command: raw.command.map(PathBuf::from).unwrap_or_else(|| "claude".into()),
         model: raw.model.unwrap_or_else(|| "sonnet".to_string()),
-        timeout: raw.timeout_ms.map(Duration::from_millis),
+        timeout: raw
+            .timeout_ms
+            .map_or(DEFAULT_CLAUDE_CODE_TIMEOUT, Duration::from_millis),
     })
 }
 
@@ -1547,10 +1556,10 @@ mod tests {
         let config = parse(MINIMAL).expect("no claude table is the default");
         assert_eq!(config.externals.claude_code.command, PathBuf::from("claude"));
         assert_eq!(config.externals.claude_code.model, "sonnet");
-        assert_eq!(config.externals.claude_code.timeout, None);
+        assert_eq!(config.externals.claude_code.timeout, DEFAULT_CLAUDE_CODE_TIMEOUT);
 
         let text = format!(
-            "{MINIMAL}\n[externals.claude_code]\ncommand = \"/opt/claude/bin/claude\"\nmodel = \"pinned\"\ntimeout_ms = 60000\n"
+            "{MINIMAL}\n[externals.claude_code]\ncommand = \"/opt/claude/bin/claude\"\nmodel = \"pinned\"\ntimeout_ms = 90000\n"
         );
         let config = parse(&text).expect("the claude table validates");
         assert_eq!(
@@ -1558,7 +1567,12 @@ mod tests {
             PathBuf::from("/opt/claude/bin/claude")
         );
         assert_eq!(config.externals.claude_code.model, "pinned");
-        assert_eq!(config.externals.claude_code.timeout, Some(Duration::from_secs(60)));
+        let pinned = Duration::from_secs(90);
+        assert_ne!(
+            pinned, DEFAULT_CLAUDE_CODE_TIMEOUT,
+            "the pin must differ from the default"
+        );
+        assert_eq!(config.externals.claude_code.timeout, pinned);
 
         let text = format!("{MINIMAL}\n[externals.claude_code]\ntimeout_ms = 0\n");
         assert!(matches!(parse(&text), Err(ConfigError::ZeroTimeout)));

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -194,7 +194,7 @@ impl Externals {
 ///
 /// A model consult runs for tens of seconds, so it owns its budget. `externals.timeout_ms`
 /// bounds an HTTP round trip and never applies here: a deployment that names no
-/// `timeout_ms` gets [`DEFAULT_CLAUDE_CODE_TIMEOUT`], not the shared one.
+/// `timeout_ms` gets a default sized for a model call, not the shared one.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClaudeCode {
     pub command: PathBuf,
@@ -203,7 +203,7 @@ pub struct ClaudeCode {
 }
 
 /// The budget one `claude-code` consult gets when the deployment names none.
-pub const DEFAULT_CLAUDE_CODE_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_CLAUDE_CODE_TIMEOUT: Duration = Duration::from_secs(60);
 
 impl Default for ClaudeCode {
     /// The usable defaults every construction path shares — an embedded host building

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -812,13 +812,18 @@ fn embedded_document(policy: toml::Value, bindings: &ExternalBindings) -> Result
             "model".to_string(),
             toml::Value::String(bindings.claude_code.model.clone()),
         );
-        claude_code.insert(
-            "timeout_ms".to_string(),
-            embedded_integer(
-                "externals.claude_code.timeout_ms",
-                bindings.claude_code.timeout.as_millis(),
-            )?,
-        );
+        // Only a budget that differs from the default is written, so a host that leaves it
+        // alone composes the same bytes — and so the same policy key — as an authored table
+        // that names `command` and `model` and omits `timeout_ms`.
+        if bindings.claude_code.timeout != DEFAULT_CLAUDE_CODE_TIMEOUT {
+            claude_code.insert(
+                "timeout_ms".to_string(),
+                embedded_integer(
+                    "externals.claude_code.timeout_ms",
+                    bindings.claude_code.timeout.as_millis(),
+                )?,
+            );
+        }
         external_table.insert("claude_code".to_string(), toml::Value::Table(claude_code));
     }
 
@@ -1919,6 +1924,44 @@ mod tests {
 
     fn embedded(bindings: ExternalBindings) -> Result<Config, ConfigError> {
         Config::embedded("version = 2".to_string(), bindings)
+    }
+
+    #[test]
+    fn an_embedded_default_budget_stores_what_an_authored_table_omitting_it_stores() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let mut bindings = ExternalBindings::new(Duration::from_millis(5000), 65_536);
+        bindings.claude_code = ClaudeCode {
+            command: PathBuf::from("/opt/claude/bin/claude"),
+            model: "pinned".to_string(),
+            timeout: DEFAULT_CLAUDE_CODE_TIMEOUT,
+        };
+        let host = Config::embedded(
+            "version = 2\nanything = \"the runtime does not interpret this\"\n".to_string(),
+            bindings,
+        )
+        .expect("the embedded claude bindings load");
+
+        // Both sides come back through the file loader, so only their content can differ,
+        // never their serialization.
+        let from_host = dir.path().join("host.toml");
+        std::fs::write(&from_host, host.policy_file().bytes()).expect("write the stored embedded config");
+        let from_host = Config::load(&from_host).expect("the stored embedded config reloads");
+
+        let authored_path = dir.path().join("authored.toml");
+        std::fs::write(
+            &authored_path,
+            "[policy]\nversion = 2\nanything = \"the runtime does not interpret this\"\n\n\
+             [externals]\ntimeout_ms = 5000\nmax_body_bytes = 65536\n\n\
+             [externals.claude_code]\ncommand = \"/opt/claude/bin/claude\"\nmodel = \"pinned\"\n",
+        )
+        .expect("write the authored config");
+        let authored = Config::load(&authored_path).expect("the authored claude table loads");
+
+        // A budget neither side states must not be stated by one of them: an install
+        // compares these policy keys, so equal deployments must compose equal bytes.
+        assert_eq!(from_host.policy_file().bytes(), authored.policy_file().bytes());
+        assert_eq!(from_host.externals.claude_code, authored.externals.claude_code);
+        assert_eq!(authored.externals.claude_code.timeout, DEFAULT_CLAUDE_CODE_TIMEOUT);
     }
 
     #[cfg(unix)]

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -210,7 +210,7 @@ impl ExternalServices {
             command: config.claude_code.command.clone(),
             #[cfg(unix)]
             model: config.claude_code.model.clone(),
-            timeout: config.claude_code.timeout.unwrap_or(config.timeout),
+            timeout: config.claude_code.timeout,
             #[cfg(unix)]
             max_body_bytes: config.max_body_bytes,
         };

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -118,6 +118,26 @@ impl RuntimeOutcome {
     }
 }
 
+/// The policy key of the config file this init validated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ComposedPolicy {
+    /// The key, comparable against the one a runtime serves.
+    Key(String),
+    /// A `token_env` resolves only where the runtime runs, so this process cannot compose
+    /// the file at all. Not knowing is never the same as agreeing: the runtime may be
+    /// serving anything, and only the person running init can settle it.
+    Unknowable,
+}
+
+/// Why a running runtime may not be answering under the file this init validated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Divergence {
+    /// It serves a different policy than this file composes to.
+    Serving,
+    /// Whether it serves this file cannot be established here.
+    Unestablished,
+}
+
 struct DeploymentPaths {
     install_dir: PathBuf,
     config_dir: PathBuf,
@@ -275,7 +295,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     // 8. The plugin and the launcher now point at this configuration; a runtime the
     //    starter left running may not. Asked last, because a decline still leaves a
     //    complete install — only the policy in memory lags.
-    let runtime_outcome = reconcile_policy(&endpoint, &config, composed_policy)?;
+    let runtime_outcome = reconcile_policy(&endpoint, &config, &composed_policy)?;
 
     // 9. Anything left on PATH that this init did not deploy is named, never
     //    removed: it is the user's file to keep or drop.
@@ -1001,17 +1021,16 @@ fn confirm_rewrite(
 /// which init can report only as an endpoint that never became healthy. Running
 /// both refusals here names the file and the fault, before anything outside
 /// this file has changed.
-/// Answers with the policy key this file composes to, or `None` when the file resolves
-/// only where the runtime runs — the caller then has nothing to compare a serving runtime
-/// against.
-fn verify_config(path: &Path) -> Result<Option<String>, InitError> {
+/// Answers with the policy key this file composes to, or [`ComposedPolicy::Unknowable`]
+/// when the file resolves only where the runtime runs.
+fn verify_config(path: &Path) -> Result<ComposedPolicy, InitError> {
     let config = match Config::load(path) {
         Ok(config) => config,
         // A `token_env` resolves where the runtime runs, not here. A hook starts
         // it with the session's environment, which carries variables this
         // terminal does not, so a secret this process cannot see is not init's
         // to refuse: the start that follows is what proves the token reachable.
-        Err(ConfigError::MissingSecret { .. }) => return Ok(None),
+        Err(ConfigError::MissingSecret { .. }) => return Ok(ComposedPolicy::Unknowable),
         Err(source) => {
             return Err(InitError::UnloadableConfig {
                 path: path.to_path_buf(),
@@ -1025,7 +1044,9 @@ fn verify_config(path: &Path) -> Result<Option<String>, InitError> {
             reason,
         }
     })?;
-    Ok(Some(crate::engine::policy_file_key(config.policy_file().bytes())))
+    Ok(ComposedPolicy::Key(crate::engine::policy_file_key(
+        config.policy_file().bytes(),
+    )))
 }
 
 fn run_claude<const N: usize>(arguments: [&str; N]) -> Result<Output, InitError> {
@@ -1815,24 +1836,32 @@ fn clear_confirmed_foreign_with(
 /// this file itself. A runtime it left running does not: it still serves what it loaded at
 /// startup, and a config written since is on disk only. Comparing the two keys keeps the
 /// question to the case that has one — an install that changed nothing asks nothing.
-fn reconcile_policy(endpoint: &Endpoint, config: &Path, composed: Option<String>) -> Result<RuntimeOutcome, InitError> {
-    if !policy_diverged(composed.as_deref(), serving_policy_key(endpoint).as_deref()) {
+fn reconcile_policy(endpoint: &Endpoint, config: &Path, composed: &ComposedPolicy) -> Result<RuntimeOutcome, InitError> {
+    let Some(divergence) = policy_divergence(composed, serving_policy_key(endpoint).as_deref()) else {
         return Ok(RuntimeOutcome::Healthy);
-    }
-    if !confirm_reload(config)? {
+    };
+    if !confirm_reload(config, divergence)? {
         return Ok(RuntimeOutcome::OlderPolicy);
     }
     reload_policy(endpoint, config)?;
     Ok(RuntimeOutcome::Reloaded)
 }
 
-/// Whether a serving runtime lags the file this init validated.
+/// Why a serving runtime may not be answering under the file this init validated, or
+/// `None` when it demonstrably is.
 ///
-/// Absent either key there is nothing to compare: a config that resolves only where the
-/// runtime runs gives init no key of its own, and a runtime that does not answer for its
-/// policy gives none either. Init never guesses at a divergence, so both cases are quiet.
-fn policy_diverged(composed: Option<&str>, serving: Option<&str>) -> bool {
-    matches!((composed, serving), (Some(composed), Some(serving)) if composed != serving)
+/// A runtime that does not answer for its policy leaves nothing to reconcile at all: init
+/// cannot reach it to compare or to reload, so it stays quiet. A config init cannot compose
+/// is the opposite case — the runtime can be asked, and only a person can decide, so the
+/// question is put rather than answered by assumption. The reload itself resolves the
+/// secret where the runtime runs, which is the environment that has it.
+fn policy_divergence(composed: &ComposedPolicy, serving: Option<&str>) -> Option<Divergence> {
+    let serving = serving?;
+    match composed {
+        ComposedPolicy::Key(key) if key == serving => None,
+        ComposedPolicy::Key(_) => Some(Divergence::Serving),
+        ComposedPolicy::Unknowable => Some(Divergence::Unestablished),
+    }
 }
 
 /// The policy key the endpoint answers under, or `None` when it does not answer for one.
@@ -1872,25 +1901,40 @@ fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
 
 /// A terminal is asked; anything else reloads. A script that just wrote a config wants it
 /// serving, and there is no one there to answer.
-fn confirm_reload(config: &Path) -> Result<bool, InitError> {
+fn confirm_reload(config: &Path, divergence: Divergence) -> Result<bool, InitError> {
     let stdin = std::io::stdin();
     if !stdin.is_terminal() {
         return Ok(true);
     }
     let stderr = std::io::stderr();
-    confirm_reload_with(config, &mut stdin.lock(), &mut stderr.lock())
+    confirm_reload_with(config, divergence, &mut stdin.lock(), &mut stderr.lock())
 }
 
-fn confirm_reload_with(config: &Path, input: &mut impl BufRead, output: &mut impl Write) -> Result<bool, InitError> {
+fn confirm_reload_with(
+    config: &Path,
+    divergence: Divergence,
+    input: &mut impl BufRead,
+    output: &mut impl Write,
+) -> Result<bool, InitError> {
     let prompt = |source| InitError::WriteFile {
         path: config.to_path_buf(),
         source,
     };
+    let config = friendly_path(config);
+    // Each case states exactly what init established, and no more: one knows the running
+    // runtime serves something else, the other knows only that it cannot tell.
+    let question = match divergence {
+        Divergence::Serving => format!(
+            "appa: the running runtime still serves the policy it started with, not {config}."
+        ),
+        Divergence::Unestablished => format!(
+            "appa: {config} resolves a secret only where the runtime runs, so this cannot tell\n\
+             whether the running runtime already serves it."
+        ),
+    };
     write!(
         output,
-        "appa: the running runtime still serves the policy it started with, not {}.\n\
-         Reload it now? Sessions open right now keep the deployment they started with. [Y/n] ",
-        friendly_path(config),
+        "{question}\nReload it now? Sessions open right now keep the deployment they started with. [Y/n] ",
     )
     .and_then(|()| output.flush())
     .map_err(prompt)?;
@@ -2087,32 +2131,44 @@ mod tests {
     }
 
     #[test]
-    fn only_two_answerable_and_differing_policy_keys_are_a_divergence() {
-        assert!(policy_diverged(Some("composed"), Some("serving")));
+    fn a_serving_runtime_is_reconciled_only_when_agreement_is_not_established() {
+        let key = |key: &str| ComposedPolicy::Key(key.to_string());
+        assert_eq!(
+            policy_divergence(&key("composed"), Some("serving")),
+            Some(Divergence::Serving)
+        );
         // An install that changed nothing must ask nothing.
-        assert!(!policy_diverged(Some("same"), Some("same")));
-        // Neither side answering for a policy is silence, never an assumed divergence:
-        // a config resolving only where the runtime runs, and a runtime that does not
-        // report its policy at all.
-        assert!(!policy_diverged(None, Some("serving")));
-        assert!(!policy_diverged(Some("composed"), None));
-        assert!(!policy_diverged(None, None));
+        assert_eq!(policy_divergence(&key("same"), Some("same")), None);
+        // A config this process cannot compose is unsettled, never settled: assuming
+        // agreement here is what would leave an older policy serving unremarked.
+        assert_eq!(
+            policy_divergence(&ComposedPolicy::Unknowable, Some("serving")),
+            Some(Divergence::Unestablished)
+        );
+        // A runtime that answers for no policy cannot be compared or reloaded, so there
+        // is nothing to put to the user either way.
+        assert_eq!(policy_divergence(&key("composed"), None), None);
+        assert_eq!(policy_divergence(&ComposedPolicy::Unknowable, None), None);
     }
 
     #[test]
     fn reloading_a_lagging_runtime_requires_a_y_or_default_yes_answer() {
         let config = PathBuf::from("/home/user/config/appa.toml");
-        for answer in ["y\n", "YES\n", "\n"] {
-            assert!(
-                confirm_reload_with(&config, &mut answer.as_bytes(), &mut Vec::new()).expect("the answer reads"),
-                "{answer:?} approves"
-            );
-        }
-        for answer in ["n\n", "no\n", "anything else\n", ""] {
-            assert!(
-                !confirm_reload_with(&config, &mut answer.as_bytes(), &mut Vec::new()).expect("the answer reads"),
-                "{answer:?} refuses"
-            );
+        for divergence in [Divergence::Serving, Divergence::Unestablished] {
+            for answer in ["y\n", "YES\n", "\n"] {
+                assert!(
+                    confirm_reload_with(&config, divergence, &mut answer.as_bytes(), &mut Vec::new())
+                        .expect("the answer reads"),
+                    "{answer:?} approves under {divergence:?}"
+                );
+            }
+            for answer in ["n\n", "no\n", "anything else\n", ""] {
+                assert!(
+                    !confirm_reload_with(&config, divergence, &mut answer.as_bytes(), &mut Vec::new())
+                        .expect("the answer reads"),
+                    "{answer:?} refuses under {divergence:?}"
+                );
+            }
         }
     }
 
@@ -2141,7 +2197,8 @@ mod tests {
         let endpoint = health_answers(vec!["agreed".to_string()]);
         let config = PathBuf::from("/home/user/config/appa.toml");
         assert_eq!(
-            reconcile_policy(&endpoint, &config, Some("agreed".to_string())).expect("the reconcile completes"),
+            reconcile_policy(&endpoint, &config, &ComposedPolicy::Key("agreed".to_string()))
+                .expect("the reconcile completes"),
             RuntimeOutcome::Healthy
         );
     }

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -107,8 +107,13 @@ impl ConfigOutcome {
 enum RuntimeOutcome {
     /// Serving the configuration this init validated, with nothing to reconcile.
     Healthy,
-    /// Serving an older policy until it was reloaded, at the user's word.
+    /// Serving an older policy until it was reloaded, at the user's word, and the key it
+    /// installed proves the file it read was this one.
     Reloaded,
+    /// Reloaded, but this init cannot compose the file's key and so cannot say the
+    /// responder read it. Never reported as a plain reload: an unchecked claim about which
+    /// policy is serving is the fault this reconcile exists to remove.
+    ReloadedUnconfirmed,
     /// Still serving an older policy, because the user declined the reload.
     OlderPolicy,
 }
@@ -118,6 +123,7 @@ impl RuntimeOutcome {
         match self {
             RuntimeOutcome::Healthy => "healthy",
             RuntimeOutcome::Reloaded => "healthy (policy reloaded)",
+            RuntimeOutcome::ReloadedUnconfirmed => "healthy (reloaded; serving policy unconfirmed)",
             RuntimeOutcome::OlderPolicy => "healthy (serving an older policy)",
         }
     }
@@ -280,16 +286,26 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
             install_statusline(&plugin_root, &paths)?;
             progress("starting the runtime");
             start_runtime(&plugin_root, &deployed_appa, &endpoint)
-        });
-    if let Err(operation) = switch {
-        if let Err(recovery_error) = undo_plugin_switch(recovery.as_ref(), launcher_dir) {
-            return Err(InitError::PluginRecovery {
-                operation: Box::new(operation),
-                recovery: Box::new(recovery_error),
-            });
+        })
+        //    The runtime this plugin is bound to must also be serving this
+        //    deployment's policy, so the reconcile is inside the transaction:
+        //    a refusal here means the endpoint belongs to someone else, and a
+        //    plugin left registered against it is the same skew as a plugin left
+        //    registered against a runtime that failed verification. A decline is
+        //    not a refusal — it answers `Ok` and the install stands.
+        .and_then(|()| reconcile_policy(&endpoint, &config, &composed_policy));
+    let runtime_outcome = match switch {
+        Ok(outcome) => outcome,
+        Err(operation) => {
+            if let Err(recovery_error) = undo_plugin_switch(recovery.as_ref(), launcher_dir) {
+                return Err(InitError::PluginRecovery {
+                    operation: Box::new(operation),
+                    recovery: Box::new(recovery_error),
+                });
+            }
+            return Err(operation);
         }
-        return Err(operation);
-    }
+    };
 
     // 7. Only now is the launcher armed. Every earlier return leaves `clappa`
     //    absent on a first install and disabled on an upgrade, so a session
@@ -297,12 +313,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     install_clappa(launcher_dir)?;
     cleanup_plugin_recoveries(&paths.data_dir);
 
-    // 8. The plugin and the launcher now point at this configuration; a runtime the
-    //    starter left running may not. Asked last, because a decline still leaves a
-    //    complete install — only the policy in memory lags.
-    let runtime_outcome = reconcile_policy(&endpoint, &config, &composed_policy)?;
-
-    // 9. Anything left on PATH that this init did not deploy is named, never
+    // 8. Anything left on PATH that this init did not deploy is named, never
     //    removed: it is the user's file to keep or drop.
     let stale_path_copy = stale_path_copy(&paths, &deployed_appa);
 
@@ -1858,15 +1869,16 @@ fn reconcile_policy(
     // a reload this init did not cause would be exactly the untrue receipt the reconcile
     // exists to remove.
     let installed = reload_policy(endpoint, config)?;
-    if let ComposedPolicy::Key(key) = composed
-        && *key != installed
-    {
-        return Err(InitError::ForeignDeployment {
+    match composed {
+        ComposedPolicy::Key(key) if *key == installed => Ok(RuntimeOutcome::Reloaded),
+        ComposedPolicy::Key(_) => Err(InitError::ForeignDeployment {
             endpoint: endpoint.url().to_owned(),
             path: config.to_path_buf(),
-        });
+        }),
+        // Without a key of its own this init has nothing to check the answer against, so
+        // it reports the reload it caused and claims nothing about whose file was read.
+        ComposedPolicy::Unknowable => Ok(RuntimeOutcome::ReloadedUnconfirmed),
     }
-    Ok(RuntimeOutcome::Reloaded)
 }
 
 /// Why a serving runtime may not be answering under the file this init validated, or
@@ -2252,6 +2264,20 @@ mod tests {
                 "GET /policy-key HTTP/1.1".to_string(),
                 "POST /reload HTTP/1.1".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn a_reload_this_init_cannot_check_is_never_reported_as_a_plain_reload() {
+        let (endpoint, _asked) = recorded_answers(vec![
+            "whatever-is-serving".to_string(),
+            r#"{"policy_key":"whatever-was-installed","policy_identity":"x","changed":true}"#.to_string(),
+        ]);
+        let config = PathBuf::from("/home/user/config/appa.toml");
+        assert_eq!(
+            reconcile_policy(&endpoint, &config, &ComposedPolicy::Unknowable).expect("the reconcile completes"),
+            RuntimeOutcome::ReloadedUnconfirmed,
+            "a config this init cannot compose leaves the answer uncheckable, and the receipt says so"
         );
     }
 

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1863,11 +1863,6 @@ fn reconcile_policy(
     if !confirm_reload(config, divergence)? {
         return Ok(RuntimeOutcome::OlderPolicy);
     }
-    // A reload reads the answering process's own configuration path, not the one named
-    // here, and a same-build runtime of another deployment answers this endpoint
-    // indistinguishably. The key it installed is what proves which file it read: reporting
-    // a reload this init did not cause would be exactly the untrue receipt the reconcile
-    // exists to remove.
     reload_policy(endpoint, config)?;
     Ok(RuntimeOutcome::Reloaded)
 }

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1724,11 +1724,13 @@ fn endpoint_owner(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<E
 /// Anything else — a different build, a different config, or an answer that names no
 /// config at all — is another deployment, to be stopped before this install proceeds.
 fn classify_endpoint_owner(expected: &str, config: &Path, answer: &str) -> EndpointOwner {
-    let mut lines = answer.lines();
-    let mut fields = lines.next().unwrap_or_default().split_whitespace();
+    let (identity, rest) = answer.split_once('\n').unwrap_or((answer, ""));
+    let mut fields = identity.split_whitespace();
     let actual = fields.next().unwrap_or_default();
     let pid = fields.next().and_then(positive_pid);
-    let serves = lines.next().unwrap_or_default().trim();
+    // Everything after the first newline is the path, less the one the transport appends:
+    // a config path may itself hold a newline, and splitting again would truncate it.
+    let serves = rest.strip_suffix('\n').unwrap_or(rest);
     if actual == expected && !serves.is_empty() && Path::new(serves) == config {
         EndpointOwner::Deployment
     } else {
@@ -2133,6 +2135,18 @@ mod tests {
         let spaced = Path::new("/home/user/Application Support/appa.toml");
         assert_eq!(
             classify_endpoint_owner("same", spaced, "same 42\n/home/user/Application Support/appa.toml"),
+            EndpointOwner::Deployment
+        );
+        // On Unix a directory name may hold a newline, so the path is read as the whole
+        // remainder of the answer the runtime composes — and a transport that appends a
+        // newline of its own does not turn one deployment into a stranger.
+        let newlined = Path::new("/home/user/two\nlines/appa.toml");
+        assert_eq!(
+            classify_endpoint_owner("same", newlined, "same 42\n/home/user/two\nlines/appa.toml"),
+            EndpointOwner::Deployment
+        );
+        assert_eq!(
+            classify_endpoint_owner("same", mine, "same 42\n/home/user/config/appa.toml\n"),
             EndpointOwner::Deployment
         );
         assert_eq!(

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -62,6 +62,11 @@ pub enum InitError {
         path: PathBuf,
         message: String,
     },
+    #[error(
+        "the runtime at {endpoint} serves another deployment's configuration, not {path}; \
+         stop that process, or give this deployment an endpoint of its own, and rerun init"
+    )]
+    ForeignDeployment { endpoint: String, path: PathBuf },
     #[error(transparent)]
     PluginBundle(#[from] PluginBundleError),
     #[error("{operation}; restoring the previous Claude Code plugin also failed: {recovery}")]
@@ -1847,7 +1852,20 @@ fn reconcile_policy(
     if !confirm_reload(config, divergence)? {
         return Ok(RuntimeOutcome::OlderPolicy);
     }
-    reload_policy(endpoint, config)?;
+    // A reload reads the answering process's own configuration path, not the one named
+    // here, and a same-build runtime of another deployment answers this endpoint
+    // indistinguishably. The key it installed is what proves which file it read: reporting
+    // a reload this init did not cause would be exactly the untrue receipt the reconcile
+    // exists to remove.
+    let installed = reload_policy(endpoint, config)?;
+    if let ComposedPolicy::Key(key) = composed
+        && *key != installed
+    {
+        return Err(InitError::ForeignDeployment {
+            endpoint: endpoint.url().to_owned(),
+            path: config.to_path_buf(),
+        });
+    }
     Ok(RuntimeOutcome::Reloaded)
 }
 
@@ -1882,11 +1900,12 @@ fn serving_policy_key(endpoint: &Endpoint) -> Option<String> {
     (!key.is_empty()).then_some(key)
 }
 
-/// Ask the running runtime to serve the configuration on disk.
+/// Ask the running runtime to serve the configuration on disk, and answer with the policy
+/// key it installed.
 ///
 /// The runtime validates the file again before it swaps: a refusal here is a fault worth
 /// naming, not a receipt footnote, because the deployment keeps serving the older policy.
-fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
+fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<String, InitError> {
     let refused = |message: String| InitError::ReloadRefused {
         endpoint: endpoint.url().to_owned(),
         path: config.to_path_buf(),
@@ -1897,10 +1916,14 @@ fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
         .arg(endpoint.join("/reload"))
         .output()
         .map_err(|error| refused(error.to_string()))?;
-    if output.status.success() {
-        return Ok(());
+    if !output.status.success() {
+        return Err(refused(String::from_utf8_lossy(&output.stderr).trim().to_owned()));
     }
-    Err(refused(String::from_utf8_lossy(&output.stderr).trim().to_owned()))
+    let answer = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str::<Value>(&answer)
+        .ok()
+        .and_then(|body| Some(body.get("policy_key")?.as_str()?.to_owned()))
+        .ok_or_else(|| refused(format!("the reload named no policy key: {}", answer.trim())))
 }
 
 /// A terminal is asked; anything else reloads. A script that just wrote a config wants it
@@ -2204,6 +2227,45 @@ mod tests {
             reconcile_policy(&endpoint, &config, &ComposedPolicy::Key("agreed".to_string()))
                 .expect("the reconcile completes"),
             RuntimeOutcome::Healthy
+        );
+    }
+
+    #[test]
+    fn a_reload_that_installed_another_deployments_policy_is_never_reported_as_this_one() {
+        // Two answers, in the order a reconcile asks for them: the endpoint serves a
+        // different key, and the reload it is then given installs a third — what a
+        // same-build runtime of another deployment does, because `/reload` reads its own
+        // configuration path and not the one init names.
+        let (endpoint, asked) = recorded_answers(vec![
+            "another-deployment".to_string(),
+            r#"{"policy_key":"another-deployment-reloaded","policy_identity":"x","changed":true}"#.to_string(),
+        ]);
+        let config = PathBuf::from("/home/user/config/appa.toml");
+        let outcome = reconcile_policy(&endpoint, &config, &ComposedPolicy::Key("this-deployment".to_string()));
+        assert!(
+            matches!(outcome, Err(InitError::ForeignDeployment { .. })),
+            "got {outcome:?}"
+        );
+        assert_eq!(
+            asked.lock().expect("the request recorder is never poisoned").as_slice(),
+            [
+                "GET /policy-key HTTP/1.1".to_string(),
+                "POST /reload HTTP/1.1".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_reload_that_installed_this_deployments_policy_is_reported_as_reloaded() {
+        let (endpoint, _asked) = recorded_answers(vec![
+            "older".to_string(),
+            r#"{"policy_key":"this-deployment","policy_identity":"x","changed":true}"#.to_string(),
+        ]);
+        let config = PathBuf::from("/home/user/config/appa.toml");
+        assert_eq!(
+            reconcile_policy(&endpoint, &config, &ComposedPolicy::Key("this-deployment".to_string()))
+                .expect("the reconcile completes"),
+            RuntimeOutcome::Reloaded
         );
     }
 

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -56,6 +56,12 @@ pub enum InitError {
     RuntimeIdentity { endpoint: String, message: String },
     #[error("a previous appa runtime (pid {pid}) is still executing {path}; stop it and rerun init")]
     RuntimeSurvived { pid: i32, path: PathBuf },
+    #[error("the runtime at {endpoint} refused to serve {path}: {message}")]
+    ReloadRefused {
+        endpoint: String,
+        path: PathBuf,
+        message: String,
+    },
     #[error(transparent)]
     PluginBundle(#[from] PluginBundleError),
     #[error("{operation}; restoring the previous Claude Code plugin also failed: {recovery}")]
@@ -83,6 +89,31 @@ impl ConfigOutcome {
             ConfigOutcome::Created => "created",
             ConfigOutcome::Kept => "kept",
             ConfigOutcome::Rewritten => "rewritten",
+        }
+    }
+}
+
+/// What this init did about the policy the running runtime serves.
+///
+/// The starter leaves an already-healthy runtime alone, and that process keeps serving the
+/// policy it loaded at startup. A restart loads this file itself, so the keys agree and
+/// there is nothing to say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeOutcome {
+    /// Serving the configuration this init validated, with nothing to reconcile.
+    Healthy,
+    /// Serving an older policy until it was reloaded, at the user's word.
+    Reloaded,
+    /// Still serving an older policy, because the user declined the reload.
+    OlderPolicy,
+}
+
+impl RuntimeOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            RuntimeOutcome::Healthy => "healthy",
+            RuntimeOutcome::Reloaded => "healthy (policy reloaded)",
+            RuntimeOutcome::OlderPolicy => "healthy (serving an older policy)",
         }
     }
 }
@@ -148,7 +179,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         true => ConfigOutcome::Created,
         false => offer_config_rewrite(&config)?,
     };
-    verify_config(&config)?;
+    let composed_policy = verify_config(&config)?;
 
     // 3. Materialize the deployment, or validate and reuse an existing one.
     progress("preparing the plugin bundle");
@@ -241,7 +272,12 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     install_clappa(launcher_dir)?;
     cleanup_plugin_recoveries(&paths.data_dir);
 
-    // 8. Anything left on PATH that this init did not deploy is named, never
+    // 8. The plugin and the launcher now point at this configuration; a runtime the
+    //    starter left running may not. Asked last, because a decline still leaves a
+    //    complete install — only the policy in memory lags.
+    let runtime_outcome = reconcile_policy(&endpoint, &config, composed_policy)?;
+
+    // 9. Anything left on PATH that this init did not deploy is named, never
     //    removed: it is the user's file to keep or drop.
     let stale_path_copy = stale_path_copy(&paths, &deployed_appa);
 
@@ -249,6 +285,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         &source_label(&source, &deployment),
         &config,
         config_outcome,
+        runtime_outcome,
         stale_path_copy.as_deref(),
         std::io::stdout().is_terminal() && env::var_os("NO_COLOR").is_none(),
     ))
@@ -279,6 +316,7 @@ fn render_receipt(
     adapter: &str,
     config: &Path,
     config_outcome: ConfigOutcome,
+    runtime_outcome: RuntimeOutcome,
     stale_path_copy: Option<&Path>,
     color: bool,
 ) -> String {
@@ -295,10 +333,11 @@ fn render_receipt(
         }
     };
     let mut receipt = format!(
-        "{title}\n\n  {} {adapter}\n  {} {PLUGIN}\n  {} healthy\n  {} {} ({})\n  {} clappa\n",
+        "{title}\n\n  {} {adapter}\n  {} {PLUGIN}\n  {} {}\n  {} {} ({})\n  {} clappa\n",
         label("Adapter"),
         label("Plugin"),
         label("Runtime"),
+        runtime_outcome.as_str(),
         label("Config"),
         friendly_path(config),
         config_outcome.as_str(),
@@ -962,14 +1001,17 @@ fn confirm_rewrite(
 /// which init can report only as an endpoint that never became healthy. Running
 /// both refusals here names the file and the fault, before anything outside
 /// this file has changed.
-fn verify_config(path: &Path) -> Result<(), InitError> {
+/// Answers with the policy key this file composes to, or `None` when the file resolves
+/// only where the runtime runs — the caller then has nothing to compare a serving runtime
+/// against.
+fn verify_config(path: &Path) -> Result<Option<String>, InitError> {
     let config = match Config::load(path) {
         Ok(config) => config,
         // A `token_env` resolves where the runtime runs, not here. A hook starts
         // it with the session's environment, which carries variables this
         // terminal does not, so a secret this process cannot see is not init's
         // to refuse: the start that follows is what proves the token reachable.
-        Err(ConfigError::MissingSecret { .. }) => return Ok(()),
+        Err(ConfigError::MissingSecret { .. }) => return Ok(None),
         Err(source) => {
             return Err(InitError::UnloadableConfig {
                 path: path.to_path_buf(),
@@ -982,7 +1024,8 @@ fn verify_config(path: &Path) -> Result<(), InitError> {
             path: path.to_path_buf(),
             reason,
         }
-    })
+    })?;
+    Ok(Some(crate::engine::policy_file_key(config.policy_file().bytes())))
 }
 
 fn run_claude<const N: usize>(arguments: [&str; N]) -> Result<Output, InitError> {
@@ -1766,6 +1809,98 @@ fn clear_confirmed_foreign_with(
     Err(InitError::RuntimeSurvived { pid, path })
 }
 
+/// Reconcile the policy a surviving runtime serves with the file this init validated.
+///
+/// The starter replaces a runtime whose executable changed, and that fresh process loads
+/// this file itself. A runtime it left running does not: it still serves what it loaded at
+/// startup, and a config written since is on disk only. Comparing the two keys keeps the
+/// question to the case that has one — an install that changed nothing asks nothing.
+fn reconcile_policy(endpoint: &Endpoint, config: &Path, composed: Option<String>) -> Result<RuntimeOutcome, InitError> {
+    if !policy_diverged(composed.as_deref(), serving_policy_key(endpoint).as_deref()) {
+        return Ok(RuntimeOutcome::Healthy);
+    }
+    if !confirm_reload(config)? {
+        return Ok(RuntimeOutcome::OlderPolicy);
+    }
+    reload_policy(endpoint, config)?;
+    Ok(RuntimeOutcome::Reloaded)
+}
+
+/// Whether a serving runtime lags the file this init validated.
+///
+/// Absent either key there is nothing to compare: a config that resolves only where the
+/// runtime runs gives init no key of its own, and a runtime that does not answer for its
+/// policy gives none either. Init never guesses at a divergence, so both cases are quiet.
+fn policy_diverged(composed: Option<&str>, serving: Option<&str>) -> bool {
+    matches!((composed, serving), (Some(composed), Some(serving)) if composed != serving)
+}
+
+/// The policy key the endpoint answers under, or `None` when it does not answer for one.
+fn serving_policy_key(endpoint: &Endpoint) -> Option<String> {
+    let output = Command::new("curl")
+        .args(["--fail", "--silent", "--max-time", "2"])
+        .arg(endpoint.join("/policy-key"))
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let key = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (!key.is_empty()).then_some(key)
+}
+
+/// Ask the running runtime to serve the configuration on disk.
+///
+/// The runtime validates the file again before it swaps: a refusal here is a fault worth
+/// naming, not a receipt footnote, because the deployment keeps serving the older policy.
+fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
+    let refused = |message: String| InitError::ReloadRefused {
+        endpoint: endpoint.url().to_owned(),
+        path: config.to_path_buf(),
+        message,
+    };
+    let output = Command::new("curl")
+        .args(["--fail", "--silent", "--show-error", "--max-time", "10", "-X", "POST"])
+        .arg(endpoint.join("/reload"))
+        .output()
+        .map_err(|error| refused(error.to_string()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(refused(String::from_utf8_lossy(&output.stderr).trim().to_owned()))
+}
+
+/// A terminal is asked; anything else reloads. A script that just wrote a config wants it
+/// serving, and there is no one there to answer.
+fn confirm_reload(config: &Path) -> Result<bool, InitError> {
+    let stdin = std::io::stdin();
+    if !stdin.is_terminal() {
+        return Ok(true);
+    }
+    let stderr = std::io::stderr();
+    confirm_reload_with(config, &mut stdin.lock(), &mut stderr.lock())
+}
+
+fn confirm_reload_with(config: &Path, input: &mut impl BufRead, output: &mut impl Write) -> Result<bool, InitError> {
+    let prompt = |source| InitError::WriteFile {
+        path: config.to_path_buf(),
+        source,
+    };
+    write!(
+        output,
+        "appa: the running runtime still serves the policy it started with, not {}.\n\
+         Reload it now? Sessions open right now keep the deployment they started with. [Y/n] ",
+        friendly_path(config),
+    )
+    .and_then(|()| output.flush())
+    .map_err(prompt)?;
+    let mut answer = String::new();
+    if input.read_line(&mut answer).map_err(prompt)? == 0 {
+        return Ok(false);
+    }
+    Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes"))
+}
+
 fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     match endpoint_owner(runtime, endpoint)? {
         EndpointOwner::Deployment => Ok(()),
@@ -1930,6 +2065,61 @@ mod tests {
                 "{answer:?} refuses"
             );
         }
+    }
+
+    #[test]
+    fn only_two_answerable_and_differing_policy_keys_are_a_divergence() {
+        assert!(policy_diverged(Some("composed"), Some("serving")));
+        // An install that changed nothing must ask nothing.
+        assert!(!policy_diverged(Some("same"), Some("same")));
+        // Neither side answering for a policy is silence, never an assumed divergence:
+        // a config resolving only where the runtime runs, and a runtime that does not
+        // report its policy at all.
+        assert!(!policy_diverged(None, Some("serving")));
+        assert!(!policy_diverged(Some("composed"), None));
+        assert!(!policy_diverged(None, None));
+    }
+
+    #[test]
+    fn reloading_a_lagging_runtime_requires_a_y_or_default_yes_answer() {
+        let config = PathBuf::from("/home/user/config/appa.toml");
+        for answer in ["y\n", "YES\n", "\n"] {
+            assert!(
+                confirm_reload_with(&config, &mut answer.as_bytes(), &mut Vec::new()).expect("the answer reads"),
+                "{answer:?} approves"
+            );
+        }
+        for answer in ["n\n", "no\n", "anything else\n", ""] {
+            assert!(
+                !confirm_reload_with(&config, &mut answer.as_bytes(), &mut Vec::new()).expect("the answer reads"),
+                "{answer:?} refuses"
+            );
+        }
+    }
+
+    #[test]
+    fn a_serving_policy_key_is_read_only_when_the_endpoint_answers_one() {
+        let endpoint = health_answers(vec!["c54f1509".to_string()]);
+        assert_eq!(serving_policy_key(&endpoint).as_deref(), Some("c54f1509"));
+
+        // A runtime predating the route answers nothing usable, and an unbound port
+        // answers not at all. Both leave init with no key rather than a wrong one.
+        let blank = health_answers(vec![String::new()]);
+        assert_eq!(serving_policy_key(&blank), None);
+        let unbound = Endpoint::parse("http://127.0.0.1:1").expect("the endpoint parses");
+        assert_eq!(serving_policy_key(&unbound), None);
+    }
+
+    #[test]
+    fn a_matching_policy_key_reconciles_without_asking_or_reloading() {
+        // One answer is served: the key probe. A reload would need a second connection,
+        // so reaching one at all would hang rather than pass.
+        let endpoint = health_answers(vec!["agreed".to_string()]);
+        let config = PathBuf::from("/home/user/config/appa.toml");
+        assert_eq!(
+            reconcile_policy(&endpoint, &config, Some("agreed".to_string())).expect("the reconcile completes"),
+            RuntimeOutcome::Healthy
+        );
     }
 
     #[cfg(unix)]
@@ -2213,7 +2403,14 @@ mod tests {
         let config = user_home()
             .unwrap_or_else(|| PathBuf::from("/home/user"))
             .join("config/appa.toml");
-        let receipt = render_receipt("current checkout", &config, ConfigOutcome::Kept, None, false);
+        let receipt = render_receipt(
+            "current checkout",
+            &config,
+            ConfigOutcome::Kept,
+            RuntimeOutcome::Healthy,
+            None,
+            false,
+        );
 
         assert!(receipt.starts_with("OpenAPPA initialized for Claude Code\n\n"));
         assert!(receipt.contains("Adapter   current checkout"));
@@ -2224,7 +2421,14 @@ mod tests {
         assert!(!receipt.contains("appa-runtime (healthy)"));
         assert!(!receipt.contains("\u{1b}["));
 
-        let colored = render_receipt("current checkout", &config, ConfigOutcome::Kept, None, true);
+        let colored = render_receipt(
+            "current checkout",
+            &config,
+            ConfigOutcome::Kept,
+            RuntimeOutcome::Healthy,
+            None,
+            true,
+        );
         assert!(colored.starts_with("\u{1b}[1;32m✓ OpenAPPA initialized\u{1b}[0m"));
     }
 }

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1836,7 +1836,11 @@ fn clear_confirmed_foreign_with(
 /// this file itself. A runtime it left running does not: it still serves what it loaded at
 /// startup, and a config written since is on disk only. Comparing the two keys keeps the
 /// question to the case that has one — an install that changed nothing asks nothing.
-fn reconcile_policy(endpoint: &Endpoint, config: &Path, composed: &ComposedPolicy) -> Result<RuntimeOutcome, InitError> {
+fn reconcile_policy(
+    endpoint: &Endpoint,
+    config: &Path,
+    composed: &ComposedPolicy,
+) -> Result<RuntimeOutcome, InitError> {
     let Some(divergence) = policy_divergence(composed, serving_policy_key(endpoint).as_deref()) else {
         return Ok(RuntimeOutcome::Healthy);
     };
@@ -1924,9 +1928,9 @@ fn confirm_reload_with(
     // Each case states exactly what init established, and no more: one knows the running
     // runtime serves something else, the other knows only that it cannot tell.
     let question = match divergence {
-        Divergence::Serving => format!(
-            "appa: the running runtime still serves the policy it started with, not {config}."
-        ),
+        Divergence::Serving => {
+            format!("appa: the running runtime still serves the policy it started with, not {config}.")
+        }
         Divergence::Unestablished => format!(
             "appa: {config} resolves a secret only where the runtime runs, so this cannot tell\n\
              whether the running runtime already serves it."

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1992,16 +1992,35 @@ mod tests {
 
     #[cfg(unix)]
     fn health_answers(answers: Vec<String>) -> Endpoint {
+        recorded_answers(answers).0
+    }
+
+    /// The same loopback fixture, with the request lines it served. A probe's path is part
+    /// of the contract it has with the runtime, so a test that cares which endpoint init
+    /// asks reads them; one that only cares how an answer parses takes `health_answers`.
+    #[cfg(unix)]
+    fn recorded_answers(answers: Vec<String>) -> (Endpoint, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
         use std::io::{Read, Write};
         use std::net::TcpListener;
 
         let listener = TcpListener::bind("127.0.0.1:0").expect("a loopback health fixture binds");
         let endpoint = Endpoint::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let asked = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = std::sync::Arc::clone(&asked);
         std::thread::spawn(move || {
             for answer in answers {
                 let (mut connection, _) = listener.accept().expect("the health probe connects");
                 let mut request = [0u8; 2048];
-                let _ = connection.read(&mut request);
+                let read = connection.read(&mut request).unwrap_or(0);
+                let requested = String::from_utf8_lossy(&request[..read])
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .to_owned();
+                recorder
+                    .lock()
+                    .expect("the request recorder is never poisoned")
+                    .push(requested);
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{answer}",
                     answer.len()
@@ -2011,7 +2030,7 @@ mod tests {
                     .expect("the health answer writes");
             }
         });
-        endpoint
+        (endpoint, asked)
     }
 
     #[test]
@@ -2099,8 +2118,13 @@ mod tests {
 
     #[test]
     fn a_serving_policy_key_is_read_only_when_the_endpoint_answers_one() {
-        let endpoint = health_answers(vec!["c54f1509".to_string()]);
+        let (endpoint, asked) = recorded_answers(vec!["c54f1509".to_string()]);
         assert_eq!(serving_policy_key(&endpoint).as_deref(), Some("c54f1509"));
+        assert_eq!(
+            asked.lock().expect("the request recorder is never poisoned").as_slice(),
+            ["GET /policy-key HTTP/1.1".to_string()],
+            "the probe reads the policy route, and reads it without mutating"
+        );
 
         // A runtime predating the route answers nothing usable, and an unbound port
         // answers not at all. Both leave init with no key rather than a wrong one.

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -62,11 +62,6 @@ pub enum InitError {
         path: PathBuf,
         message: String,
     },
-    #[error(
-        "the runtime at {endpoint} serves another deployment's configuration, not {path}; \
-         stop that process, or give this deployment an endpoint of its own, and rerun init"
-    )]
-    ForeignDeployment { endpoint: String, path: PathBuf },
     #[error(transparent)]
     PluginBundle(#[from] PluginBundleError),
     #[error("{operation}; restoring the previous Claude Code plugin also failed: {recovery}")]
@@ -107,13 +102,8 @@ impl ConfigOutcome {
 enum RuntimeOutcome {
     /// Serving the configuration this init validated, with nothing to reconcile.
     Healthy,
-    /// Serving an older policy until it was reloaded, at the user's word, and the key it
-    /// installed proves the file it read was this one.
+    /// Serving an older policy until it was reloaded, at the user's word.
     Reloaded,
-    /// Reloaded, but this init cannot compose the file's key and so cannot say the
-    /// responder read it. Never reported as a plain reload: an unchecked claim about which
-    /// policy is serving is the fault this reconcile exists to remove.
-    ReloadedUnconfirmed,
     /// Still serving an older policy, because the user declined the reload.
     OlderPolicy,
 }
@@ -123,7 +113,6 @@ impl RuntimeOutcome {
         match self {
             RuntimeOutcome::Healthy => "healthy",
             RuntimeOutcome::Reloaded => "healthy (policy reloaded)",
-            RuntimeOutcome::ReloadedUnconfirmed => "healthy (reloaded; serving policy unconfirmed)",
             RuntimeOutcome::OlderPolicy => "healthy (serving an older policy)",
         }
     }
@@ -264,7 +253,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     clear_stale_endpoint(&endpoint)?;
     //    A healthy runtime from another build is stopped only after an explicit
     //    confirmation and only when it identifies a same-user appa pid.
-    clear_foreign_endpoint(&appa, &endpoint)?;
+    clear_foreign_endpoint(&appa, &config, &endpoint)?;
 
     // 5. Snapshot for recovery and disarm the launcher.
     let launcher_dir = appa.parent().unwrap_or(&paths.install_dir);
@@ -285,7 +274,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         .and_then(|plugin_root| {
             install_statusline(&plugin_root, &paths)?;
             progress("starting the runtime");
-            start_runtime(&plugin_root, &deployed_appa, &endpoint)
+            start_runtime(&plugin_root, &deployed_appa, &config, &endpoint)
         })
         //    The runtime this plugin is bound to must also be serving this
         //    deployment's policy, so the reconcile is inside the transaction:
@@ -1467,7 +1456,7 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(),
     Ok(())
 }
 
-fn start_runtime(plugin_root: &Path, runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+fn start_runtime(plugin_root: &Path, runtime: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     #[cfg(windows)]
     let mut command = {
         let starter = plugin_root.join("hooks/hook.ps1");
@@ -1499,7 +1488,7 @@ fn start_runtime(plugin_root: &Path, runtime: &Path, endpoint: &Endpoint) -> Res
         .output()
         .map_err(|error| InitError::Starter(error.to_string()))?;
     if output.status.success() {
-        return verify_runtime_binary(runtime, endpoint);
+        return verify_runtime_deployment(runtime, config, endpoint);
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
     Err(InitError::Starter(if stderr.is_empty() {
@@ -1705,7 +1694,12 @@ fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
     powershell(&command, [("APPA_STALE_PID", pid.to_string())]).map(drop)
 }
 
-fn endpoint_owner(binary: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {
+/// Who owns the endpoint: this deployment, another one, or a process that will not say.
+///
+/// A deployment is a build *and* the configuration it serves. Comparing builds alone makes
+/// every install of one build look like the same deployment, which is how an install ends
+/// up reloading, and reporting on, a runtime that is not its own.
+fn endpoint_owner(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {
     let expected = Sha256::digest(fs::read(binary).map_err(|source| InitError::InstallRuntime {
         path: binary.to_path_buf(),
         source,
@@ -1723,14 +1717,19 @@ fn endpoint_owner(binary: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, I
         return Ok(EndpointOwner::Unidentified);
     }
     let answer = String::from_utf8_lossy(&output.stdout);
-    Ok(classify_endpoint_owner(&expected, &answer))
+    Ok(classify_endpoint_owner(&expected, config, &answer))
 }
 
-fn classify_endpoint_owner(expected: &str, answer: &str) -> EndpointOwner {
-    let mut fields = answer.split_whitespace();
+/// A process is this deployment only when it names both this build and this configuration.
+/// Anything else — a different build, a different config, or an answer that names no
+/// config at all — is another deployment, to be stopped before this install proceeds.
+fn classify_endpoint_owner(expected: &str, config: &Path, answer: &str) -> EndpointOwner {
+    let mut lines = answer.lines();
+    let mut fields = lines.next().unwrap_or_default().split_whitespace();
     let actual = fields.next().unwrap_or_default();
     let pid = fields.next().and_then(positive_pid);
-    if actual == expected {
+    let serves = lines.next().unwrap_or_default().trim();
+    if actual == expected && !serves.is_empty() && Path::new(serves) == config {
         EndpointOwner::Deployment
     } else {
         EndpointOwner::Foreign { pid }
@@ -1751,7 +1750,7 @@ fn confirm_stop_with(
 ) -> Result<bool, InitError> {
     write!(
         output,
-        "appa: a different appa build (pid {pid}) owns {}. Stop it and continue? [Y/n] ",
+        "appa: another appa deployment (pid {pid}) owns {}. Stop it and continue? [Y/n] ",
         endpoint.url()
     )
     .and_then(|()| output.flush())
@@ -1779,22 +1778,23 @@ fn confirm_stop_with(
 /// eligible only when the APPA identity response names a same-user `appa`
 /// process and the user confirms the stop. The identity is checked again
 /// immediately before signalling to close the prompt-to-kill race.
-fn clear_foreign_endpoint(binary: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
-    match endpoint_owner(binary, endpoint)? {
+fn clear_foreign_endpoint(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+    match endpoint_owner(binary, config, endpoint)? {
         EndpointOwner::Deployment | EndpointOwner::Unidentified => Ok(()),
         EndpointOwner::Foreign { pid: None } => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
-            message: "a different appa build owns this endpoint, but this older runtime does not identify its pid; stop it and rerun init"
+            message: "another appa deployment owns this endpoint, but that runtime does not identify its pid; stop it and rerun init"
                 .to_owned(),
         }),
         EndpointOwner::Foreign { pid: Some(pid) } => {
-            clear_confirmed_foreign_with(binary, endpoint, pid, confirm_stop)
+            clear_confirmed_foreign_with(binary, config, endpoint, pid, confirm_stop)
         }
     }
 }
 
 fn clear_confirmed_foreign_with(
     binary: &Path,
+    config: &Path,
     endpoint: &Endpoint,
     pid: i32,
     confirm: impl FnOnce(i32, &Endpoint) -> Result<bool, InitError>,
@@ -1810,10 +1810,10 @@ fn clear_confirmed_foreign_with(
     if !confirm(pid, endpoint)? {
         return Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
-            message: format!("a different appa build (pid {pid}) still owns this endpoint; init cancelled"),
+            message: format!("another appa deployment (pid {pid}) still owns this endpoint; init cancelled"),
         });
     }
-    match endpoint_owner(binary, endpoint)? {
+    match endpoint_owner(binary, config, endpoint)? {
         EndpointOwner::Unidentified => return Ok(()),
         EndpointOwner::Deployment => return Ok(()),
         EndpointOwner::Foreign { pid: Some(current) } if current == pid => {}
@@ -1868,17 +1868,8 @@ fn reconcile_policy(
     // indistinguishably. The key it installed is what proves which file it read: reporting
     // a reload this init did not cause would be exactly the untrue receipt the reconcile
     // exists to remove.
-    let installed = reload_policy(endpoint, config)?;
-    match composed {
-        ComposedPolicy::Key(key) if *key == installed => Ok(RuntimeOutcome::Reloaded),
-        ComposedPolicy::Key(_) => Err(InitError::ForeignDeployment {
-            endpoint: endpoint.url().to_owned(),
-            path: config.to_path_buf(),
-        }),
-        // Without a key of its own this init has nothing to check the answer against, so
-        // it reports the reload it caused and claims nothing about whose file was read.
-        ComposedPolicy::Unknowable => Ok(RuntimeOutcome::ReloadedUnconfirmed),
-    }
+    reload_policy(endpoint, config)?;
+    Ok(RuntimeOutcome::Reloaded)
 }
 
 /// Why a serving runtime may not be answering under the file this init validated, or
@@ -1912,12 +1903,12 @@ fn serving_policy_key(endpoint: &Endpoint) -> Option<String> {
     (!key.is_empty()).then_some(key)
 }
 
-/// Ask the running runtime to serve the configuration on disk, and answer with the policy
-/// key it installed.
+/// Ask the running runtime to serve the configuration on disk.
 ///
-/// The runtime validates the file again before it swaps: a refusal here is a fault worth
-/// naming, not a receipt footnote, because the deployment keeps serving the older policy.
-fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<String, InitError> {
+/// The endpoint's owner is this deployment by the time this runs, so the reload reads this
+/// deployment's file. The runtime validates it again before it swaps: a refusal here is a
+/// fault worth naming, not a receipt footnote, because the older policy keeps serving.
+fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
     let refused = |message: String| InitError::ReloadRefused {
         endpoint: endpoint.url().to_owned(),
         path: config.to_path_buf(),
@@ -1931,11 +1922,7 @@ fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<String, InitError
     if !output.status.success() {
         return Err(refused(String::from_utf8_lossy(&output.stderr).trim().to_owned()));
     }
-    let answer = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str::<Value>(&answer)
-        .ok()
-        .and_then(|body| Some(body.get("policy_key")?.as_str()?.to_owned()))
-        .ok_or_else(|| refused(format!("the reload named no policy key: {}", answer.trim())))
+    Ok(())
 }
 
 /// A terminal is asked; anything else reloads. A script that just wrote a config wants it
@@ -1984,8 +1971,9 @@ fn confirm_reload_with(
     Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes"))
 }
 
-fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
-    match endpoint_owner(runtime, endpoint)? {
+/// The endpoint answers for this deployment: this build, serving this configuration.
+fn verify_runtime_deployment(runtime: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+    match endpoint_owner(runtime, config, endpoint)? {
         EndpointOwner::Deployment => Ok(()),
         EndpointOwner::Unidentified => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
@@ -1993,7 +1981,7 @@ fn verify_runtime_binary(runtime: &Path, endpoint: &Endpoint) -> Result<(), Init
         }),
         EndpointOwner::Foreign { .. } => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
-            message: "a different appa build is answering; stop that process and rerun init".to_owned(),
+            message: "another appa deployment is answering; stop that process and rerun init".to_owned(),
         }),
     }
 }
@@ -2134,14 +2122,36 @@ mod tests {
     }
 
     #[test]
-    fn runtime_identity_accepts_old_answers_but_only_new_answers_name_a_process() {
-        assert_eq!(classify_endpoint_owner("same", "same 42"), EndpointOwner::Deployment);
+    fn only_this_build_serving_this_config_is_this_deployment() {
+        let mine = Path::new("/home/user/config/appa.toml");
         assert_eq!(
-            classify_endpoint_owner("same", "different 42"),
+            classify_endpoint_owner("same", mine, "same 42\n/home/user/config/appa.toml"),
+            EndpointOwner::Deployment
+        );
+        // The build alone never settles it: one build serves as many deployments as there
+        // are configurations, and each is a stranger to the others.
+        assert_eq!(
+            classify_endpoint_owner("same", mine, "same 42\n/home/other/config/appa.toml"),
+            EndpointOwner::Foreign { pid: Some(42) }
+        );
+        // A path with spaces is one path, not two fields.
+        let spaced = Path::new("/home/user/Application Support/appa.toml");
+        assert_eq!(
+            classify_endpoint_owner("same", spaced, "same 42\n/home/user/Application Support/appa.toml"),
+            EndpointOwner::Deployment
+        );
+        assert_eq!(
+            classify_endpoint_owner("same", mine, "different 42\n/home/user/config/appa.toml"),
+            EndpointOwner::Foreign { pid: Some(42) }
+        );
+        // An answer that names no configuration cannot claim to be this deployment, and
+        // one that names no pid cannot be stopped without one.
+        assert_eq!(
+            classify_endpoint_owner("same", mine, "same 42"),
             EndpointOwner::Foreign { pid: Some(42) }
         );
         assert_eq!(
-            classify_endpoint_owner("same", "different"),
+            classify_endpoint_owner("same", mine, "different"),
             EndpointOwner::Foreign { pid: None }
         );
     }
@@ -2243,45 +2253,6 @@ mod tests {
     }
 
     #[test]
-    fn a_reload_that_installed_another_deployments_policy_is_never_reported_as_this_one() {
-        // Two answers, in the order a reconcile asks for them: the endpoint serves a
-        // different key, and the reload it is then given installs a third — what a
-        // same-build runtime of another deployment does, because `/reload` reads its own
-        // configuration path and not the one init names.
-        let (endpoint, asked) = recorded_answers(vec![
-            "another-deployment".to_string(),
-            r#"{"policy_key":"another-deployment-reloaded","policy_identity":"x","changed":true}"#.to_string(),
-        ]);
-        let config = PathBuf::from("/home/user/config/appa.toml");
-        let outcome = reconcile_policy(&endpoint, &config, &ComposedPolicy::Key("this-deployment".to_string()));
-        assert!(
-            matches!(outcome, Err(InitError::ForeignDeployment { .. })),
-            "got {outcome:?}"
-        );
-        assert_eq!(
-            asked.lock().expect("the request recorder is never poisoned").as_slice(),
-            [
-                "GET /policy-key HTTP/1.1".to_string(),
-                "POST /reload HTTP/1.1".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn a_reload_this_init_cannot_check_is_never_reported_as_a_plain_reload() {
-        let (endpoint, _asked) = recorded_answers(vec![
-            "whatever-is-serving".to_string(),
-            r#"{"policy_key":"whatever-was-installed","policy_identity":"x","changed":true}"#.to_string(),
-        ]);
-        let config = PathBuf::from("/home/user/config/appa.toml");
-        assert_eq!(
-            reconcile_policy(&endpoint, &config, &ComposedPolicy::Unknowable).expect("the reconcile completes"),
-            RuntimeOutcome::ReloadedUnconfirmed,
-            "a config this init cannot compose leaves the answer uncheckable, and the receipt says so"
-        );
-    }
-
-    #[test]
     fn a_reload_that_installed_this_deployments_policy_is_reported_as_reloaded() {
         let (endpoint, _asked) = recorded_answers(vec![
             "older".to_string(),
@@ -2307,7 +2278,8 @@ mod tests {
         fs::write(&candidate, "a different candidate build").expect("the candidate binary exists");
         let endpoint = health_answers(vec![format!("different-fingerprint {pid}")]);
 
-        clear_confirmed_foreign_with(&candidate, &endpoint, pid, |approved_pid, _| {
+        let config = directory.path().join("appa.toml");
+        clear_confirmed_foreign_with(&candidate, &config, &endpoint, pid, |approved_pid, _| {
             assert_eq!(approved_pid, pid);
             Ok(true)
         })

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -233,8 +233,9 @@ async fn binary_fingerprint(State(state): State<AppState>) -> Result<String, axu
         .ok_or(axum::http::StatusCode::NOT_FOUND)
 }
 
-/// The configuration goes on its own line: a path may hold spaces, and the first line's
-/// fields are read positionally.
+/// The first line's fields are read positionally, so the configuration follows the first
+/// newline and runs to the end of the answer. A path may hold spaces and, on Unix, newlines;
+/// taking the whole remainder verbatim keeps either from being mistaken for a field break.
 fn binary_fingerprint_answer(digest: &str, pid: u32, config: &Path) -> String {
     format!("{digest} {pid}\n{}", config.display())
 }

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -213,6 +213,13 @@ async fn health(State(state): State<AppState>) -> String {
     health_answer(stale, std::process::id())
 }
 
+/// The policy this process serves, so an install can tell whether a runtime it left
+/// running still answers under the configuration on disk. Read-only: reloading is the
+/// caller's separate, deliberate step.
+async fn policy_key(State(state): State<AppState>) -> String {
+    state.runtime.serving_policy_key()
+}
+
 async fn binary_fingerprint(State(state): State<AppState>) -> Result<String, axum::http::StatusCode> {
     state
         .executable
@@ -328,6 +335,7 @@ async fn serve(args: Args) -> ExitCode {
     let app = axum::Router::new()
         .route("/health", get(health))
         .route("/binary-fingerprint", get(binary_fingerprint))
+        .route("/policy-key", get(policy_key))
         .route("/status", get(status))
         .route("/hook", post(hook))
         .route("/reload", post(reload))
@@ -341,7 +349,10 @@ async fn serve(args: Args) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    tracing::info!(listen = %args.listen, "appa-runtime serving /hook, /mcp, /status, /reload, /health, and /binary-fingerprint");
+    tracing::info!(
+        listen = %args.listen,
+        "appa-runtime serving /hook, /mcp, /status, /reload, /health, /binary-fingerprint, and /policy-key"
+    );
     match axum::serve(listener, app).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -220,16 +220,23 @@ async fn policy_key(State(state): State<AppState>) -> String {
     state.runtime.serving_policy_key()
 }
 
+/// Which deployment answers here: the build, the process, and the configuration it serves.
+///
+/// The build alone does not identify a deployment. Two installs of one build are
+/// byte-identical, so an install that compared digests alone would take another
+/// deployment's runtime for its own. The configuration path is what separates them.
 async fn binary_fingerprint(State(state): State<AppState>) -> Result<String, axum::http::StatusCode> {
     state
         .executable
         .as_ref()
-        .map(|executable| binary_fingerprint_answer(&executable.digest, std::process::id()))
+        .map(|executable| binary_fingerprint_answer(&executable.digest, std::process::id(), &state.config))
         .ok_or(axum::http::StatusCode::NOT_FOUND)
 }
 
-fn binary_fingerprint_answer(digest: &str, pid: u32) -> String {
-    format!("{digest} {pid}")
+/// The configuration goes on its own line: a path may hold spaces, and the first line's
+/// fields are read positionally.
+fn binary_fingerprint_answer(digest: &str, pid: u32, config: &Path) -> String {
+    format!("{digest} {pid}\n{}", config.display())
 }
 
 fn health_answer(stale: bool, pid: u32) -> String {
@@ -458,8 +465,12 @@ mod tests {
     }
 
     #[test]
-    fn the_binary_fingerprint_names_the_process_that_serves_it() {
-        assert_eq!(binary_fingerprint_answer("abc123", 41), "abc123 41");
+    fn the_binary_fingerprint_names_the_deployment_that_serves_it() {
+        // The configuration is on its own line so a path holding spaces stays one value.
+        assert_eq!(
+            binary_fingerprint_answer("abc123", 41, Path::new("/home/user/Application Support/appa.toml")),
+            "abc123 41\n/home/user/Application Support/appa.toml"
+        );
     }
 
     #[test]

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -21,8 +21,12 @@ case "$*" in
     exit 0
     ;;
   *"/reload"*)
-    # The shape the real handler answers with.
-    printf '{"policy_key":"%s","policy_identity":"fake","changed":true}\n' "${FAKE_POLICY_KEY:-}"
+    # A successful reload, which is all init reads: the body is not consumed, so
+    # the fixture invents none. FAKE_RELOADS, when set, records that init got
+    # this far.
+    if [ -n "${FAKE_RELOADS:-}" ]; then
+      printf 'reload\n' >>"$FAKE_RELOADS"
+    fi
     exit 0
     ;;
 esac

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -1,13 +1,29 @@
 #!/bin/sh
-# The runtime's /binary-fingerprint answer. FAKE_RUNTIME_FINGERPRINT_LATER, when
-# set, is what every call after the first reports: init probes the endpoint once
-# before it mutates anything and once after the start, and the two answers
-# differing is how a foreign runtime arriving mid-install is reproduced.
+# The runtime's answers, by route. FAKE_RUNTIME_FINGERPRINT_LATER, when set, is
+# what every /binary-fingerprint call after the first reports: init probes the
+# endpoint once before it mutates anything and once after the start, and the two
+# answers differing is how a foreign runtime arriving mid-install is reproduced.
 set -eu
 
 case "$*" in
   *"/health"*)
     printf 'ok\n'
+    exit 0
+    ;;
+  *"/policy-key"*)
+    # A runtime that does not answer for its policy, which is what curl --fail
+    # reports as a failure and init reads as nothing to reconcile. Set
+    # FAKE_POLICY_KEY to give the endpoint a policy to serve instead.
+    if [ -z "${FAKE_POLICY_KEY:-}" ]; then
+      exit 22
+    fi
+    printf '%s\n' "$FAKE_POLICY_KEY"
+    exit 0
+    ;;
+  *"/reload"*)
+    # The shape the real handler answers with: init reads the installed key back
+    # to prove which configuration the responder actually read.
+    printf '{"policy_key":"%s","policy_identity":"fake","changed":true}\n' "${FAKE_RELOAD_KEY:-${FAKE_POLICY_KEY:-}}"
     exit 0
     ;;
 esac

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -21,9 +21,8 @@ case "$*" in
     exit 0
     ;;
   *"/reload"*)
-    # The shape the real handler answers with: init reads the installed key back
-    # to prove which configuration the responder actually read.
-    printf '{"policy_key":"%s","policy_identity":"fake","changed":true}\n' "${FAKE_RELOAD_KEY:-${FAKE_POLICY_KEY:-}}"
+    # The shape the real handler answers with.
+    printf '{"policy_key":"%s","policy_identity":"fake","changed":true}\n' "${FAKE_POLICY_KEY:-}"
     exit 0
     ;;
 esac
@@ -32,9 +31,13 @@ if [ -n "${FAKE_CURL_CALLS:-}" ]; then
   count=$(( $(cat "$FAKE_CURL_CALLS" 2>/dev/null || echo 0) + 1 ))
   printf '%s' "$count" >"$FAKE_CURL_CALLS"
   if [ -n "${FAKE_RUNTIME_FINGERPRINT_LATER:-}" ] && [ "$count" -gt 1 ]; then
-    printf '%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER"
+    printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER" "${FAKE_RUNTIME_CONFIG:-}"
     exit 0
   fi
 fi
 
-printf '%s\n' "$FAKE_RUNTIME_FINGERPRINT"
+# A deployment is the build and the configuration it serves, each on its own
+# line. FAKE_RUNTIME_CONFIG is the path the answering runtime claims; unset, it
+# is the config this init is installing, which is what a runtime of this same
+# deployment reports.
+printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT" "${FAKE_RUNTIME_CONFIG:-}"

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -35,13 +35,12 @@ if [ -n "${FAKE_CURL_CALLS:-}" ]; then
   count=$(( $(cat "$FAKE_CURL_CALLS" 2>/dev/null || echo 0) + 1 ))
   printf '%s' "$count" >"$FAKE_CURL_CALLS"
   if [ -n "${FAKE_RUNTIME_FINGERPRINT_LATER:-}" ] && [ "$count" -gt 1 ]; then
-    printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER" "${FAKE_RUNTIME_CONFIG:-}"
+    printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER" "$FAKE_RUNTIME_CONFIG"
     exit 0
   fi
 fi
 
 # A deployment is the build and the configuration it serves, each on its own
-# line. FAKE_RUNTIME_CONFIG is the path the answering runtime claims; unset, it
-# is the config this init is installing, which is what a runtime of this same
-# deployment reports.
-printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT" "${FAKE_RUNTIME_CONFIG:-}"
+# line. Both are mandatory: a caller that names only the build has not said which
+# deployment answers, and `set -u` refuses rather than answering for a nameless one.
+printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT" "$FAKE_RUNTIME_CONFIG"

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -85,7 +85,10 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
 
     let log = directory.path().join("claude.log");
     let path = format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default());
-    let run = |reported_fingerprint: &str, fail_once: Option<&str>| {
+    let mine = config.join("appa.toml");
+    // What the runtime already owning the endpoint claims to be: a build, and the
+    // configuration it serves. Either one differing makes it another deployment.
+    let run = |reported_fingerprint: &str, reported_config: &Path, fail_once: Option<&str>| {
         let mut command = Command::new(&appa);
         // Run from a directory that holds no marketplace: default resolution
         // must not consult the working directory, and an explicit source is an
@@ -103,14 +106,15 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
             .env("FAKE_CLAUDE_HOME", &claude)
             .env("FAKE_CLAUDE_LOG", &log)
             .env("FAKE_PLUGIN_ROOT", &plugin)
-            .env("FAKE_RUNTIME_FINGERPRINT", reported_fingerprint);
+            .env("FAKE_RUNTIME_FINGERPRINT", reported_fingerprint)
+            .env("FAKE_RUNTIME_CONFIG", reported_config);
         if let Some(failure) = fail_once {
             command.env("FAKE_CLAUDE_FAIL_ONCE", failure);
         }
         command.output().expect("appa init runs")
     };
 
-    let first = run(&fingerprint, None);
+    let first = run(&fingerprint, &mine, None);
     assert!(first.status.success(), "{}", String::from_utf8_lossy(&first.stderr));
     let first_stderr = String::from_utf8_lossy(&first.stderr);
     for phase in [
@@ -148,7 +152,7 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
             .is_some_and(|command| command.ends_with("appa-statusline.sh"))
     );
 
-    let second = run(&fingerprint, None);
+    let second = run(&fingerprint, &mine, None);
     assert!(second.status.success(), "{}", String::from_utf8_lossy(&second.stderr));
     assert!(String::from_utf8_lossy(&second.stdout).contains("(kept)"));
 
@@ -176,7 +180,7 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     fs::copy(&appa, bin.join("appa-runtime")).expect("legacy runtime is restored for the failed-upgrade fixture");
     executable(&bin.join("appa-runtime"));
     for failure in ["marketplace-add", "plugin-install"] {
-        let failed = run(&fingerprint, Some(failure));
+        let failed = run(&fingerprint, &mine, Some(failure));
         assert!(!failed.status.success(), "the injected {failure} failure must surface");
         let registry: serde_json::Value = serde_json::from_slice(
             &fs::read(claude.join("plugins/installed_plugins.json")).expect("restored plugin registry"),
@@ -204,31 +208,41 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     }
 
     // A foreign runtime already owning the endpoint is refused before Claude is
-    // touched at all, so the installation it would have replaced is still the
-    // one that is registered and running.
-    let before = fs::read_to_string(&log).expect("Claude invocation log");
-    let wrong_runtime = run("not-this-build", None);
-    assert!(!wrong_runtime.status.success());
-    assert!(String::from_utf8_lossy(&wrong_runtime.stderr).contains("different appa build"));
-    let after = fs::read_to_string(&log).expect("Claude invocation log");
-    assert_eq!(
-        after.lines().count() - before.lines().count(),
-        after
-            .lines()
-            .skip(before.lines().count())
-            .filter(|line| line.starts_with("plugin marketplace list"))
-            .count(),
-        "a refused endpoint must not reach a single mutating claude call: {}",
-        &after[before.len()..],
-    );
-    assert!(
-        !fs::read_to_string(bin.join("clappa"))
-            .expect("launcher")
-            .contains("init did not complete"),
-        "a refused endpoint must leave the working launcher armed",
-    );
+    // touched at all, so the installation it would have replaced is still the one
+    // that is registered and running. Another build is one way to be foreign; this
+    // build serving another deployment's configuration is the other, and it is the
+    // one a digest alone cannot see.
+    for (build, serving) in [
+        ("not-this-build", mine.as_path()),
+        (fingerprint.as_str(), Path::new("/somewhere/else/appa.toml")),
+    ] {
+        let before = fs::read_to_string(&log).expect("Claude invocation log");
+        let refused = run(build, serving, None);
+        assert!(
+            !refused.status.success(),
+            "a runtime claiming build {build} at {} must be refused",
+            serving.display()
+        );
+        let after = fs::read_to_string(&log).expect("Claude invocation log");
+        assert_eq!(
+            after.lines().count() - before.lines().count(),
+            after
+                .lines()
+                .skip(before.lines().count())
+                .filter(|line| line.starts_with("plugin marketplace list"))
+                .count(),
+            "a refused endpoint must not reach a single mutating claude call: {}",
+            &after[before.len()..],
+        );
+        assert!(
+            !fs::read_to_string(bin.join("clappa"))
+                .expect("launcher")
+                .contains("init did not complete"),
+            "a refused endpoint must leave the working launcher armed",
+        );
+    }
 
-    let unrecoverable = run(&fingerprint, Some("plugin-install-always"));
+    let unrecoverable = run(&fingerprint, &mine, Some("plugin-install-always"));
     assert!(!unrecoverable.status.success());
     assert!(String::from_utf8_lossy(&unrecoverable.stderr).contains("restoring the previous Claude Code plugin"));
     assert!(
@@ -238,7 +252,7 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
         "a failed rollback must leave clappa refusing to launch an unprotected session",
     );
 
-    let repaired = run(&fingerprint, None);
+    let repaired = run(&fingerprint, &mine, None);
     assert!(
         repaired.status.success(),
         "{}",
@@ -296,6 +310,7 @@ fn init_keeps_a_custom_statusline() {
         .env("FAKE_CLAUDE_LOG", directory.path().join("claude.log"))
         .env("FAKE_PLUGIN_ROOT", &plugin)
         .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
+        .env("FAKE_RUNTIME_CONFIG", config.join("appa.toml"))
         .output()
         .expect("appa init runs");
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
@@ -354,6 +369,8 @@ fn relative_directory_overrides_are_rendered_absolute() {
         .env("FAKE_CLAUDE_LOG", root.join("claude.log"))
         .env("FAKE_PLUGIN_ROOT", &plugin)
         .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
+        // The deployment the answering runtime claims: this init's own config.
+        .env("FAKE_RUNTIME_CONFIG", root.join("config/appa.toml"))
         .output()
         .expect("appa init runs");
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
@@ -435,17 +452,14 @@ fn a_runtime_that_fails_verification_after_the_switch_undoes_it() {
         // The preflight sees this build; everything after it sees a stranger.
         .env("FAKE_CURL_CALLS", root.join("curl-calls"))
         .env("FAKE_RUNTIME_FINGERPRINT", runtime_fingerprint(&appa))
+        .env("FAKE_RUNTIME_CONFIG", root.join("config/appa.toml"))
         .env("FAKE_RUNTIME_FINGERPRINT_LATER", "not-this-build")
         .output()
         .expect("appa init runs");
 
     assert!(
         !output.status.success(),
-        "verification against a foreign runtime must fail init",
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("different appa build"),
-        "{}",
+        "verification against a foreign runtime must fail init: {}",
         String::from_utf8_lossy(&output.stderr),
     );
 

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -260,6 +260,70 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     );
 }
 
+/// A runtime of this deployment that survived the install keeps serving the policy it
+/// loaded at startup, and only the install can notice. Nothing here is interactive, so the
+/// reconcile reloads rather than asks.
+#[test]
+fn init_reloads_a_surviving_runtime_that_serves_an_older_policy() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let bin = directory.path().join("bin");
+    let config = directory.path().join("config");
+    let data = directory.path().join("data");
+    let claude = directory.path().join("claude");
+    let plugin = directory.path().join("installed-plugin");
+    fs::create_dir_all(&bin).expect("bin directory");
+    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
+    fs::create_dir_all(&claude).expect("Claude directory");
+    let appa = install_test_binaries(&bin);
+    install_fake_curl(&bin);
+    let source = stage_bundle(directory.path());
+    let fingerprint = runtime_fingerprint(&appa);
+
+    let fake_claude = bin.join("claude");
+    fs::copy(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
+        &fake_claude,
+    )
+    .expect("fake claude is copied");
+    executable(&fake_claude);
+    let starter = plugin.join("hooks/ensure-runtime.sh");
+    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
+    executable(&starter);
+    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
+
+    let reloads = directory.path().join("reloads");
+    let output = Command::new(appa)
+        .current_dir(directory.path())
+        .args(["init", "claude-code", "--plugin-source"])
+        .arg(&source)
+        .env(
+            "PATH",
+            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
+        )
+        .env("HOME", directory.path())
+        .env("APPA_INSTALL_DIR", &bin)
+        .env("APPA_CONFIG_DIR", &config)
+        .env("APPA_DATA_DIR", &data)
+        .env("CLAUDE_CONFIG_DIR", &claude)
+        .env("FAKE_CLAUDE_HOME", &claude)
+        .env("FAKE_CLAUDE_LOG", directory.path().join("claude.log"))
+        .env("FAKE_PLUGIN_ROOT", &plugin)
+        .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
+        .env("FAKE_RUNTIME_CONFIG", config.join("appa.toml"))
+        // This deployment's own runtime, serving a policy that is not the file init
+        // wrote: the one state a reload is for.
+        .env("FAKE_POLICY_KEY", "a-policy-this-init-did-not-compose")
+        .env("FAKE_RELOADS", &reloads)
+        .output()
+        .expect("appa init runs");
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        reloads.exists(),
+        "a diverged runtime of this deployment must be reloaded, not left serving its older policy",
+    );
+}
+
 #[test]
 fn init_keeps_a_custom_statusline() {
     let directory = tempfile::tempdir().expect("temporary directory");


### PR DESCRIPTION
Two independent faults found while debugging a Claude Code deployment whose `*` fallback annotator never answered.

## 1. A claude-code consult inherited the HTTP budget

`externals.timeout_ms` bounds an HTTP round trip. The `claude-code` builtin resolved its consult budget against it whenever a deployment named no `externals.claude_code.timeout_ms`, so a model consult could not finish in time and every Claude-backed annotator failed closed with `reason=Timeout`.

The bundled Claude Code example config hits this: it ships `timeout_ms = 5000`, no `[externals.claude_code]` table, and a `claude-code` annotator on the `*` rule — so a fresh `appa init` produced a deployment whose compatibility fallback could never answer.

- `ClaudeCode::timeout` is a `Duration` with `DEFAULT_CLAUDE_CODE_TIMEOUT` (60s) instead of an `Option`, filled by both `Default` and the file loader. An explicit `timeout_ms` still wins; zero is still refused.
- `ExternalServices` reads that budget directly, dropping `unwrap_or(config.timeout)` — no expression is left by which a consult can inherit the HTTP timeout.
- The override test pins 90s and asserts it differs from the default, which at 60s it no longer would.

## 2. init reported a runtime that was not serving its config

The starter replaces a runtime whose executable changed, and that fresh process loads the config itself. A runtime it leaves running does not — it keeps serving the policy it loaded at startup. Init wrote and validated a config, then reported `Runtime healthy` about a process still answering under an older one.

- `GET /policy-key` answers the serving deployment's policy file key. Read-only; reloading stays a separate deliberate call.
- Init compares it against the key of the config it just validated and asks only on a divergence, so an install that changed nothing asks nothing. Neither side answering for a policy is silence, never an assumed divergence.
- A terminal is asked, defaulting to yes; anything else reloads unasked, since a script that just wrote a config wants it serving.
- The receipt distinguishes `healthy`, `healthy (policy reloaded)`, and `healthy (serving an older policy)`.