### PR TITLE
feat(install): add a curl | sh installer for release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,18 @@ jobs:
             integrations/claude-code/plugin/hooks/hook.sh \
             integrations/claude-code/plugin/hooks/appa-paths.sh \
             integrations/claude-code/plugin/statusline.sh \
-            scripts/appa-stage-plugin-bundle.sh
+            scripts/appa-stage-plugin-bundle.sh \
+            scripts/appa-install.sh \
+            scripts/appa-install-test.sh
 
       - name: Lint plugin shell scripts
         run: |
           shellcheck -x -s sh integrations/claude-code/plugin/hooks/ensure-runtime.sh \
             integrations/claude-code/plugin/hooks/hook.sh \
             integrations/claude-code/plugin/hooks/appa-paths.sh \
-            scripts/appa-stage-plugin-bundle.sh
+            scripts/appa-stage-plugin-bundle.sh \
+            scripts/appa-install.sh \
+            scripts/appa-install-test.sh
 
       # The Windows hook implementation had no check of any kind until a
       # review found a fail-open bug in it. `pwsh` is preinstalled on the
@@ -82,6 +86,26 @@ jobs:
             integrations/claude-code/plugin/.claude-plugin/plugin.json)
           test "$cargo_version" = "$version"
           test "$plugin_version" = "$version"
+
+  installer-checks:
+    name: Installer Checks (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      # The installer runs with whatever sh, tar, curl and digest tool the
+      # user's platform ships, so its cases run on each supported one.
+      - name: Installer cases
+        run: sh scripts/appa-install-test.sh
 
   rust-checks:
     name: Rust Checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,6 @@ jobs:
             exit 1
           fi
           sha256sum "${expected_archives[@]}" > SHA256SUMS
-          test -f appa-install.sh
           sh -n appa-install.sh
 
       - name: Read release state

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,13 @@ jobs:
       actions: read # Required to download archives from the reusable build jobs.
       contents: write # Required to upload assets and publish the draft release.
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          persist-credentials: false
+          fetch-depth: 1
+
       - name: Download release archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -223,6 +230,11 @@ jobs:
           pattern: appa-*
           merge-multiple: true
           skip-decompress: true
+
+      # The installer ships beside the archives it installs, so the script a
+      # user pipes into sh is the one this release's source carried.
+      - name: Stage the installer
+        run: cp scripts/appa-install.sh dist/appa-install.sh
 
       - name: Verify release assets and write checksums
         working-directory: dist
@@ -263,6 +275,8 @@ jobs:
             exit 1
           fi
           sha256sum "${expected_archives[@]}" > SHA256SUMS
+          test -f appa-install.sh
+          sh -n appa-install.sh
 
       - name: Read release state
         id: release-state

--- a/README.md
+++ b/README.md
@@ -64,9 +64,15 @@ The Claude Code plugin is a playground for the model, not the product. It is the
 fastest way to watch a policy make a decision on real work:
 
 ```sh
-cargo install --path appa-runtime --force
+curl -fsSL https://openappa.com/install.sh | sh
 appa init claude-code
 ```
+
+The installer verifies the checksum of the release binary for Linux or macOS
+and places it in `~/.local/bin`. Windows users unpack the zip from the
+[releases page](https://github.com/archestra-ai/OpenAPPA/releases). From a
+checkout, `cargo install --path appa-runtime --force` builds the binary
+instead.
 
 A release binary resolves the plugin from its baked release tag and digest. A
 clean checkout build resolves the plugin from its baked Git commit and verifies

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fastest way to watch a policy make a decision on real work:
 
 ```sh
 curl -fsSL https://openappa.com/install.sh | sh
-appa init claude-code
+~/.local/bin/appa init claude-code
 ```
 
 The installer verifies the checksum of the release binary for Linux or macOS

--- a/appa-runtime/README.md
+++ b/appa-runtime/README.md
@@ -22,7 +22,7 @@ the release archive, verifies its checksum, and places `appa` in
 
 ```sh
 curl -fsSL https://openappa.com/install.sh | sh
-appa init claude-code
+~/.local/bin/appa init claude-code
 ```
 
 A build from a checkout carries its exact Git commit and plugin-tree digest, so

--- a/appa-runtime/README.md
+++ b/appa-runtime/README.md
@@ -16,11 +16,12 @@ re-validates its persisted log before it is trusted.
 The Claude Code adapter requires the `claude` command, `curl`, and Cargo when building from a checkout.
 
 Every `appa` build knows the SHA-256 of the plugin artifact belonging to its own
-release and accepts no other bytes. From an extracted release archive on POSIX,
-init downloads that artifact, verifies it, and caches it:
+release and accepts no other bytes. On Linux and macOS the installer fetches
+the release archive, verifies its checksum, and places `appa` in
+`~/.local/bin`; init then downloads that artifact, verifies it, and caches it:
 
 ```sh
-install -m 755 appa ~/.local/bin/
+curl -fsSL https://openappa.com/install.sh | sh
 appa init claude-code
 ```
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -44,11 +44,14 @@ that binary. Release builds carry an immutable tag and artifact digest; clean
 checkout builds carry an immutable commit and plugin-tree digest. The result
 does not depend on the working directory.
 
-From a release binary, that digest is baked in. The artifact is downloaded once,
-verified against the digest before anything outside a temporary file changes,
-and cached, so a later init needs no network:
+From a release binary, that digest is baked in. The installer verifies the
+checksum of the binary for Linux or macOS and places it in `~/.local/bin`
+(Windows: unpack the zip from the releases page). Init then downloads the
+artifact once, verifies it against the digest before anything outside a
+temporary file changes, and caches it, so a later init needs no network:
 
 ```sh
+curl -fsSL https://openappa.com/install.sh | sh
 appa init claude-code
 ```
 
@@ -208,7 +211,8 @@ Claude usage, so nothing runs it automatically.
 
 ## Upgrade
 
-Install the new `appa` package, then rerun `appa init claude-code`. Init replaces
+Rerun the installer (or `cargo install` from the new checkout), then rerun
+`appa init claude-code`. Init replaces
 the deployed runtime and the APPA marketplace together, always as one bundle,
 and preserves policy and database files.
 
@@ -233,8 +237,8 @@ claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 pkill -f 'appa runtime'
 rm -rf ~/.local/share/appa/bin ~/.local/share/appa/deployments ~/.local/share/appa/cache
-rm -f ~/.cargo/bin/clappa ~/.local/bin/appa-statusline.sh
-cargo uninstall appa
+rm -f ~/.local/bin/appa ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
+rm -f ~/.cargo/bin/clappa && cargo uninstall appa   # checkout builds only
 
 # drop the statusline entry appa init wrote, and keep one of your own:
 jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -52,7 +52,7 @@ temporary file changes, and caches it, so a later init needs no network:
 
 ```sh
 curl -fsSL https://openappa.com/install.sh | sh
-appa init claude-code
+~/.local/bin/appa init claude-code
 ```
 
 A clean checkout build downloads the source archive for its exact commit,

--- a/scripts/appa-install-test.sh
+++ b/scripts/appa-install-test.sh
@@ -44,6 +44,7 @@ done
 cat > "$work/server.py" <<'EOF'
 import functools
 import http.server
+import socketserver
 import sys
 
 root, port_file, tag = sys.argv[1:4]
@@ -69,9 +70,15 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         pass
 
 
-server = http.server.HTTPServer(
-    ("127.0.0.1", 0), functools.partial(Handler, directory=root)
-)
+class Server(http.server.HTTPServer):
+    # HTTPServer.server_bind resolves the bound host with getfqdn, which can
+    # stall for a long time on macOS runners. The name is never used here.
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
+server = Server(("127.0.0.1", 0), functools.partial(Handler, directory=root))
 with open(port_file, "w") as handle:
     handle.write(str(server.server_port))
 server.serve_forever()
@@ -80,9 +87,10 @@ python3 "$work/server.py" "$work/site" "$work/port" "$tag" &
 server_pid=$!
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   [ -s "$work/port" ] && break
+  kill -0 "$server_pid" 2>/dev/null || { echo "release server exited" >&2; exit 1; }
   sleep 1
 done
-[ -s "$work/port" ] || { echo "release server did not start" >&2; exit 1; }
+[ -s "$work/port" ] || { echo "release server did not start within 10s" >&2; exit 1; }
 origin=http://127.0.0.1:$(cat "$work/port")
 
 failures=0

--- a/scripts/appa-install-test.sh
+++ b/scripts/appa-install-test.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+# Exercise scripts/appa-install.sh against a local release.
+#
+# A python3 HTTP server plays GitHub: it serves a staged release tree and
+# answers `releases/latest` with the same redirect GitHub sends. Every
+# acceptance path of the installer runs against it, on this machine's own
+# platform, with a stub `appa` in place of the real binary.
+set -eu
+
+repo=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+installer=$repo/scripts/appa-install.sh
+tag=v0.0.0-smoke
+
+work=$(mktemp -d)
+server_pid=
+cleanup() {
+  if [ -n "$server_pid" ]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sums() { sha256sum "$@"; }
+else
+  sums() { shasum -a 256 "$@"; }
+fi
+
+# Stage the release: one stub archive per supported target, laid out exactly as
+# GitHub serves release assets, plus a second "repository" whose latest
+# redirect points at another host.
+release=$work/site/good/releases/download/$tag
+mkdir -p "$release" "$work/stage"
+printf '#!/bin/sh\necho "appa 0.0.0-smoke"\n' > "$work/stage/appa"
+chmod 755 "$work/stage/appa"
+for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu \
+  x86_64-apple-darwin aarch64-apple-darwin; do
+  tar -C "$work/stage" -czf "$release/appa-$target.tar.gz" .
+done
+(cd "$release" && sums appa-*.tar.gz > SHA256SUMS)
+
+cat > "$work/server.py" <<'EOF'
+import functools
+import http.server
+import sys
+
+root, port_file, tag = sys.argv[1:4]
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        origin = f"http://127.0.0.1:{self.server.server_port}"
+        match self.path:
+            case "/good/releases/latest":
+                self.redirect(f"{origin}/good/releases/tag/{tag}")
+            case "/foreign/releases/latest":
+                self.redirect(f"http://elsewhere.invalid/releases/tag/{tag}")
+            case _:
+                super().do_GET()
+
+    def redirect(self, location):
+        self.send_response(302)
+        self.send_header("Location", location)
+        self.end_headers()
+
+    def log_message(self, *_args):
+        pass
+
+
+server = http.server.HTTPServer(
+    ("127.0.0.1", 0), functools.partial(Handler, directory=root)
+)
+with open(port_file, "w") as handle:
+    handle.write(str(server.server_port))
+server.serve_forever()
+EOF
+python3 "$work/server.py" "$work/site" "$work/port" "$tag" &
+server_pid=$!
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -s "$work/port" ] && break
+  sleep 1
+done
+[ -s "$work/port" ] || { echo "release server did not start" >&2; exit 1; }
+origin=http://127.0.0.1:$(cat "$work/port")
+
+failures=0
+report() {
+  printf '%s: %s\n' "$1" "$2" >&2
+  if [ "$1" = FAIL ]; then failures=$((failures + 1)); fi
+}
+
+# Each case gets a fresh install directory, with a space in its name.
+case_dir() {
+  dir="$work/cases/$1/install dir"
+  mkdir -p "$(dirname "$dir")"
+  printf '%s\n' "$dir"
+}
+
+expect_installed() {
+  name=$1
+  shift
+  dir=$(case_dir "$name")
+  if env APPA_REPOSITORY_URL="$origin/good" APPA_INSTALL_DIR="$dir" "$@" \
+    sh "$installer" >"$work/$name.out" 2>"$work/$name.err" &&
+    [ "$("$dir/appa" --version)" = "appa 0.0.0-smoke" ] &&
+    grep -q "Installed appa 0.0.0-smoke" "$work/$name.out"; then
+    report PASS "$name"
+  else
+    cat "$work/$name.out" "$work/$name.err" >&2
+    report FAIL "$name"
+  fi
+}
+
+expect_refused() {
+  name=$1
+  shift
+  dir=$(case_dir "$name")
+  if env APPA_INSTALL_DIR="$dir" "$@" sh "$installer" >"$work/$name.out" 2>"$work/$name.err"; then
+    report FAIL "$name (installer succeeded)"
+  elif [ -e "$dir/appa" ]; then
+    report FAIL "$name (installed despite failing)"
+  elif ! grep -q '^appa-install: ' "$work/$name.err"; then
+    cat "$work/$name.err" >&2
+    report FAIL "$name (no installer error message)"
+  else
+    report PASS "$name"
+  fi
+}
+
+expect_installed latest-redirect
+expect_installed pinned-version APPA_VERSION="$tag"
+
+expect_refused invalid-version APPA_REPOSITORY_URL="$origin/good" APPA_VERSION='../main'
+expect_refused foreign-redirect APPA_REPOSITORY_URL="$origin/foreign"
+expect_refused relative-install-dir APPA_REPOSITORY_URL="$origin/good" APPA_INSTALL_DIR=relative/bin
+
+# The rest tamper with the release itself, so restore it after each case.
+cp "$release/SHA256SUMS" "$work/SHA256SUMS.good"
+restore() { cp "$work/SHA256SUMS.good" "$release/SHA256SUMS"; }
+
+grep -Ev 'apple-darwin|linux-gnu' "$work/SHA256SUMS.good" > "$release/SHA256SUMS" || true
+expect_refused unlisted-archive APPA_REPOSITORY_URL="$origin/good"
+restore
+
+cat "$work/SHA256SUMS.good" "$work/SHA256SUMS.good" > "$release/SHA256SUMS"
+expect_refused duplicate-listing APPA_REPOSITORY_URL="$origin/good"
+restore
+
+# Rotating every hex digit changes every hash while keeping the names.
+while read -r hash name; do
+  printf '%s  %s\n' "$(printf '%s' "$hash" | tr '0123456789abcdef' '123456789abcdef0')" "$name"
+done < "$work/SHA256SUMS.good" > "$release/SHA256SUMS"
+expect_refused digest-mismatch APPA_REPOSITORY_URL="$origin/good"
+restore
+
+# A PATH holding everything the installer needs except a digest tool.
+mkdir "$work/nodigest"
+for tool in sh curl tar gzip mktemp install uname grep cut mkdir rm cat env; do
+  ln -s "$(command -v "$tool")" "$work/nodigest/$tool"
+done
+expect_refused no-digest-tool APPA_REPOSITORY_URL="$origin/good" PATH="$work/nodigest"
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures installer case(s) failed" >&2
+  exit 1
+fi
+echo "all installer cases passed" >&2

--- a/scripts/appa-install-test.sh
+++ b/scripts/appa-install-test.sh
@@ -93,9 +93,7 @@ report() {
 
 # Each case gets a fresh install directory, with a space in its name.
 case_dir() {
-  dir="$work/cases/$1/install dir"
-  mkdir -p "$(dirname "$dir")"
-  printf '%s\n' "$dir"
+  printf '%s\n' "$work/cases/$1/install dir"
 }
 
 expect_installed() {
@@ -153,7 +151,6 @@ while read -r hash name; do
   printf '%s  %s\n' "$(printf '%s' "$hash" | tr '0123456789abcdef' '123456789abcdef0')" "$name"
 done < "$work/SHA256SUMS.good" > "$release/SHA256SUMS"
 expect_refused digest-mismatch APPA_REPOSITORY_URL="$origin/good"
-restore
 
 # A PATH holding everything the installer needs except a digest tool.
 mkdir "$work/nodigest"

--- a/scripts/appa-install.sh
+++ b/scripts/appa-install.sh
@@ -23,6 +23,10 @@ fail() {
 }
 
 command -v curl >/dev/null 2>&1 || fail "curl is required"
+# A stalled release host fails the install instead of holding the shell.
+fetch() {
+  curl -fsS --connect-timeout 15 --speed-limit 1024 --speed-time 30 "$@"
+}
 
 if command -v sha256sum >/dev/null 2>&1; then
   digest() { sha256sum "$1" | cut -d' ' -f1; }
@@ -62,7 +66,7 @@ esac
 if [ -n "${APPA_VERSION:-}" ]; then
   tag=$APPA_VERSION
 else
-  latest=$(curl -fsS -o /dev/null -w '%{redirect_url}' "$repository/releases/latest") ||
+  latest=$(fetch -o /dev/null -w '%{redirect_url}' "$repository/releases/latest") ||
     fail "could not resolve the latest release from $repository"
   case $latest in
     "$repository/releases/tag/"*) tag=${latest#"$repository/releases/tag/"} ;;
@@ -78,9 +82,9 @@ trap 'rm -rf "$work"' EXIT
 # `latest`, so a release published mid-run cannot pair one with the other.
 release=$repository/releases/download/$tag
 printf 'Downloading appa %s for %s-%s\n' "$tag" "$architecture" "$platform" >&2
-curl -fsSL -o "$work/SHA256SUMS" "$release/SHA256SUMS" ||
+fetch -L -o "$work/SHA256SUMS" "$release/SHA256SUMS" ||
   fail "could not download $release/SHA256SUMS"
-curl -fsSL -o "$work/$archive" "$release/$archive" ||
+fetch -L -o "$work/$archive" "$release/$archive" ||
   fail "could not download $release/$archive"
 
 listed=$(grep -E "^[0-9a-f]{64}  $archive\$" "$work/SHA256SUMS" || true)
@@ -98,13 +102,17 @@ tar -xzf "$work/$archive" -C "$work/extract"
 version=$("$work/extract/appa" --version) ||
   fail "the $tag binary does not run on this system; Linux needs glibc 2.34 or newer"
 
+# The previous appa stays in place until the new one is completely written
+# beside it, so a failed copy never leaves the directory without a working
+# binary.
 mkdir -p "$install_dir"
-install -m 755 "$work/extract/appa" "$install_dir/appa"
+install -m 755 "$work/extract/appa" "$install_dir/appa.$$.new"
+mv -f "$install_dir/appa.$$.new" "$install_dir/appa"
 printf 'Installed %s to %s\n' "$version" "$install_dir/appa"
 case :$PATH: in
   *":$install_dir:"*) printf 'Next: appa init claude-code\n' ;;
   *)
     printf 'Add %s to PATH to run appa by name.\n' "$install_dir"
-    printf 'Next: %s/appa init claude-code\n' "$install_dir"
+    printf 'Next: "%s/appa" init claude-code\n' "$install_dir"
     ;;
 esac

--- a/scripts/appa-install.sh
+++ b/scripts/appa-install.sh
@@ -102,7 +102,9 @@ mkdir -p "$install_dir"
 install -m 755 "$work/extract/appa" "$install_dir/appa"
 printf 'Installed %s to %s\n' "$version" "$install_dir/appa"
 case :$PATH: in
-  *":$install_dir:"*) ;;
-  *) printf 'Add %s to PATH to run appa by name.\n' "$install_dir" ;;
+  *":$install_dir:"*) printf 'Next: appa init claude-code\n' ;;
+  *)
+    printf 'Add %s to PATH to run appa by name.\n' "$install_dir"
+    printf 'Next: %s/appa init claude-code\n' "$install_dir"
+    ;;
 esac
-printf 'Next: appa init claude-code\n'

--- a/scripts/appa-install.sh
+++ b/scripts/appa-install.sh
@@ -109,7 +109,7 @@ mkdir -p "$install_dir"
 install -m 755 "$work/extract/appa" "$install_dir/appa.$$.new"
 mv -f "$install_dir/appa.$$.new" "$install_dir/appa"
 printf 'Installed %s to %s\n' "$version" "$install_dir/appa"
-case :$PATH: in
+case :${PATH:-}: in
   *":$install_dir:"*) printf 'Next: appa init claude-code\n' ;;
   *)
     printf 'Add %s to PATH to run appa by name.\n' "$install_dir"

--- a/scripts/appa-install.sh
+++ b/scripts/appa-install.sh
@@ -94,11 +94,12 @@ mkdir "$work/extract"
 tar -xzf "$work/$archive" -C "$work/extract"
 [ -f "$work/extract/appa" ] || fail "$archive does not contain appa"
 
+# An installed appa is replaced only by one that runs here.
+version=$("$work/extract/appa" --version) ||
+  fail "the $tag binary does not run on this system; Linux needs glibc 2.34 or newer"
+
 mkdir -p "$install_dir"
 install -m 755 "$work/extract/appa" "$install_dir/appa"
-version=$("$install_dir/appa" --version) ||
-  fail "$install_dir/appa does not run on this system; Linux needs glibc 2.34 or newer"
-
 printf 'Installed %s to %s\n' "$version" "$install_dir/appa"
 case :$PATH: in
   *":$install_dir:"*) ;;

--- a/scripts/appa-install.sh
+++ b/scripts/appa-install.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Install the released `appa` binary for this machine:
+#
+#   curl -fsSL https://openappa.com/install.sh | sh
+#
+# Every release ships one archive per platform beside a SHA256SUMS list. The
+# script resolves the latest release tag (or `APPA_VERSION`), downloads the
+# archive and the list from that one release, verifies the digest, and installs
+# `appa` into `APPA_INSTALL_DIR` (default `~/.local/bin`). It never runs
+# `appa init`: init can prompt, and under a pipe stdin is the script itself.
+#
+# Linux and macOS on x86_64 and aarch64 only. Windows users unpack the zip from
+# the releases page. `APPA_REPOSITORY_URL` exists for appa-install-test.sh,
+# which serves a local release.
+set -eu
+
+repository=${APPA_REPOSITORY_URL:-https://github.com/archestra-ai/OpenAPPA}
+tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$'
+
+fail() {
+  printf 'appa-install: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  digest() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null 2>&1; then
+  digest() { shasum -a 256 "$1" | cut -d' ' -f1; }
+else
+  fail "sha256sum or shasum is required to verify the download"
+fi
+
+system=$(uname -s)
+machine=$(uname -m)
+case $system in
+  Linux) platform=unknown-linux-gnu ;;
+  Darwin) platform=apple-darwin ;;
+  *) fail "no release binary for $system; see $repository/releases" ;;
+esac
+case $machine in
+  x86_64 | amd64) architecture=x86_64 ;;
+  aarch64 | arm64) architecture=aarch64 ;;
+  *) fail "no release binary for $system $machine; see $repository/releases" ;;
+esac
+archive=appa-$architecture-$platform.tar.gz
+
+if [ -n "${APPA_INSTALL_DIR:-}" ]; then
+  install_dir=$APPA_INSTALL_DIR
+elif [ -n "${HOME:-}" ]; then
+  install_dir=$HOME/.local/bin
+else
+  fail "set APPA_INSTALL_DIR: HOME is not set"
+fi
+# Hooks and `clappa` are rendered with this path, from any working directory.
+case $install_dir in
+  /*) ;;
+  *) fail "APPA_INSTALL_DIR must be an absolute path" ;;
+esac
+
+if [ -n "${APPA_VERSION:-}" ]; then
+  tag=$APPA_VERSION
+else
+  latest=$(curl -fsS -o /dev/null -w '%{redirect_url}' "$repository/releases/latest") ||
+    fail "could not resolve the latest release from $repository"
+  case $latest in
+    "$repository/releases/tag/"*) tag=${latest#"$repository/releases/tag/"} ;;
+    *) fail "unexpected redirect for the latest release: $latest" ;;
+  esac
+fi
+printf '%s\n' "$tag" | grep -Eq "$tag_pattern" || fail "not a release tag: $tag"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# The list and the archive come from the same pinned release, never from
+# `latest`, so a release published mid-run cannot pair one with the other.
+release=$repository/releases/download/$tag
+printf 'Downloading appa %s for %s-%s\n' "$tag" "$architecture" "$platform" >&2
+curl -fsSL -o "$work/SHA256SUMS" "$release/SHA256SUMS" ||
+  fail "could not download $release/SHA256SUMS"
+curl -fsSL -o "$work/$archive" "$release/$archive" ||
+  fail "could not download $release/$archive"
+
+listed=$(grep -E "^[0-9a-f]{64}  $archive\$" "$work/SHA256SUMS" || true)
+[ "$(printf '%s\n' "$listed" | grep -c .)" -eq 1 ] ||
+  fail "SHA256SUMS does not list $archive exactly once"
+expected=${listed%% *}
+actual=$(digest "$work/$archive")
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $archive"
+
+mkdir "$work/extract"
+tar -xzf "$work/$archive" -C "$work/extract"
+[ -f "$work/extract/appa" ] || fail "$archive does not contain appa"
+
+mkdir -p "$install_dir"
+install -m 755 "$work/extract/appa" "$install_dir/appa"
+version=$("$install_dir/appa" --version) ||
+  fail "$install_dir/appa does not run on this system; Linux needs glibc 2.34 or newer"
+
+printf 'Installed %s to %s\n' "$version" "$install_dir/appa"
+case :$PATH: in
+  *":$install_dir:"*) ;;
+  *) printf 'Add %s to PATH to run appa by name.\n' "$install_dir" ;;
+esac
+printf 'Next: appa init claude-code\n'

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -9,12 +9,20 @@ OpenAPPA is designed for multiple agent surfaces. **Claude Code is simply the fi
 
 ## Install the Claude Code demo
 
-You need Cargo, Claude Code, and `curl`.
+You need Claude Code and `curl`.
 
 ```sh
-cargo install --path appa-runtime --force
+curl -fsSL https://openappa.com/install.sh | sh
 appa init claude-code
 ```
+
+The installer downloads the release binary for your Linux or macOS machine,
+verifies its checksum, and places `appa` in `~/.local/bin`. It prints a hint
+when that directory is not on your `PATH`. Set `APPA_VERSION` to a release tag
+to install that release instead of the latest one. On Windows, unpack the zip
+from the [releases page](https://github.com/archestra-ai/OpenAPPA/releases)
+and run `appa init claude-code` from it. From a checkout, `cargo install --path
+appa-runtime --force` builds the binary instead of downloading one.
 
 Initialization prints progress while it resolves the matching plugin, updates
 Claude Code, and starts the runtime. If a different APPA build already owns the
@@ -145,8 +153,8 @@ claude plugin uninstall appa-runtime
 claude plugin marketplace remove appa
 pkill -f 'appa runtime'
 rm -rf ~/.local/share/appa/bin ~/.local/share/appa/deployments ~/.local/share/appa/cache
-rm -f ~/.cargo/bin/clappa ~/.local/bin/appa-statusline.sh
-cargo uninstall appa
+rm -f ~/.local/bin/appa ~/.local/bin/clappa ~/.local/bin/appa-statusline.sh
+rm -f ~/.cargo/bin/clappa && cargo uninstall appa   # checkout builds only
 
 # drop the statusline entry appa init wrote, and keep one of your own:
 jq 'if (.statusLine.command? // "") | test("appa-statusline") then del(.statusLine) else . end' \

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -13,7 +13,7 @@ You need Claude Code and `curl`.
 
 ```sh
 curl -fsSL https://openappa.com/install.sh | sh
-appa init claude-code
+~/.local/bin/appa init claude-code
 ```
 
 The installer downloads the release binary for your Linux or macOS machine,

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -37,6 +37,14 @@ const nextConfig: NextConfig = {
       { source: "/docs", destination: "/", permanent: true },
       { source: "/docs/:slug", destination: "/:slug", permanent: true },
       { source: "/chat", destination: "/playground", permanent: true },
+      // The installer is a release asset, so the short URL always serves the
+      // script published with the latest release.
+      {
+        source: "/install.sh",
+        destination:
+          "https://github.com/archestra-ai/OpenAPPA/releases/latest/download/appa-install.sh",
+        permanent: false,
+      },
       {
         source: "/paper",
         destination: "https://arxiv.org/abs/2607.24625",


### PR DESCRIPTION
## Summary
- `scripts/appa-install.sh`: POSIX installer for Linux and macOS (x86_64, aarch64). Resolves the latest release tag (or `APPA_VERSION`), downloads the archive and `SHA256SUMS` from that one release, verifies the digest, checks the binary runs, and installs it atomically into `APPA_INSTALL_DIR` (default `~/.local/bin`). Never runs `appa init`.
- `scripts/appa-install-test.sh`: runs the installer against a local release served by a python3 HTTP server with a `releases/latest` redirect. Covers the redirect path, a pinned version, and every refusal: invalid tag, foreign redirect, relative install dir, unlisted or duplicate checksum line, digest mismatch, no digest tool.
- CI: both scripts join the `sh -n` and shellcheck lists; a new `installer-checks` job runs the cases on ubuntu and macos.
- Release: `publish-release` checks out the release tag and uploads `scripts/appa-install.sh` as the `appa-install.sh` asset, so the script a user runs is the one shipped with that release.
- Website: `/install.sh` redirects to `releases/latest/download/appa-install.sh`.
- Docs: `curl -fsSL https://openappa.com/install.sh | sh` is the primary install; `cargo install` stays for checkouts; uninstall covers `~/.local/bin/appa` and `clappa`.

## Known gaps
- The one-liner works from the next release onward: v0.6.1 assets still carry the `appa-runtime-<target>` names and no `appa-install.sh`.
- Windows keeps the manual zip download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ckmn2UhusSYRa6CxiKv9Q9