### PR TITLE
refactor: consolidate the day's merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,12 @@ jobs:
         run: rustup show
 
       # Only what is platform-specific here: the config and data directory
-      # rules, the proc_pidpath process discovery the stop set verifies with,
-      # and the hooks a materialized deployment renders. Not a second full
-      # workspace check, clippy and test run.
+      # rules, the process ownership check init stops a runtime with, and the
+      # hooks a materialized deployment renders. Not a second full workspace
+      # check, clippy and test run.
       - name: Deployment tests
         run: |
-          cargo test --locked --package appa --lib init:: -- --include-ignored --skip real_claude
+          cargo test --locked --package appa --lib init::
           cargo test --locked --package appa --lib plugin_bundle::
           cargo test --locked --package appa --test init_cli
           cargo test --locked --package appa --test plugin_hooks

--- a/appa-engine/src/admit.rs
+++ b/appa-engine/src/admit.rs
@@ -52,6 +52,8 @@ pub enum AdmitError {
     SanitizerBindingMismatch,
     #[error("the bound sanitizer is not registered for output, or the raw result does not satisfy its `from`")]
     SanitizerTransitionUnmet,
+    #[error("the bound sanitizer's transition awaits membership answers")]
+    MembershipNeeded(crate::label::MembershipNeeded),
     #[error(
         "the derivation still narrows the bound its dispatch pinned: the residual is the agent's to accept or improve at the confined stage"
     )]
@@ -119,11 +121,9 @@ pub(crate) fn bound_candidate(
         .sanitizer(sanitizer)
         .ok_or_else(|| AdmitError::UnknownTool(sanitizer.as_str().to_string()))?;
     let raw_label = contract.output_label();
-    // An undecided derivation cannot land here: a bound sanitizer's evidence was pinned at
-    // binding, so the same answers decide the transition again.
     let derived = registered
         .derive_output(&raw_label, &contract.tags, context)
-        .map_err(|_| AdmitError::SanitizerTransitionUnmet)?
+        .map_err(AdmitError::MembershipNeeded)?
         .ok_or(AdmitError::SanitizerTransitionUnmet)?;
     let receiving = views.receiving_bound(dispatch).ok_or(AdmitError::NotOpen)?;
     let residual = confined_residual(receiving, &derived);
@@ -765,6 +765,107 @@ mod tests {
                 },
             ),
             Err(AdmitError::ConfinedResidual)
+        );
+    }
+
+    /// A bound sanitizer whose `from` names a group derives only under that group's answer:
+    /// an admission whose context lacks it asks for the atom instead of reporting the
+    /// transition unmet.
+    #[test]
+    fn a_bound_derivation_missing_a_membership_answer_asks_for_it() {
+        let team = crate::label::GroupRef::Named(crate::names::GroupName::new("team"));
+        let team_atom = crate::label::SymbolicAtom::Group(team.clone());
+        let declassify = crate::names::SanitizerName::new("declassify");
+        let get = ToolAnnotation {
+            description: Some("A test tool.".to_string()),
+            name: ToolName::new("get_ticket"),
+            tags: vec![],
+            delta: Delta {
+                trust: Some(SUSPICIOUS),
+                audience: Some(DeclaredAudience::literal(internal())),
+            },
+            parameters: crate::params::ToolParameters::open(),
+            emits: EffectSet::new([EffectKind::new("read")]).unwrap(),
+            requires: Default::default(),
+        };
+        let reg = Registry::build_covered(RegistryConfig {
+            trust_chain: TrustChain::new(vec!["suspicious".into(), "trusted".into()]),
+            tools: vec![ToolDeclaration::Declared(get)],
+            annotators: vec![],
+            authorities: vec![],
+            sanitizers: vec![Sanitizer {
+                name: declassify.clone(),
+                on: SanitizerPoints {
+                    input: false,
+                    output: true,
+                },
+                transition: DeclaredTransition::Audience {
+                    from_includes: DeclaredAudience::Union(
+                        crate::label::Clause::new([], [team], []).expect("a group clause"),
+                    ),
+                    to: DeclaredAudience::literal(internal()),
+                },
+                scope: Scope::default(),
+                hint: None,
+            }],
+            audience: crate::audience::AudienceConfig {
+                sources: vec![crate::audience::SourceRegistration {
+                    provider: "slack".to_string(),
+                    templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                }],
+                groups: vec![crate::audience::NamedAudience {
+                    name: crate::names::GroupName::new("team"),
+                    within: None,
+                    from: vec![crate::audience::SelectorSpec {
+                        provider: "slack".to_string(),
+                        selector: "user-group/team".to_string(),
+                    }],
+                }],
+                ..crate::audience::AudienceConfig::default()
+            },
+        })
+        .unwrap();
+        let call = get_call();
+        let (mut log, dispatch) = open_log(&call);
+        let answered = crate::label::TestContext {
+            expansions: crate::label::Expansions::new([(
+                team_atom.clone(),
+                std::collections::BTreeSet::from([ReaderId::new("insider")]),
+            )]),
+            ..crate::label::TestContext::default()
+        };
+        log.push(Fact::OutputSanitizerBound {
+            trajectory: traj(),
+            dispatch: dispatch.clone(),
+            plan: crate::plan::PlanId::new(1),
+            sanitizer: declassify.clone(),
+            contribution: crate::plan::bound_contribution(
+                &reg,
+                &reg.annotation_of(&call).expect("the fixture registers the tool"),
+                &declassify,
+                &answered.context(),
+            )
+            .expect("the binding answered the group")
+            .expect("declassify applies to this output"),
+            evidence: crate::audience::AudienceEvidence::default(),
+        });
+        let p = views_of(&log);
+
+        assert_eq!(
+            admit(
+                &reg,
+                &p.view(&traj()),
+                &dispatch,
+                &call,
+                ResultAdmission::SuccessSanitized {
+                    body: ValueBody::new("redacted"),
+                    sanitizer: declassify,
+                    raw_digest: RawResultDigest::of(b"ticket"),
+                },
+            ),
+            Err(AdmitError::MembershipNeeded(crate::label::MembershipNeeded {
+                needed: vec![team_atom]
+            }))
         );
     }
 

--- a/appa-engine/src/admit.rs
+++ b/appa-engine/src/admit.rs
@@ -113,7 +113,7 @@ pub(crate) fn bound_candidate(
     raw_digest: RawResultDigest,
     body: ValueBody,
     context: &MembershipContext<'_>,
-) -> Result<(crate::authority::Transition, DerivedCandidate, SanitizerLineage), AdmitError> {
+) -> Result<(DerivedCandidate, SanitizerLineage), AdmitError> {
     if views.bound_sanitizer(dispatch) != Some(sanitizer) {
         return Err(AdmitError::SanitizerBindingMismatch);
     }
@@ -128,7 +128,6 @@ pub(crate) fn bound_candidate(
     let receiving = views.receiving_bound(dispatch).ok_or(AdmitError::NotOpen)?;
     let residual = confined_residual(receiving, &derived);
     Ok((
-        registered.transition.applied(),
         DerivedCandidate::Result {
             dispatch: dispatch.clone(),
             source: raw_digest,
@@ -230,7 +229,7 @@ pub(crate) fn admit_result(
             sanitizer,
             raw_digest,
         } => {
-            let (transition, derived, lineage) = bound_candidate(
+            let (derived, lineage) = bound_candidate(
                 registry, views, dispatch, &contract, &sanitizer, raw_digest, body, context,
             )?;
             let DerivedCandidate::Result { value, residual, .. } = &derived else {
@@ -245,10 +244,7 @@ pub(crate) fn admit_result(
                 Fact::CandidateDerived {
                     trajectory: trajectory.clone(),
                     subject: crate::basis::SubjectKey::ConfinedResult(dispatch.clone()),
-                    via: crate::candidate::DerivedVia {
-                        name: sanitizer,
-                        transition,
-                    },
+                    sanitizer,
                     derived,
                     lineage,
                     evidence: evidence.clone(),

--- a/appa-engine/src/admit.rs
+++ b/appa-engine/src/admit.rs
@@ -828,10 +828,13 @@ mod tests {
         let call = get_call();
         let (mut log, dispatch) = open_log(&call);
         let answered = crate::label::TestContext {
-            expansions: crate::label::Expansions::new([(
-                team_atom.clone(),
-                std::collections::BTreeSet::from([ReaderId::new("insider")]),
-            )]),
+            expansions: crate::label::Expansions::new(
+                [(
+                    team_atom.clone(),
+                    std::collections::BTreeSet::from([ReaderId::new("insider")]),
+                )],
+                [],
+            ),
             ..crate::label::TestContext::default()
         };
         log.push(Fact::OutputSanitizerBound {

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -108,7 +108,7 @@ impl AudienceEvidence {
 
     /// Does this evidence carry every entry of `other`? An operation may extend what an
     /// earlier record pinned, never contradict or drop it.
-    pub fn contains(&self, other: &AudienceEvidence) -> bool {
+    pub(crate) fn contains(&self, other: &AudienceEvidence) -> bool {
         other.sources.iter().all(|claims| self.sources.contains(claims))
             && other.lookups.iter().all(|lookup| self.lookups.contains(lookup))
             && other.identity.iter().all(|mapping| self.identity.contains(mapping))
@@ -265,7 +265,7 @@ pub fn folded_claims(evidence: &AudienceEvidence) -> Result<BTreeMap<String, Mem
 /// equality: no dot folding, no `+suffix` stripping, no alias folding, and the local part
 /// keeps its case ([`ReaderId::new`] lowercases only the domain). A malformed claimed email
 /// is an invalid answer, never a silent fallback.
-pub fn verified_email_principal(claims: &MemberClaims) -> Result<ReaderId, EvidenceRefusal> {
+pub(crate) fn verified_email_principal(claims: &MemberClaims) -> Result<ReaderId, EvidenceRefusal> {
     match &claims.verified_email {
         None => Ok(ReaderId::new(claims.id.clone())),
         Some(email) => match crate::label::address_parts(email) {
@@ -489,7 +489,7 @@ impl AudienceRegistry {
     }
 
     /// The declared `within` assertions, as the evaluation consumes them.
-    pub fn within_assertions(&self) -> &crate::label::WithinAssertions {
+    pub(crate) fn within_assertions(&self) -> &crate::label::WithinAssertions {
         &self.within
     }
 

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -115,34 +115,63 @@ impl AudienceEvidence {
     }
 
     /// This act's evidence read under an earlier record's pins: the pinned entries come
-    /// first and win, and only answers for keys the pins do not hold are added. A chain of
-    /// operations over one value reads each primitive under one answer.
-    pub fn inheriting(&self, pinned: &AudienceEvidence) -> AudienceEvidence {
+    /// first, an answer restating a pin is that one entry, and an answer for a key the pins
+    /// hold with different content is a contradiction the operation refuses. Nothing here
+    /// dedups the act's own entries: two answers for one key stay two, for validation to
+    /// refuse. A chain of operations over one value reads each primitive under one answer.
+    pub fn inheriting(&self, pinned: &AudienceEvidence) -> Result<AudienceEvidence, EvidenceRefusal> {
         let mut merged = pinned.clone();
         for claims in &self.sources {
-            let held = merged
+            let held = pinned
                 .sources
                 .iter()
-                .any(|entry| entry.provider == claims.provider && entry.selector == claims.selector);
-            if !held {
-                merged.sources.push(claims.clone());
+                .find(|entry| entry.provider == claims.provider && entry.selector == claims.selector);
+            match held {
+                None => merged.sources.push(claims.clone()),
+                Some(entry) if entry == claims => {}
+                Some(_) => return Err(EvidenceRefusal::ContradictedPin { entry: claims.entry() }),
             }
         }
         for lookup in &self.lookups {
-            let held = merged
+            let held = pinned
                 .lookups
                 .iter()
-                .any(|entry| entry.provider == lookup.provider && entry.member == lookup.member);
-            if !held {
-                merged.lookups.push(lookup.clone());
+                .find(|entry| entry.provider == lookup.provider && entry.member == lookup.member);
+            match held {
+                None => merged.lookups.push(lookup.clone()),
+                Some(entry) if entry == lookup => {}
+                Some(_) => return Err(EvidenceRefusal::ContradictedPin { entry: lookup.entry() }),
             }
         }
         for mapping in &self.identity {
-            if !merged.identity.iter().any(|entry| entry.id == mapping.id) {
-                merged.identity.push(mapping.clone());
+            match pinned.identity.iter().find(|entry| entry.id == mapping.id) {
+                None => merged.identity.push(mapping.clone()),
+                Some(entry) if entry == mapping => {}
+                Some(_) => return Err(EvidenceRefusal::ContradictedPin { entry: mapping.entry() }),
             }
         }
-        merged
+        Ok(merged)
+    }
+}
+
+impl SourceClaims {
+    /// The entry as a refusal names it.
+    fn entry(&self) -> String {
+        format!("source {}:{}", self.provider, self.selector)
+    }
+}
+
+impl MemberLookup {
+    /// The entry as a refusal names it.
+    fn entry(&self) -> String {
+        format!("lookup {}", self.member)
+    }
+}
+
+impl IdentityMapping {
+    /// The entry as a refusal names it.
+    fn entry(&self) -> String {
+        format!("identity mapping for {}", self.id)
     }
 }
 
@@ -185,6 +214,8 @@ pub enum EvidenceRefusal {
     UnroutableLookup { provider: String, member: String },
     #[error("evidence entry {entry} is neither an inherited pin nor requested by this operation")]
     UnrequestedEvidence { entry: String },
+    #[error("evidence entry {entry} contradicts the answer an earlier record of this chain pinned")]
+    ContradictedPin { entry: String },
 }
 
 /// One operation-wide claim per provider id, folded across every occurrence the evidence
@@ -711,9 +742,7 @@ impl AudienceRegistry {
                 selector: claims.selector.clone(),
             };
             if !requested.selectors.contains(&spec) && !inherited.sources.contains(claims) {
-                return Err(EvidenceRefusal::UnrequestedEvidence {
-                    entry: format!("source {}:{}", claims.provider, claims.selector),
-                });
+                return Err(EvidenceRefusal::UnrequestedEvidence { entry: claims.entry() });
             }
         }
         for lookup in &evidence.lookups {
@@ -722,9 +751,7 @@ impl AudienceRegistry {
                 selector: lookup.member.clone(),
             };
             if !requested.lookups.contains(&spec) && !inherited.lookups.contains(lookup) {
-                return Err(EvidenceRefusal::UnrequestedEvidence {
-                    entry: format!("lookup {}", lookup.member),
-                });
+                return Err(EvidenceRefusal::UnrequestedEvidence { entry: lookup.entry() });
             }
         }
         // An identity mapping is requested only through a member the admitted evidence
@@ -748,9 +775,7 @@ impl AudienceRegistry {
                 IdentityImplementation::VerifiedEmail => false,
             };
             if !requested && !inherited.identity.contains(mapping) {
-                return Err(EvidenceRefusal::UnrequestedEvidence {
-                    entry: format!("identity mapping for {}", mapping.id),
-                });
+                return Err(EvidenceRefusal::UnrequestedEvidence { entry: mapping.entry() });
             }
         }
         Ok(())

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -643,6 +643,7 @@ impl AudienceRegistry {
         }
 
         let mut answers: Vec<(SymbolicAtom, BTreeSet<ReaderId>)> = Vec::new();
+        let mut principals: Vec<(ReaderId, ReaderId)> = Vec::new();
 
         // Reader canonicalizations from lookups.
         let mut seen_lookups = BTreeSet::new();
@@ -671,10 +672,7 @@ impl AudienceRegistry {
                 }
                 Some(claims) => identity.principal(&resolved(claims))?,
             };
-            answers.push((
-                SymbolicAtom::Reader(ReaderId::new(lookup.member.clone())),
-                BTreeSet::from([principal]),
-            ));
+            principals.push((ReaderId::new(lookup.member.clone()), principal));
         }
 
         // Source-qualified selector atoms answer directly.
@@ -713,7 +711,7 @@ impl AudienceRegistry {
             }
         }
 
-        Ok(Expansions::new(answers))
+        Ok(Expansions::new(answers, principals))
     }
 
     /// The operation-scope test on one act's pinned evidence: every entry is an inherited
@@ -1309,12 +1307,12 @@ mod tests {
         };
         let expansions = registry.expansions(&evidence).unwrap();
         assert_eq!(
-            expansions.members(&SymbolicAtom::Reader(ReaderId::new("slack:U012345"))),
-            Some(&BTreeSet::from([ReaderId::new("alice@corp.com")]))
+            expansions.principal(&ReaderId::new("slack:U012345")),
+            Some(&ReaderId::new("alice@corp.com"))
         );
         assert_eq!(
-            expansions.members(&SymbolicAtom::Reader(ReaderId::new("slack:UGONE"))),
-            Some(&BTreeSet::from([ReaderId::new("slack:UGONE")])),
+            expansions.principal(&ReaderId::new("slack:UGONE")),
+            Some(&ReaderId::new("slack:UGONE")),
             "not found keeps the qualified identity"
         );
     }

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -497,7 +497,9 @@ impl AudienceRegistry {
         self.groups.values().filter(move |group| group.within == Some(level))
     }
 
-    fn route_selector(&self, provider: &str, selector: &str) -> Result<SelectorSpec, Unroutable> {
+    /// The one routing rule for a selector: its provider is registered and one of that
+    /// provider's templates matches it.
+    pub(crate) fn route_selector(&self, provider: &str, selector: &str) -> Result<SelectorSpec, Unroutable> {
         let templates = self
             .providers
             .get(provider)
@@ -577,15 +579,12 @@ impl AudienceRegistry {
     /// refuse the evidence — the live act and its replay hold it to the same test.
     pub fn expansions(&self, evidence: &AudienceEvidence) -> Result<Expansions, EvidenceRefusal> {
         for claims in &evidence.sources {
-            let routable = self
-                .templates(&claims.provider)
-                .is_some_and(|templates| templates.iter().any(|template| template.matches(&claims.selector)));
-            if !routable {
-                return Err(EvidenceRefusal::UnroutableSelector {
+            self.route_selector(&claims.provider, &claims.selector).map_err(|_| {
+                EvidenceRefusal::UnroutableSelector {
                     provider: claims.provider.clone(),
                     selector: claims.selector.clone(),
-                });
-            }
+                }
+            })?;
         }
         for lookup in &evidence.lookups {
             if !self.providers().contains(&lookup.provider) {

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -1017,45 +1017,28 @@ mod tests {
 
     #[test]
     fn verified_email_is_conservative() {
-        // Same verified corporate email from two providers: one principal.
-        let gw = member("google-workspace:alice@corp.com", Some("alice@corp.com"));
-        let slack = member("slack:U012345", Some("alice@corp.com"));
-        assert_eq!(
-            verified_email_principal(&gw).unwrap(),
-            verified_email_principal(&slack).unwrap()
-        );
-        assert_eq!(verified_email_principal(&gw).unwrap().as_str(), "alice@corp.com");
-
-        // A personal email stays a different principal — no corporate guessing.
-        let github = member("github:alice", Some("alice@gmail.com"));
-        assert_ne!(
-            verified_email_principal(&github).unwrap(),
-            verified_email_principal(&gw).unwrap()
-        );
-
-        // No verified email: the qualified identity stands.
-        assert_eq!(
-            verified_email_principal(&member("github:alice", None))
-                .unwrap()
-                .as_str(),
-            "github:alice"
-        );
-
-        // Domain case folds; the local part never does, and no dots or +suffixes fold.
-        assert_eq!(
-            verified_email_principal(&member("x:1", Some("Alice@CORP.com")))
-                .unwrap()
-                .as_str(),
-            "Alice@corp.com"
-        );
-        assert_ne!(
-            verified_email_principal(&member("x:1", Some("a.lice@corp.com"))).unwrap(),
-            verified_email_principal(&member("x:2", Some("alice@corp.com"))).unwrap()
-        );
-        assert_ne!(
-            verified_email_principal(&member("x:1", Some("alice+x@corp.com"))).unwrap(),
-            verified_email_principal(&member("x:2", Some("alice@corp.com"))).unwrap()
-        );
+        // One verified corporate address is one principal whichever provider reports it; a
+        // personal address, a missing one, and any local-part variation each stay distinct.
+        // Only the domain case folds: no dots, no +suffixes, and never the local part.
+        for (id, email, principal) in [
+            (
+                "google-workspace:alice@corp.com",
+                Some("alice@corp.com"),
+                "alice@corp.com",
+            ),
+            ("slack:U012345", Some("alice@corp.com"), "alice@corp.com"),
+            ("github:alice", Some("alice@gmail.com"), "alice@gmail.com"),
+            ("github:alice", None, "github:alice"),
+            ("x:1", Some("Alice@CORP.com"), "Alice@corp.com"),
+            ("x:1", Some("a.lice@corp.com"), "a.lice@corp.com"),
+            ("x:1", Some("alice+x@corp.com"), "alice+x@corp.com"),
+        ] {
+            assert_eq!(
+                verified_email_principal(&member(id, email)).unwrap(),
+                ReaderId::new(principal),
+                "{id} with {email:?}"
+            );
+        }
 
         // A malformed claimed email is an invalid answer, not a fallback.
         for bad in ["nodomain", "two@at@signs", "@corp.com", "alice@", "a b@corp.com"] {
@@ -1065,14 +1048,12 @@ mod tests {
         // An address is the principal itself: a reader written as one — by a policy, by a
         // tool argument, by an annotation — is the reader the verified claim resolves to,
         // so an ordinary email recipient meets the directory member who holds that address.
-        assert_eq!(verified_email_principal(&gw).unwrap(), ReaderId::new("alice@corp.com"));
         // The reader ingress folds domain case the same way, so one identity has one
-        // spelling wherever it is written.
+        // spelling wherever it is written; a qualified id and an opaque reader stay as written.
         assert_eq!(
             ReaderId::new("Alice@CORP.com"),
             verified_email_principal(&member("x:1", Some("Alice@corp.com"))).unwrap()
         );
-        // Nothing else is touched: a qualified id and an opaque reader stay as written.
         assert_eq!(ReaderId::new("slack:U1").as_str(), "slack:U1");
         assert_eq!(ReaderId::new("Insider").as_str(), "Insider");
     }
@@ -1214,144 +1195,124 @@ mod tests {
         );
     }
 
+    /// Which refusal a case expects.
+    type Refuses = fn(&EvidenceRefusal) -> bool;
+
+    fn slack(selector: &str, members: Vec<MemberClaims>) -> SourceClaims {
+        SourceClaims {
+            provider: "slack".into(),
+            selector: selector.into(),
+            members,
+        }
+    }
+
+    fn sources(sources: Vec<SourceClaims>) -> AudienceEvidence {
+        AudienceEvidence {
+            sources,
+            ..AudienceEvidence::default()
+        }
+    }
+
     #[test]
     fn evidence_validation_refuses_duplicates_and_foreign_claims() {
         let registry = registry(corp_config());
-        let twice = AudienceEvidence {
-            sources: vec![
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "viewer".into(),
-                    members: vec![],
+        let refused: [(&str, AudienceEvidence, Refuses); 7] = [
+            (
+                "one selector answered twice",
+                sources(vec![
+                    slack("viewer", vec![]),
+                    slack("viewer", vec![member("slack:U1", None)]),
+                ]),
+                |refusal| matches!(refusal, EvidenceRefusal::DuplicateSelector { .. }),
+            ),
+            (
+                "a member outside the provider's namespace",
+                sources(vec![slack("viewer", vec![member("github:alice", None)])]),
+                |refusal| matches!(refusal, EvidenceRefusal::ForeignMember { .. }),
+            ),
+            (
+                // A bare provider prefix names no member: it is not inside the namespace.
+                "a bare provider prefix as a member",
+                sources(vec![slack("viewer", vec![member("slack:", None)])]),
+                |refusal| matches!(refusal, EvidenceRefusal::ForeignMember { .. }),
+            ),
+            (
+                "a malformed verified email",
+                sources(vec![slack("viewer", vec![member("slack:U1", Some("not-an-email"))])]),
+                |refusal| matches!(refusal, EvidenceRefusal::MalformedEmail { .. }),
+            ),
+            (
+                // One member twice under one selector could seat two principals for one id.
+                "one member twice under one selector",
+                sources(vec![slack(
+                    "viewer",
+                    vec![
+                        member("slack:U1", Some("a@corp.com")),
+                        member("slack:U1", Some("a@corp.com")),
+                    ],
+                )]),
+                |refusal| matches!(refusal, EvidenceRefusal::DuplicateMember { .. }),
+            ),
+            (
+                // One id, one operation-wide claim set: two verified emails across two
+                // selectors would resolve to two principals.
+                "one member with two verified emails across selectors",
+                sources(vec![
+                    slack("viewer", vec![member("slack:U1", Some("a@corp.com"))]),
+                    slack("full-members", vec![member("slack:U1", Some("b@corp.com"))]),
+                ]),
+                |refusal| matches!(refusal, EvidenceRefusal::ConflictingClaims { .. }),
+            ),
+            (
+                // A source may not canonicalize a member it does not own.
+                "a lookup answering for another member",
+                AudienceEvidence {
+                    lookups: vec![MemberLookup {
+                        provider: "slack".into(),
+                        member: "slack:U1".into(),
+                        claims: Some(member("google-workspace:alice", Some("alice@corp.com"))),
+                    }],
+                    ..AudienceEvidence::default()
                 },
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "viewer".into(),
-                    members: vec![member("slack:U1", None)],
-                },
-            ],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&twice),
-            Err(EvidenceRefusal::DuplicateSelector { .. })
-        ));
+                |refusal| matches!(refusal, EvidenceRefusal::ForeignLookupClaims { .. }),
+            ),
+        ];
+        for (case, evidence, expected) in refused {
+            match registry.expansions(&evidence) {
+                Err(refusal) => assert!(expected(&refusal), "{case}: {refusal:?}"),
+                Ok(_) => panic!("{case}: admitted"),
+            }
+        }
 
-        let foreign = AudienceEvidence {
-            sources: vec![SourceClaims {
-                provider: "slack".into(),
-                selector: "viewer".into(),
-                members: vec![member("github:alice", None)],
-            }],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&foreign),
-            Err(EvidenceRefusal::ForeignMember { .. })
-        ));
-
-        let malformed = AudienceEvidence {
-            sources: vec![SourceClaims {
-                provider: "slack".into(),
-                selector: "viewer".into(),
-                members: vec![member("slack:U1", Some("not-an-email"))],
-            }],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&malformed),
-            Err(EvidenceRefusal::MalformedEmail { .. })
-        ));
-
-        // One member twice under one selector could seat two principals for one id.
-        let doubled = AudienceEvidence {
-            sources: vec![SourceClaims {
-                provider: "slack".into(),
-                selector: "viewer".into(),
-                members: vec![
-                    member("slack:U1", Some("a@corp.com")),
-                    member("slack:U1", Some("a@corp.com")),
-                ],
-            }],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&doubled),
-            Err(EvidenceRefusal::DuplicateMember { .. })
-        ));
-
-        // A bare provider prefix names no member: it is not inside the provider's namespace.
-        let bare = AudienceEvidence {
-            sources: vec![SourceClaims {
-                provider: "slack".into(),
-                selector: "viewer".into(),
-                members: vec![member("slack:", None)],
-            }],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&bare),
-            Err(EvidenceRefusal::ForeignMember { .. })
-        ));
-
-        // One id, one operation-wide claim set: the same member reported with different
-        // verified emails across two selectors would resolve to two principals.
-        let conflicting = AudienceEvidence {
-            sources: vec![
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "viewer".into(),
-                    members: vec![member("slack:U1", Some("a@corp.com"))],
-                },
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "full-members".into(),
-                    members: vec![member("slack:U1", Some("b@corp.com"))],
-                },
-            ],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&conflicting),
-            Err(EvidenceRefusal::ConflictingClaims { .. })
-        ));
-        // The same claims twice are consistent, not conflicting.
-        let agreeing = AudienceEvidence {
-            sources: vec![
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "viewer".into(),
-                    members: vec![member("slack:U1", Some("a@corp.com"))],
-                },
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "full-members".into(),
-                    members: vec![member("slack:U1", Some("a@corp.com"))],
-                },
-            ],
-            ..AudienceEvidence::default()
-        };
-        assert!(registry.expansions(&agreeing).is_ok());
+        // The same claims twice are consistent, not conflicting; nor are two domain-case
+        // spellings of one address, which resolve to one principal.
+        for (case, evidence) in [
+            (
+                "one claim repeated",
+                sources(vec![
+                    slack("viewer", vec![member("slack:U1", Some("a@corp.com"))]),
+                    slack("full-members", vec![member("slack:U1", Some("a@corp.com"))]),
+                ]),
+            ),
+            (
+                "one address under two domain cases",
+                sources(vec![
+                    slack("viewer", vec![member("slack:U1", Some("Alice@CORP.com"))]),
+                    slack("full-members", vec![member("slack:U1", Some("Alice@corp.com"))]),
+                ]),
+            ),
+        ] {
+            assert!(registry.expansions(&evidence).is_ok(), "{case}");
+        }
 
         // A silent occurrence is no counter-claim: the viewer reports its own verified
         // address, the membership collection reports the same id and knows no address, and
         // the one verified claim seats the principal for both — the common shape of a token
         // owner who belongs to the organization the policy selected.
-        let silent_elsewhere = AudienceEvidence {
-            sources: vec![
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "viewer".into(),
-                    members: vec![member("slack:U1", Some("a@corp.com"))],
-                },
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "full-members".into(),
-                    members: vec![member("slack:U1", None), member("slack:U2", None)],
-                },
-            ],
-            ..AudienceEvidence::default()
-        };
+        let silent_elsewhere = sources(vec![
+            slack("viewer", vec![member("slack:U1", Some("a@corp.com"))]),
+            slack("full-members", vec![member("slack:U1", None), member("slack:U2", None)]),
+        ]);
         let expansions = registry
             .expansions(&silent_elsewhere)
             .expect("a silent occurrence defers to the verified claim");
@@ -1370,43 +1331,6 @@ mod tests {
             BTreeSet::from([ReaderId::new("a@corp.com"), ReaderId::new("slack:U2")]),
             "the folded claim seats one principal for the id everywhere it occurs"
         );
-
-        // Two claims conflict when they name different readers, not when two sources spell
-        // one address with different domain case: both resolve to the same principal.
-        let spelled_twice = AudienceEvidence {
-            sources: vec![
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "viewer".into(),
-                    members: vec![member("slack:U1", Some("Alice@CORP.com"))],
-                },
-                SourceClaims {
-                    provider: "slack".into(),
-                    selector: "full-members".into(),
-                    members: vec![member("slack:U1", Some("Alice@corp.com"))],
-                },
-            ],
-            ..AudienceEvidence::default()
-        };
-        assert!(
-            registry.expansions(&spelled_twice).is_ok(),
-            "one address under two domain cases is one claim"
-        );
-
-        // A lookup's claims must be for the member asked — a source may not canonicalize a
-        // member it does not own.
-        let hijack = AudienceEvidence {
-            lookups: vec![MemberLookup {
-                provider: "slack".into(),
-                member: "slack:U1".into(),
-                claims: Some(member("google-workspace:alice", Some("alice@corp.com"))),
-            }],
-            ..AudienceEvidence::default()
-        };
-        assert!(matches!(
-            registry.expansions(&hijack),
-            Err(EvidenceRefusal::ForeignLookupClaims { .. })
-        ));
 
         // A Rust-constructed identity mapping with a reserved principal fails validation,
         // not the eventual decode of the record it was pinned into.

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -780,6 +780,59 @@ impl AudienceRegistry {
     }
 }
 
+/// One act's operation-scope ledger, live and at replay alike: the union of the evidence
+/// the act's records pin, the pins of the records the act continues, and the atoms the
+/// act's decision read — its contexts' asks plus the deterministic gate atoms it answered
+/// before deciding. Settled when the act closes: every pinned entry is an inherited pin or
+/// answers a collected ask ([`AudienceRegistry::only_requested`]), so a live act cannot
+/// pre-load evidence and a log cannot smuggle evidence no operation requested.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ActLedger {
+    evidence: AudienceEvidence,
+    inherited: AudienceEvidence,
+    reads: BTreeSet<SymbolicAtom>,
+}
+
+impl ActLedger {
+    pub(crate) fn of(evidence: AudienceEvidence, inherited: AudienceEvidence) -> ActLedger {
+        ActLedger {
+            evidence,
+            inherited,
+            reads: BTreeSet::new(),
+        }
+    }
+
+    /// The evidence the act's records pin so far.
+    pub(crate) fn evidence(&self) -> &AudienceEvidence {
+        &self.evidence
+    }
+
+    /// Union one more record's pinned evidence in: the records of one act pin one answer
+    /// per key.
+    pub(crate) fn pin(&mut self, evidence: &AudienceEvidence) -> Result<(), EvidenceRefusal> {
+        self.evidence = evidence.inheriting(&self.evidence)?;
+        Ok(())
+    }
+
+    /// Count `pins` — entries a record this act continues already pinned — as inherited.
+    pub(crate) fn inherit(&mut self, pins: &AudienceEvidence) -> Result<(), EvidenceRefusal> {
+        self.inherited = self.inherited.inheriting(pins)?;
+        Ok(())
+    }
+
+    /// Log atoms the act read: a context's asks after a decision ran over it, or the gate
+    /// atoms answered before one.
+    pub(crate) fn read(&mut self, atoms: impl IntoIterator<Item = SymbolicAtom>) {
+        self.reads.extend(atoms);
+    }
+
+    /// The operation-scope test over everything logged.
+    pub(crate) fn settle(&self, audience: &AudienceRegistry) -> Result<(), EvidenceRefusal> {
+        let reads: Vec<SymbolicAtom> = self.reads.iter().cloned().collect();
+        audience.only_requested(&self.evidence, &self.inherited, &reads)
+    }
+}
+
 /// The identity implementation applied to one operation's claims: the shipped normalization
 /// recomputed, or a custom implementation's pinned mappings looked up.
 struct IdentityTable<'a> {
@@ -872,6 +925,93 @@ mod tests {
                 from: vec![spec("google-workspace", "group/finance@corp.com")],
             }],
             identity: None,
+        }
+    }
+
+    /// The ledger's verdict reads sets: pinned one act at a time as the live engine does,
+    /// or one record and one ask at a time as replay does, the settlement is the same, and
+    /// it is exactly "every pin is inherited or answers a read".
+    mod ledger {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// The corp registry's six selectors: which atoms request each is the fixture's
+        /// own statement of the configuration, independent of `needed_primitives`.
+        const SELECTORS: [(&str, &str); 6] = [
+            ("google-workspace", "viewer"),
+            ("google-workspace", "full-members"),
+            ("slack", "viewer"),
+            ("slack", "full-members"),
+            ("google-workspace", "group/finance@corp.com"),
+            ("slack", "user-group/a"),
+        ];
+
+        fn claims(selector: usize) -> SourceClaims {
+            let (provider, selector) = SELECTORS[selector];
+            SourceClaims {
+                provider: provider.to_string(),
+                selector: selector.to_string(),
+                members: vec![member(&format!("{provider}:u1"), None)],
+            }
+        }
+
+        fn evidence(selectors: impl IntoIterator<Item = usize>) -> AudienceEvidence {
+            AudienceEvidence {
+                sources: selectors.into_iter().map(claims).collect(),
+                ..AudienceEvidence::default()
+            }
+        }
+
+        fn atom(index: usize) -> (SymbolicAtom, &'static [usize]) {
+            match index {
+                0 => (SymbolicAtom::Chain(ChainAudience::Self_), &[0, 2]),
+                // internal closes over self and every group asserted within it.
+                1 => (SymbolicAtom::Chain(ChainAudience::Internal), &[0, 1, 2, 3, 4]),
+                2 => (SymbolicAtom::Group(GroupRef::Named(GroupName::new("finance"))), &[4]),
+                _ => (
+                    SymbolicAtom::Group(GroupRef::Source {
+                        provider: "slack".into(),
+                        selector: "user-group/a".into(),
+                    }),
+                    &[5],
+                ),
+            }
+        }
+
+        proptest! {
+            #[test]
+            fn settlement_is_the_same_live_and_record_by_record(
+                pins in prop::collection::btree_set(0usize..6, 0..5),
+                inherited in prop::collection::btree_set(0usize..6, 0..4),
+                reads in prop::collection::btree_set(0usize..4, 0..4),
+            ) {
+                let registry = registry(corp_config());
+                let mut live = ActLedger::of(evidence(pins.clone()), evidence(inherited.clone()));
+                live.read(reads.iter().map(|index| atom(*index).0));
+
+                let mut replay = ActLedger::default();
+                for pin in pins.iter().rev() {
+                    replay.pin(&evidence([*pin])).expect("one act pins one answer per key");
+                }
+                for pin in inherited.iter().rev() {
+                    replay.inherit(&evidence([*pin])).expect("one chain pins one answer per key");
+                }
+                for read in reads.iter().rev() {
+                    replay.read([atom(*read).0]);
+                }
+                // The verdict is order-free; which unjustified entry a refusal names follows
+                // the pin order, so the two sides may name different ones.
+                let (live, replay) = (live.settle(&registry), replay.settle(&registry));
+                prop_assert_eq!(live.is_ok(), replay.is_ok());
+                for verdict in [&live, &replay] {
+                    let unrequested = matches!(verdict, Ok(()) | Err(EvidenceRefusal::UnrequestedEvidence { .. }));
+                    prop_assert!(unrequested, "{verdict:?}");
+                }
+
+                let requested: BTreeSet<usize> = reads.iter().flat_map(|index| atom(*index).1.iter().copied()).collect();
+                let justified = pins.iter().all(|pin| inherited.contains(pin) || requested.contains(pin));
+                prop_assert_eq!(live.is_ok(), justified);
+            }
         }
     }
 

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -419,18 +419,19 @@ pub enum Unroutable {
     UnmappedChain(ChainAudience),
 }
 
+/// One member lookup to perform: the qualified member and the provider that owns it.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LookupSpec {
+    pub provider: String,
+    pub member: String,
+}
+
 /// The primitive requests one round must answer: which selectors to consult and which member
 /// lookups to perform. Identity inputs are derived from the claims those answers carry.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NeededPrimitives {
     pub selectors: BTreeSet<SelectorSpec>,
-    pub lookups: BTreeSet<SelectorSpec>,
-}
-
-impl NeededPrimitives {
-    pub fn is_empty(&self) -> bool {
-        self.selectors.is_empty() && self.lookups.is_empty()
-    }
+    pub lookups: BTreeSet<LookupSpec>,
 }
 
 impl AudienceRegistry {
@@ -561,9 +562,9 @@ impl AudienceRegistry {
                     if !self.providers.contains_key(provider) {
                         return Err(Unroutable::UnknownProvider(provider.to_string()));
                     }
-                    needed.lookups.insert(SelectorSpec {
+                    needed.lookups.insert(LookupSpec {
                         provider: provider.to_string(),
-                        selector: reader.as_str().to_string(),
+                        member: reader.as_str().to_string(),
                     });
                 }
             }
@@ -743,9 +744,9 @@ impl AudienceRegistry {
             }
         }
         for lookup in &evidence.lookups {
-            let spec = SelectorSpec {
+            let spec = LookupSpec {
                 provider: lookup.provider.clone(),
-                selector: lookup.member.clone(),
+                member: lookup.member.clone(),
             };
             if !requested.lookups.contains(&spec) && !inherited.lookups.contains(lookup) {
                 return Err(EvidenceRefusal::UnrequestedEvidence { entry: lookup.entry() });

--- a/appa-engine/src/candidate.rs
+++ b/appa-engine/src/candidate.rs
@@ -7,14 +7,6 @@ use crate::label::Label;
 use crate::names::SanitizerName;
 use crate::value::{DispatchId, LabeledValue, OfferId, RawResultDigest, ResolvedCall};
 
-/// The transformer whose application one candidate record audits: the sanitizer that derived
-/// the value, and the resolved transition it applied.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DerivedVia {
-    pub name: SanitizerName,
-    pub transition: crate::authority::Transition,
-}
-
 /// The sanitizers a candidate's chain has already spent, in application order.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "Vec<SanitizerName>", into = "Vec<SanitizerName>")]

--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -48,7 +48,7 @@ impl Delta {
     }
 
     /// The symbolic atoms this delta writes into the label.
-    pub fn symbolic_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
+    pub(crate) fn symbolic_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
         self.audience.iter().flat_map(DeclaredAudience::symbolic_atoms)
     }
 }

--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -48,11 +48,8 @@ impl Delta {
     }
 
     /// The symbolic atoms this delta writes into the label.
-    pub fn symbolic_atoms(&self) -> Box<dyn Iterator<Item = SymbolicAtom> + '_> {
-        match &self.audience {
-            Some(audience) => audience.symbolic_atoms(),
-            None => Box::new(std::iter::empty()),
-        }
+    pub fn symbolic_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
+        self.audience.iter().flat_map(DeclaredAudience::symbolic_atoms)
     }
 }
 
@@ -105,13 +102,13 @@ pub enum AudienceRequirement {
 }
 
 impl AudienceRequirement {
-    /// The symbolic atoms this requirement writes: a static recipient set's and a cap's. A
-    /// placeholder's atoms are the call's, read when its argument is.
-    pub fn symbolic_atoms(&self) -> Box<dyn Iterator<Item = SymbolicAtom> + '_> {
+    /// The audience this requirement writes: a static recipient set or a cap. A
+    /// placeholder's audience is the call's, read when its argument is.
+    pub(crate) fn declared(&self) -> Option<&DeclaredAudience> {
         match self {
-            AudienceRequirement::Includes(RecipientSpec::Static(recipients)) => recipients.symbolic_atoms(),
-            AudienceRequirement::Cap(cap) => cap.symbolic_atoms(),
-            AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => Box::new(std::iter::empty()),
+            AudienceRequirement::Includes(RecipientSpec::Static(recipients)) => Some(recipients),
+            AudienceRequirement::Cap(cap) => Some(cap),
+            AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => None,
         }
     }
 }
@@ -183,12 +180,6 @@ impl ToolAnnotation {
         self.delta.output_label()
     }
 
-    /// The symbolic atoms this annotation writes: its delta's, its static recipients' and
-    /// its cap's. Load validation routes each one; a placeholder's atoms ride the call.
-    pub fn symbolic_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
-        annotation_atoms(&self.delta, &self.requires)
-    }
-
     /// Every atom evaluating this annotation may ask for beyond a placeholder's: the atoms of
     /// its audience requirements, and — only where a requirement compares the committed label
     /// extensionally — its delta's, plus each written reader whose provider prefix names a
@@ -209,11 +200,12 @@ impl ToolAnnotation {
             })
             .into_iter()
             .flatten();
-        delta.chain(requirements.iter().flat_map(move |requirement| match requirement {
-            AudienceRequirement::Includes(RecipientSpec::Static(recipients)) => recipients.needed_atoms(providers),
-            AudienceRequirement::Cap(cap) => cap.needed_atoms(providers),
-            AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => Box::new(std::iter::empty()),
-        }))
+        delta.chain(
+            requirements
+                .iter()
+                .filter_map(AudienceRequirement::declared)
+                .flat_map(move |declared| declared.needed_atoms(providers)),
+        )
     }
 }
 
@@ -224,7 +216,8 @@ fn annotation_atoms<'a>(delta: &'a Delta, requires: &'a Requires) -> impl Iterat
         requires
             .audience_requirements()
             .iter()
-            .flat_map(AudienceRequirement::symbolic_atoms),
+            .filter_map(AudienceRequirement::declared)
+            .flat_map(DeclaredAudience::symbolic_atoms),
     )
 }
 

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -3693,7 +3693,7 @@ pub(crate) fn membership_context<'e>(registry: &'e Registry, act: &'e ActEvidenc
 fn require_atoms(act: &ActEvidence, atoms: impl IntoIterator<Item = SymbolicAtom>) -> Result<(), TransitionError> {
     let mut needed: Vec<SymbolicAtom> = atoms
         .into_iter()
-        .filter(|atom| act.expansions.members(atom).is_none())
+        .filter(|atom| !act.expansions.answered(atom))
         .collect();
     if needed.is_empty() {
         return Ok(());
@@ -3769,7 +3769,7 @@ pub(crate) fn compose_batch<'a>(
                 needed.extend(
                     approval_atoms(registry, prepared)
                         .into_iter()
-                        .filter(|atom| under.expansions.members(atom).is_none()),
+                        .filter(|atom| !under.expansions.answered(atom)),
                 );
             }
             per_call.push((under, spends));

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -267,11 +267,7 @@ impl Engine {
             EngineEvent::BindFork(binding) => self.decide_binding(view, &binding),
             EngineEvent::ExecuteOffer(execution) => self.decide_offer(view, &execution, &act),
         }?;
-        // The operation-scope test, after the decision's reads are complete: every pinned
-        // entry is inherited or answers an ask this act actually made.
-        self.registry
-            .audience()
-            .only_requested(&act.evidence, &act.inherited.borrow(), &act.expansions.reads())?;
+        act.settle(self.registry.audience())?;
         Ok(decision)
     }
 
@@ -310,11 +306,7 @@ impl Engine {
         inherited: AudienceEvidence,
     ) -> Result<ActEvidence, TransitionError> {
         let expansions = self.registry.audience().expansions(&evidence)?;
-        Ok(ActEvidence {
-            evidence,
-            expansions,
-            inherited: std::cell::RefCell::new(inherited),
-        })
+        Ok(ActEvidence::new(evidence, expansions, inherited))
     }
 
     fn context<'e>(&'e self, act: &'e ActEvidence) -> MembershipContext<'e> {
@@ -609,7 +601,7 @@ impl Engine {
         nonce: crate::value::OfferNonce,
         act: &ActEvidence,
     ) -> Result<EngineDecision, TransitionError> {
-        match branch::submit_child_return(views, child, &body, &act.evidence).map_err(branch_refusal)? {
+        match branch::submit_child_return(views, child, &body, &act.pinned()).map_err(branch_refusal)? {
             branch::RawCrossing::Merged(crossing) => {
                 facts.extend(crossing);
                 Ok(EngineDecision {
@@ -1322,7 +1314,7 @@ impl Engine {
             call,
             admission,
             &self.context(act),
-            &act.evidence,
+            &act.pinned(),
         )
         .map_err(|error| match error {
             AdmitError::SanitizerTransitionUnmet | AdmitError::SanitizerBindingMismatch => {
@@ -1647,11 +1639,11 @@ impl Engine {
         }
         act.inherit(&recorded.evidence)?;
         let under = self.act_evidence(
-            act.evidence.inheriting(&recorded.evidence)?,
+            act.pinned().inheriting(&recorded.evidence)?,
             AudienceEvidence::default(),
         )?;
         let follow_up = self.decided_follow_up(views, batch, &proposals, &recorded.released, &under)?;
-        act.expansions.absorb_reads(&under.expansions);
+        act.absorb(&under);
         Ok(Some(EngineDecision {
             append: None,
             follow_up,
@@ -2003,7 +1995,7 @@ impl Engine {
                 let subject = subject_at(position);
                 let pinned = views.candidate_evidence(&subject);
                 act.inherit(&pinned)?;
-                let under = self.act_evidence(act.evidence.inheriting(&pinned)?, AudienceEvidence::default())?;
+                let under = self.act_evidence(act.pinned().inheriting(&pinned)?, AudienceEvidence::default())?;
                 Ok((views.standing_call(&subject).unwrap_or(call), under))
             })
             .collect::<Result<_, TransitionError>>()?;
@@ -2089,7 +2081,7 @@ impl Engine {
             }
         }
         for (_, under) in &standing {
-            act.expansions.absorb_reads(&under.expansions);
+            act.absorb(under);
         }
         Ok(FollowUp::Proposals {
             released,
@@ -2260,7 +2252,7 @@ impl Engine {
             call,
             ResultAdmission::CandidateAccepted { offer: execution.offer },
             &self.context(act),
-            &act.evidence,
+            &act.pinned(),
         )
         .unwrap_or_else(|error| unreachable!("the confined stage admits what the log already proved: {error}"));
         facts.extend(admitted);
@@ -2364,7 +2356,7 @@ impl Engine {
             call,
             ResultAdmission::CandidateAdmissible,
             &self.context(act),
-            &act.evidence,
+            &act.pinned(),
         )
         .unwrap_or_else(|error| unreachable!("the confined stage admits what this act just derived: {error}"));
         facts.extend(admitted);
@@ -2822,9 +2814,9 @@ impl Engine {
             // atoms that contract reads were pinned by the hop that derived it.
             let pinned = views.candidate_evidence(&recorded.subject);
             act.inherit(&pinned)?;
-            let under = self.act_evidence(act.evidence.inheriting(&pinned)?, AudienceEvidence::default())?;
+            let under = self.act_evidence(act.pinned().inheriting(&pinned)?, AudienceEvidence::default())?;
             let reblocked = self.reblocked(views, recorded, execution, &under)?;
-            act.expansions.absorb_reads(&under.expansions);
+            act.absorb(&under);
             return Ok(match reblocked {
                 Some(block) => OfferFollowUp::Substituted { block: Box::new(block) },
                 None => OfferFollowUp::Invalidated,
@@ -3639,46 +3631,57 @@ pub(crate) enum ComposeRefusal {
     Evidence(crate::audience::EvidenceRefusal),
 }
 
-/// One act's audience reading: the merged pinned evidence its records persist, the
-/// membership answers that evidence recomputes to, and the inherited pins — entries earlier
-/// records of this chain already pinned, which the operation-scope test excuses. Built only
-/// through validation, so a context over it always reads admissible answers.
+/// One act's audience reading: the membership answers its merged pinned evidence recomputes
+/// to, over the act's operation-scope ledger. Built only through validation, so a context
+/// over it always reads admissible answers. Interior mutability on the ledger: overlay
+/// contexts built mid-decision discover pins and asks the act-building event could not name.
 #[derive(Clone, Debug)]
 pub(crate) struct ActEvidence {
-    evidence: AudienceEvidence,
     expansions: Expansions,
-    inherited: std::cell::RefCell<AudienceEvidence>,
+    ledger: std::cell::RefCell<crate::audience::ActLedger>,
 }
 
 impl ActEvidence {
-    /// Assemble from parts a caller validated together: the transition validator recomputes
-    /// `expansions` from `evidence` before building this. The validator runs its own
-    /// per-act operation-scope audit, so no inherited pins are carried here.
-    pub(crate) fn validated(evidence: AudienceEvidence, expansions: Expansions) -> ActEvidence {
+    fn new(evidence: AudienceEvidence, expansions: Expansions, inherited: AudienceEvidence) -> ActEvidence {
         ActEvidence {
-            evidence,
             expansions,
-            inherited: std::cell::RefCell::default(),
+            ledger: std::cell::RefCell::new(crate::audience::ActLedger::of(evidence, inherited)),
         }
+    }
+
+    /// Assemble from parts a caller validated together: the transition validator recomputes
+    /// `expansions` from `evidence` before building this. The validator keeps its own
+    /// per-act ledger, so no inherited pins are carried here.
+    pub(crate) fn validated(evidence: AudienceEvidence, expansions: Expansions) -> ActEvidence {
+        ActEvidence::new(evidence, expansions, AudienceEvidence::default())
     }
 
     /// The evidence a record of this act pins.
     pub(crate) fn pinned(&self) -> AudienceEvidence {
-        self.evidence.clone()
+        self.ledger.borrow().evidence().clone()
     }
 
-    /// The context's answers and ask log, for the validator's per-act audit.
+    /// The context's answers and ask log, for the validator's per-act ledger.
     pub(crate) fn expansions(&self) -> &Expansions {
         &self.expansions
     }
 
     /// Count `pins` — entries a record this act continues already pinned — as inherited, so
-    /// the operation-scope test excuses them. Interior mutability: overlay contexts built
-    /// mid-decision discover pins the act-building event could not name.
+    /// the operation-scope test excuses them.
     fn inherit(&self, pins: &AudienceEvidence) -> Result<(), crate::audience::EvidenceRefusal> {
-        let merged = self.inherited.borrow().inheriting(pins)?;
-        *self.inherited.borrow_mut() = merged;
-        Ok(())
+        self.ledger.borrow_mut().inherit(pins)
+    }
+
+    /// Count an overlay context's asks as this act's: it read on the act's behalf.
+    fn absorb(&self, overlay: &ActEvidence) {
+        self.ledger.borrow_mut().read(overlay.expansions.reads());
+    }
+
+    /// The operation-scope test, after the decision's reads are complete.
+    fn settle(&self, audience: &crate::audience::AudienceRegistry) -> Result<(), crate::audience::EvidenceRefusal> {
+        let mut ledger = self.ledger.borrow_mut();
+        ledger.read(self.expansions.reads());
+        ledger.settle(audience)
     }
 }
 
@@ -3751,7 +3754,7 @@ pub(crate) fn compose_batch<'a>(
                 Some(prepared) => {
                     act.inherit(&prepared.evidence).map_err(ComposeRefusal::Evidence)?;
                     let merged = act
-                        .evidence
+                        .pinned()
                         .inheriting(&prepared.evidence)
                         .map_err(ComposeRefusal::Evidence)?;
                     let expansions = registry
@@ -3864,7 +3867,7 @@ pub(crate) fn compose_batch<'a>(
     // operation-scope justification must count those asks.
     for (under, _) in &per_call {
         if let std::borrow::Cow::Owned(under) = under {
-            act.expansions.absorb_reads(&under.expansions);
+            act.absorb(under);
         }
     }
     Ok(composed)

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1987,8 +1987,8 @@ impl Engine {
             .map(|(position, call)| {
                 let subject = subject_at(position);
                 let pinned = views.candidate_evidence(&subject);
-                act.inherit(&pinned)?;
-                let under = self.act_evidence(act.pinned().inheriting(&pinned)?, AudienceEvidence::default())?;
+                act.inherit(pinned)?;
+                let under = self.act_evidence(act.pinned().inheriting(pinned)?, AudienceEvidence::default())?;
                 Ok((views.standing_call(&subject).unwrap_or(call), under))
             })
             .collect::<Result<_, TransitionError>>()?;
@@ -2791,8 +2791,8 @@ impl Engine {
             // The candidate may stand under another contract than the offer was planned on; the
             // atoms that contract reads were pinned by the hop that derived it.
             let pinned = views.candidate_evidence(&recorded.subject);
-            act.inherit(&pinned)?;
-            let under = self.act_evidence(act.pinned().inheriting(&pinned)?, AudienceEvidence::default())?;
+            act.inherit(pinned)?;
+            let under = self.act_evidence(act.pinned().inheriting(pinned)?, AudienceEvidence::default())?;
             let reblocked = self.reblocked(views, recorded, execution, &under)?;
             act.absorb(&under);
             return Ok(match reblocked {

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -634,7 +634,7 @@ impl Engine {
                     digest: RawResultDigest::of(body.as_str().as_bytes()),
                     body,
                     policy: ReturnPolicy::Raw,
-                    evidence: act.pinned(),
+                    evidence: act.pinned().clone(),
                 });
                 let (batch, staged) = self.pending_stage(
                     view,
@@ -704,7 +704,7 @@ impl Engine {
             digest,
             body: body.clone(),
             policy: ReturnPolicy::Sanitized(name.clone()),
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         if name.is_attest_schema() {
             let receiving = views.current_label().clone();
@@ -776,7 +776,7 @@ impl Engine {
                 residual: residual.clone(),
             },
             lineage: lineage.clone(),
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         let Some(residual) = residual else {
             // The derivation narrows nothing: candidate and merge land atomically.
@@ -789,7 +789,7 @@ impl Engine {
                     raw_digest: digest,
                 },
                 None,
-                act.pinned(),
+                act.pinned().clone(),
             ));
             return Ok(EngineDecision {
                 append: Some(self.decided(view, return_act(child), facts)?),
@@ -845,7 +845,7 @@ impl Engine {
             fork: fork.clone(),
             digest,
             reason: reason.clone(),
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         Ok(EngineDecision {
             append: Some(self.decided(view, return_act(child), facts)?),
@@ -1280,7 +1280,7 @@ impl Engine {
                                 sanitizer,
                                 derived: candidate,
                                 lineage,
-                                evidence: act.pinned(),
+                                evidence: act.pinned().clone(),
                             },
                             act,
                         );
@@ -1692,7 +1692,7 @@ impl Engine {
                             batch: batch.id.clone(),
                             position: position as u32,
                             effects: contract.emits.clone(),
-                            evidence: act.pinned(),
+                            evidence: act.pinned().clone(),
                         },
                     }
                 })
@@ -1762,7 +1762,7 @@ impl Engine {
             // The act's own pinned answers: batch payload, compared on repeat. A release that
             // spends an approval reads under the approval's pins too, but those are the
             // approval record's — replay re-merges them from it.
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         facts.extend(composed.iter().flatten().flat_map(|release| release.facts.clone()));
         // What this decision moves, derived before the offers that have to record where it lands.
@@ -1947,7 +1947,7 @@ impl Engine {
                 subject: subject.clone(),
                 plan: executable.clone(),
                 basis,
-                evidence: under.pinned(),
+                evidence: under.pinned().clone(),
             });
         }
         (block_id, ids, facts)
@@ -2312,7 +2312,7 @@ impl Engine {
                 residual,
             },
             lineage,
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         if staged {
             let (batch, confined) = self.staged(
@@ -2510,7 +2510,7 @@ impl Engine {
             value,
             derivation,
             Some(residual),
-            act.pinned(),
+            act.pinned().clone(),
         ));
         Ok(EngineDecision {
             append: Some(self.decided(view, crate::basis::DecidedAct::Offer(execution.offer), facts)?),
@@ -2578,7 +2578,7 @@ impl Engine {
                 residual: residual.clone(),
             },
             lineage: lineage.clone(),
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         let Some(residual) = residual else {
             // The successor owes nothing: candidate and merge land atomically.
@@ -2591,7 +2591,7 @@ impl Engine {
                     raw_digest: pending.digest,
                 },
                 None,
-                act.pinned(),
+                act.pinned().clone(),
             ));
             return Ok(EngineDecision {
                 append: Some(self.decided(view, crate::basis::DecidedAct::Offer(execution.offer), facts)?),
@@ -2729,7 +2729,7 @@ impl Engine {
             sanitizer: sanitizer.clone(),
             derived,
             lineage,
-            evidence: under.pinned(),
+            evidence: under.pinned().clone(),
         });
         let staged = Sequence::advance_of(self, view, &facts);
         let act = crate::basis::DecidedAct::Offer(execution.offer);
@@ -3113,7 +3113,7 @@ impl Engine {
                 .collect(),
             sanitizer: recorded.plan.sanitizer().cloned(),
             basis: views.basis_after(&advance, &subject),
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
         let batch = self.declaring(crate::basis::DecidedAct::Offer(execution.offer), advance, facts);
         Ok(EngineDecision {
@@ -3439,7 +3439,7 @@ fn approved_release(
         authority: given.authority.clone(),
         covers: given.covers.clone(),
         reviewed: given.reviewed.clone(),
-        evidence: act.pinned(),
+        evidence: act.pinned().clone(),
     }));
     if let Some(sanitizer) = &approval.sanitizer {
         facts.push(Fact::OutputSanitizerBound {
@@ -3450,7 +3450,7 @@ fn approved_release(
             contribution: crate::plan::bound_contribution(registry, contract, sanitizer, &context)
                 .expect("the compose gate answers a spent approval's sanitizer atoms")
                 .expect("a prepared approval binds an output sanitizer enumeration found applicable"),
-            evidence: act.pinned(),
+            evidence: act.pinned().clone(),
         });
     }
     facts
@@ -3565,7 +3565,7 @@ pub(crate) fn opened_dispatch(
         receiving: current.clone(),
         proposed_effects: contract.emits.clone(),
         annotation: call.annotation().cloned(),
-        evidence: act.pinned(),
+        evidence: act.pinned().clone(),
         subject,
     };
     (dispatch, fact)
@@ -3632,8 +3632,8 @@ impl ActEvidence {
     }
 
     /// The evidence a record of this act pins.
-    pub(crate) fn pinned(&self) -> AudienceEvidence {
-        self.ledger.borrow().evidence().clone()
+    pub(crate) fn pinned(&self) -> std::cell::Ref<'_, AudienceEvidence> {
+        std::cell::Ref::map(self.ledger.borrow(), crate::audience::ActLedger::evidence)
     }
 
     /// The act's pinned answers merged with `fresh`, read without snapshotting them first.
@@ -3833,7 +3833,7 @@ pub(crate) fn compose_batch<'a>(
                 consumes,
                 prepares_fork,
                 facts,
-                evidence: under.pinned(),
+                evidence: under.pinned().clone(),
             }
         };
         if position + 1 < proposals.len() || refused {

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11589,42 +11589,8 @@ mod tests {
         ReaderId::new(format!("{local}@corp.com"))
     }
 
-    #[test]
-    fn a_public_placeholder_argument_is_the_public_audience() {
-        let e = audience_engine(vec![], known(TRUSTED, Audience::restricted([ReaderId::new("auditor")])));
-        let restricted = vec![opened(&e)];
-        let decision = e
-            .handle(
-                &viewing(&e, &restricted),
-                batch("b1", Vec::new(), vec![send_to("public")]),
-            )
-            .expect("the batch decides");
-        let (released, blocked) = answered(&decision);
-        assert!(released.is_empty());
-        assert_eq!(
-            blocked[0].block.raw.requirement_gaps,
-            vec![crate::check::Gap::Includes {
-                recipients: DeclaredAudience::Public
-            }]
-        );
-        assert!(
-            blocked[0].offers.is_empty(),
-            "no authority holds a reader ceiling, so nothing covers a Public recipient"
-        );
-
-        let e = audience_engine(vec![], known(TRUSTED, Audience::public()));
-        let public = vec![opened(&e)];
-        let decision = e
-            .handle(&viewing(&e, &public), batch("b2", Vec::new(), vec![send_to("public")]))
-            .expect("the batch decides");
-        let (released, blocked) = answered(&decision);
-        assert_eq!(tool_names(released), ["send"]);
-        assert!(blocked.is_empty());
-    }
-
-    #[test]
-    fn a_public_reader_ceiling_covers_a_public_placeholder_recipient() {
-        let officer = crate::authority::Authority {
+    fn public_ceiling_officer() -> crate::authority::Authority {
+        crate::authority::Authority {
             name: AuthorityName::new("officer"),
             mandate: crate::authority::Mandate {
                 reader_ceiling: Some(DeclaredAudience::literal(Audience::public())),
@@ -11632,20 +11598,51 @@ mod tests {
             },
             scope: crate::authority::Scope::default(),
             hint: None,
-        };
-        let e = audience_engine(
-            vec![officer],
-            known(TRUSTED, Audience::restricted([ReaderId::new("auditor")])),
-        );
-        let restricted = vec![opened(&e)];
-        let decision = e
-            .handle(
-                &viewing(&e, &restricted),
-                batch("b1", Vec::new(), vec![send_to("public")]),
-            )
-            .expect("the batch decides");
-        let (_, blocked) = answered(&decision);
-        assert_eq!(blocked[0].offers.len(), 1, "one ruling plan names the officer");
+        }
+    }
+
+    #[test]
+    fn a_public_placeholder_argument_is_the_public_audience() {
+        let auditor = || Audience::restricted([ReaderId::new("auditor")]);
+        for (case, authorities, label, released, offers) in [
+            (
+                "no authority holds a reader ceiling, so nothing covers a Public recipient",
+                vec![],
+                auditor(),
+                vec![],
+                0,
+            ),
+            ("a public label releases", vec![], Audience::public(), vec!["send"], 0),
+            (
+                "a public reader ceiling offers one ruling plan",
+                vec![public_ceiling_officer()],
+                auditor(),
+                vec![],
+                1,
+            ),
+        ] {
+            let e = audience_engine(authorities, known(TRUSTED, label));
+            let log = vec![opened(&e)];
+            let decision = e
+                .handle(&viewing(&e, &log), batch("b1", Vec::new(), vec![send_to("public")]))
+                .expect("the batch decides");
+            let (released_calls, blocked) = answered(&decision);
+            assert_eq!(tool_names(released_calls), released, "{case}");
+            match blocked {
+                [] => assert_eq!(offers, 0, "{case}"),
+                [block] => {
+                    assert_eq!(
+                        block.block.raw.requirement_gaps,
+                        vec![crate::check::Gap::Includes {
+                            recipients: DeclaredAudience::Public
+                        }],
+                        "{case}"
+                    );
+                    assert_eq!(block.offers.len(), offers, "{case}");
+                }
+                more => panic!("{case}: one proposal blocks at most once, got {more:?}"),
+            }
+        }
     }
 
     #[test]
@@ -11747,6 +11744,17 @@ mod tests {
             Err(crate::audience::Unroutable::UnknownGroup(_))
         ));
 
+        let decision = e
+            .handle(&viewing(&e, &log), batch("b4", Vec::new(), vec![send_to("@")]))
+            .expect("a malformed spelling still decides");
+        assert!(answered(&decision).0.is_empty());
+    }
+
+    #[test]
+    fn evidence_is_scoped_to_the_asked_atoms_and_the_registered_sources() {
+        let e = audience_engine(vec![], known(TRUSTED, Audience::restricted([corp_reader("alice")])));
+        let log = vec![opened(&e)];
+
         // Evidence outside the registered sources is refused, not ignored.
         let foreign = source_evidence(vec![crate::audience::SourceClaims {
             provider: "github".to_string(),
@@ -11786,11 +11794,6 @@ mod tests {
             .handle(&viewing(&e, &log), evidenced_batch("b3", vec![send_to("@team")], exact))
             .expect("the asked answers decide");
         assert_eq!(tool_names(answered(&decision).0), ["send"]);
-
-        let decision = e
-            .handle(&viewing(&e, &log), batch("b4", Vec::new(), vec![send_to("@")]))
-            .expect("a malformed spelling still decides");
-        assert!(answered(&decision).0.is_empty());
     }
 
     #[test]

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use crate::admit::{self, AdmitError, ResultAdmission};
 use crate::audience::AudienceEvidence;
 use crate::branch::{self, BranchError};
-use crate::candidate::{CallStage, ConfinedFrom, DerivedCandidate, DerivedVia, SanitizerLineage};
+use crate::candidate::{CallStage, ConfinedFrom, DerivedCandidate, SanitizerLineage};
 use crate::check::{self, CheckOutcome, Narrowing, RawBlock};
 use crate::contract::ToolAnnotation;
 use crate::execute::{self, PlanError};
@@ -768,10 +768,7 @@ impl Engine {
         facts.push(Fact::CandidateDerived {
             trajectory: views.trajectory().clone(),
             subject: crate::basis::SubjectKey::Return(id.clone()),
-            via: DerivedVia {
-                name: name.clone(),
-                transition: registered.transition.applied(),
-            },
+            sanitizer: name.clone(),
             derived: DerivedCandidate::Return {
                 source: digest,
                 from: ConfinedFrom::Bound,
@@ -790,7 +787,6 @@ impl Engine {
                 ReturnDerivation::Sanitized {
                     sanitizer: name.clone(),
                     raw_digest: digest,
-                    transition: registered.transition.applied(),
                 },
                 None,
                 act.pinned(),
@@ -1241,7 +1237,7 @@ impl Engine {
                         if let Some(registered) = self.registry.sanitizer(&sanitizer) {
                             require_atoms(act, registered.needed_atoms(self.registry.audience().providers()))?;
                         }
-                        let (transition, candidate, lineage) = crate::admit::bound_candidate(
+                        let (candidate, lineage) = crate::admit::bound_candidate(
                             &self.registry,
                             &views,
                             dispatch,
@@ -1281,10 +1277,7 @@ impl Engine {
                             Fact::CandidateDerived {
                                 trajectory: views.trajectory().clone(),
                                 subject: crate::basis::SubjectKey::ConfinedResult(dispatch.clone()),
-                                via: DerivedVia {
-                                    name: sanitizer,
-                                    transition,
-                                },
+                                sanitizer,
                                 derived: candidate,
                                 lineage,
                                 evidence: act.pinned(),
@@ -2313,10 +2306,7 @@ impl Engine {
         facts.push(Fact::CandidateDerived {
             trajectory: views.trajectory().clone(),
             subject: crate::basis::SubjectKey::ConfinedResult(dispatch.clone()),
-            via: crate::candidate::DerivedVia {
-                name: sanitizer.clone(),
-                transition: registered.transition.applied(),
-            },
+            sanitizer: sanitizer.clone(),
             derived: DerivedCandidate::Result {
                 dispatch: dispatch.clone(),
                 source: source_digest,
@@ -2503,16 +2493,11 @@ impl Engine {
                     .last()
                     .expect("a return candidate's lineage names the sanitizer that derived it")
                     .clone();
-                let subject = crate::basis::SubjectKey::Return(id.clone());
-                let Some(crate::candidate::DerivedVia { transition, .. }) = views.candidate_via(&subject) else {
-                    return Err(TransitionError::SanitizerUnapplicable);
-                };
                 (
                     value,
                     ReturnDerivation::Sanitized {
                         sanitizer,
                         raw_digest: pending.digest,
-                        transition: transition.clone(),
                     },
                 )
             }
@@ -2588,10 +2573,7 @@ impl Engine {
         facts.push(Fact::CandidateDerived {
             trajectory: views.trajectory().clone(),
             subject: crate::basis::SubjectKey::Return(id.clone()),
-            via: DerivedVia {
-                name: sanitizer.clone(),
-                transition: registered.transition.applied(),
-            },
+            sanitizer: sanitizer.clone(),
             derived: DerivedCandidate::Return {
                 source: source_digest,
                 from: ConfinedFrom::Offer(execution.offer),
@@ -2610,7 +2592,6 @@ impl Engine {
                 ReturnDerivation::Sanitized {
                     sanitizer: sanitizer.clone(),
                     raw_digest: pending.digest,
-                    transition: registered.transition.applied(),
                 },
                 None,
                 act.pinned(),
@@ -2748,10 +2729,7 @@ impl Engine {
         facts.push(Fact::CandidateDerived {
             trajectory: trajectory.clone(),
             subject: recorded.subject.clone(),
-            via: DerivedVia {
-                name: sanitizer.clone(),
-                transition: registered.transition.applied(),
-            },
+            sanitizer: sanitizer.clone(),
             derived,
             lineage,
             evidence: under.pinned(),
@@ -14680,6 +14658,89 @@ mod tests {
             assert_eq!(identity(&forward), identity(&backward));
         }
 
+        fn declassify_to(to: DeclaredAudience) -> crate::authority::Sanitizer {
+            crate::authority::Sanitizer {
+                name: SanitizerName::new("declassify"),
+                on: crate::authority::SanitizerPoints {
+                    input: false,
+                    output: true,
+                },
+                transition: crate::authority::DeclaredTransition::Audience {
+                    from_includes: DeclaredAudience::restricted([]),
+                    to,
+                },
+                scope: crate::authority::Scope::default(),
+                hint: None,
+            }
+        }
+
+        /// A sanitized return, derived and merged, then read back from its wire form.
+        fn sanitized_return_log(e: &Engine) -> Vec<Fact> {
+            let child = TrajectoryId::new("child");
+            let log = spawn_family(e, None, &child);
+            let body = ValueBody::new("what I found");
+            let submitted = e
+                .handle(
+                    &viewing(e, &log),
+                    child_report_with(&log, &child, &body, vec![], no_answers()),
+                )
+                .expect("the submission stands");
+            let log = [log, appended_facts(submitted)].concat();
+            let evidence = vec![Evidence::Sanitizer {
+                sanitizer: SanitizerName::new("declassify"),
+                source: RawResultDigest::of(body.as_str().as_bytes()),
+                derived: ValueBody::new("clean"),
+            }];
+            let derived = e
+                .handle(
+                    &viewing(e, &log),
+                    child_report_with(&log, &child, &body, evidence, no_answers()),
+                )
+                .expect("the derivation stands as the candidate");
+            let log = [log, appended_facts(derived)].concat();
+            let wire = serde_json::to_string(&log).expect("facts serialize");
+            serde_json::from_str(&wire).expect("facts deserialize")
+        }
+
+        /// A derivation record names its sanitizer and the transition it applied is the
+        /// registry's: the same policy replays the record from its wire form, and a policy
+        /// whose sanitizer transitions differ is another policy, refused as a whole.
+        #[test]
+        fn a_sanitizers_transition_is_policy_identity_not_a_records_claim() {
+            let identity = |cfg: &RegistryConfig| {
+                let profile = crate::profile::DeploymentProfile::declare(crate::profile::covering_declaration(cfg))
+                    .expect("the covering declaration declares");
+                crate::profile::identity_of(
+                    cfg,
+                    &ReturnPolicy::Sanitized(SanitizerName::new("declassify")),
+                    &profile,
+                )
+            };
+            // A public `to` narrows nothing, so the derivation merges in one act.
+            let to_public = returning_with_sources(vec![declassify_to(DeclaredAudience::Public)]);
+            let to_alice = returning_with_sources(vec![declassify_to(DeclaredAudience::restricted([corp_reader(
+                "alice",
+            )]))]);
+            assert_ne!(identity(&to_public), identity(&to_alice));
+
+            let policy = ReturnPolicy::Sanitized(SanitizerName::new("declassify"));
+            let e = open_engine_returning(to_public, policy.clone());
+            let log = sanitized_return_log(&e);
+            assert!(log.iter().any(|fact| matches!(
+                fact,
+                Fact::ChildReturn {
+                    derivation: ReturnDerivation::Sanitized { .. },
+                    ..
+                }
+            )));
+            assert_eq!(e.validate_replay(&log), Ok(()));
+            assert_ne!(
+                open_engine_returning(to_alice, policy).validate_replay(&log),
+                Ok(()),
+                "a changed transition is another policy"
+            );
+        }
+
         fn child_report_with(
             log: &[Fact],
             child: &TrajectoryId,
@@ -14761,22 +14822,10 @@ mod tests {
             );
             let acceptance = stage.offers[0].0;
             let facts = appended_facts(derived);
-            let Some(via) = facts.iter().find_map(|fact| match fact {
-                Fact::CandidateDerived { via, .. } => Some(via.clone()),
-                _ => None,
-            }) else {
-                panic!("the derivation stands as the candidate")
-            };
-            assert_eq!(
-                via,
-                DerivedVia {
-                    name: SanitizerName::new("declassify"),
-                    transition: crate::authority::Transition::Audience {
-                        from_includes: DeclaredAudience::restricted([]),
-                        to: symbolic("team"),
-                    },
-                }
-            );
+            assert!(facts.iter().any(|fact| matches!(
+                fact,
+                Fact::CandidateDerived { sanitizer, .. } if sanitizer == &SanitizerName::new("declassify")
+            )));
             let log = [log, facts].concat();
             assert_eq!(e.validate_replay(&log), Ok(()));
 

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -285,14 +285,14 @@ impl Engine {
             EngineEvent::ExecuteOffer(execution) => {
                 let views = projection.view(&execution.trajectory);
                 match views.offer(&execution.offer) {
-                    Some(offer) => (execution.audience.inheriting(&offer.evidence), offer.evidence.clone()),
+                    Some(offer) => (execution.audience.inheriting(&offer.evidence)?, offer.evidence.clone()),
                     None => (execution.audience.clone(), AudienceEvidence::default()),
                 }
             }
             EngineEvent::Outcome(report) => {
                 let views = projection.view(report.dispatch.trajectory());
                 match views.dispatch_evidence(&report.dispatch) {
-                    Some(pinned) => (report.audience.inheriting(pinned), pinned.clone()),
+                    Some(pinned) => (report.audience.inheriting(pinned)?, pinned.clone()),
                     None => (report.audience.clone(), AudienceEvidence::default()),
                 }
             }
@@ -1643,8 +1643,11 @@ impl Engine {
         if recorded.evidence != batch.audience {
             return Err(TransitionError::BatchIdentityConflict);
         }
-        act.inherit(&recorded.evidence);
-        let under = self.act_evidence(act.evidence.inheriting(&recorded.evidence), AudienceEvidence::default())?;
+        act.inherit(&recorded.evidence)?;
+        let under = self.act_evidence(
+            act.evidence.inheriting(&recorded.evidence)?,
+            AudienceEvidence::default(),
+        )?;
         let follow_up = self.decided_follow_up(views, batch, &proposals, &recorded.released, &under)?;
         act.expansions.absorb_reads(&under.expansions);
         Ok(Some(EngineDecision {
@@ -1752,6 +1755,7 @@ impl Engine {
         .map_err(|refusal| match refusal {
             ComposeRefusal::Malformed(error) => TransitionError::Call(error),
             ComposeRefusal::MembershipNeeded(needed) => TransitionError::from(needed),
+            ComposeRefusal::Evidence(refusal) => TransitionError::ForeignEvidence(refusal),
         })?;
 
         let released: Vec<Released> = composed
@@ -1996,8 +2000,8 @@ impl Engine {
             .map(|(position, call)| {
                 let subject = subject_at(position);
                 let pinned = views.candidate_evidence(&subject);
-                act.inherit(&pinned);
-                let under = self.act_evidence(act.evidence.inheriting(&pinned), AudienceEvidence::default())?;
+                act.inherit(&pinned)?;
+                let under = self.act_evidence(act.evidence.inheriting(&pinned)?, AudienceEvidence::default())?;
                 Ok((views.standing_call(&subject).unwrap_or(call), under))
             })
             .collect::<Result<_, TransitionError>>()?;
@@ -2815,8 +2819,8 @@ impl Engine {
             // The candidate may stand under another contract than the offer was planned on; the
             // atoms that contract reads were pinned by the hop that derived it.
             let pinned = views.candidate_evidence(&recorded.subject);
-            act.inherit(&pinned);
-            let under = self.act_evidence(act.evidence.inheriting(&pinned), AudienceEvidence::default())?;
+            act.inherit(&pinned)?;
+            let under = self.act_evidence(act.evidence.inheriting(&pinned)?, AudienceEvidence::default())?;
             let reblocked = self.reblocked(views, recorded, execution, &under)?;
             act.expansions.absorb_reads(&under.expansions);
             return Ok(match reblocked {
@@ -3630,6 +3634,7 @@ impl ComposingBatch<'_> {
 pub(crate) enum ComposeRefusal {
     Malformed(EngineError),
     MembershipNeeded(crate::label::MembershipNeeded),
+    Evidence(crate::audience::EvidenceRefusal),
 }
 
 /// One act's audience reading: the merged pinned evidence its records persist, the
@@ -3668,10 +3673,10 @@ impl ActEvidence {
     /// Count `pins` — entries a record this act continues already pinned — as inherited, so
     /// the operation-scope test excuses them. Interior mutability: overlay contexts built
     /// mid-decision discover pins the act-building event could not name.
-    fn inherit(&self, pins: &AudienceEvidence) {
-        let mut inherited = self.inherited.borrow_mut();
-        let merged = inherited.inheriting(pins);
-        *inherited = merged;
+    fn inherit(&self, pins: &AudienceEvidence) -> Result<(), crate::audience::EvidenceRefusal> {
+        let merged = self.inherited.borrow().inheriting(pins)?;
+        *self.inherited.borrow_mut() = merged;
+        Ok(())
     }
 }
 
@@ -3742,12 +3747,15 @@ pub(crate) fn compose_batch<'a>(
             let spends = if singleton { approval(&views, call) } else { None };
             let under = match spends.and_then(|offer| views.approval(&offer)) {
                 Some(prepared) => {
-                    act.inherit(&prepared.evidence);
-                    let merged = act.evidence.inheriting(&prepared.evidence);
+                    act.inherit(&prepared.evidence).map_err(ComposeRefusal::Evidence)?;
+                    let merged = act
+                        .evidence
+                        .inheriting(&prepared.evidence)
+                        .map_err(ComposeRefusal::Evidence)?;
                     let expansions = registry
                         .audience()
                         .expansions(&merged)
-                        .expect("two validated evidence sets merge into a validated one");
+                        .map_err(ComposeRefusal::Evidence)?;
                     std::borrow::Cow::Owned(ActEvidence::validated(merged, expansions))
                 }
                 None => std::borrow::Cow::Borrowed(act),
@@ -11991,6 +11999,93 @@ mod tests {
         );
     }
 
+    fn wide_as_reported() -> Vec<crate::audience::MemberClaims> {
+        vec![
+            slack_member("slack:UA", Some("alice@corp.com")),
+            slack_member("slack:UC", Some("carol@other.com")),
+        ]
+    }
+
+    /// The officer's approval, armed over `wide` reported as alice and an outsider, for a
+    /// proposal whose own evidence the test supplies: the spend reads that evidence under the
+    /// approval's pins.
+    fn spending_under_pins(fresh: crate::audience::AudienceEvidence) -> Result<EngineDecision, TransitionError> {
+        let officer = crate::authority::Authority {
+            name: AuthorityName::new("officer"),
+            mandate: crate::authority::Mandate {
+                reader_ceiling: Some(DeclaredAudience::literal(Audience::public())),
+                ..crate::authority::Mandate::default()
+            },
+            scope: crate::authority::Scope::default(),
+            hint: None,
+        };
+        let alice = Audience::restricted([corp_reader("alice")]);
+        let e = audience_engine(vec![officer], known(TRUSTED, alice.clone()));
+        let opening = vec![opened(&e)];
+        let pinned = source_evidence(vec![user_group("wide", wide_as_reported())]);
+        let blocked = appended_facts(
+            e.handle(
+                &viewing(&e, &opening),
+                evidenced_batch("b1", vec![send_to("@wide")], pinned),
+            )
+            .expect("the batch decides"),
+        );
+        let (offer, plan) = opened_offers(&blocked)[0].clone();
+        let log = [opening, blocked].concat();
+        let approved = appended_facts(
+            execute_offer(
+                &e,
+                &log,
+                offer,
+                OfferOutcome::Approved(evidence_for(offer, &plan, "send", partial(TRUSTED, alice))),
+            )
+            .expect("the officer's ruling arms the call"),
+        );
+        let log = [log, approved].concat();
+        e.handle(&viewing(&e, &log), evidenced_batch("b2", vec![send_to("@wide")], fresh))
+    }
+
+    /// A fresh answer for a key the approval pinned is read under the pin: the same answer
+    /// again is fine, a different one is a contradiction the spend refuses — never an entry
+    /// silently dropped in favour of the pin.
+    #[test]
+    fn a_spend_refuses_a_fresh_answer_that_contradicts_a_pinned_key() {
+        let same = source_evidence(vec![user_group("wide", wide_as_reported())]);
+        assert!(
+            spending_under_pins(same).is_ok(),
+            "restating the pin is not a contradiction"
+        );
+        let contradicting = source_evidence(vec![user_group(
+            "wide",
+            vec![slack_member("slack:UB", Some("bob@corp.com"))],
+        )]);
+        assert!(matches!(
+            spending_under_pins(contradicting),
+            Err(TransitionError::ForeignEvidence(
+                crate::audience::EvidenceRefusal::ContradictedPin { .. }
+            ))
+        ));
+    }
+
+    /// Two admissible evidence sets can still disagree once merged — the pinned selector and
+    /// a fresh one report the same member under different verified addresses. The spend
+    /// refuses the merged reading as it refuses any other conflicting claim.
+    #[test]
+    fn a_spend_refuses_a_merged_reading_whose_claims_conflict() {
+        let conflicting = source_evidence(vec![user_group(
+            "narrow",
+            vec![slack_member("slack:UA", Some("mallory@other.com"))],
+        )]);
+        assert_eq!(
+            spending_under_pins(conflicting).err(),
+            Some(TransitionError::ForeignEvidence(
+                crate::audience::EvidenceRefusal::ConflictingClaims {
+                    id: "slack:UA".to_string()
+                }
+            ))
+        );
+    }
+
     #[test]
     fn replay_refuses_a_provider_admission_no_act_declared() {
         let e = batch_engine();
@@ -14219,11 +14314,28 @@ mod tests {
             );
             assert_eq!(
                 routes(source_evidence(vec![
-                    user_group("board", vec![slack_member("slack:UA", Some("alice@corp.com"))]),
-                    user_group("team", vec![slack_member("slack:UA", Some("alice@corp.com"))]),
+                    user_group("board", vec![]),
+                    user_group("team", vec![])
                 ])),
                 recorded,
-                "fresh answers that would lift the cap change nothing: the answers the block consumed stand"
+                "restating the answers the block consumed reads them once"
+            );
+            assert!(
+                matches!(
+                    e.recovery_routes(
+                        &view,
+                        &subject,
+                        &source_evidence(vec![user_group(
+                            "team",
+                            vec![slack_member("slack:UA", Some("alice@corp.com"))]
+                        )]),
+                        RouteDepth::ONE
+                    ),
+                    Err(crate::route::RouteError::Evidence(
+                        crate::audience::EvidenceRefusal::ContradictedPin { .. }
+                    ))
+                ),
+                "a fresh answer that would lift the cap contradicts the answer the block consumed"
             );
             assert!(matches!(
                 e.recovery_routes(

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11939,7 +11939,9 @@ mod tests {
                     *evidence = crate::audience::AudienceEvidence::default();
                 }
             }),
-            Err(TransitionRefusal::ForgedEvidence),
+            Err(TransitionRefusal::UnansweredDecision {
+                needed: vec![group_atom("team")]
+            }),
             "a decision over an unanswered symbolic audience claims answers it does not pin"
         );
     }
@@ -11998,6 +12000,52 @@ mod tests {
             e.validate_replay(&[log, tampered].concat()),
             Err(TransitionRefusal::ForgedEvidence),
             "an approval that drops the offer's pins is forged"
+        );
+    }
+
+    /// A record pinning evidence the act could not have consumed names why: a selector
+    /// answered twice is the duplicate, not an unspecified forgery.
+    #[test]
+    fn replay_names_the_refusal_of_a_duplicated_pin() {
+        let officer = crate::authority::Authority {
+            name: AuthorityName::new("officer"),
+            mandate: crate::authority::Mandate {
+                reader_ceiling: Some(DeclaredAudience::literal(Audience::public())),
+                ..crate::authority::Mandate::default()
+            },
+            scope: crate::authority::Scope::default(),
+            hint: None,
+        };
+        let e = audience_engine(
+            vec![officer],
+            known(TRUSTED, Audience::restricted([corp_reader("alice")])),
+        );
+        let opening = vec![opened(&e)];
+        let mut blocked = appended_facts(
+            e.handle(
+                &viewing(&e, &opening),
+                evidenced_batch(
+                    "b1",
+                    vec![send_to("@wide")],
+                    source_evidence(vec![user_group("wide", wide_as_reported())]),
+                ),
+            )
+            .expect("the batch decides"),
+        );
+        for fact in &mut blocked {
+            if let Fact::ProposalBatchDecided { evidence, .. } = fact {
+                let again = evidence.sources[0].clone();
+                evidence.sources.push(again);
+            }
+        }
+        assert_eq!(
+            e.validate_replay(&[opening, blocked].concat()),
+            Err(TransitionRefusal::ForeignEvidence(
+                crate::audience::EvidenceRefusal::DuplicateSelector {
+                    provider: "slack".to_string(),
+                    selector: "user-group/wide".to_string(),
+                }
+            ))
         );
     }
 

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1263,6 +1263,7 @@ impl Engine {
                             AdmitError::SanitizerTransitionUnmet | AdmitError::SanitizerBindingMismatch => {
                                 TransitionError::SanitizerUnapplicable
                             }
+                            AdmitError::MembershipNeeded(needed) => TransitionError::from(needed),
                             other => unreachable!("the outcome path derives what the log already proved: {other}"),
                         })?;
                         let DerivedCandidate::Result { residual: Some(_), .. } = &candidate else {
@@ -1327,6 +1328,7 @@ impl Engine {
             AdmitError::SanitizerTransitionUnmet | AdmitError::SanitizerBindingMismatch => {
                 TransitionError::SanitizerUnapplicable
             }
+            AdmitError::MembershipNeeded(needed) => TransitionError::from(needed),
             other => unreachable!("the outcome path admits what the log already proved: {other}"),
         })?;
         let admitted = batch.iter().find_map(|fact| match fact {

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -1631,10 +1631,7 @@ impl Engine {
             return Err(TransitionError::BatchIdentityConflict);
         }
         act.inherit(&recorded.evidence)?;
-        let under = self.act_evidence(
-            act.pinned().inheriting(&recorded.evidence)?,
-            AudienceEvidence::default(),
-        )?;
+        let under = self.act_evidence(act.inheriting(&recorded.evidence)?, AudienceEvidence::default())?;
         let follow_up = self.decided_follow_up(views, batch, &proposals, &recorded.released, &under)?;
         act.absorb(&under);
         Ok(Some(EngineDecision {
@@ -1988,7 +1985,7 @@ impl Engine {
                 let subject = subject_at(position);
                 let pinned = views.candidate_evidence(&subject);
                 act.inherit(pinned)?;
-                let under = self.act_evidence(act.pinned().inheriting(pinned)?, AudienceEvidence::default())?;
+                let under = self.act_evidence(act.inheriting(pinned)?, AudienceEvidence::default())?;
                 Ok((views.standing_call(&subject).unwrap_or(call), under))
             })
             .collect::<Result<_, TransitionError>>()?;
@@ -2792,7 +2789,7 @@ impl Engine {
             // atoms that contract reads were pinned by the hop that derived it.
             let pinned = views.candidate_evidence(&recorded.subject);
             act.inherit(pinned)?;
-            let under = self.act_evidence(act.pinned().inheriting(pinned)?, AudienceEvidence::default())?;
+            let under = self.act_evidence(act.inheriting(pinned)?, AudienceEvidence::default())?;
             let reblocked = self.reblocked(views, recorded, execution, &under)?;
             act.absorb(&under);
             return Ok(match reblocked {
@@ -3637,6 +3634,11 @@ impl ActEvidence {
     /// The evidence a record of this act pins.
     pub(crate) fn pinned(&self) -> AudienceEvidence {
         self.ledger.borrow().evidence().clone()
+    }
+
+    /// The act's pinned answers merged with `fresh`, read without snapshotting them first.
+    fn inheriting(&self, fresh: &AudienceEvidence) -> Result<AudienceEvidence, crate::audience::EvidenceRefusal> {
+        self.ledger.borrow().evidence().inheriting(fresh)
     }
 
     /// The context's answers and ask log, for the validator's per-act ledger.

--- a/appa-engine/src/fact.rs
+++ b/appa-engine/src/fact.rs
@@ -2,9 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::authority::Transition;
 use crate::basis::SubjectKey;
-use crate::candidate::{DerivedCandidate, DerivedVia, SanitizerLineage};
+use crate::candidate::{DerivedCandidate, SanitizerLineage};
 use crate::check::{Gap, Narrowing};
 use crate::execute::AuthorityReview;
 use crate::label::Label;
@@ -27,15 +26,14 @@ pub enum ReturnPolicy {
 }
 
 /// How a child's returned value crossed to the parent — the audit half of [`Fact::ChildReturn`]. A
-/// sanitized crossing records the declared transition and the raw submission's digest; the raw
-/// text itself stays confined in the child.
+/// sanitized crossing records the sanitizer and the raw submission's digest; the transition it
+/// applied is the registry's, and the raw text itself stays confined in the child.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReturnDerivation {
     Raw,
     Sanitized {
         sanitizer: SanitizerName,
         raw_digest: RawResultDigest,
-        transition: Transition,
     },
 }
 
@@ -268,10 +266,12 @@ pub enum Fact {
         #[serde(default, skip_serializing_if = "crate::audience::AudienceEvidence::is_empty")]
         evidence: crate::audience::AudienceEvidence,
     },
+    /// One sanitizer's derivation of a subject's value; the transition it applied is the
+    /// registry's, recomputed at replay.
     CandidateDerived {
         trajectory: TrajectoryId,
         subject: SubjectKey,
-        via: DerivedVia,
+        sanitizer: SanitizerName,
         derived: DerivedCandidate,
         lineage: SanitizerLineage,
         #[serde(default, skip_serializing_if = "crate::audience::AudienceEvidence::is_empty")]

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -77,10 +77,10 @@ impl ReaderId {
     }
 
     /// A literal reader ID: `public`, `self`, and `internal` are reserved audience states —
-    /// never readers — and the `@` mark is reserved for group references. Every ingress that
-    /// builds a reader set applies this rule.
+    /// never readers — the `@` mark is reserved for group references, and an empty id names
+    /// no one. Every ingress that builds a reader set applies this rule.
     pub fn is_literal(&self) -> bool {
-        !matches!(self.0.as_str(), "public" | "self" | "internal") && !self.0.starts_with('@')
+        !self.0.is_empty() && !matches!(self.0.as_str(), "public" | "self" | "internal") && !self.0.starts_with('@')
     }
 
     /// The provider prefix of a qualified reader (`slack:U012345` → `slack`), when one exists.
@@ -1239,7 +1239,7 @@ mod tests {
 
     #[test]
     fn reserved_spellings_are_never_readers() {
-        for reserved in ["public", "self", "internal", "@finance"] {
+        for reserved in ["public", "self", "internal", "@finance", ""] {
             assert!(!ReaderId::new(reserved).is_literal());
             assert!(Clause::new([], [], [reader(reserved)]).is_err());
         }

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -1086,6 +1086,40 @@ mod tests {
             prop_assert_eq!(a.combine(&identity), a.clone());
         }
 
+        /// An empty clause anywhere is nobody: the fail-closed floor absorbs every fold, and
+        /// denotes the empty set under every assignment.
+        #[test]
+        fn nobody_absorbs(a in label_strategy(), (within, expansions) in assignment_strategy()) {
+            let nobody = Label::new(a.trust, Audience::nobody());
+            prop_assert_eq!(a.combine(&nobody).audience, Audience::nobody());
+            let providers = providers();
+            let context = MembershipContext::new(&within, &providers, &expansions);
+            prop_assert_eq!(eval(&Audience::nobody(), &context), Some(BTreeSet::new()));
+        }
+
+        /// The four universal edges decide without a single membership answer: public covers
+        /// everything and fits only a public cap; a restricted audience never covers the
+        /// universe and always fits it.
+        #[test]
+        fn universal_edges_decide_without_membership(
+            label in label_strategy(),
+            clause in clause_strategy(),
+        ) {
+            let nothing = Expansions::new([]);
+            let within = WithinAssertions::default();
+            let providers = providers();
+            let context = MembershipContext::new(&within, &providers, &nothing);
+            let restricted = DeclaredAudience::Union(clause);
+            prop_assert_eq!(label.within_cap(&DeclaredAudience::Public, &context), Evaluation::Holds);
+            if label.audience.is_public() {
+                prop_assert_eq!(label.covers(&DeclaredAudience::Public, &context), Evaluation::Holds);
+                prop_assert_eq!(label.covers(&restricted, &context), Evaluation::Holds);
+                prop_assert_eq!(label.within_cap(&restricted, &context), Evaluation::Fails);
+            } else {
+                prop_assert_eq!(label.covers(&DeclaredAudience::Public, &context), Evaluation::Fails);
+            }
+        }
+
         #[test]
         fn canonicalization_is_idempotent(a in audience_strategy()) {
             let again = Audience::of_clauses(a.clauses.iter().cloned());
@@ -1229,29 +1263,6 @@ mod tests {
 
     fn context_free() -> (WithinAssertions, BTreeSet<String>, Expansions) {
         (WithinAssertions::default(), providers(), Expansions::default())
-    }
-
-    #[test]
-    fn the_four_universal_edges_are_decided() {
-        let (nothing, providers, unanswered) = context_free();
-        let context = MembershipContext::new(&nothing, &providers, &unanswered);
-        let restricted = Label::new(Trust::new(1), Audience::restricted([reader("a")]));
-        let public = Label::new(Trust::new(1), Audience::public());
-        let some = DeclaredAudience::restricted([reader("a")]);
-
-        // Public covers everything, restricted never covers public — decided with no answers.
-        assert_eq!(public.covers(&DeclaredAudience::Public, &context), Evaluation::Holds);
-        assert_eq!(public.covers(&some, &context), Evaluation::Holds);
-        assert_eq!(
-            restricted.covers(&DeclaredAudience::Public, &context),
-            Evaluation::Fails
-        );
-        // Everything is within a public cap, public is never within a restricted cap.
-        assert_eq!(
-            restricted.within_cap(&DeclaredAudience::Public, &context),
-            Evaluation::Holds
-        );
-        assert_eq!(public.within_cap(&some, &context), Evaluation::Fails);
     }
 
     #[test]

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -1386,41 +1386,57 @@ mod tests {
 
     #[test]
     fn canonicalization_rules_are_exactly_three() {
-        // Empty clause collapses to nobody and is never dropped.
-        let disjoint = Audience::restricted([reader("alice")]).combine(&Audience::restricted([reader("bob")]));
-        assert_eq!(disjoint, Audience::nobody());
-        assert!(!disjoint.is_public(), "nobody is not public");
-        let with_symbols = Audience::of_clauses([clause([ChainAudience::Internal], [], [])]).combine(&disjoint);
-        assert_eq!(
-            with_symbols,
-            Audience::nobody(),
-            "an empty clause absorbs the intersection"
-        );
-
-        // Stable-reader clauses merge by exact intersection.
-        let ab = Audience::restricted([reader("a"), reader("b")]);
-        let bc = Audience::restricted([reader("b"), reader("c")]);
-        assert_eq!(ab.combine(&bc), Audience::restricted([reader("b")]));
-        let email = Audience::restricted([reader("a@x.example"), reader("b")]);
-        assert_eq!(
-            email.combine(&Audience::restricted([reader("a@x.example")])),
-            Audience::restricted([reader("a@x.example")]),
-            "the email principal namespace is reserved, hence stable and mergeable"
-        );
+        let chain = |level| Audience::of_clauses([clause([level], [], [])]);
+        let readers = |readers: &[&str]| Audience::restricted(readers.iter().map(|reader| ReaderId::new(*reader)));
+        for (case, left, right, expected) in [
+            // An empty clause collapses to nobody and is never dropped.
+            (
+                "disjoint stable readers",
+                readers(&["alice"]),
+                readers(&["bob"]),
+                Audience::nobody(),
+            ),
+            (
+                "an empty clause absorbs the intersection",
+                chain(ChainAudience::Internal),
+                Audience::nobody(),
+                Audience::nobody(),
+            ),
+            // Stable-reader clauses merge by exact intersection.
+            (
+                "overlapping stable readers",
+                readers(&["a", "b"]),
+                readers(&["b", "c"]),
+                readers(&["b"]),
+            ),
+            // The email principal namespace is reserved, hence stable and mergeable.
+            (
+                "an email principal",
+                readers(&["a@x.example", "b"]),
+                readers(&["a@x.example"]),
+                readers(&["a@x.example"]),
+            ),
+            // Structural subsumption retains the narrower clause and drops the broader one.
+            (
+                "a narrower chain",
+                chain(ChainAudience::Self_),
+                chain(ChainAudience::Internal),
+                chain(ChainAudience::Self_),
+            ),
+            (
+                "a narrower group clause",
+                Audience::of_clauses([clause([], ["finance"], ["a"])]),
+                Audience::of_clauses([clause([], ["finance"], ["a", "b"])]),
+                Audience::of_clauses([clause([], ["finance"], ["a"])]),
+            ),
+        ] {
+            assert_eq!(left.combine(&right), expected, "{case}");
+        }
+        assert!(!Audience::nobody().is_public(), "nobody is not public");
 
         // A reader a deployment could canonicalize keeps its clause: raw-disjoint is not
         // principal-disjoint, so no exact intersection may erase it.
-        let qualified = Audience::restricted([reader("slack:u1")]);
-        let plain = Audience::restricted([reader("a")]);
-        assert_eq!(qualified.combine(&plain).clauses().count(), 2);
-
-        // Structural subsumption retains the narrower clause and drops the broader one.
-        let self_only = Audience::of_clauses([clause([ChainAudience::Self_], [], [])]);
-        let internal = Audience::of_clauses([clause([ChainAudience::Internal], [], [])]);
-        assert_eq!(self_only.combine(&internal), self_only);
-        let narrow = Audience::of_clauses([clause([], ["finance"], ["a"])]);
-        let broad = Audience::of_clauses([clause([], ["finance"], ["a", "b"])]);
-        assert_eq!(narrow.combine(&broad), narrow);
+        assert_eq!(readers(&["slack:u1"]).combine(&readers(&["a"])).clauses().count(), 2);
     }
 
     #[test]

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -581,13 +581,6 @@ impl Expansions {
     pub(crate) fn reads(&self) -> Vec<SymbolicAtom> {
         self.reads.borrow().iter().cloned().collect()
     }
-
-    /// Fold another context's asks into this log — an overlay context reads on behalf of the
-    /// same act, and the act's justification must count those asks.
-    pub(crate) fn absorb_reads(&self, other: &Expansions) {
-        let absorbed: Vec<SymbolicAtom> = other.reads.borrow().iter().cloned().collect();
-        self.reads.borrow_mut().extend(absorbed);
-    }
 }
 
 /// Everything an audience evaluation reads beside the audiences themselves: the policy's

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -499,12 +499,12 @@ impl DeclaredAudience {
 /// the source reports — consulted by derivation and by extensional closure, never by
 /// canonicalization.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct WithinAssertions {
+pub(crate) struct WithinAssertions {
     targets: BTreeMap<GroupName, ChainAudience>,
 }
 
 impl WithinAssertions {
-    pub fn new(targets: impl IntoIterator<Item = (GroupName, ChainAudience)>) -> WithinAssertions {
+    pub(crate) fn new(targets: impl IntoIterator<Item = (GroupName, ChainAudience)>) -> WithinAssertions {
         WithinAssertions {
             targets: targets.into_iter().collect(),
         }
@@ -591,10 +591,10 @@ impl Expansions {
 /// readers canonicalize), and the operation's answers. The first two are policy, fixed for
 /// the trajectory; the answers are the operation's pinned evidence.
 #[derive(Clone, Copy, Debug)]
-pub struct MembershipContext<'a> {
-    pub within: &'a WithinAssertions,
-    pub providers: &'a BTreeSet<String>,
-    pub expansions: &'a Expansions,
+pub(crate) struct MembershipContext<'a> {
+    pub(crate) within: &'a WithinAssertions,
+    pub(crate) providers: &'a BTreeSet<String>,
+    pub(crate) expansions: &'a Expansions,
 }
 
 /// Test fixture: owned context parts, so a unit test borrows one binding instead of three.
@@ -614,7 +614,7 @@ impl TestContext {
 }
 
 impl<'a> MembershipContext<'a> {
-    pub fn new(
+    pub(crate) fn new(
         within: &'a WithinAssertions,
         providers: &'a BTreeSet<String>,
         expansions: &'a Expansions,

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -521,40 +521,60 @@ pub struct MembershipNeeded {
     pub needed: Vec<SymbolicAtom>,
 }
 
-/// The membership answers one operation reads: one exact reader set per symbolic atom,
-/// post-identity and post-closure. Built by the operation's driver from pinned primitive
-/// evidence — source answers, member lookups, identity mappings — and rebuilt identically on
-/// replay, so a live decision and its replay read the same directory answers. An empty set is
-/// a valid answer.
+/// The membership answers one operation reads: one exact reader set per group or chain
+/// atom, post-identity and post-closure, and one principal per canonicalized reader. Built
+/// by the operation's driver from pinned primitive evidence — source answers, member
+/// lookups, identity mappings — and rebuilt identically on replay, so a live decision and
+/// its replay read the same directory answers. An empty set is a valid answer.
 ///
-/// Every ask through [`Expansions::members`] — answered or not — lands in the reads log, so
-/// after a decision runs the log names exactly the atoms the operation deterministically
-/// requested. The log is bookkeeping, never an answer: it takes no part in equality.
+/// Every ask — answered or not — lands in the reads log, so after a decision runs the log
+/// names exactly the atoms the operation deterministically requested. The log is
+/// bookkeeping, never an answer: it takes no part in equality.
 #[derive(Clone, Debug, Default)]
 pub struct Expansions {
-    answers: BTreeMap<SymbolicAtom, BTreeSet<ReaderId>>,
+    members: BTreeMap<SymbolicAtom, BTreeSet<ReaderId>>,
+    principals: BTreeMap<ReaderId, ReaderId>,
     reads: std::cell::RefCell<BTreeSet<SymbolicAtom>>,
 }
 
 impl PartialEq for Expansions {
     fn eq(&self, other: &Expansions) -> bool {
-        self.answers == other.answers
+        self.members == other.members && self.principals == other.principals
     }
 }
 
 impl Eq for Expansions {}
 
 impl Expansions {
-    pub fn new(answers: impl IntoIterator<Item = (SymbolicAtom, BTreeSet<ReaderId>)>) -> Expansions {
+    pub(crate) fn new(
+        members: impl IntoIterator<Item = (SymbolicAtom, BTreeSet<ReaderId>)>,
+        principals: impl IntoIterator<Item = (ReaderId, ReaderId)>,
+    ) -> Expansions {
         Expansions {
-            answers: answers.into_iter().collect(),
+            members: members.into_iter().collect(),
+            principals: principals.into_iter().collect(),
             reads: std::cell::RefCell::default(),
         }
     }
 
+    /// The reader set a group or chain atom denotes, where the operation answered it.
     pub(crate) fn members(&self, atom: &SymbolicAtom) -> Option<&BTreeSet<ReaderId>> {
         self.reads.borrow_mut().insert(atom.clone());
-        self.answers.get(atom)
+        self.members.get(atom)
+    }
+
+    /// The principal a qualified reader canonicalizes to, where the operation answered it.
+    pub(crate) fn principal(&self, reader: &ReaderId) -> Option<&ReaderId> {
+        self.reads.borrow_mut().insert(SymbolicAtom::Reader(reader.clone()));
+        self.principals.get(reader)
+    }
+
+    /// Is the atom answered, whichever kind it is?
+    pub(crate) fn answered(&self, atom: &SymbolicAtom) -> bool {
+        match atom {
+            SymbolicAtom::Reader(reader) => self.principal(reader).is_some(),
+            SymbolicAtom::Chain(_) | SymbolicAtom::Group(_) => self.members(atom).is_some(),
+        }
     }
 
     /// The atoms asked so far, sorted. A snapshot: later asks keep logging.
@@ -614,16 +634,11 @@ impl<'a> MembershipContext<'a> {
     /// registered source — then the operation's pinned canonicalization, or the atom to ask.
     fn principal(&self, reader: &ReaderId) -> Result<ReaderId, SymbolicAtom> {
         match reader.provider_prefix() {
-            Some(provider) if self.providers.contains(provider) => {
-                let atom = SymbolicAtom::Reader(reader.clone());
-                match self.expansions.members(&atom) {
-                    Some(answer) => {
-                        debug_assert_eq!(answer.len(), 1, "a reader canonicalization answers one principal");
-                        Ok(answer.first().cloned().unwrap_or_else(|| reader.clone()))
-                    }
-                    None => Err(atom),
-                }
-            }
+            Some(provider) if self.providers.contains(provider) => self
+                .expansions
+                .principal(reader)
+                .cloned()
+                .ok_or_else(|| SymbolicAtom::Reader(reader.clone())),
             _ => Ok(reader.clone()),
         }
     }
@@ -1020,23 +1035,22 @@ mod tests {
                             internal.extend(self_closed.iter().cloned());
                         }
                     }
-                    let expansions = Expansions::new([
-                        (SymbolicAtom::Chain(ChainAudience::Self_), self_closed),
-                        (SymbolicAtom::Chain(ChainAudience::Internal), internal),
-                        (SymbolicAtom::Group(named("finance")), finance),
-                        (SymbolicAtom::Group(named("legal")), legal),
-                        (
-                            SymbolicAtom::Group(GroupRef::Source {
-                                provider: "slack".into(),
-                                selector: "user-group/eng".into(),
-                            }),
-                            eng,
-                        ),
-                        (
-                            SymbolicAtom::Reader(ReaderId::new("slack:u1")),
-                            BTreeSet::from([principal]),
-                        ),
-                    ]);
+                    let expansions = Expansions::new(
+                        [
+                            (SymbolicAtom::Chain(ChainAudience::Self_), self_closed),
+                            (SymbolicAtom::Chain(ChainAudience::Internal), internal),
+                            (SymbolicAtom::Group(named("finance")), finance),
+                            (SymbolicAtom::Group(named("legal")), legal),
+                            (
+                                SymbolicAtom::Group(GroupRef::Source {
+                                    provider: "slack".into(),
+                                    selector: "user-group/eng".into(),
+                                }),
+                                eng,
+                            ),
+                        ],
+                        [(ReaderId::new("slack:u1"), principal)],
+                    );
                     (within, expansions)
                 },
             )
@@ -1105,7 +1119,7 @@ mod tests {
             label in label_strategy(),
             clause in clause_strategy(),
         ) {
-            let nothing = Expansions::new([]);
+            let nothing = Expansions::new([], []);
             let within = WithinAssertions::default();
             let providers = providers();
             let context = MembershipContext::new(&within, &providers, &nothing);
@@ -1313,15 +1327,18 @@ mod tests {
             }
             other => panic!("expected a membership ask, got {other:?}"),
         }
-        let answered = Expansions::new([(
-            SymbolicAtom::Chain(ChainAudience::Internal),
-            BTreeSet::from([reader("alice@corp.com")]),
-        )]);
+        let answered = Expansions::new(
+            [(
+                SymbolicAtom::Chain(ChainAudience::Internal),
+                BTreeSet::from([reader("alice@corp.com")]),
+            )],
+            [],
+        );
         assert_eq!(
             internal_label.covers(&alice, &MembershipContext::new(&nothing, &providers, &answered)),
             Evaluation::Holds
         );
-        let empty = Expansions::new([(SymbolicAtom::Chain(ChainAudience::Internal), BTreeSet::new())]);
+        let empty = Expansions::new([(SymbolicAtom::Chain(ChainAudience::Internal), BTreeSet::new())], []);
         assert_eq!(
             internal_label.covers(&alice, &MembershipContext::new(&nothing, &providers, &empty)),
             Evaluation::Fails,
@@ -1339,26 +1356,26 @@ mod tests {
         // $recipient = slack:U012345, where Slack reports Alice's verified corporate email
         // and the internal closure holds her principal: the cross-provider case end-to-end.
         let recipient = DeclaredAudience::restricted([reader("slack:U012345")]);
-        let unanswered = Expansions::new([(
-            SymbolicAtom::Chain(ChainAudience::Internal),
-            BTreeSet::from([reader("alice@corp.com")]),
-        )]);
+        let unanswered = Expansions::new(
+            [(
+                SymbolicAtom::Chain(ChainAudience::Internal),
+                BTreeSet::from([reader("alice@corp.com")]),
+            )],
+            [],
+        );
         match internal_label.covers(&recipient, &MembershipContext::new(&nothing, &providers, &unanswered)) {
             Evaluation::Needs(MembershipNeeded { needed }) => {
                 assert_eq!(needed, vec![SymbolicAtom::Reader(reader("slack:U012345"))]);
             }
             other => panic!("expected a canonicalization ask, got {other:?}"),
         }
-        let answered = Expansions::new([
-            (
+        let answered = Expansions::new(
+            [(
                 SymbolicAtom::Chain(ChainAudience::Internal),
                 BTreeSet::from([reader("alice@corp.com")]),
-            ),
-            (
-                SymbolicAtom::Reader(reader("slack:U012345")),
-                BTreeSet::from([reader("alice@corp.com")]),
-            ),
-        ]);
+            )],
+            [(reader("slack:U012345"), reader("alice@corp.com"))],
+        );
         assert_eq!(
             internal_label.covers(&recipient, &MembershipContext::new(&nothing, &providers, &answered)),
             Evaluation::Holds

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -472,22 +472,25 @@ impl DeclaredAudience {
         DeclaredAudience::Union(clause)
     }
 
-    pub(crate) fn symbolic_atoms(&self) -> Box<dyn Iterator<Item = SymbolicAtom> + '_> {
+    fn clause(&self) -> Option<&Clause> {
         match self {
-            DeclaredAudience::Public => Box::new(std::iter::empty()),
-            DeclaredAudience::Union(clause) => Box::new(clause.symbolic_atoms()),
+            DeclaredAudience::Public => None,
+            DeclaredAudience::Union(clause) => Some(clause),
         }
+    }
+
+    pub(crate) fn symbolic_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
+        self.clause().into_iter().flat_map(Clause::symbolic_atoms)
     }
 
     /// See [`Clause::needed_atoms`].
     pub(crate) fn needed_atoms<'a>(
         &'a self,
         providers: &'a BTreeSet<String>,
-    ) -> Box<dyn Iterator<Item = SymbolicAtom> + 'a> {
-        match self {
-            DeclaredAudience::Public => Box::new(std::iter::empty()),
-            DeclaredAudience::Union(clause) => Box::new(clause.needed_atoms(providers)),
-        }
+    ) -> impl Iterator<Item = SymbolicAtom> + 'a {
+        self.clause()
+            .into_iter()
+            .flat_map(move |clause| clause.needed_atoms(providers))
     }
 }
 

--- a/appa-engine/src/names.rs
+++ b/appa-engine/src/names.rs
@@ -69,7 +69,10 @@ impl AudienceArgument {
         }
         match value.strip_prefix('@') {
             Some(reference) => crate::label::GroupRef::parse(reference).map(AudienceArgument::Group),
-            None => Some(AudienceArgument::Reader(crate::label::ReaderId::new(value))),
+            None => {
+                let reader = crate::label::ReaderId::new(value);
+                reader.is_literal().then_some(AudienceArgument::Reader(reader))
+            }
         }
     }
 }
@@ -117,6 +120,7 @@ mod tests {
         );
         assert_eq!(AudienceArgument::parse("@"), None);
         assert_eq!(AudienceArgument::parse("@slack:"), None);
+        assert_eq!(AudienceArgument::parse(""), None, "an empty id names no reader");
         assert_eq!(GroupName::new("auditors").to_string(), "@auditors");
     }
 }

--- a/appa-engine/src/names.rs
+++ b/appa-engine/src/names.rs
@@ -45,13 +45,14 @@ impl std::fmt::Display for GroupName {
     }
 }
 
-/// How an `includes($arg)` placeholder reads its actual string argument: the reserved word
-/// `public` is the Public audience itself, `self` and `internal` are the built-in chain
-/// audiences, an `@`-marked spelling is a group reference — a configured named audience or a
+/// One audience entry as policy and tool arguments spell it: the reserved word `public` is
+/// the Public audience itself, `self` and `internal` are the built-in chain audiences, an
+/// `@`-marked spelling is a group reference — a configured named audience or a
 /// source-qualified selector — and any other string is one literal reader ID. `@` with no
-/// name after it, and a malformed selector form, read as nothing.
+/// name after it, and a malformed selector form, read as nothing. The one grammar: a
+/// declared audience list and an `includes($arg)` placeholder's actual both read through it.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum AudienceArgument {
+pub enum AudienceArgument {
     Public,
     Chain(crate::label::ChainAudience),
     Group(crate::label::GroupRef),
@@ -59,7 +60,7 @@ pub(crate) enum AudienceArgument {
 }
 
 impl AudienceArgument {
-    pub(crate) fn parse(value: &str) -> Option<AudienceArgument> {
+    pub fn parse(value: &str) -> Option<AudienceArgument> {
         if value == "public" {
             return Some(AudienceArgument::Public);
         }

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -2188,6 +2188,291 @@ mod tests {
         assert!(plan_atoms(&registry, contract, exec(&planned.plans[0])).is_empty());
     }
 
+    /// The four gathering collectors, each against the scope rule its enumeration mirrors:
+    /// three named groups, each read by exactly one kind of component, so every set below
+    /// names which rule admitted it.
+    mod gathering {
+        use super::*;
+        use crate::authority::DeclaredTransition;
+        use crate::candidate::SanitizerLineage;
+        use crate::check::{Gap, Narrowing, RawBlock};
+        use crate::label::{Clause, GroupRef};
+        use crate::names::{GroupName, SanitizerName, TagName};
+        use crate::profile::{DeploymentProfile, ProfileDeclaration};
+        use crate::registry::PlannerCap;
+        use std::collections::BTreeSet;
+
+        fn group(name: &str) -> DeclaredAudience {
+            DeclaredAudience::Union(
+                Clause::new([], [GroupRef::Named(GroupName::new(name))], []).expect("a group clause"),
+            )
+        }
+
+        fn atoms(names: &[&str]) -> BTreeSet<SymbolicAtom> {
+            names
+                .iter()
+                .map(|name| SymbolicAtom::Group(GroupRef::Named(GroupName::new(*name))))
+                .collect()
+        }
+
+        fn tags(tags: &[&str]) -> Vec<TagName> {
+            tags.iter().map(|tag| TagName::new(*tag)).collect()
+        }
+
+        fn tool(name: &str, tool_tags: &[&str], delta: Delta) -> ToolAnnotation {
+            ToolAnnotation {
+                description: Some("A test tool.".to_string()),
+                name: ToolName::new(name),
+                tags: tags(tool_tags),
+                delta,
+                parameters: crate::params::ToolParameters::open(),
+                emits: EffectSet::default(),
+                requires: Requires::default(),
+            }
+        }
+
+        fn authority(name: &str, ceiling: &str, scope: &[&str]) -> Authority {
+            Authority {
+                name: AuthorityName::new(name),
+                mandate: Mandate {
+                    reader_ceiling: Some(group(ceiling)),
+                    ..Mandate::default()
+                },
+                scope: Scope { tags: tags(scope) },
+                hint: None,
+            }
+        }
+
+        fn sanitizer(name: &str, on: SanitizerPoints, from: &str, scope: &[&str]) -> Sanitizer {
+            Sanitizer {
+                name: SanitizerName::new(name),
+                on,
+                transition: DeclaredTransition::Audience {
+                    from_includes: group(from),
+                    to: DeclaredAudience::restricted([ReaderId::new("insider")]),
+                },
+                scope: Scope { tags: tags(scope) },
+                hint: None,
+            }
+        }
+
+        const INPUT: SanitizerPoints = SanitizerPoints {
+            input: true,
+            output: false,
+        };
+        const OUTPUT: SanitizerPoints = SanitizerPoints {
+            input: false,
+            output: true,
+        };
+
+        /// `desk` (authority, tag `mail`) reads `team`; `scrub` (input) and `redact` (output,
+        /// unscoped) read `legal`; `far` (authority, tag `unrelated`), `aside` (output, tag
+        /// `unrelated`) and the `note` tool's delta read `press`.
+        fn registry(confined_results: &[&str], confined_child_return: bool) -> Registry {
+            let named = |name: &str| crate::audience::NamedAudience {
+                name: GroupName::new(name),
+                within: None,
+                from: vec![crate::audience::SelectorSpec {
+                    provider: "slack".to_string(),
+                    selector: format!("user-group/{name}"),
+                }],
+            };
+            let config = RegistryConfig {
+                trust_chain: chain(),
+                tools: declared(vec![
+                    tool("send", &["mail"], Delta::NONE),
+                    tool(
+                        "note",
+                        &[],
+                        Delta {
+                            trust: None,
+                            audience: Some(group("press")),
+                        },
+                    ),
+                ]),
+                authorities: vec![
+                    authority("desk", "team", &["mail"]),
+                    authority("far", "press", &["unrelated"]),
+                ],
+                sanitizers: vec![
+                    sanitizer("scrub", INPUT, "legal", &[]),
+                    sanitizer("redact", OUTPUT, "legal", &[]),
+                    sanitizer("aside", OUTPUT, "press", &["unrelated"]),
+                ],
+                audience: crate::audience::AudienceConfig {
+                    sources: vec![crate::audience::SourceRegistration {
+                        provider: "slack".to_string(),
+                        templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                    }],
+                    groups: vec![named("team"), named("legal"), named("press")],
+                    ..crate::audience::AudienceConfig::default()
+                },
+                annotators: vec![],
+            };
+            let profile = DeploymentProfile::declare(ProfileDeclaration {
+                confined_results: confined_results.iter().map(|name| ToolName::new(*name)).collect(),
+                confined_child_return,
+                ..crate::profile::covering_declaration(&config)
+            })
+            .expect("the gathering profile declares");
+            Registry::build(config, PlannerCap::default(), profile).expect("the gathering registry builds")
+        }
+
+        fn send(registry: &Registry) -> ToolAnnotation {
+            registry
+                .tool(&ToolName::new("send"))
+                .and_then(ToolDeclaration::declared)
+                .cloned()
+                .expect("send is declared")
+        }
+
+        fn raw(gaps: Vec<Gap>, narrowing: bool) -> RawBlock {
+            RawBlock {
+                requirement_gaps: gaps,
+                narrowing: narrowing.then(|| Narrowing {
+                    from: known(TRUSTED, Audience::public()),
+                    to: known(TRUSTED, Audience::restricted([ReaderId::new("insider")])),
+                }),
+            }
+        }
+
+        fn includes() -> Gap {
+            Gap::Includes {
+                recipients: group("team"),
+            }
+        }
+
+        fn lineage(names: &[&str]) -> SanitizerLineage {
+            SanitizerLineage::try_from(names.iter().map(|name| SanitizerName::new(*name)).collect::<Vec<_>>())
+                .expect("a lineage without repeats")
+        }
+
+        #[test]
+        fn a_block_reads_each_component_the_gap_it_carries_consults() {
+            let unconfined = registry(&[], false);
+            let confined = registry(&["send"], false);
+            let contract = send(&unconfined);
+            let collect = |registry: &Registry, raw: &RawBlock, role: CallRole| -> BTreeSet<SymbolicAtom> {
+                block_atoms(registry, &contract, raw, role).into_iter().collect()
+            };
+            assert_eq!(
+                collect(&unconfined, &raw(vec![includes()], false), CallRole::Ordinary),
+                atoms(&["team", "legal"]),
+                "an includes gap reads the in-scope authority and the in-scope input sanitizer"
+            );
+            assert_eq!(
+                collect(&unconfined, &raw(vec![includes()], false), CallRole::MarkedSpawn),
+                atoms(&["team"]),
+                "a marked spawn never routes through an input sanitizer"
+            );
+            assert_eq!(
+                collect(
+                    &unconfined,
+                    &raw(vec![Gap::Cap { cap: group("team") }], false),
+                    CallRole::Ordinary
+                ),
+                atoms(&["press"]),
+                "a cap gap reads every tool's delta and no authority"
+            );
+            assert_eq!(
+                collect(
+                    &unconfined,
+                    &raw(
+                        vec![Gap::TrustFloor {
+                            required: TRUSTED,
+                            actual: SUSPICIOUS
+                        }],
+                        false
+                    ),
+                    CallRole::Ordinary
+                ),
+                atoms(&[]),
+                "a trust-floor gap consults no reader ceiling"
+            );
+            assert_eq!(
+                collect(&unconfined, &raw(vec![], true), CallRole::Ordinary),
+                atoms(&[]),
+                "a narrowing at an unconfined result point reads no output sanitizer"
+            );
+            assert_eq!(
+                collect(&confined, &raw(vec![], true), CallRole::Ordinary),
+                atoms(&["legal"]),
+                "a narrowing at a confined result point reads the in-scope output sanitizers"
+            );
+        }
+
+        #[test]
+        fn a_confined_stage_reads_the_unspent_in_scope_output_sanitizers() {
+            let registry = registry(&["send"], false);
+            let contract = send(&registry);
+            let collect = |lineage: &SanitizerLineage| -> BTreeSet<SymbolicAtom> {
+                confined_stage_atoms(&registry, &contract, lineage)
+                    .into_iter()
+                    .collect()
+            };
+            assert_eq!(collect(&lineage(&[])), atoms(&["legal"]));
+            assert_eq!(
+                collect(&lineage(&["redact"])),
+                atoms(&[]),
+                "a spent sanitizer is not read again"
+            );
+        }
+
+        #[test]
+        fn a_child_return_reads_output_sanitizers_only_where_the_deployment_confines_it() {
+            let collect = |registry: &Registry, lineage: &SanitizerLineage| -> BTreeSet<SymbolicAtom> {
+                return_stage_atoms(registry, lineage).into_iter().collect()
+            };
+            assert_eq!(collect(&registry(&[], false), &lineage(&[])), atoms(&[]));
+            let confined = registry(&[], true);
+            assert_eq!(
+                collect(&confined, &lineage(&[])),
+                atoms(&["legal"]),
+                "only an unscoped output sanitizer applies to a return"
+            );
+            assert_eq!(collect(&confined, &lineage(&["redact"])), atoms(&[]));
+        }
+
+        #[test]
+        fn a_plan_reads_its_rulings_as_far_as_their_gaps_consult_the_mandate_and_its_steps() {
+            let registry = registry(&[], false);
+            let contract = send(&registry);
+            let collect = |required: Vec<RequiredRuling>, steps: Vec<RemedyStep>| -> BTreeSet<SymbolicAtom> {
+                let plan = ExecutableRemedyPlan {
+                    id: PlanId::new(0),
+                    steps,
+                    required,
+                };
+                plan_atoms(&registry, &contract, &plan).into_iter().collect()
+            };
+            let desk = |covers: Vec<Gap>| RequiredRuling {
+                authority: AuthorityName::new("desk"),
+                covers,
+            };
+            assert_eq!(
+                collect(
+                    vec![desk(vec![includes()])],
+                    vec![
+                        RemedyStep::Authorize(AuthorityName::new("desk")),
+                        RemedyStep::Sanitize(SanitizerName::new("redact")),
+                    ]
+                ),
+                atoms(&["team", "legal"])
+            );
+            assert_eq!(
+                collect(
+                    vec![desk(vec![Gap::TrustFloor {
+                        required: TRUSTED,
+                        actual: SUSPICIOUS
+                    }])],
+                    vec![RemedyStep::Accept(raw(vec![], true).narrowing.expect("a narrowing"))]
+                ),
+                atoms(&[]),
+                "a ruling over no includes gap reads no ceiling; accepting reads nothing"
+            );
+        }
+    }
+
     #[test]
     fn an_undecided_mandate_refuses_enumeration_with_its_atom_never_a_smaller_menu() {
         let tool = ToolAnnotation {

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -2578,7 +2578,7 @@ mod tests {
         );
 
         let answered = crate::label::TestContext {
-            expansions: crate::label::Expansions::new([(atom, BTreeSet::from([ReaderId::new("hr")]))]),
+            expansions: crate::label::Expansions::new([(atom, BTreeSet::from([ReaderId::new("hr")]))], []),
             ..Default::default()
         };
         let planned = plan(&registry, &views, blocked(), &answered.context()).expect("every atom is answered");

--- a/appa-engine/src/projection.rs
+++ b/appa-engine/src/projection.rs
@@ -78,11 +78,9 @@ pub(crate) struct RecordedOffer {
     pub(crate) end: Option<OfferEnd>,
 }
 
-/// The live derived candidate of one subject, with the transformer that claimed it and the chain
-/// that produced it.
+/// The live derived candidate of one subject, with the chain that produced it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RecordedCandidate {
-    pub(crate) via: crate::candidate::DerivedVia,
     pub(crate) derived: DerivedCandidate,
     pub(crate) lineage: SanitizerLineage,
     /// The pinned audience evidence the hop that derived this candidate consumed: what a
@@ -515,7 +513,6 @@ impl Projection {
                 }
                 Fact::CandidateDerived {
                     subject,
-                    via,
                     derived,
                     lineage,
                     evidence,
@@ -524,7 +521,6 @@ impl Projection {
                     candidates.insert(
                         subject.clone(),
                         RecordedCandidate {
-                            via: via.clone(),
                             derived: derived.clone(),
                             lineage: lineage.clone(),
                             evidence: match derived {
@@ -1180,12 +1176,6 @@ impl Views<'_> {
     /// stage plans from it, and a successor replaces it.
     pub(crate) fn candidate(&self, subject: &SubjectKey) -> Option<&DerivedCandidate> {
         self.projection.candidates.get(subject).map(|held| &held.derived)
-    }
-
-    /// The transformer this subject's live candidate claims: the sanitizer hop that
-    /// derived it. The crossing paths branch on it.
-    pub(crate) fn candidate_via(&self, subject: &SubjectKey) -> Option<&crate::candidate::DerivedVia> {
-        self.projection.candidates.get(subject).map(|held| &held.via)
     }
 
     /// Where this call subject's candidate stands: the label its substituted bytes

--- a/appa-engine/src/projection.rs
+++ b/appa-engine/src/projection.rs
@@ -1228,12 +1228,16 @@ impl Views<'_> {
 
     /// The pinned audience evidence the hop that derived this subject's candidate consumed;
     /// empty for a subject no hop has touched.
-    pub(crate) fn candidate_evidence(&self, subject: &SubjectKey) -> AudienceEvidence {
+    pub(crate) fn candidate_evidence(&self, subject: &SubjectKey) -> &AudienceEvidence {
+        const NONE: &AudienceEvidence = &AudienceEvidence {
+            sources: Vec::new(),
+            lookups: Vec::new(),
+            identity: Vec::new(),
+        };
         self.projection
             .candidates
             .get(subject)
-            .map(|held| held.evidence.clone())
-            .unwrap_or_default()
+            .map_or(NONE, |held| &held.evidence)
     }
 
     /// The call this subject stands on now: the candidate an input hop derived, or the proposal

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -1341,20 +1341,13 @@ fn check_selector(
     spec: &SelectorSpec,
     context: impl Fn() -> String,
 ) -> Result<(), LoadError> {
-    let fault = match registry.templates(&spec.provider) {
-        None => Unroutable::UnknownProvider(spec.provider.clone()),
-        Some(templates) if !templates.iter().any(|template| template.matches(&spec.selector)) => {
-            Unroutable::UnknownSelector {
-                provider: spec.provider.clone(),
-                selector: spec.selector.clone(),
-            }
-        }
-        Some(_) => return Ok(()),
-    };
-    Err(LoadError::UnroutableAudience {
-        context: context(),
-        fault,
-    })
+    registry
+        .route_selector(&spec.provider, &spec.selector)
+        .map(|_| ())
+        .map_err(|fault| LoadError::UnroutableAudience {
+            context: context(),
+            fault,
+        })
 }
 
 /// Every group reference a policy declaration writes must resolve at load: a named audience

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -240,7 +240,7 @@ impl BlockContext {
         evidence = evidence.inheriting(&decided.evidence)?;
         // A candidate an input hop derived may stand under another contract than the proposal;
         // the atoms that contract reads were pinned by the hop.
-        evidence = evidence.inheriting(&views.candidate_evidence(subject))?;
+        evidence = evidence.inheriting(views.candidate_evidence(subject))?;
         let expansions = registry.audience().expansions(&evidence)?;
 
         let stage = views.call_stage(subject);

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -229,21 +229,18 @@ impl BlockContext {
             .ok_or(RouteError::UnknownSubject)?
             .into_owned();
 
-        // The supplied answers must be admissible on their own — a duplicate or unroutable
-        // claim refuses loudly here, before recorded pins shadow it silently.
-        registry.audience().expansions(answers)?;
         let mut evidence = answers.clone();
         if let Some((_, offers)) = views.pending_block(subject) {
             for (offer, _) in &offers {
                 if let Some(recorded) = views.offer(offer) {
-                    evidence = evidence.inheriting(&recorded.evidence);
+                    evidence = evidence.inheriting(&recorded.evidence)?;
                 }
             }
         }
-        evidence = evidence.inheriting(&decided.evidence);
+        evidence = evidence.inheriting(&decided.evidence)?;
         // A candidate an input hop derived may stand under another contract than the proposal;
         // the atoms that contract reads were pinned by the hop.
-        evidence = evidence.inheriting(&views.candidate_evidence(subject));
+        evidence = evidence.inheriting(&views.candidate_evidence(subject))?;
         let expansions = registry.audience().expansions(&evidence)?;
 
         let stage = views.call_stage(subject);

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -486,7 +486,7 @@ impl<'a> Search<'a> {
             let mut unanswered: Vec<SymbolicAtom> =
                 plan::block_atoms(self.registry, &context.contract, &eval, context.role)
                     .into_iter()
-                    .filter(|atom| self.context.expansions.members(atom).is_none())
+                    .filter(|atom| !self.context.expansions.answered(atom))
                     .collect();
             if !unanswered.is_empty() {
                 unanswered.sort();

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -484,6 +484,12 @@ impl From<crate::label::MembershipNeeded> for TransitionError {
     }
 }
 
+impl From<crate::label::MembershipNeeded> for TransitionRefusal {
+    fn from(needed: crate::label::MembershipNeeded) -> TransitionRefusal {
+        TransitionRefusal::UnansweredDecision { needed: needed.needed }
+    }
+}
+
 /// One engine interaction's outcome: the sealed batch to append against its basis
 /// revision, and the one typed follow-up package. The runtime appends the whole batch
 /// before it performs any follow-up item.
@@ -711,10 +717,15 @@ pub enum TransitionRefusal {
     SplitAdmission,
     #[error("an admitted value does not carry the label its source derives")]
     ForgedLabel,
-    #[error(
-        "a record persists audience evidence other than what its operation consumed, or claims a decision its pinned evidence cannot answer"
-    )]
+    #[error("a record persists audience evidence or an annotation other than what its operation consumed")]
     ForgedEvidence,
+    #[error("a record pins audience evidence its operation could not have consumed: {0}")]
+    ForeignEvidence(#[from] crate::audience::EvidenceRefusal),
+    #[error(
+        "a record claims a decision its pinned evidence cannot answer: {}",
+        needed.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+    )]
+    UnansweredDecision { needed: Vec<crate::label::SymbolicAtom> },
     #[error("a second value is admitted for one dispatch or child return")]
     RepeatAdmission,
     #[error("admitted value names a dispatch not opened earlier in the log")]
@@ -1520,7 +1531,7 @@ impl<'a> Sequence<'a> {
                 let role = views.call_role(subject);
                 let context = self.context(expansions);
                 let CheckOutcome::Block(block) = crate::check::evaluate(&contract, views, candidate, &stage, &context)
-                    .map_err(|_| TransitionRefusal::ForgedEvidence)?
+                    .map_err(TransitionRefusal::from)?
                 else {
                     return Err(TransitionRefusal::UnbackedOffer);
                 };
@@ -1546,7 +1557,7 @@ impl<'a> Sequence<'a> {
                 )
                 // A recorded act whose pinned evidence leaves an enumeration read undecided
                 // reconstructed a menu the evidence cannot back.
-                .map_err(|_| TransitionRefusal::ForgedEvidence)?
+                .map_err(TransitionRefusal::from)?
                 .plans
                 .iter()
                 .filter_map(crate::plan::RemedyPlan::executable)
@@ -1589,7 +1600,7 @@ impl<'a> Sequence<'a> {
                     &lineage,
                     &self.context(expansions),
                 )
-                .map_err(|_| TransitionRefusal::ForgedEvidence)
+                .map_err(TransitionRefusal::from)
             }
             crate::basis::SubjectKey::Return(id) => {
                 let child = id.child();
@@ -1646,7 +1657,7 @@ impl<'a> Sequence<'a> {
                     &lineage,
                     &self.context(expansions),
                 )
-                .map_err(|_| TransitionRefusal::ForgedEvidence)
+                .map_err(TransitionRefusal::from)
             }
             crate::basis::SubjectKey::Approval(_) => Err(TransitionRefusal::ForeignOffer),
         }
@@ -2270,9 +2281,8 @@ impl<'a> Sequence<'a> {
             &act,
         )
         .map_err(|refusal| match refusal {
-            crate::engine::ComposeRefusal::MembershipNeeded(_) | crate::engine::ComposeRefusal::Evidence(_) => {
-                TransitionRefusal::ForgedEvidence
-            }
+            crate::engine::ComposeRefusal::MembershipNeeded(needed) => needed.into(),
+            crate::engine::ComposeRefusal::Evidence(refusal) => refusal.into(),
             crate::engine::ComposeRefusal::Malformed(error) => match error {
                 crate::engine::EngineError::InvalidCall(error) => TransitionRefusal::InvalidPayload(error),
                 crate::engine::EngineError::UnknownTool(tool) | crate::engine::EngineError::ProviderRunTool(tool) => {
@@ -2419,7 +2429,7 @@ impl<'a> Sequence<'a> {
                             name,
                             &self.context(expansions),
                         )
-                        .map_err(|_| TransitionRefusal::ForgedEvidence)?,
+                        .map_err(TransitionRefusal::from)?,
                     },
                     evidence: (!approval.rulings.is_empty() || approval.sanitizer.is_some()).then(|| evidence.clone()),
                 };
@@ -2431,7 +2441,7 @@ impl<'a> Sequence<'a> {
                 return match checked {
                     Ok(CheckOutcome::Block(_)) => Ok(()),
                     Ok(CheckOutcome::Allow) => Err(TransitionRefusal::UnreleasedDispatch),
-                    Err(_) => Err(TransitionRefusal::ForgedEvidence),
+                    Err(needed) => Err(needed.into()),
                 };
             }
             Obligation::Free => {}
@@ -2442,7 +2452,7 @@ impl<'a> Sequence<'a> {
             Ok(CheckOutcome::Allow) if remedy.is_some() => Err(TransitionRefusal::DanglingRemedy),
             Ok(CheckOutcome::Allow) => Ok(()),
             Ok(CheckOutcome::Block(_)) => Err(TransitionRefusal::UnreleasedDispatch),
-            Err(_) => Err(TransitionRefusal::ForgedEvidence),
+            Err(needed) => Err(needed.into()),
         }
     }
 
@@ -2775,7 +2785,7 @@ impl<'a> Sequence<'a> {
                 match registered.derive_output(&fold, &[], &self.context(&expansions)) {
                     Ok(Some(_)) => {}
                     Ok(None) => return Err(TransitionRefusal::ReturnRecordMismatch),
-                    Err(_) => return Err(TransitionRefusal::ForgedEvidence),
+                    Err(needed) => return Err(needed.into()),
                 }
             }
         }
@@ -2822,12 +2832,9 @@ impl<'a> Sequence<'a> {
             .ok_or_else(|| TransitionRefusal::UnknownSanitizer(name.as_str().to_string()))?;
         let fold = views.branch_label(child);
         let derives = match reason {
-            crate::fact::ReturnRejection::MandateUnmet => {
-                match registered.derive_output(&fold, &[], &self.context(&expansions)) {
-                    Ok(derived) => derived.is_none(),
-                    Err(_) => return Err(TransitionRefusal::ForgedEvidence),
-                }
-            }
+            crate::fact::ReturnRejection::MandateUnmet => registered
+                .derive_output(&fold, &[], &self.context(&expansions))?
+                .is_none(),
             crate::fact::ReturnRejection::PreconditionUnmet => name.is_attest_schema(),
         };
         if !derives {
@@ -2892,11 +2899,9 @@ impl<'a> Sequence<'a> {
             .registry()
             .audience()
             .expansions(evidence)
-            .map_err(|_| TransitionRefusal::ForgedEvidence)?;
+            .map_err(TransitionRefusal::from)?;
         let mut audit = self.audit.borrow_mut();
-        audit.evidence = evidence
-            .inheriting(&audit.evidence)
-            .map_err(|_| TransitionRefusal::ForgedEvidence)?;
+        audit.evidence = evidence.inheriting(&audit.evidence).map_err(TransitionRefusal::from)?;
         Ok(expansions)
     }
 
@@ -2916,10 +2921,7 @@ impl<'a> Sequence<'a> {
     /// Count `pins` — entries pinned by a record the open act continues — as inherited.
     fn audit_inherit(&self, pins: &AudienceEvidence) -> Result<(), TransitionRefusal> {
         let mut audit = self.audit.borrow_mut();
-        audit.inherited = audit
-            .inherited
-            .inheriting(pins)
-            .map_err(|_| TransitionRefusal::ForgedEvidence)?;
+        audit.inherited = audit.inherited.inheriting(pins).map_err(TransitionRefusal::from)?;
         Ok(())
     }
 
@@ -2936,7 +2938,7 @@ impl<'a> Sequence<'a> {
                 crate::audience::EvidenceRefusal::UnrequestedEvidence { entry } => {
                     TransitionRefusal::UnrequestedEvidence { entry }
                 }
-                _ => TransitionRefusal::ForgedEvidence,
+                other => TransitionRefusal::ForeignEvidence(other),
             })
     }
 
@@ -3101,7 +3103,7 @@ impl<'a> Sequence<'a> {
         let label = match registered.derive_output(&from_label, &contract.tags, &self.context(&expansions)) {
             Ok(Some(label)) => label,
             Ok(None) => return Err(TransitionRefusal::SanitizerUnapplicable),
-            Err(_) => return Err(TransitionRefusal::ForgedEvidence),
+            Err(needed) => return Err(needed.into()),
         };
         if value.label != label {
             return Err(TransitionRefusal::ForgedLabel);
@@ -3212,7 +3214,7 @@ impl<'a> Sequence<'a> {
         let label = match registered.derive_output(&from_label, &[], &self.context(expansions)) {
             Ok(Some(label)) => label,
             Ok(None) => return Err(TransitionRefusal::SanitizerUnapplicable),
-            Err(_) => return Err(TransitionRefusal::ForgedEvidence),
+            Err(needed) => return Err(needed.into()),
         };
         if value.label != label {
             return Err(TransitionRefusal::ForgedLabel);
@@ -3321,7 +3323,7 @@ impl<'a> Sequence<'a> {
             match registered.derive_input(&stage.released(&views.current_label()), &before_contract.tags, &context) {
                 Ok(Some(derived)) => derived,
                 Ok(None) => return Err(TransitionRefusal::SanitizerUnapplicable),
-                Err(_) => return Err(TransitionRefusal::ForgedEvidence),
+                Err(needed) => return Err(needed.into()),
             };
         if label != &derived {
             return Err(TransitionRefusal::ForgedLabel);
@@ -3332,8 +3334,8 @@ impl<'a> Sequence<'a> {
             return Err(TransitionRefusal::UnbackedOffer);
         };
         let next = CallStage::substituting(derived, lineage.clone());
-        let after = crate::check::evaluate(&contract, &views, call, &next, &context)
-            .map_err(|_| TransitionRefusal::ForgedEvidence)?;
+        let after =
+            crate::check::evaluate(&contract, &views, call, &next, &context).map_err(TransitionRefusal::from)?;
         if !crate::plan::substitution_helps(&before, &after) {
             return Err(TransitionRefusal::SanitizerUnapplicable);
         }

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 
 use crate::audience::AudienceEvidence;
-use crate::candidate::{CallStage, ConfinedFrom, DerivedCandidate, DerivedVia, SanitizerLineage};
+use crate::candidate::{CallStage, ConfinedFrom, DerivedCandidate, SanitizerLineage};
 use crate::check::{CheckOutcome, Gap, Narrowing};
 use crate::contract::ToolAnnotation;
 use crate::engine::Engine;
@@ -1205,11 +1205,11 @@ impl<'a> Sequence<'a> {
             Fact::CandidateDerived {
                 trajectory,
                 subject,
-                via,
+                sanitizer,
                 derived,
                 lineage,
                 evidence,
-            } => self.candidate_derived(trajectory, subject, via, derived, lineage, evidence)?,
+            } => self.candidate_derived(trajectory, subject, sanitizer, derived, lineage, evidence)?,
             Fact::CandidateAccepted {
                 trajectory,
                 subject,
@@ -2682,10 +2682,7 @@ impl<'a> Sequence<'a> {
         sanitizer: &SanitizerName,
         derivation: &ReturnDerivation,
     ) -> Result<Label, TransitionRefusal> {
-        let ReturnDerivation::Sanitized {
-            raw_digest, transition, ..
-        } = derivation
-        else {
+        let ReturnDerivation::Sanitized { raw_digest, .. } = derivation else {
             return Err(TransitionRefusal::ReturnPolicyMismatch);
         };
         let subject = crate::basis::SubjectKey::Return(id.clone());
@@ -2699,13 +2696,6 @@ impl<'a> Sequence<'a> {
         let lineage = views.lineage(&subject);
         if lineage.names().last() != Some(sanitizer) {
             return Err(TransitionRefusal::ReturnRecordMismatch);
-        }
-        let derived_at = match views.candidate_via(&subject) {
-            Some(DerivedVia { transition, .. }) => transition,
-            _ => return Err(TransitionRefusal::ReturnRecordMismatch),
-        };
-        if derived_at != transition {
-            return Err(TransitionRefusal::SanitizerUnapplicable);
         }
         Ok(candidate.label.clone())
     }
@@ -2964,24 +2954,17 @@ impl<'a> Sequence<'a> {
         &mut self,
         trajectory: &TrajectoryId,
         subject: &crate::basis::SubjectKey,
-        via: &DerivedVia,
+        sanitizer: &SanitizerName,
         derived: &DerivedCandidate,
         lineage: &SanitizerLineage,
         evidence: &AudienceEvidence,
     ) -> Result<(), TransitionRefusal> {
         let expansions = self.recorded_expansions(evidence)?;
-        let DerivedVia {
-            name: sanitizer,
-            transition,
-        } = via;
         let registered = self
             .engine
             .registry()
             .sanitizer(sanitizer)
             .ok_or_else(|| TransitionRefusal::UnknownSanitizer(sanitizer.as_str().to_string()))?;
-        if registered.transition.applied() != *transition {
-            return Err(TransitionRefusal::SanitizerUnapplicable);
-        }
         let (dispatch, source, from, value, residual) = match derived {
             DerivedCandidate::Call {
                 source,

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -1483,12 +1483,12 @@ impl<'a> Sequence<'a> {
         match act {
             crate::basis::DecidedAct::Offer(offer) => {
                 if let Some(recorded) = views.offer(offer) {
-                    self.audit_inherit(&recorded.evidence);
+                    self.audit_inherit(&recorded.evidence)?;
                 }
             }
             crate::basis::DecidedAct::Outcome(dispatch) => {
                 if let Some(pinned) = views.dispatch_evidence(dispatch) {
-                    self.audit_inherit(pinned);
+                    self.audit_inherit(pinned)?;
                 }
             }
             _ => {}
@@ -1661,7 +1661,7 @@ impl<'a> Sequence<'a> {
         let views = self.projection.view(trajectory);
         let recorded = ending_offer(&views, trajectory, offer)?;
         // The executing act inherits the accepted offer's pinned evidence.
-        self.audit_inherit(&recorded.evidence);
+        self.audit_inherit(&recorded.evidence)?;
         let (basis, subject) = (recorded.basis, recorded.subject.clone());
         let owed = match (&subject, recorded.plan.hop().is_some()) {
             (SubjectKey::Call { .. }, false) => Owed::Approval(*offer),
@@ -1764,7 +1764,7 @@ impl<'a> Sequence<'a> {
         if !evidence.contains(&recorded.evidence) {
             return Err(TransitionRefusal::ForgedEvidence);
         }
-        self.audit_inherit(&recorded.evidence);
+        self.audit_inherit(&recorded.evidence)?;
         // The live approval act answered its whole deterministic gate — the standing block's
         // atoms and the chosen plan's — before ruling; mirror the same ask here.
         let stage = views.call_stage(&recorded.subject);
@@ -2270,7 +2270,9 @@ impl<'a> Sequence<'a> {
             &act,
         )
         .map_err(|refusal| match refusal {
-            crate::engine::ComposeRefusal::MembershipNeeded(_) => TransitionRefusal::ForgedEvidence,
+            crate::engine::ComposeRefusal::MembershipNeeded(_) | crate::engine::ComposeRefusal::Evidence(_) => {
+                TransitionRefusal::ForgedEvidence
+            }
             crate::engine::ComposeRefusal::Malformed(error) => match error {
                 crate::engine::EngineError::InvalidCall(error) => TransitionRefusal::InvalidPayload(error),
                 crate::engine::EngineError::UnknownTool(tool) | crate::engine::EngineError::ProviderRunTool(tool) => {
@@ -2398,7 +2400,7 @@ impl<'a> Sequence<'a> {
             }
             Obligation::Consuming(offer) => {
                 let approval = views.approval(&offer).ok_or(TransitionRefusal::UnknownApproval)?;
-                self.audit_inherit(&approval.evidence);
+                self.audit_inherit(&approval.evidence)?;
                 let expected = Remedy {
                     rulings: approval
                         .rulings
@@ -2892,8 +2894,9 @@ impl<'a> Sequence<'a> {
             .expansions(evidence)
             .map_err(|_| TransitionRefusal::ForgedEvidence)?;
         let mut audit = self.audit.borrow_mut();
-        let union = evidence.inheriting(&audit.evidence);
-        audit.evidence = union;
+        audit.evidence = evidence
+            .inheriting(&audit.evidence)
+            .map_err(|_| TransitionRefusal::ForgedEvidence)?;
         Ok(expansions)
     }
 
@@ -2911,10 +2914,13 @@ impl<'a> Sequence<'a> {
     }
 
     /// Count `pins` — entries pinned by a record the open act continues — as inherited.
-    fn audit_inherit(&self, pins: &AudienceEvidence) {
+    fn audit_inherit(&self, pins: &AudienceEvidence) -> Result<(), TransitionRefusal> {
         let mut audit = self.audit.borrow_mut();
-        let merged = audit.inherited.inheriting(pins);
-        audit.inherited = merged;
+        audit.inherited = audit
+            .inherited
+            .inheriting(pins)
+            .map_err(|_| TransitionRefusal::ForgedEvidence)?;
+        Ok(())
     }
 
     /// Settle the open act's operation-scope audit: every pinned entry is an inherited pin
@@ -3065,7 +3071,7 @@ impl<'a> Sequence<'a> {
                 if recorded.plan.hop() != Some(sanitizer) || &recorded.subject != subject {
                     return Err(TransitionRefusal::UnbackedOffer);
                 }
-                self.audit_inherit(&recorded.evidence);
+                self.audit_inherit(&recorded.evidence)?;
                 let current = views.candidate(subject).ok_or(TransitionRefusal::UnknownOffer)?;
                 let DerivedCandidate::Result {
                     value: predecessor,
@@ -3113,7 +3119,7 @@ impl<'a> Sequence<'a> {
             self.derived.insert(dispatch.clone(), Derived::Sanitized(value.clone()));
         }
         if let Some(pinned) = views.dispatch_evidence(dispatch) {
-            self.audit_inherit(pinned);
+            self.audit_inherit(pinned)?;
         }
         self.audit_reads(&expansions);
         Ok(())
@@ -3170,7 +3176,7 @@ impl<'a> Sequence<'a> {
                 if recorded.plan.hop() != Some(sanitizer) || &recorded.subject != subject {
                     return Err(TransitionRefusal::UnbackedOffer);
                 }
-                self.audit_inherit(&recorded.evidence);
+                self.audit_inherit(&recorded.evidence)?;
                 let expected = views.lineage(subject).extend(sanitizer.clone());
                 if expected.as_ref() != Some(lineage) {
                     return Err(TransitionRefusal::SanitizerUnapplicable);
@@ -3340,7 +3346,7 @@ impl<'a> Sequence<'a> {
         // The live hop's act gated the standing block's whole atom set before offering.
         let role = views.call_role(subject);
         self.audit_atoms(crate::plan::block_atoms(registry, &before_contract, &before, role));
-        self.audit_inherit(&recorded.evidence);
+        self.audit_inherit(&recorded.evidence)?;
         self.audit_reads(expansions);
         Ok(())
     }

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -878,19 +878,6 @@ impl Remedy {
     }
 }
 
-/// The per-act operation-scope audit: the union of the pinned evidence the act's records
-/// carry, the asks their validations re-made (plus the deterministic gate atoms the live act
-/// answered), and the pins of the records the act continues. Settled when the act closes:
-/// every pinned entry must be an inherited pin or answer a collected ask — the same
-/// `only_requested` test the live act passed, so a log cannot smuggle evidence no operation
-/// requested.
-#[derive(Default)]
-struct ActAudit {
-    evidence: AudienceEvidence,
-    inherited: AudienceEvidence,
-    reads: BTreeSet<crate::label::SymbolicAtom>,
-}
-
 /// The one sequential transition validator. It admits records one at a time against the
 /// state the records before them built, and folds each admitted record into that state through
 /// [`Projection::fold`] — the same fold a held view advances by, so validation and projection can
@@ -917,7 +904,7 @@ pub(crate) struct Sequence<'a> {
     owing: Option<Owed>,
     substituted: Option<Substitution>,
     /// Interior mutability because contributions come from `&self` validation helpers.
-    audit: std::cell::RefCell<ActAudit>,
+    audit: std::cell::RefCell<crate::audience::ActLedger>,
 }
 
 struct Substitution {
@@ -2892,7 +2879,7 @@ impl<'a> Sequence<'a> {
     /// The membership answers a record's pinned primitives recompute to. Every pinned entry
     /// must belong to a registered source: junk or foreign evidence never validates, whatever
     /// answers it would add. The one funnel every evidence-carrying record passes, so it also
-    /// unions the evidence into the open act's operation-scope audit.
+    /// pins the evidence into the open act's ledger.
     fn recorded_expansions(&self, evidence: &AudienceEvidence) -> Result<Expansions, TransitionRefusal> {
         let expansions = self
             .engine
@@ -2900,40 +2887,34 @@ impl<'a> Sequence<'a> {
             .audience()
             .expansions(evidence)
             .map_err(TransitionRefusal::from)?;
-        let mut audit = self.audit.borrow_mut();
-        audit.evidence = evidence.inheriting(&audit.evidence).map_err(TransitionRefusal::from)?;
+        self.audit.borrow_mut().pin(evidence).map_err(TransitionRefusal::from)?;
         Ok(expansions)
     }
 
-    /// Fold a validation context's asks into the open act's audit, after the record's
+    /// Fold a validation context's asks into the open act's ledger, after the record's
     /// re-derivations ran over it.
     fn audit_reads(&self, expansions: &Expansions) {
-        self.audit.borrow_mut().reads.extend(expansions.reads());
+        self.audit.borrow_mut().read(expansions.reads());
     }
 
     /// Contribute the deterministic gate atoms the live act answered before this record's
     /// decision ran — a validation that re-derives less than the live gates demanded still
     /// justifies the evidence those gates gathered.
     fn audit_atoms(&self, atoms: impl IntoIterator<Item = crate::label::SymbolicAtom>) {
-        self.audit.borrow_mut().reads.extend(atoms);
+        self.audit.borrow_mut().read(atoms);
     }
 
     /// Count `pins` — entries pinned by a record the open act continues — as inherited.
     fn audit_inherit(&self, pins: &AudienceEvidence) -> Result<(), TransitionRefusal> {
-        let mut audit = self.audit.borrow_mut();
-        audit.inherited = audit.inherited.inheriting(pins).map_err(TransitionRefusal::from)?;
-        Ok(())
+        self.audit.borrow_mut().inherit(pins).map_err(TransitionRefusal::from)
     }
 
-    /// Settle the open act's operation-scope audit: every pinned entry is an inherited pin
-    /// or answers a collected ask, exactly the test the live act passed.
+    /// Settle the open act's ledger: every pinned entry is an inherited pin or answers a
+    /// collected ask, exactly the test the live act passed.
     fn settle_audit(&self) -> Result<(), TransitionRefusal> {
         let audit = std::mem::take(&mut *self.audit.borrow_mut());
-        let reads: Vec<crate::label::SymbolicAtom> = audit.reads.into_iter().collect();
-        self.engine
-            .registry()
-            .audience()
-            .only_requested(&audit.evidence, &audit.inherited, &reads)
+        audit
+            .settle(self.engine.registry().audience())
             .map_err(|refusal| match refusal {
                 crate::audience::EvidenceRefusal::UnrequestedEvidence { entry } => {
                     TransitionRefusal::UnrequestedEvidence { entry }

--- a/appa-example-agent/src/agent.rs
+++ b/appa-example-agent/src/agent.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 
 use crate::budget::{Exhausted, ForkUnavailable, Limits, RunBudget};
-use crate::provider::OpenAiCompatible;
+use crate::provider::{OpenAiCompatible, ProviderError};
 use crate::record::{CallId, Record, Recorded};
 use crate::tools::{CONTROL_TOOL, ToolCatalogue, ToolShim};
 use crate::wire::{ChatCompletionRequest, WireMessage, WireToolCall};
@@ -93,7 +93,7 @@ pub enum StopReason {
     #[error("the run exhausted its budget")]
     BudgetExhausted,
     #[error("inference failed: {0}")]
-    InferenceFailed(String),
+    InferenceFailed(ProviderError),
     #[error("the runtime refused the run: {0}")]
     Refused(String),
 }
@@ -716,7 +716,7 @@ impl Run<'_> {
                         }
                         Ok(completion.message)
                     }
-                    Ok(Err(error)) => Err(StopReason::InferenceFailed(error.to_string())),
+                    Ok(Err(error)) => Err(StopReason::InferenceFailed(error)),
                     Err(_) => Err(StopReason::BudgetExhausted),
                 }
             }
@@ -746,7 +746,7 @@ impl Run<'_> {
                         }
                         Ok(completion.message.content)
                     }
-                    Ok(Err(error)) => Err(StopReason::InferenceFailed(error.to_string())),
+                    Ok(Err(error)) => Err(StopReason::InferenceFailed(error)),
                     Err(_) => Ok(None),
                 }
             }

--- a/appa-example-agent/src/provider.rs
+++ b/appa-example-agent/src/provider.rs
@@ -132,6 +132,11 @@ pub enum ProviderError {
     Timeout { attempts: u32, timeout: Duration },
     #[error("inference transport fault after {attempts} attempt(s)")]
     Transport { attempts: u32 },
+    /// The endpoint answered, but could not serve: a transient status (408, 429, 5xx) on
+    /// the last of the bounded attempts.
+    #[error("inference endpoint was unavailable (HTTP {code}) on the last of {attempts} attempt(s)")]
+    Unavailable { code: u16, attempts: u32 },
+    /// The endpoint answered with a status no retry changes: a rejected key, a bad request.
     #[error("inference endpoint returned HTTP {code} after {attempts} attempt(s)")]
     Status { code: u16, attempts: u32 },
     #[error("inference response was oversized or malformed after {attempts} attempt(s)")]
@@ -187,6 +192,7 @@ impl AttemptFault {
                 timeout: request_timeout,
             },
             AttemptFault::Transport => ProviderError::Transport { attempts },
+            AttemptFault::Status { code, .. } if self.retryable() => ProviderError::Unavailable { code, attempts },
             AttemptFault::Status { code, .. } => ProviderError::Status { code, attempts },
             AttemptFault::Malformed => ProviderError::Malformed { attempts },
             AttemptFault::NoChoice => ProviderError::NoChoice { attempts },
@@ -429,7 +435,7 @@ mod tests {
             .await
             .expect_err("the outage persists");
 
-        assert_eq!(error, ProviderError::Status { code: 429, attempts: 3 });
+        assert_eq!(error, ProviderError::Unavailable { code: 429, attempts: 3 });
         assert_eq!(*attempts.lock().expect("not poisoned"), 3);
     }
 

--- a/appa-example-agent/src/provider.rs
+++ b/appa-example-agent/src/provider.rs
@@ -128,7 +128,7 @@ pub struct ProviderCompletion {
 /// on a guess.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ProviderError {
-    #[error("inference exceeded the {timeout:?} request deadline on each of {attempts} attempt(s)")]
+    #[error("inference exceeded the {timeout:?} request deadline on the last of {attempts} attempt(s)")]
     Timeout { attempts: u32, timeout: Duration },
     #[error("inference transport fault after {attempts} attempt(s)")]
     Transport { attempts: u32 },
@@ -154,9 +154,11 @@ impl AttemptFault {
     /// failed connection are kept apart because they call for opposite
     /// remedies: a deadline that a long generation legitimately outgrows wants
     /// a longer deadline, since every retry then meets the same wall, while a
-    /// flapping endpoint wants more attempts, spaced further apart.
+    /// flapping endpoint wants more attempts, spaced further apart. A
+    /// connection that never came up is a transport fault even when it
+    /// timed out: the request deadline never started.
     fn of(error: &reqwest::Error) -> Self {
-        if error.is_timeout() {
+        if error.is_timeout() && !error.is_connect() {
             AttemptFault::Timeout
         } else {
             AttemptFault::Transport
@@ -482,6 +484,34 @@ mod tests {
             .expect_err("the endpoint never answers in time");
 
         assert_eq!(error, ProviderError::Timeout { attempts: 3, timeout });
+        assert_eq!(*attempts.lock().expect("not poisoned"), 3);
+    }
+
+    #[tokio::test]
+    async fn a_connection_the_endpoint_drops_is_a_transport_fault_not_a_deadline() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("a loopback port");
+        let address = listener.local_addr().expect("the listener has an address");
+        let attempts = Arc::new(Mutex::new(0u32));
+        tokio::spawn({
+            let attempts = Arc::clone(&attempts);
+            async move {
+                while let Ok((socket, _)) = listener.accept().await {
+                    *attempts.lock().expect("not poisoned") += 1;
+                    drop(socket);
+                }
+            }
+        });
+        let config = OpenAiConfig::new(format!("http://{address}"), "fixture/model", "test-key")
+            .with_request_timeout(Duration::from_secs(5))
+            .with_test_retry_policy(3, Duration::ZERO, Duration::ZERO);
+        let error = OpenAiCompatible::with_http_client(config, HttpClient::loopback())
+            .complete(request())
+            .await
+            .expect_err("the endpoint never answers");
+
+        assert_eq!(error, ProviderError::Transport { attempts: 3 });
         assert_eq!(*attempts.lock().expect("not poisoned"), 3);
     }
 }

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -17,9 +17,10 @@ use appa_engine::contract::{
 use appa_engine::engine::Engine;
 use appa_engine::fact::ReturnPolicy;
 use appa_engine::fact::{EffectKind, EffectSet};
-use appa_engine::label::{Audience, ChainAudience, Clause, DeclaredAudience, GroupRef, Label, ReaderId, Trust};
+use appa_engine::label::{Audience, ChainAudience, Clause, DeclaredAudience, Label, ReaderId, Trust};
 use appa_engine::names::{
-    AnnotatorName, AuthorityName, GroupName, IdentityImplementationName, MarkName, SanitizerName, SurfaceName, TagName,
+    AnnotatorName, AudienceArgument, AuthorityName, GroupName, IdentityImplementationName, MarkName, SanitizerName,
+    SurfaceName, TagName,
 };
 use appa_engine::params::ToolParameters;
 use appa_engine::profile::{
@@ -1169,15 +1170,6 @@ fn parse_declared_audience(list: &[String], context: &str) -> Result<DeclaredAud
         context: context.to_string(),
         reason,
     };
-    if list.iter().any(|r| r == "public") {
-        return if list.len() == 1 {
-            Ok(DeclaredAudience::Public)
-        } else {
-            Err(refused(
-                "`public` is the whole universe and cannot be combined with other entries".to_string(),
-            ))
-        };
-    }
     if list.is_empty() {
         return Err(refused("empty reader set".to_string()));
     }
@@ -1190,20 +1182,23 @@ fn parse_declared_audience(list: &[String], context: &str) -> Result<DeclaredAud
     let mut groups = Vec::new();
     let mut readers = Vec::new();
     for entry in list {
-        if let Some(level) = ChainAudience::parse(entry) {
-            if chain.replace(level).is_some() {
+        match AudienceArgument::parse(entry) {
+            Some(AudienceArgument::Public) if list.len() == 1 => return Ok(DeclaredAudience::Public),
+            Some(AudienceArgument::Public) => {
                 return Err(refused(
-                    "two built-in audiences in one union: the outer one already contains the inner".to_string(),
+                    "`public` is the whole universe and cannot be combined with other entries".to_string(),
                 ));
             }
-            continue;
-        }
-        match entry.strip_prefix('@') {
-            Some(mention) => match GroupRef::parse(mention) {
-                Some(group) => groups.push(group),
-                None => return Err(refused(format!("`@{mention}` names no audience"))),
-            },
-            None => readers.push(ReaderId::new(entry)),
+            Some(AudienceArgument::Chain(level)) => {
+                if chain.replace(level).is_some() {
+                    return Err(refused(
+                        "two built-in audiences in one union: the outer one already contains the inner".to_string(),
+                    ));
+                }
+            }
+            Some(AudienceArgument::Group(group)) => groups.push(group),
+            Some(AudienceArgument::Reader(reader)) => readers.push(reader),
+            None => return Err(refused(format!("`{entry}` names no audience"))),
         }
     }
     Clause::new(chain, groups, readers)
@@ -1278,6 +1273,7 @@ fn parse_points(tokens: &[String], name: &str) -> Result<SanitizerPoints, Config
 #[cfg(test)]
 mod tests {
     use super::*;
+    use appa_engine::label::GroupRef;
 
     const DECLARATIONS: &str = r#"
 version = 2

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -52,7 +52,9 @@ fn main() {
 
     if let Some(reference) = release {
         assert!(!reference.trim().is_empty(), "APPA_RELEASE_REF must not be empty");
+        let digest = release_plugin_digest();
         println!("cargo:rustc-env=APPA_RELEASE_REF={reference}");
+        println!("cargo:rustc-env=APPA_PLUGIN_SHA256={digest}");
         return;
     }
 
@@ -66,6 +68,24 @@ fn main() {
             println!("cargo:rustc-env=APPA_PLUGIN_SOURCE_ROOT={}", repository.display());
         }
     }
+}
+
+/// The SHA-256 of the release plugin archive this build accepts, as 64 hex
+/// characters. A release binary resolves its plugin from nothing else, so a
+/// release build without it is refused here rather than at someone's install.
+fn release_plugin_digest() -> String {
+    let Some(digest) = env::var("APPA_PLUGIN_SHA256").ok() else {
+        panic!(
+            "a release build (APPA_RELEASE_REF is set) requires APPA_PLUGIN_SHA256, \
+             the SHA-256 of the release plugin archive"
+        );
+    };
+    let digest = digest.trim().to_owned();
+    assert!(
+        digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "APPA_PLUGIN_SHA256 must be 64 hexadecimal characters, got {digest:?}"
+    );
+    digest
 }
 
 fn plugin_is_dirty(repository: &Path) -> bool {

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -53,7 +53,6 @@ fn main() {
     if let Some(reference) = release {
         assert!(!reference.trim().is_empty(), "APPA_RELEASE_REF must not be empty");
         println!("cargo:rustc-env=APPA_RELEASE_REF={reference}");
-        println!("cargo:rustc-env=APPA_PLUGIN_SOURCE_KIND=release");
         return;
     }
 

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -1,14 +1,10 @@
 #[path = "src/plugin_layout.rs"]
 mod plugin_layout;
 
-use std::collections::BTreeMap;
 use std::env;
 use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-use sha2::{Digest, Sha256};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=APPA_PLUGIN_SHA256");
@@ -47,7 +43,7 @@ fn main() {
         repository
     };
     plugin_layout::stage_repository(identity_source, &staged).expect("stage the plugin source for build identity");
-    let digest = canonical_tree_digest(&staged).expect("digest the staged plugin source");
+    let digest = plugin_layout::canonical_tree_digest(&staged).expect("digest the staged plugin source");
     println!("cargo:rustc-env=APPA_PLUGIN_TREE_SHA256={}", hex(&digest));
 
     if let Some(reference) = release {
@@ -195,66 +191,4 @@ fn watch_git_identity(repository: &Path) {
 
 fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-
-fn canonical_tree_digest(root: &Path) -> std::io::Result<[u8; 32]> {
-    let mut entries = BTreeMap::<String, Option<PathBuf>>::new();
-    collect(root, root, &mut entries)?;
-    let mut hasher = Sha256::new();
-    for (relative, absolute) in entries {
-        absorb(&mut hasher, relative.as_bytes());
-        match absolute {
-            None => {
-                hasher.update(*b"d");
-                absorb(&mut hasher, &[]);
-            }
-            Some(path) => {
-                hasher.update(*b"f");
-                let mut file = fs::File::open(path)?;
-                let length = file.metadata()?.len();
-                hasher.update(length.to_be_bytes());
-                let mut buffer = [0u8; 64 * 1024];
-                loop {
-                    let read = file.read(&mut buffer)?;
-                    if read == 0 {
-                        break;
-                    }
-                    hasher.update(&buffer[..read]);
-                }
-            }
-        }
-    }
-    Ok(hasher.finalize().into())
-}
-
-fn absorb(hasher: &mut Sha256, bytes: &[u8]) {
-    hasher.update((bytes.len() as u64).to_be_bytes());
-    hasher.update(bytes);
-}
-
-fn collect(root: &Path, directory: &Path, entries: &mut BTreeMap<String, Option<PathBuf>>) -> std::io::Result<()> {
-    for entry in fs::read_dir(directory)? {
-        let entry = entry?;
-        let absolute = entry.path();
-        let relative = absolute.strip_prefix(root).map_err(std::io::Error::other)?;
-        let portable = relative
-            .components()
-            .map(|component| component.as_os_str().to_str())
-            .collect::<Option<Vec<_>>>()
-            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "plugin path is not UTF-8"))?
-            .join("/");
-        let kind = entry.file_type()?;
-        if kind.is_dir() {
-            entries.insert(portable, None);
-            collect(root, &absolute, entries)?;
-        } else if kind.is_file() {
-            entries.insert(portable, Some(absolute));
-        } else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("{} is neither a regular file nor a directory", absolute.display()),
-            ));
-        }
-    }
-    Ok(())
 }

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -140,7 +140,7 @@ pub enum OpenError {
 /// as a deny.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum EventError {
-    #[error("[appa] a call is already outstanding; propose one call at a time")]
+    #[error("a call is already outstanding; propose one call at a time")]
     CallOutstanding,
     #[error(
         "the substituted {tool} call did not run and is now closed; propose your call again (a substituted call needs a fresh offer)"

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -317,9 +317,18 @@ struct Inner {
     modules: crate::builtins::ModuleRegistry,
     executing: std::sync::Mutex<std::collections::BTreeSet<String>>,
     permits: std::sync::Mutex<std::collections::BTreeMap<String, Vec<Actor>>>,
+    /// Trajectories a prompt reached since their turn last settled. Claude Code sends no
+    /// `Stop` hook for a turn the user interrupted, so the prompt is the only sign the
+    /// previous turn is over; the next tool call or turn end settles what it left behind.
+    prompted: std::sync::Mutex<std::collections::BTreeSet<String>>,
     /// The gates every process-costing consult of this runtime passes; deployment reloads
     /// clone them, so old and new snapshots contend on the same permits.
     gates: ConsultGates,
+}
+
+/// The trajectory an actor's events belong to: the child when the harness names one.
+pub(crate) fn acting_trajectory(actor: &Actor) -> &TrajectoryId {
+    actor.child.as_ref().unwrap_or(&actor.root)
 }
 
 impl Inner {
@@ -427,6 +436,7 @@ impl Runtime {
                 modules,
                 executing: std::sync::Mutex::new(std::collections::BTreeSet::new()),
                 permits: std::sync::Mutex::new(std::collections::BTreeMap::new()),
+                prompted: std::sync::Mutex::new(std::collections::BTreeSet::new()),
                 gates,
             }),
         })
@@ -691,6 +701,29 @@ impl Runtime {
             holders.retain(|holder| holder != acting);
             !holders.is_empty()
         });
+    }
+
+    /// A prompt reached this actor. Nothing is recorded: the mark lives in memory and is
+    /// consumed by the actor's next tool call or turn end, whichever comes first. A
+    /// restarted runtime forgets it and the next proposal refuses until a turn end closes
+    /// the abandoned call.
+    pub(crate) fn note_prompt(&self, acting: &Actor) {
+        let mut prompted = self
+            .inner
+            .prompted
+            .lock()
+            .expect("the prompted mutex is never poisoned");
+        prompted.insert(acting_trajectory(acting).0.clone());
+    }
+
+    /// Whether a prompt reached this actor since its turn last settled. Consumed once.
+    pub(crate) fn take_prompted(&self, acting: &Actor) -> bool {
+        let mut prompted = self
+            .inner
+            .prompted
+            .lock()
+            .expect("the prompted mutex is never poisoned");
+        prompted.remove(acting_trajectory(acting).0.as_str())
     }
 
     fn spend_vouch(&self, quoted: &OfferId, acting: &Actor) {

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -185,31 +185,13 @@ impl Session {
         &self.trajectory
     }
 
-    /// The user submitted a prompt. The prompt text is not an engine
-    /// event: nothing is reported to the engine, nothing is recorded,
-    /// and offer freshness stays the engine's judgment — a stale offer
-    /// declines at execution by live re-plan.
-    ///
-    /// The prompt is still the second signal that the previous turn is
-    /// over. Claude Code sends no `Stop` hook for a turn the user
-    /// interrupted, so a call left open by that turn would reach here
-    /// unclosed and refuse the first proposal of the new turn. The
-    /// prompt closes it exactly as the turn end would have.
-    pub async fn on_prompt(&self) -> Result<(), EventError> {
-        self.close_unreported("the prompt").await
-    }
-
-    /// The actor finished a turn. A call still open here got no outcome
+    /// The actor's turn is over. A call still open here got no outcome
     /// hook and will never get one: Claude Code reports none for a call
-    /// refused at its permission prompt. Left open it refuses every
-    /// later proposal as a second call in flight, for the life of the
-    /// trajectory.
-    pub async fn on_turn_end(&self) -> Result<(), EventError> {
-        self.close_unreported("the turn end").await
-    }
-
-    /// Close the call the previous turn left open. Two hooks reach
-    /// here: the turn end, and the next prompt when no turn end came.
+    /// refused at its permission prompt, and none for a turn the user
+    /// interrupted. Left open it refuses every later proposal as a
+    /// second call in flight, for the life of the trajectory. Two
+    /// hooks reach here: the turn end, and the first tool call after a
+    /// prompt that no turn end preceded.
     ///
     /// The close is `Indeterminate`, not a failure. What the runtime
     /// observed is the absence of a report, which does not say whether
@@ -221,9 +203,9 @@ impl Session {
     ///
     /// Not an engine event when nothing is carried, which is every
     /// ordinary turn: the view is read, no fact is appended.
-    async fn close_unreported(&self, at: &'static str) -> Result<(), EventError> {
+    pub async fn on_turn_end(&self) -> Result<(), EventError> {
         let Some(open) = self.carried_call()? else {
-            tracing::debug!(trajectory = %self.trajectory.0, at, "no call outstanding");
+            tracing::debug!(trajectory = %self.trajectory.0, "no call outstanding");
             return Ok(());
         };
         self.abandon_open(&ToolOutcome::Indeterminate).await?;
@@ -231,7 +213,6 @@ impl Session {
             trajectory = %self.trajectory.0,
             dispatch = ?open.id,
             tool = %open.tool,
-            at,
             "call closed as unreported",
         );
         Ok(())
@@ -4295,58 +4276,6 @@ context_control = true
             Runtime::open(config_with(FETCH_AND_SEND, None), path, None),
             Err(OpenError::Damaged(_)),
         ));
-    }
-
-    #[tokio::test]
-    async fn a_prompt_records_nothing() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_runtime(&dir);
-        let session = runtime.create_session(root()).expect("a fresh id opens");
-        session.on_prompt().await.expect("a prompt with nothing open acks");
-        assert!(only_the_opening(&runtime));
-    }
-
-    /// The user interrupted the turn: the call got no outcome hook and
-    /// the turn got no `Stop` hook. The next prompt closes the call, so
-    /// the new turn's first proposal releases.
-    #[tokio::test]
-    async fn a_prompt_closes_a_call_an_interrupted_turn_left_open() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = Runtime::open(config_with(FETCH_AND_SEND, None), dir.path().join("appa.db"), None)
-            .expect("the deployment opens");
-        let session = runtime.create_session(root()).expect("a fresh id opens");
-        session
-            .on_tool_call(fetch(serde_json::json!({"a": 1})), false)
-            .await
-            .expect("the call releases");
-        assert!(matches!(
-            session.on_tool_call(fetch(serde_json::json!({"a": 2})), false).await,
-            Err(EventError::CallOutstanding),
-        ));
-
-        session.on_prompt().await.expect("the prompt closes it");
-
-        assert!(runtime.open_dispatches(&root(), &root()).is_empty());
-        assert!(
-            runtime
-                .audit(&root())
-                .expect("the audit reads")
-                .iter()
-                .any(|entry| matches!(
-                    &entry.event,
-                    crate::engine::AuditEvent::Closed {
-                        outcome: crate::engine::DispatchOutcome::Unknown
-                    }
-                )),
-            "the unreported dispatch closed as unknown, not as a run that failed"
-        );
-        assert_eq!(
-            session
-                .on_tool_call(fetch(serde_json::json!({"a": 2})), false)
-                .await
-                .expect("the new turn proposes freely"),
-            ToolCallDecision::Allow { spawn: None },
-        );
     }
 
     #[tokio::test]

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -681,7 +681,7 @@ impl Session {
                 },
                 _ => return Ok(decision),
             }
-            if evidence == carried {
+            if evidence.len() == carried.len() {
                 return Err(EventError::UnexpectedDecision);
             }
         }

--- a/appa-runtime/src/consult.rs
+++ b/appa-runtime/src/consult.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use appa_engine::audience::MemberClaims;
 use appa_engine::authority::{Authority, DeclaredTransition, Sanitizer};
 use appa_engine::check::Gap;
-use appa_engine::label::{Clause, DeclaredAudience, GroupRef, Trust};
+use appa_engine::label::{Clause, DeclaredAudience, GroupRef, ReaderId, Trust};
 use appa_engine::registry::TrustChain;
 
 /// Which registered external a consult addresses. Closed: the wire
@@ -157,7 +157,7 @@ impl WireAudience {
             serde_json::Value::Array(readers) => readers
                 .iter()
                 .map(|reader| match reader.as_str() {
-                    Some(reader) if is_literal_reader(reader) => Some(reader.to_string()),
+                    Some(reader) if ReaderId::new(reader).is_literal() => Some(reader.to_string()),
                     _ => None,
                 })
                 .collect::<Option<Vec<String>>>()
@@ -174,13 +174,6 @@ impl Serialize for WireAudience {
             WireAudience::Readers(readers) => readers.serialize(serializer),
         }
     }
-}
-
-/// Is `reader` an id an external answer may name? `public`, `self`, and `internal` are
-/// audience states, not readers; an `@` mark is a group reference only a source expands; an
-/// empty id names no one.
-pub(crate) fn is_literal_reader(reader: &str) -> bool {
-    !reader.is_empty() && !matches!(reader, "public" | "self" | "internal") && !reader.starts_with('@')
 }
 
 /// The `@`-marked spelling of one group reference, as policy writes it — the reference's
@@ -674,7 +667,7 @@ pub struct PrincipalAnswer {
 impl PrincipalAnswer {
     pub fn from_wire(answer: &serde_json::Value) -> Option<PrincipalAnswer> {
         let answer: PrincipalAnswer = serde_json::from_value(answer.clone()).ok()?;
-        is_literal_reader(&answer.principal).then_some(answer)
+        ReaderId::new(answer.principal.as_str()).is_literal().then_some(answer)
     }
 }
 

--- a/appa-runtime/src/consult.rs
+++ b/appa-runtime/src/consult.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use appa_engine::audience::MemberClaims;
 use appa_engine::authority::{Authority, DeclaredTransition, Sanitizer};
 use appa_engine::check::Gap;
-use appa_engine::label::{Clause, DeclaredAudience, GroupRef, ReaderId, Trust};
+use appa_engine::label::{Clause, DeclaredAudience, ReaderId, Trust};
 use appa_engine::registry::TrustChain;
 
 /// Which registered external a consult addresses. Closed: the wire
@@ -176,12 +176,6 @@ impl Serialize for WireAudience {
     }
 }
 
-/// The `@`-marked spelling of one group reference, as policy writes it — the reference's
-/// own `Display`.
-pub(crate) fn group_mark(group: &GroupRef) -> String {
-    group.to_string()
-}
-
 /// One declared union clause's entries, in the policy's own spellings: the chain audience,
 /// the `@` group marks, then the literal readers.
 pub(crate) fn clause_entries(clause: &Clause) -> Vec<String> {
@@ -189,7 +183,7 @@ pub(crate) fn clause_entries(clause: &Clause) -> Vec<String> {
         .chain()
         .map(|chain| chain.as_str().to_string())
         .into_iter()
-        .chain(clause.groups().map(group_mark))
+        .chain(clause.groups().map(ToString::to_string))
         .chain(clause.readers().iter().map(|reader| reader.as_str().to_string()))
         .collect()
 }
@@ -839,6 +833,7 @@ fn annotation_schema(declaration: &AnnotationDeclaration) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use appa_engine::label::GroupRef;
 
     fn chain() -> TrustChain {
         TrustChain::new(vec!["suspicious".to_string(), "trusted".to_string()])

--- a/appa-runtime/src/consult.rs
+++ b/appa-runtime/src/consult.rs
@@ -757,48 +757,36 @@ fn sanitizer_schema() -> serde_json::Value {
     })
 }
 
-/// The stand-in member for a mandate vocabulary with no member of its own. A schema needs a
-/// non-empty `enum`: `{"enum": []}` is a schema no validator accepts, and `maxItems: 0`
-/// states the same bound in a keyword OpenAI's strict subset refuses, so either spelling
-/// loses the whole request before the model sees the call — the annotator then answers
-/// nothing and the call is refused for an operational reason no policy chose.
-///
-/// The name cannot collide with a policy value: it is rendered only when the vocabulary has
-/// no member to collide with. An answer that picks it anyway is refused like any other value
-/// outside the mandate, because [`AnnotationAnswer::from_wire`] confines every leaf to the
-/// declared vocabulary.
-const UNINHABITED_VOCABULARY: &str = "__appa_no_such_value__";
+/// One closed string vocabulary as a schema `enum`; `None` when it has no member, because
+/// `{"enum": []}` is a schema no validator accepts and the shape that needs it is left out.
+fn closed_enum(vocabulary: &[String]) -> Option<serde_json::Value> {
+    (!vocabulary.is_empty()).then(|| serde_json::json!({"type": "string", "enum": vocabulary}))
+}
 
-/// One closed string vocabulary as a schema `enum`, never empty.
-fn closed_enum(vocabulary: &[impl AsRef<str>]) -> serde_json::Value {
-    let members: Vec<&str> = match vocabulary.is_empty() {
-        true => vec![UNINHABITED_VOCABULARY],
-        false => vocabulary.iter().map(AsRef::as_ref).collect(),
-    };
-    serde_json::json!({"type": "string", "enum": members})
+/// The items of an array over a closed vocabulary. An array position cannot be left out,
+/// so a vocabulary with no member names one stand-in that no mandate permits and
+/// [`AnnotationAnswer::from_wire`] refuses on every leaf; the empty array is then the only
+/// value that decodes.
+fn array_items(vocabulary: &[String]) -> serde_json::Value {
+    closed_enum(vocabulary).unwrap_or_else(|| serde_json::json!({"type": "string", "enum": ["__appa_no_such_value__"]}))
 }
 
 fn dynamic_audience_schema(audiences: &[String]) -> serde_json::Value {
-    let readers: Vec<&str> = audiences
-        .iter()
-        .map(String::as_str)
-        .filter(|audience| *audience != "public")
-        .collect();
     serde_json::json!({
         "oneOf": [
             {"type": "string", "const": "public"},
-            {"type": "array", "items": closed_enum(&readers)}
+            {"type": "array", "items": array_items(audiences)}
         ]
     })
 }
 
 /// The strict-mode-compatible schema for one annotation answer: every accepted shape is a
 /// variant with all its properties required, so an OpenAI-compatible provider can enforce
-/// it as written.
+/// it as written. A shape that needs a rank is offered only when the mandate names one.
 fn annotation_schema(declaration: &AnnotationDeclaration) -> serde_json::Value {
     let trust = closed_enum(&declaration.trust_ranks);
     let audience = dynamic_audience_schema(&declaration.audiences);
-    let effect = closed_enum(&declaration.effects);
+    let effect = array_items(&declaration.effects);
     let object = |pairs: &[(&str, &serde_json::Value)]| {
         serde_json::json!({
             "type": "object",
@@ -824,24 +812,33 @@ fn annotation_schema(declaration: &AnnotationDeclaration) -> serde_json::Value {
             object(&[("contains", &audience), ("within", &audience)])
         ]
     });
-    let attention = serde_json::json!({"type": "array", "items": closed_enum(&declaration.attention_marks)});
-    let delta = serde_json::json!({"oneOf": [
-        object(&[]),
-        object(&[("trust", &trust)]),
-        object(&[("audience", &audience)]),
-        object(&[("trust", &trust), ("audience", &audience)]),
-    ]});
-    let requires = serde_json::json!({"oneOf": [
+    let attention = serde_json::json!({"type": "array", "items": array_items(&declaration.attention_marks)});
+    let mut delta = vec![object(&[]), object(&[("audience", &audience)])];
+    let mut requires = vec![
         object(&[("history", &history), ("attention", &attention)]),
-        object(&[("trust", &trust), ("history", &history), ("attention", &attention)]),
-        object(&[("audience", &required_audience), ("history", &history), ("attention", &attention)]),
         object(&[
-            ("trust", &trust),
             ("audience", &required_audience),
             ("history", &history),
-            ("attention", &attention)
+            ("attention", &attention),
         ]),
-    ]});
+    ];
+    if let Some(trust) = &trust {
+        delta.push(object(&[("trust", trust)]));
+        delta.push(object(&[("trust", trust), ("audience", &audience)]));
+        requires.push(object(&[
+            ("trust", trust),
+            ("history", &history),
+            ("attention", &attention),
+        ]));
+        requires.push(object(&[
+            ("trust", trust),
+            ("audience", &required_audience),
+            ("history", &history),
+            ("attention", &attention),
+        ]));
+    }
+    let delta = serde_json::json!({"oneOf": delta});
+    let requires = serde_json::json!({"oneOf": requires});
     let emits = serde_json::json!({"type": "array", "items": effect});
     object(&[("delta", &delta), ("requires", &requires), ("emits", &emits)])
 }
@@ -1243,7 +1240,7 @@ mod tests {
         );
         assert_eq!(prompt.schema["additionalProperties"], serde_json::json!(false));
         assert_eq!(
-            prompt.schema["properties"]["delta"]["oneOf"][1]["properties"]["trust"]["enum"],
+            prompt.schema["properties"]["delta"]["oneOf"][2]["properties"]["trust"]["enum"],
             serde_json::json!(["suspicious", "trusted"])
         );
         assert_eq!(
@@ -1277,113 +1274,128 @@ mod tests {
         );
     }
 
-    /// Every `enum` in a rendered schema, at any depth.
-    fn enum_sizes(schema: &serde_json::Value, found: &mut Vec<usize>) {
+    /// Every `enum` member list and every property name in a rendered schema, at any depth.
+    fn walk(schema: &serde_json::Value, enums: &mut Vec<Vec<String>>, properties: &mut Vec<String>) {
         match schema {
             serde_json::Value::Object(fields) => {
                 for (key, value) in fields {
-                    match (key.as_str(), value.as_array()) {
-                        ("enum", Some(members)) => found.push(members.len()),
-                        _ => enum_sizes(value, found),
+                    match (key.as_str(), value) {
+                        ("enum", serde_json::Value::Array(members)) => enums.push(
+                            members
+                                .iter()
+                                .filter_map(|member| member.as_str().map(str::to_string))
+                                .collect(),
+                        ),
+                        ("properties", serde_json::Value::Object(named)) => {
+                            properties.extend(named.keys().cloned());
+                            named.values().for_each(|value| walk(value, enums, properties));
+                        }
+                        _ => walk(value, enums, properties),
                     }
                 }
             }
-            serde_json::Value::Array(items) => items.iter().for_each(|item| enum_sizes(item, found)),
+            serde_json::Value::Array(items) => items.iter().for_each(|item| walk(item, enums, properties)),
             _ => {}
         }
     }
 
-    /// Every `maxItems` in a rendered schema, at any depth.
-    fn mentions_max_items(schema: &serde_json::Value) -> bool {
-        match schema {
-            serde_json::Value::Object(fields) => fields
-                .iter()
-                .any(|(key, value)| key == "maxItems" || mentions_max_items(value)),
-            serde_json::Value::Array(items) => items.iter().any(mentions_max_items),
-            _ => false,
+    fn neutral(extra: serde_json::Value) -> serde_json::Value {
+        let mut answer = serde_json::json!({
+            "delta": {}, "requires": {"history": [], "attention": []}, "emits": []
+        });
+        for (key, value) in extra.as_object().expect("an object").clone() {
+            match key.as_str() {
+                "delta" | "emits" => answer[key] = value,
+                mark => answer["requires"][mark] = value,
+            }
         }
+        answer
     }
 
     /// A mandate can name no rank, no reader, no mark and no effect kind — the policy loader
-    /// accepts an explicitly empty bound for each. Such a mandate still has to render a
-    /// schema every backend accepts, or the annotator answers nothing and the call is refused
-    /// for an operational reason no policy chose: `{"enum": []}` is a schema no validator
-    /// accepts, and `maxItems` is outside the strict subset the OpenAI transport sends under
-    /// `strict: true`. The stand-in member keeps the enum inhabited, and the decoder refuses
-    /// it on every leaf because no mandate permits it.
+    /// accepts an explicitly empty bound for each. The rendered schema then offers no shape
+    /// that needs a rank, keeps every `enum` inhabited, and every value it admits decodes,
+    /// except the stand-in an empty array vocabulary carries, which no leaf accepts.
     #[test]
-    fn an_empty_mandate_vocabulary_renders_a_schema_every_backend_accepts() {
-        let declaration = AnnotationDeclaration {
+    fn an_empty_mandate_vocabulary_renders_only_shapes_that_decode() {
+        let ranks = ["suspicious".to_string(), "trusted".to_string()];
+        let full = annotation_declaration();
+        let no_ranks = AnnotationDeclaration {
+            trust_ranks: vec![],
+            ..annotation_declaration()
+        };
+        let nothing = AnnotationDeclaration {
             inputs: vec![],
             trust_ranks: vec![],
             audiences: vec![],
             attention_marks: vec![],
             effects: vec![],
         };
-        let schema = annotation_schema(&declaration);
-
-        let mut sizes = Vec::new();
-        enum_sizes(&schema, &mut sizes);
-        assert!(!sizes.is_empty(), "the walk reached no enum at all: {schema}");
-        assert!(
-            sizes.iter().all(|size| *size > 0),
-            "an empty vocabulary renders an empty enum: {schema}"
-        );
-        assert!(
-            !mentions_max_items(&schema),
-            "maxItems is outside OpenAI's strict subset: {schema}"
-        );
-
-        assert_eq!(
-            AnnotationAnswer::from_wire(
-                &serde_json::json!({"delta": {}, "requires": {"history": [], "attention": []}, "emits": []}),
-                &declaration
-            )
-            .map(|answer| answer.emits),
-            Some(vec![]),
-            "the neutral annotation still decodes under an empty vocabulary"
-        );
-
-        let neutral = |extra: serde_json::Value| {
-            let mut answer = serde_json::json!({
-                "delta": {}, "requires": {"history": [], "attention": []}, "emits": []
-            });
-            for (key, value) in extra.as_object().expect("an object").clone() {
-                match key.as_str() {
-                    "delta" | "emits" => answer[key] = value,
-                    mark => answer["requires"][mark] = value,
+        for (name, declaration, offers_a_rank, carries_a_stand_in) in [
+            ("full", &full, true, false),
+            ("no ranks", &no_ranks, false, false),
+            ("nothing", &nothing, false, true),
+        ] {
+            let schema = annotation_schema(declaration);
+            let (mut enums, mut properties) = (Vec::new(), Vec::new());
+            walk(&schema, &mut enums, &mut properties);
+            assert!(!enums.is_empty(), "{name}: the walk reached no enum: {schema}");
+            assert!(
+                enums.iter().all(|members| !members.is_empty()),
+                "{name}: an empty enum is a schema no validator accepts: {schema}"
+            );
+            assert_eq!(
+                properties.iter().any(|property| property == "trust"),
+                offers_a_rank,
+                "{name}: a shape needing a rank is offered exactly when the mandate names one: {schema}"
+            );
+            let stand_ins: Vec<&String> = enums
+                .iter()
+                .flatten()
+                .filter(|member| !ranks.contains(member) && !full_vocabulary(&full).contains(member))
+                .collect();
+            assert_eq!(
+                !stand_ins.is_empty(),
+                carries_a_stand_in,
+                "{name}: a stand-in appears exactly for an empty array vocabulary: {schema}"
+            );
+            for stand_in in stand_ins {
+                for (leaf, answer) in [
+                    (
+                        "delta.audience",
+                        neutral(serde_json::json!({"delta": {"audience": [stand_in]}})),
+                    ),
+                    (
+                        "requires.attention",
+                        neutral(serde_json::json!({"attention": [stand_in]})),
+                    ),
+                    (
+                        "requires.history",
+                        neutral(serde_json::json!({"history": [{"contains": stand_in}]})),
+                    ),
+                    ("emits", neutral(serde_json::json!({"emits": [stand_in]}))),
+                ] {
+                    assert_eq!(
+                        AnnotationAnswer::from_wire(&answer, declaration),
+                        None,
+                        "{name}: the stand-in is admitted at {leaf}"
+                    );
                 }
             }
-            answer
-        };
-        for (leaf, answer) in [
-            (
-                "delta.trust",
-                neutral(serde_json::json!({"delta": {"trust": UNINHABITED_VOCABULARY}})),
-            ),
-            (
-                "delta.audience",
-                neutral(serde_json::json!({"delta": {"audience": [UNINHABITED_VOCABULARY]}})),
-            ),
-            (
-                "requires.trust",
-                neutral(serde_json::json!({"trust": UNINHABITED_VOCABULARY})),
-            ),
-            (
-                "requires.attention",
-                neutral(serde_json::json!({"attention": [UNINHABITED_VOCABULARY]})),
-            ),
-            (
-                "requires.history",
-                neutral(serde_json::json!({"history": [{"contains": UNINHABITED_VOCABULARY}]})),
-            ),
-            ("emits", neutral(serde_json::json!({"emits": [UNINHABITED_VOCABULARY]}))),
-        ] {
             assert_eq!(
-                AnnotationAnswer::from_wire(&answer, &declaration),
-                None,
-                "the stand-in member is admitted at {leaf}"
+                AnnotationAnswer::from_wire(&neutral(serde_json::json!({})), declaration).map(|answer| answer.emits),
+                Some(vec![]),
+                "{name}: the neutral annotation decodes"
             );
         }
+    }
+
+    fn full_vocabulary(declaration: &AnnotationDeclaration) -> Vec<String> {
+        ["public".to_string()]
+            .into_iter()
+            .chain(declaration.audiences.iter().cloned())
+            .chain(declaration.attention_marks.iter().cloned())
+            .chain(declaration.effects.iter().cloned())
+            .collect()
     }
 }

--- a/appa-runtime/src/describe.rs
+++ b/appa-runtime/src/describe.rs
@@ -9,7 +9,7 @@ use std::fmt::Write as _;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
-use crate::config::Config;
+use crate::config::{Config, Externals, Section};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ConfigDescription {
@@ -43,12 +43,23 @@ impl ConfigState {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct PolicyDescription {
     tools: Vec<String>,
-    audience: Option<AudienceDescription>,
+    audience: AudienceSide,
 }
 
-/// The audience side of a loadable policy, offline: what the configuration itself declares.
-/// Live provider group catalogues are session facts this command does not reach.
+/// The audience side of the policy, as far as this command can describe it offline.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum AudienceSide {
+    /// No policy to compile: the configuration is missing, unreadable, or not TOML.
+    #[default]
+    Absent,
+    /// The policy does not compile; the error names why.
+    Uncompiled(String),
+    Declared(AudienceDescription),
+}
+
+/// What the configuration itself declares about audiences. Live provider group catalogues
+/// are session facts this command does not reach.
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct AudienceDescription {
     /// One entry per registered source: the provider, its advertised selector templates,
     /// and whether `[externals.audience.<provider>]` binds it.
@@ -74,18 +85,41 @@ struct GroupDescription {
     from: Vec<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum IdentityDescription {
-    #[default]
     VerifiedEmail,
-    Custom {
-        name: String,
-        binding_configured: bool,
-    },
+    Custom { name: String, binding_configured: bool },
 }
 
-/// The declared audience configuration, with binding status answered by `bound(section, name)`.
-fn audience_description(compiled: &appa_policy::Config, bound: &dyn Fn(&str, &str) -> bool) -> AudienceDescription {
+/// Where the `[externals]` bindings are read from: the loaded configuration, or the raw TOML
+/// of one that does not load.
+#[derive(Clone, Copy)]
+enum Bindings<'a> {
+    Loaded(&'a Externals),
+    Raw(&'a toml::Value),
+}
+
+impl Bindings<'_> {
+    fn bound(self, section: Section, name: &str) -> bool {
+        match self {
+            Bindings::Loaded(externals) => match section {
+                Section::Authorities => externals.authorities.contains_key(name),
+                Section::Sanitizers => externals.sanitizers.contains_key(name),
+                Section::Annotators => externals.annotators.contains_key(name),
+                Section::Audience => externals.audience.contains_key(name),
+                Section::Identity => externals.identity.contains_key(name),
+            },
+            Bindings::Raw(root) => root
+                .get("externals")
+                .and_then(|externals| externals.get(section.name()))
+                .and_then(|table| table.get(name))
+                .is_some(),
+        }
+    }
+}
+
+/// The declared audience configuration, with each source's and the identity's binding status.
+fn audience_description(compiled: &appa_policy::Config, bindings: Bindings<'_>) -> AudienceDescription {
     let audience = compiled.registry().audience();
     let spelled = |spec: &appa_engine::audience::SelectorSpec| spec.to_string();
     AudienceDescription {
@@ -100,7 +134,7 @@ fn audience_description(compiled: &appa_policy::Config, bound: &dyn Fn(&str, &st
                     .flatten()
                     .map(|template| template.as_str().to_string())
                     .collect(),
-                binding_configured: bound("audience", provider),
+                binding_configured: bindings.bound(Section::Audience, provider),
             })
             .collect(),
         self_from: audience
@@ -125,7 +159,7 @@ fn audience_description(compiled: &appa_policy::Config, bound: &dyn Fn(&str, &st
             appa_engine::audience::IdentityImplementation::VerifiedEmail => IdentityDescription::VerifiedEmail,
             appa_engine::audience::IdentityImplementation::Custom(name) => IdentityDescription::Custom {
                 name: name.as_str().to_string(),
-                binding_configured: bound("identity", name.as_str()),
+                binding_configured: bindings.bound(Section::Identity, name.as_str()),
             },
         },
     }
@@ -172,21 +206,17 @@ fn inspect(path: &Path) -> (ConfigDescription, PolicyDescription) {
                     .retain(|battery| seen_batteries.insert(battery.clone()));
 
                 if let Some(root_policy) = root.get("policy") {
-                    describe_policy_value(root_policy, &root, &mut policy);
+                    describe_policy_value(root_policy, Bindings::Raw(&root), &mut policy);
                 }
 
                 if let Ok(loaded) = Config::load(path) {
                     config.state = ConfigState::Loadable;
                     config.diagnostic = None;
-                    describe_policy_value(loaded.policy_file().value(), &root, &mut policy);
-                    if let Ok(source) = toml::to_string(loaded.policy_file().value())
-                        && let Ok(compiled) = appa_policy::Config::from_toml_str(&source)
-                    {
-                        policy.audience = Some(audience_description(&compiled, &|section, name| match section {
-                            "audience" => loaded.externals.audience.contains_key(name),
-                            _ => loaded.externals.identity.contains_key(name),
-                        }));
-                    }
+                    describe_policy_value(
+                        loaded.policy_file().value(),
+                        Bindings::Loaded(&loaded.externals),
+                        &mut policy,
+                    );
                 }
             }
         },
@@ -195,7 +225,7 @@ fn inspect(path: &Path) -> (ConfigDescription, PolicyDescription) {
     (config, policy)
 }
 
-fn describe_policy_value(policy_value: &toml::Value, root: &toml::Value, out: &mut PolicyDescription) {
+fn describe_policy_value(policy_value: &toml::Value, bindings: Bindings<'_>, out: &mut PolicyDescription) {
     out.tools = policy_value
         .get("tool")
         .and_then(toml::Value::as_array)
@@ -208,16 +238,13 @@ fn describe_policy_value(policy_value: &toml::Value, root: &toml::Value, out: &m
         .into_iter()
         .collect();
 
-    if let Ok(source) = toml::to_string(policy_value)
-        && let Ok(compiled) = appa_policy::Config::from_toml_str(&source)
-    {
-        out.audience = Some(audience_description(&compiled, &|section, name| {
-            root.get("externals")
-                .and_then(|externals| externals.get(section))
-                .and_then(|table| table.get(name))
-                .is_some()
-        }));
-    }
+    let compiled = toml::to_string(policy_value)
+        .map_err(|error| error.to_string())
+        .and_then(|source| appa_policy::Config::from_toml_str(&source).map_err(|error| error.to_string()));
+    out.audience = match compiled {
+        Ok(compiled) => AudienceSide::Declared(audience_description(&compiled, bindings)),
+        Err(error) => AudienceSide::Uncompiled(error),
+    };
 }
 
 fn battery_name(path: &Path) -> Option<String> {
@@ -246,7 +273,7 @@ pub fn render(path: &Path, adapter: &'static str) -> String {
     let _ = writeln!(output, "Policy tools: {}", list_or_none(&policy.tools));
     let _ = writeln!(output, "Audience chain: self ⊆ internal ⊆ public (built-in)");
     match &policy.audience {
-        Some(audience) => {
+        AudienceSide::Declared(audience) => {
             if audience.sources.is_empty() {
                 let _ = writeln!(output, "Audience sources: none");
             } else {
@@ -293,8 +320,14 @@ pub fn render(path: &Path, adapter: &'static str) -> String {
                 }
             }
         }
-        None => {
-            let _ = writeln!(output, "Audience configuration: unavailable (policy does not compile)");
+        AudienceSide::Uncompiled(error) => {
+            let _ = writeln!(
+                output,
+                "Audience configuration: unavailable (policy does not compile: {error})"
+            );
+        }
+        AudienceSide::Absent => {
+            let _ = writeln!(output, "Audience configuration: unavailable (no policy)");
         }
     }
     let _ = writeln!(
@@ -352,7 +385,9 @@ mod tests {
         assert_eq!(config.state, ConfigState::Loadable);
         assert_eq!(config.batteries, ["mail"]);
         assert_eq!(policy.tools, ["mail_read"]);
-        let audience = policy.audience.expect("a loadable policy describes its audience side");
+        let AudienceSide::Declared(audience) = policy.audience else {
+            panic!("a loadable policy describes its audience side: {:?}", policy.audience);
+        };
         assert_eq!(
             audience.sources,
             [SourceDescription {

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -67,7 +67,7 @@ use appa_engine::value::{
     ResolvedCall, ToolName, TrajectoryId as EngineTrajectoryId, ValueBody,
 };
 use appa_eventlog::Log;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::api::OutcomeBody;
 pub(crate) use crate::api::{OfferId, ProposedCall, SpawnBinding, ToolOutcome, TrajectoryId};
@@ -893,44 +893,33 @@ impl RuntimeEngine {
             arguments: call.arguments.get().as_bytes().to_vec(),
             annotation,
         };
-        let act = match self.act_audience(evidence) {
-            Ok(act) => act,
-            Err(AudienceFailure::Consult(requests)) => {
-                return Ok(EngineDecision::deliver(Next::ResolveExternal(requests)));
-            }
-            Err(AudienceFailure::Refused(detail)) => return Ok(deny(unresolved_audience(&call.tool, &detail))),
-        };
         // A deployment that does not control context releases the marked call
         // unmarked, so the batch may be decided twice. The mark is all that
         // differs between the two attempts.
-        let judge = || {
-            let decide = |marked: bool| {
-                let batch = ProposalBatch {
-                    id: batch_id(entropy),
-                    trajectory: engine_id(trajectory),
-                    provider_results: Vec::new(),
-                    proposals: vec![proposed.clone()],
-                    spawn: marked.then(|| SpawnMark::at(0)),
-                    offer_nonce: engine_nonce(entropy),
-                    evidence: Vec::new(),
-                    audience: act.payload.clone(),
+        let judged =
+            self.judge_under_audience(evidence, UnresolvedAudience::Denied { tool: &call.tool }, |audience| {
+                let decide = |marked: bool| {
+                    let batch = ProposalBatch {
+                        id: batch_id(entropy),
+                        trajectory: engine_id(trajectory),
+                        provider_results: Vec::new(),
+                        proposals: vec![proposed.clone()],
+                        spawn: marked.then(|| SpawnMark::at(0)),
+                        offer_nonce: engine_nonce(entropy),
+                        evidence: Vec::new(),
+                        audience: audience.clone(),
+                    };
+                    self.engine.handle(view, CoreEvent::Proposals(batch))
                 };
-                self.engine.handle(view, CoreEvent::Proposals(batch))
-            };
-            match decide(spawn) {
-                Err(TransitionError::SpawnUncontrolled) if spawn => decide(false),
-                decided => decided,
-            }
-        };
-        let decision = match judge() {
-            Ok(decision) => decision,
-            Err(TransitionError::MembershipNeeded { needed }) => {
-                return match self.audience_consult(&act, needed)? {
-                    AudienceConsult::Requests(requests) => Ok(EngineDecision::deliver(Next::ResolveExternal(requests))),
-                    AudienceConsult::Unresolved(detail) => Ok(deny(unresolved_audience(&call.tool, &detail))),
-                };
-            }
-            Err(error) => return Err(proposal_refusal(error)),
+                match decide(spawn) {
+                    Err(TransitionError::SpawnUncontrolled) if spawn => decide(false),
+                    decided => decided,
+                }
+            })?;
+        let decision = match judged {
+            AudienceRound::Judged(decision) => decision,
+            AudienceRound::Presented(decision) => return Ok(decision),
+            AudienceRound::Failed(error) => return Err(proposal_refusal(error)),
         };
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
         let then = self.deliver_proposals(decision.follow_up)?;
@@ -998,38 +987,24 @@ impl RuntimeEngine {
         evidence: &[ExternalEvidence],
         entropy: &OfferNonce,
     ) -> Result<EngineDecision, EngineRefusal> {
-        let withheld = |detail: &str| {
-            Ok(EngineDecision::deliver(Next::PresentToModel(Presentation::Blocked {
-                feedback: format!("[appa] {detail}; the result is withheld and may be retried"),
-                offers: Vec::new(),
-            })))
-        };
-        let act = match self.act_audience(evidence) {
-            Ok(act) => act,
-            Err(AudienceFailure::Consult(requests)) => {
-                return Ok(EngineDecision::deliver(Next::ResolveExternal(requests)));
-            }
-            Err(AudienceFailure::Refused(detail)) => return withheld(&detail),
-        };
-        let judge = |evidence: &[ExternalEvidence]| {
-            let report = ToolReport {
-                dispatch: dispatch.clone(),
-                outcome: engine_outcome(outcome),
-                evidence: sanitizer_evidence(evidence),
-                offer_nonce: engine_nonce(entropy),
-                audience: act.payload.clone(),
-            };
-            self.engine.handle(view, CoreEvent::Outcome(report))
-        };
-        let decision = match judge(evidence) {
-            Ok(decision) => decision,
-            Err(TransitionError::MembershipNeeded { needed }) => {
-                return match self.audience_consult(&act, needed)? {
-                    AudienceConsult::Requests(requests) => Ok(EngineDecision::deliver(Next::ResolveExternal(requests))),
-                    AudienceConsult::Unresolved(detail) => withheld(&detail),
+        let judged = self.judge_under_audience(
+            evidence,
+            UnresolvedAudience::Withheld { subject: "result" },
+            |audience| {
+                let report = ToolReport {
+                    dispatch: dispatch.clone(),
+                    outcome: engine_outcome(outcome),
+                    evidence: sanitizer_evidence(evidence),
+                    offer_nonce: engine_nonce(entropy),
+                    audience: audience.clone(),
                 };
-            }
-            Err(error) => return Err(outcome_refusal(error)),
+                self.engine.handle(view, CoreEvent::Outcome(report))
+            },
+        )?;
+        let decision = match judged {
+            AudienceRound::Judged(decision) => decision,
+            AudienceRound::Presented(decision) => return Ok(decision),
+            AudienceRound::Failed(error) => return Err(outcome_refusal(error)),
         };
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
         let then = match decision.follow_up {
@@ -1154,45 +1129,30 @@ impl RuntimeEngine {
                 }
             }
         };
-        let act = match self.act_audience(evidence) {
-            Ok(act) => act,
-            Err(AudienceFailure::Consult(requests)) => {
-                return Ok(EngineDecision::deliver(Next::ResolveExternal(requests)));
-            }
-            Err(AudienceFailure::Refused(detail)) => {
-                return Ok(no_answer(format!(
-                    "[appa] {detail}; the offer stands and may be executed again"
-                )));
-            }
-        };
-        let execution = OfferExecution {
-            trajectory: engine_id(trajectory),
-            offer: engine_offer,
-            outcome,
-            offer_nonce: engine_nonce(entropy),
-            audience: act.payload.clone(),
-        };
-        let decision = match self.engine.handle(view, CoreEvent::ExecuteOffer(execution)) {
-            Ok(decision) => decision,
-            Err(TransitionError::MembershipNeeded { needed }) => {
-                return match self.audience_consult(&act, needed)? {
-                    AudienceConsult::Requests(requests) => Ok(EngineDecision::deliver(Next::ResolveExternal(requests))),
-                    AudienceConsult::Unresolved(detail) => Ok(no_answer(format!(
-                        "[appa] {detail}; the offer stands and may be executed again"
-                    ))),
-                };
-            }
+        let judged = self.judge_under_audience(evidence, UnresolvedAudience::OfferStands, |audience| {
+            let execution = OfferExecution {
+                trajectory: engine_id(trajectory),
+                offer: engine_offer,
+                outcome,
+                offer_nonce: engine_nonce(entropy),
+                audience: audience.clone(),
+            };
+            self.engine.handle(view, CoreEvent::ExecuteOffer(execution))
+        })?;
+        let decision = match judged {
+            AudienceRound::Judged(decision) => decision,
+            AudienceRound::Presented(decision) => return Ok(decision),
             // A sanitizer's derivation the engine cannot use — malformed, schema-invalid, or not
             // a strict improvement — lands no fact and opens no dispatch; the offer stands for a
             // later deliberate retry. The external's answer is not an
             // integration fault, so it is not a refusal.
-            Err(TransitionError::Call(_) | TransitionError::SanitizerUnapplicable) => {
+            AudienceRound::Failed(TransitionError::Call(_) | TransitionError::SanitizerUnapplicable) => {
                 return Ok(no_answer(
                     "[appa] the sanitizer's derivation was not usable; the offer stands and may be executed again"
                         .to_string(),
                 ));
             }
-            Err(error) => return Err(offer_refusal(error)),
+            AudienceRound::Failed(error) => return Err(offer_refusal(error)),
         };
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
         let then = match decision.follow_up {
@@ -1361,39 +1321,25 @@ impl RuntimeEngine {
                 body: ValueBody::new(body),
             },
         };
-        let withheld = |detail: &str| {
-            Ok(EngineDecision::deliver(Next::PresentToModel(Presentation::Blocked {
-                feedback: format!("[appa] {detail}; the return is withheld and may be retried"),
-                offers: Vec::new(),
-            })))
-        };
-        let act = match self.act_audience(evidence) {
-            Ok(act) => act,
-            Err(AudienceFailure::Consult(requests)) => {
-                return Ok(EngineDecision::deliver(Next::ResolveExternal(requests)));
-            }
-            Err(AudienceFailure::Refused(detail)) => return withheld(&detail),
-        };
-        let judge = |evidence: &[ExternalEvidence]| {
-            let report = ChildReport {
-                child: engine_id(child),
-                fork: fork.clone(),
-                submission: submission.clone(),
-                evidence: sanitizer_evidence(evidence),
-                offer_nonce: engine_nonce(entropy),
-                audience: act.payload.clone(),
-            };
-            self.engine.handle(view, CoreEvent::ChildReturn(report))
-        };
-        let decision = match judge(evidence) {
-            Ok(decision) => decision,
-            Err(TransitionError::MembershipNeeded { needed }) => {
-                return match self.audience_consult(&act, needed)? {
-                    AudienceConsult::Requests(requests) => Ok(EngineDecision::deliver(Next::ResolveExternal(requests))),
-                    AudienceConsult::Unresolved(detail) => withheld(&detail),
+        let judged = self.judge_under_audience(
+            evidence,
+            UnresolvedAudience::Withheld { subject: "return" },
+            |audience| {
+                let report = ChildReport {
+                    child: engine_id(child),
+                    fork: fork.clone(),
+                    submission: submission.clone(),
+                    evidence: sanitizer_evidence(evidence),
+                    offer_nonce: engine_nonce(entropy),
+                    audience: audience.clone(),
                 };
-            }
-            Err(error) => return Err(child_refusal(error)),
+                self.engine.handle(view, CoreEvent::ChildReturn(report))
+            },
+        )?;
+        let decision = match judged {
+            AudienceRound::Judged(decision) => decision,
+            AudienceRound::Presented(decision) => return Ok(decision),
+            AudienceRound::Failed(error) => return Err(child_refusal(error)),
         };
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
         let then = match decision.follow_up {
@@ -1675,26 +1621,60 @@ impl RuntimeEngine {
     }
 
     /// The selector templates the policy registers for one provider, for a consult's
-    /// declaration.
-    fn templates_of(&self, provider: &str) -> Vec<String> {
+    /// declaration. Every primitive a consult asks for names a registered provider.
+    fn templates_of(&self, provider: &str) -> Result<Vec<String>, EngineRefusal> {
         self.engine
             .registry()
             .audience()
             .templates(provider)
             .map(|templates| templates.iter().map(|template| template.as_str().to_string()).collect())
-            .unwrap_or_default()
+            .ok_or_else(|| EngineRefusal::Invariant {
+                detail: format!("a consult names the unregistered audience provider {provider}"),
+            })
     }
 
-    /// One act's audience evidence, gathered from the consult answers: the validated
-    /// source claims and member lookups, and — under a custom identity implementation —
-    /// the identity mappings for every claimed member. A failed consult stays runtime-side
-    /// as a recorded no-answer; an answer no registered source could have served is
-    /// dropped rather than carried into an act it would refuse. The gathered payload is
-    /// pre-validated against the same test replay applies, so an inadmissible answer is an
-    /// operational refusal here, never an engine error.
+    /// One act judged under its audience evidence: the evidence gathered from the consult
+    /// answers, the act judged with it pinned, and — while the engine still needs membership
+    /// answers — the consults that gather them. An answer the act cannot obtain is presented
+    /// the way `unresolved` names.
+    fn judge_under_audience<T>(
+        &self,
+        evidence: &[ExternalEvidence],
+        unresolved: UnresolvedAudience<'_>,
+        judge: impl FnOnce(&AudienceEvidence) -> Result<T, TransitionError>,
+    ) -> Result<AudienceRound<T>, EngineRefusal> {
+        let act = match self.act_audience(evidence) {
+            Ok(act) => act,
+            Err(AudienceFailure::Consult(requests)) => {
+                return Ok(AudienceRound::Presented(EngineDecision::deliver(
+                    Next::ResolveExternal(requests),
+                )));
+            }
+            Err(AudienceFailure::Refused(detail)) => return Ok(AudienceRound::Presented(unresolved.present(&detail))),
+        };
+        match judge(&act.payload) {
+            Ok(judged) => Ok(AudienceRound::Judged(judged)),
+            Err(TransitionError::MembershipNeeded { needed }) => match self.audience_consult(&act, needed)? {
+                AudienceConsult::Requests(requests) => Ok(AudienceRound::Presented(EngineDecision::deliver(
+                    Next::ResolveExternal(requests),
+                ))),
+                AudienceConsult::Unresolved(detail) => Ok(AudienceRound::Presented(unresolved.present(&detail))),
+            },
+            Err(error) => Ok(AudienceRound::Failed(error)),
+        }
+    }
+
+    /// One act's audience evidence, gathered from the consult answers: the source claims,
+    /// member lookups, and — under a custom identity implementation — the identity mappings
+    /// for every claimed member. A failed consult stays runtime-side as a recorded no-answer;
+    /// an answer no registered source could have served is dropped rather than carried into
+    /// an act it would refuse. The gathered payload is pre-validated against the same test
+    /// replay applies — the engine's, which is the one rule on duplicate or foreign answers
+    /// — so an inadmissible answer is an operational refusal here, never an engine error.
     fn act_audience(&self, evidence: &[ExternalEvidence]) -> Result<ActAudience, AudienceFailure> {
         let audience = self.engine.registry().audience();
-        let mut gathered = GatheredAudience::default();
+        let mut payload = AudienceEvidence::default();
+        let mut unanswered = Unanswered::default();
         for entry in evidence {
             match entry {
                 ExternalEvidence::AudienceSource {
@@ -1713,15 +1693,17 @@ impl RuntimeEngine {
                     let members = members
                         .clone()
                         .filter(|members| members.iter().all(|member| qualified_by(provider, &member.id)));
-                    let spec = SelectorSpec {
-                        provider: provider.clone(),
-                        selector: selector.clone(),
-                    };
-                    // An answer outranks a no-answer for the same selector.
-                    match (gathered.sources.get(&spec), members) {
-                        (Some(Some(_)), _) => {}
-                        (_, members) => {
-                            gathered.sources.insert(spec, members);
+                    match members {
+                        Some(members) => payload.sources.push(appa_engine::audience::SourceClaims {
+                            provider: provider.clone(),
+                            selector: selector.clone(),
+                            members,
+                        }),
+                        None => {
+                            unanswered.selectors.insert(SelectorSpec {
+                                provider: provider.clone(),
+                                selector: selector.clone(),
+                            });
                         }
                     }
                 }
@@ -1741,10 +1723,14 @@ impl RuntimeEngine {
                         Some(Some(answered)) if answered.id != *member => None,
                         other => other.clone(),
                     };
-                    match (gathered.lookups.get(member), claims) {
-                        (Some((_, Some(_))), _) => {}
-                        (_, claims) => {
-                            gathered.lookups.insert(member.clone(), (provider.clone(), claims));
+                    match claims {
+                        Some(claims) => payload.lookups.push(appa_engine::audience::MemberLookup {
+                            provider: provider.clone(),
+                            member: member.clone(),
+                            claims,
+                        }),
+                        None => {
+                            unanswered.members.insert(member.clone());
                         }
                     }
                 }
@@ -1760,41 +1746,17 @@ impl RuntimeEngine {
                     if !named {
                         continue;
                     }
-                    match (gathered.identity.get(id), principal) {
-                        (Some(Some(_)), _) => {}
-                        (_, principal) => {
-                            gathered.identity.insert(id.clone(), principal.clone());
+                    match principal {
+                        Some(principal) => payload.identity.push(IdentityMapping {
+                            id: id.clone(),
+                            principal: principal.clone(),
+                        }),
+                        None => {
+                            unanswered.identities.insert(id.clone());
                         }
                     }
                 }
                 _ => {}
-            }
-        }
-        let mut payload = AudienceEvidence::default();
-        for (spec, members) in &gathered.sources {
-            if let Some(members) = members {
-                payload.sources.push(appa_engine::audience::SourceClaims {
-                    provider: spec.provider.clone(),
-                    selector: spec.selector.clone(),
-                    members: members.clone(),
-                });
-            }
-        }
-        for (member, (provider, claims)) in &gathered.lookups {
-            if let Some(claims) = claims {
-                payload.lookups.push(appa_engine::audience::MemberLookup {
-                    provider: provider.clone(),
-                    member: member.clone(),
-                    claims: claims.clone(),
-                });
-            }
-        }
-        for (id, principal) in &gathered.identity {
-            if let Some(principal) = principal {
-                payload.identity.push(IdentityMapping {
-                    id: id.clone(),
-                    principal: principal.clone(),
-                });
             }
         }
         // Under a custom identity implementation every claimed member canonicalizes through
@@ -1814,26 +1776,24 @@ impl RuntimeEngine {
                 }
             };
             for claims in claimed.values() {
-                match gathered.identity.get(&claims.id) {
-                    Some(Some(_)) => {}
-                    Some(None) => {
-                        // The member id is directory data the model has not seen: it stays
-                        // out of the model-visible refusal.
-                        tracing::debug!(implementation = name.as_str(), id = %claims.id, "identity gave no principal");
-                        return Err(AudienceFailure::Refused(format!(
-                            "identity implementation {} gave no principal for a claimed member",
-                            name.as_str(),
-                        )));
-                    }
-                    None => {
-                        let request = ExternalRequest::Identity {
-                            implementation: name.as_str().to_string(),
-                            claims: claims.clone(),
-                        };
-                        if !requests.contains(&request) {
-                            requests.push(request);
-                        }
-                    }
+                if payload.identity.iter().any(|mapping| mapping.id == claims.id) {
+                    continue;
+                }
+                if unanswered.identities.contains(&claims.id) {
+                    // The member id is directory data the model has not seen: it stays
+                    // out of the model-visible refusal.
+                    tracing::debug!(implementation = name.as_str(), id = %claims.id, "identity gave no principal");
+                    return Err(AudienceFailure::Refused(format!(
+                        "identity implementation {} gave no principal for a claimed member",
+                        name.as_str(),
+                    )));
+                }
+                let request = ExternalRequest::Identity {
+                    implementation: name.as_str().to_string(),
+                    claims: claims.clone(),
+                };
+                if !requests.contains(&request) {
+                    requests.push(request);
                 }
             }
             if !requests.is_empty() {
@@ -1850,7 +1810,7 @@ impl RuntimeEngine {
                 refusal_class(&refusal)
             )));
         }
-        Ok(ActAudience { payload, gathered })
+        Ok(ActAudience { payload, unanswered })
     }
 
     /// The consults that answer the symbolic atoms an act still needs, or the operational
@@ -1865,37 +1825,42 @@ impl RuntimeEngine {
         };
         let mut requests: Vec<ExternalRequest> = Vec::new();
         for spec in &primitives.selectors {
-            match act.gathered.sources.get(spec) {
-                Some(Some(_)) => {}
-                Some(None) => {
-                    return Ok(AudienceConsult::Unresolved(format!(
-                        "audience source {} gave no answer for {}",
-                        spec.provider, spec.selector
-                    )));
-                }
-                None => requests.push(ExternalRequest::AudienceSource {
-                    provider: spec.provider.clone(),
-                    selector: spec.selector.clone(),
-                    templates: self.templates_of(&spec.provider),
-                }),
+            let answered = act
+                .payload
+                .sources
+                .iter()
+                .any(|claims| claims.provider == spec.provider && claims.selector == spec.selector);
+            if answered {
+                continue;
             }
+            if act.unanswered.selectors.contains(spec) {
+                return Ok(AudienceConsult::Unresolved(format!(
+                    "audience source {} gave no answer for {}",
+                    spec.provider, spec.selector
+                )));
+            }
+            requests.push(ExternalRequest::AudienceSource {
+                provider: spec.provider.clone(),
+                selector: spec.selector.clone(),
+                templates: self.templates_of(&spec.provider)?,
+            });
         }
         for spec in &primitives.lookups {
-            match act.gathered.lookups.get(spec.member.as_str()) {
-                Some((_, Some(_))) => {}
-                Some((_, None)) => {
-                    // The member can be a reader a delta wrote that the model never saw.
-                    return Ok(AudienceConsult::Unresolved(format!(
-                        "audience source {} gave no answer for a member lookup",
-                        spec.provider
-                    )));
-                }
-                None => requests.push(ExternalRequest::MemberLookup {
-                    provider: spec.provider.clone(),
-                    member: spec.member.clone(),
-                    templates: self.templates_of(&spec.provider),
-                }),
+            if act.payload.lookups.iter().any(|lookup| lookup.member == spec.member) {
+                continue;
             }
+            if act.unanswered.members.contains(&spec.member) {
+                // The member can be a reader a delta wrote that the model never saw.
+                return Ok(AudienceConsult::Unresolved(format!(
+                    "audience source {} gave no answer for a member lookup",
+                    spec.provider
+                )));
+            }
+            requests.push(ExternalRequest::MemberLookup {
+                provider: spec.provider.clone(),
+                member: spec.member.clone(),
+                templates: self.templates_of(&spec.provider)?,
+            });
         }
         if requests.is_empty() {
             // Every primitive is answered and pre-validated, yet the act still asked.
@@ -2040,6 +2005,43 @@ enum AudienceConsult {
     Unresolved(String),
 }
 
+/// How an act presents an audience answer it cannot obtain: a failed or inadmissible
+/// consult, or a dynamically supplied reference no registered source serves.
+#[derive(Clone, Copy)]
+enum UnresolvedAudience<'a> {
+    /// The proposed call is denied.
+    Denied { tool: &'a str },
+    /// The value — a tool result or a child's return — is withheld and may be retried.
+    Withheld { subject: &'static str },
+    /// The offer stands and may be executed again.
+    OfferStands,
+}
+
+impl UnresolvedAudience<'_> {
+    fn present(self, detail: &str) -> EngineDecision {
+        match self {
+            UnresolvedAudience::Denied { tool } => deny(unresolved_audience(tool, detail)),
+            UnresolvedAudience::Withheld { subject } => {
+                EngineDecision::deliver(Next::PresentToModel(Presentation::Blocked {
+                    feedback: format!("[appa] {detail}; the {subject} is withheld and may be retried"),
+                    offers: Vec::new(),
+                }))
+            }
+            UnresolvedAudience::OfferStands => {
+                no_answer(format!("[appa] {detail}; the offer stands and may be executed again"))
+            }
+        }
+    }
+}
+
+/// Where one act's audience round ends: judged, presented short of a judgment (consults
+/// still owed, or an unobtainable answer), or failed in the engine for another reason.
+enum AudienceRound<T> {
+    Judged(T),
+    Presented(EngineDecision),
+    Failed(TransitionError),
+}
+
 /// Why an act cannot carry audience evidence yet: the identity consults still owed, or the
 /// operational refusal a failed or inadmissible answer forces.
 enum AudienceFailure {
@@ -2047,19 +2049,20 @@ enum AudienceFailure {
     Refused(String),
 }
 
-/// One act's gathered audience answers beside their validated payload: the payload is what
-/// the act pins, the gathered table also remembers which consults already failed.
+/// One act's validated audience payload — what the act pins — beside the consults that
+/// already produced no answer, which are never re-asked.
 struct ActAudience {
     payload: AudienceEvidence,
-    gathered: GatheredAudience,
+    unanswered: Unanswered,
 }
 
 #[derive(Debug, Default)]
-struct GatheredAudience {
-    sources: BTreeMap<SelectorSpec, Option<Vec<MemberClaims>>>,
-    /// Keyed by the qualified member; the value names the provider that answered.
-    lookups: BTreeMap<String, (String, Option<Option<MemberClaims>>)>,
-    identity: BTreeMap<String, Option<ReaderId>>,
+struct Unanswered {
+    selectors: BTreeSet<SelectorSpec>,
+    /// Qualified members whose lookup produced no answer.
+    members: BTreeSet<String>,
+    /// Member ids the custom identity implementation gave no principal for.
+    identities: BTreeSet<String>,
 }
 
 fn deny(text: String) -> EngineDecision {

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1955,6 +1955,9 @@ fn refusal_class(refusal: &appa_engine::audience::EvidenceRefusal) -> String {
         EvidenceRefusal::UnrequestedEvidence { .. } => {
             "evidence beyond this operation's inherited pins and its own asks".to_string()
         }
+        EvidenceRefusal::ContradictedPin { .. } => {
+            "an answer that contradicts the one an earlier record of this chain pinned".to_string()
+        }
     }
 }
 

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1880,9 +1880,8 @@ impl RuntimeEngine {
                 }),
             }
         }
-        // A lookup's `selector` slot carries the qualified member it canonicalizes.
         for spec in &primitives.lookups {
-            match act.gathered.lookups.get(spec.selector.as_str()) {
+            match act.gathered.lookups.get(spec.member.as_str()) {
                 Some((_, Some(_))) => {}
                 Some((_, None)) => {
                     // The member can be a reader a delta wrote that the model never saw.
@@ -1893,7 +1892,7 @@ impl RuntimeEngine {
                 }
                 None => requests.push(ExternalRequest::MemberLookup {
                     provider: spec.provider.clone(),
-                    member: spec.selector.clone(),
+                    member: spec.member.clone(),
                     templates: self.templates_of(&spec.provider),
                 }),
             }

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -794,8 +794,8 @@ impl RuntimeEngine {
             Fact::OutputSanitizerBound { sanitizer, .. } => AuditEvent::SanitizerBound {
                 sanitizer: terminal_safe(sanitizer.as_str()),
             },
-            Fact::CandidateDerived { via, .. } => AuditEvent::Sanitized {
-                sanitizer: terminal_safe(via.name.as_str()),
+            Fact::CandidateDerived { sanitizer, .. } => AuditEvent::Sanitized {
+                sanitizer: terminal_safe(sanitizer.as_str()),
             },
             Fact::ChildReturn { value, derivation, .. } => AuditEvent::ChildReturn {
                 sanitizer: match derivation {

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -40,13 +40,14 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             Err(error) => refuse(error.to_string()),
         },
         HookEvent::Prompt { actor, .. } => {
-            // A prompt gates the new turn, so a close that failed blocks
-            // it: the call is still open and the first proposal would
-            // refuse anyway, with less to say about why.
-            match on_actor(runtime, &actor, |session| async move { session.on_prompt().await }).await {
-                Ok(()) => HookDecision::Ack,
-                Err(error) => fold(error, block),
-            }
+            // The prompt text is not an engine event: nothing is reported,
+            // nothing is recorded, and offer freshness stays the engine's
+            // judgment. The prompt is only noted as the sign that the
+            // previous turn is over; a queued message arrives here while
+            // its turn's call still runs, so the call is settled at the
+            // first proposal of the new turn, when that result is in.
+            runtime.note_prompt(&actor);
+            HookDecision::Ack
         }
         HookEvent::TurnEnd { actor } => {
             // A turn end gates nothing, so it answers `Ack` whatever
@@ -54,6 +55,7 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             // turn" on this hook, which would hold the harness in a turn
             // it has finished; a close that failed leaves the call open
             // and the next proposal refuses on its own.
+            runtime.take_prompted(&actor);
             if let Err(error) = on_actor(runtime, &actor, |session| async move { session.on_turn_end().await }).await {
                 tracing::warn!(root = %actor.root.0, %error, "the turn end closed no abandoned call");
             }
@@ -61,6 +63,19 @@ pub async fn handle(runtime: &Runtime, event: HookEvent) -> HookDecision {
             HookDecision::Ack
         }
         HookEvent::ToolCall { actor, call, spawn } => {
+            if runtime.take_prompted(&actor) {
+                // The first proposal after a prompt that no turn end preceded:
+                // the user interrupted the previous turn, and whatever it left
+                // open is settled before this turn's first call, control tools
+                // included, so a vouch this turn records is never released here.
+                if let Err(error) =
+                    on_actor(runtime, &actor, |session| async move { session.on_turn_end().await }).await
+                {
+                    runtime.note_prompt(&actor);
+                    return fold(error, deny);
+                }
+                runtime.release_vouches(&actor);
+            }
             if is_control_tool(&call.tool) {
                 return control_call(runtime, &actor, &call);
             }
@@ -410,41 +425,153 @@ mod tests {
         assert_eq!(freed.1["hookSpecificOutput"]["permissionDecision"], "allow");
     }
 
-    /// The user pressed Esc while the command ran: Claude Code sends no
-    /// outcome hook for the call and no `Stop` hook for the turn. The
-    /// next prompt is the first hook to arrive, and it frees the call.
-    #[tokio::test]
-    async fn the_next_prompt_frees_a_call_an_interrupt_left_open() {
-        let dir = tempfile::tempdir().expect("a temp dir is creatable");
-        let runtime = open_runtime(&dir);
-        let propose = |command: &str| {
-            serde_json::json!({
-                "hook_event_name": "PreToolUse",
-                "session_id": "s1",
-                "tool_name": "Bash",
-                "tool_input": {"command": command},
-            })
-        };
-        let released = call_hook(
-            &runtime,
-            &serde_json::to_vec(&propose("ping -c 30 127.0.0.1")).expect("re-serializes"),
-        )
-        .await;
-        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+    fn bash_call(command: &str) -> serde_json::Value {
+        serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        })
+    }
 
-        // Interrupted: neither PostToolUse nor Stop arrives.
-        let prompt = serde_json::json!({
+    fn bash_result(command: &str) -> serde_json::Value {
+        serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "done"},
+        })
+    }
+
+    fn prompt() -> serde_json::Value {
+        serde_json::json!({
             "hook_event_name": "UserPromptSubmit",
             "session_id": "s1",
             "prompt": "never mind, list the files",
-        });
+        })
+    }
+
+    async fn hook(runtime: &Runtime, body: &serde_json::Value) -> (u16, serde_json::Value) {
+        call_hook(runtime, &serde_json::to_vec(body).expect("re-serializes")).await
+    }
+
+    fn closed_as_unknown(runtime: &Runtime) -> bool {
+        runtime
+            .audit(&appa_runtime_api::TrajectoryId("cc:s1".to_string()))
+            .expect("the audit reads")
+            .iter()
+            .any(|entry| {
+                matches!(
+                    &entry.event,
+                    crate::engine::AuditEvent::Closed {
+                        outcome: crate::engine::DispatchOutcome::Unknown
+                    }
+                )
+            })
+    }
+
+    /// The user pressed Esc while the command ran: Claude Code sends no
+    /// outcome hook for the call and no `Stop` hook for the turn. The
+    /// next prompt is the first hook to arrive; the new turn's first
+    /// proposal closes the call as unreported and releases.
+    #[tokio::test]
+    async fn the_first_call_after_a_prompt_frees_a_call_an_interrupt_left_open() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let released = hook(&runtime, &bash_call("ping -c 30 127.0.0.1")).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        let actor = Actor {
+            root: appa_runtime_api::TrajectoryId("cc:s1".to_string()),
+            child: None,
+        };
+        let quoted = OfferId("offer-1".to_string());
+        runtime.vouch(&quoted, &actor);
+
+        // Interrupted: neither PostToolUse nor Stop arrives.
+        assert_eq!(hook(&runtime, &prompt()).await, (200, serde_json::json!({})));
+        assert!(!closed_as_unknown(&runtime), "the prompt itself records nothing");
+
+        let freed = hook(&runtime, &bash_call("ls")).await;
+        assert_eq!(freed.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert!(closed_as_unknown(&runtime), "the interrupted call closed as unreported");
         assert_eq!(
-            call_hook(&runtime, &serde_json::to_vec(&prompt).expect("re-serializes")).await,
-            (200, serde_json::json!({})),
+            runtime.take_vouched(&quoted),
+            None,
+            "the interrupted turn's vouch is released"
         );
 
-        let freed = call_hook(&runtime, &serde_json::to_vec(&propose("ls")).expect("re-serializes")).await;
+        let late = hook(&runtime, &bash_result("ping -c 30 127.0.0.1")).await;
+        assert_eq!(late.1["decision"], "block", "a result for the closed call is refused");
+    }
+
+    /// The user typed while the command ran: Claude Code queues the message
+    /// and fires the prompt hook at once, then reports the command's
+    /// outcome when it finishes. The result must land on the still-open
+    /// call, and the next turn's first proposal then releases freely.
+    #[tokio::test]
+    async fn a_prompt_queued_behind_a_running_call_keeps_its_result() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let released = hook(&runtime, &bash_call("sleep 30")).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+
+        assert_eq!(hook(&runtime, &prompt()).await, (200, serde_json::json!({})));
+        assert_eq!(
+            hook(&runtime, &bash_result("sleep 30")).await,
+            (200, serde_json::json!({})),
+            "the running call's result lands on its open dispatch",
+        );
+        assert!(!closed_as_unknown(&runtime), "nothing was closed as unreported");
+
+        let next = hook(&runtime, &bash_call("ls")).await;
+        assert_eq!(next.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert!(!closed_as_unknown(&runtime));
+        let repeated = hook(&runtime, &bash_result("sleep 30")).await;
+        assert_eq!(
+            repeated.1["decision"], "block",
+            "a second report of the same result is refused"
+        );
+    }
+
+    /// A prompt writes nothing, so a store that refuses every append still
+    /// acknowledges it; the failure surfaces at the proposal that needs the
+    /// close, and the mark survives for the next proposal.
+    #[tokio::test]
+    async fn a_prompt_acknowledges_over_a_store_that_cannot_append() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let released = hook(&runtime, &bash_call("ping -c 30 127.0.0.1")).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        runtime.store().fail_commit_after(0);
+
+        assert_eq!(hook(&runtime, &prompt()).await, (200, serde_json::json!({})));
+
+        let (status, _) = hook(&runtime, &bash_call("ls")).await;
+        assert_eq!(status, 409, "the close the proposal needs is an operational refusal");
+        runtime.store().fail_commit_after(u64::MAX - 1);
+        let freed = hook(&runtime, &bash_call("ls")).await;
         assert_eq!(freed.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert!(closed_as_unknown(&runtime));
+    }
+
+    /// A turn end settles the prompt's mark too: a proposal in the turn
+    /// after a normally ended one closes nothing.
+    #[tokio::test]
+    async fn a_turn_end_settles_the_prompt_mark() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        assert_eq!(hook(&runtime, &prompt()).await, (200, serde_json::json!({})));
+        let stop = serde_json::json!({"hook_event_name": "Stop", "session_id": "s1"});
+        assert_eq!(hook(&runtime, &stop).await, (200, serde_json::json!({})));
+
+        let released = hook(&runtime, &bash_call("sleep 30")).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            hook(&runtime, &bash_result("sleep 30")).await,
+            (200, serde_json::json!({}))
+        );
+        assert!(!closed_as_unknown(&runtime));
     }
 
     #[tokio::test]
@@ -882,12 +1009,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let runtime = open_runtime(&dir);
         runtime.store().fail_commit_after(0);
-        let prompt = serde_json::json!({
-            "hook_event_name": "UserPromptSubmit",
-            "session_id": "s1",
-            "prompt": "read the report",
-        });
-        let (status, answer) = call_hook(&runtime, &serde_json::to_vec(&prompt).expect("serializes")).await;
+        let (status, answer) = hook(&runtime, &bash_call("ls")).await;
         assert_eq!(status, 409, "the harness must fail closed on a storage failure");
         assert!(
             answer.get("error").is_some(),

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -192,7 +192,7 @@ fn control_call(runtime: &Runtime, actor: &Actor, call: &ProposedCall) -> HookDe
         }
         _ => {
             tracing::debug!(trajectory = %acting.0, "control tool refused: no such offer here");
-            deny("[appa] this offer no longer stands; re-propose the call".to_string())
+            deny("this offer no longer stands; re-propose the call".to_string())
         }
     }
 }
@@ -242,8 +242,13 @@ fn fold(error: EventError, family: fn(String) -> HookDecision) -> HookDecision {
     }
 }
 
+/// A refusal of this dispatcher's own that the model will read names APPA
+/// once, here, so a session can tell a runtime refusal from its harness's;
+/// a block is marked by the adapter's withheld-result rendering instead.
 fn deny(feedback: String) -> HookDecision {
-    HookDecision::DenyCall { feedback }
+    HookDecision::DenyCall {
+        feedback: format!("[appa] {feedback}"),
+    }
 }
 
 fn block(reason: String) -> HookDecision {
@@ -572,6 +577,23 @@ mod tests {
             (200, serde_json::json!({}))
         );
         assert!(!closed_as_unknown(&runtime));
+    }
+
+    /// Every refusal of the dispatcher's own that reaches the model on the
+    /// deny wire names APPA, whichever event error produced it.
+    #[tokio::test]
+    async fn a_deny_of_the_dispatchers_own_names_appa() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let released = hook(&runtime, &bash_call("sleep 30")).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+
+        let denied = hook(&runtime, &bash_call("ls")).await;
+        assert_eq!(denied.1["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = denied.1["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .expect("a deny carries its reason");
+        assert!(reason.starts_with("[appa] "), "the deny reads: {reason}");
     }
 
     #[tokio::test]

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -295,10 +295,10 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
             outcome
         }
         Err(operation) => {
-            let unwound = compensation
-                .unwind()
-                .and_then(|()| undo_plugin_switch(recovery.as_ref(), launcher_dir));
-            if let Err(recovery_error) = unwound {
+            // Both recoveries are attempted; the first failure is the one reported.
+            let unwound = compensation.unwind();
+            let restored = undo_plugin_switch(recovery.as_ref(), launcher_dir);
+            if let Err(recovery_error) = unwound.and(restored) {
                 return Err(InitError::PluginRecovery {
                     operation: Box::new(operation),
                     recovery: Box::new(recovery_error),

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -26,6 +26,8 @@ pub enum InitError {
     CurrentExecutable(std::io::Error),
     #[error("cannot find a home directory; set HOME or the relevant APPA directory variables")]
     MissingHome,
+    #[error("cannot make the directory override {path} absolute: {source}")]
+    AbsolutePath { path: PathBuf, source: std::io::Error },
     #[error("the `claude` command is unavailable: {0}")]
     ClaudeUnavailable(std::io::Error),
     #[error("`claude {command}` failed: {message}")]
@@ -155,13 +157,20 @@ struct DeploymentPaths {
 /// entirely at hook time, so it is made absolute here, once, before any of that.
 /// This is lexical: no `canonicalize`, no case folding, consistent with
 /// refusing rather than normalizing elsewhere.
-fn absolute_directory(path: PathBuf) -> PathBuf {
-    std::path::absolute(&path).unwrap_or(path)
+fn absolute_directory(path: PathBuf) -> Result<PathBuf, InitError> {
+    std::path::absolute(&path).map_err(|source| InitError::AbsolutePath { path, source })
 }
 
 /// The platform config file used by installed deployments and `appa describe`.
 pub fn installed_config_path() -> PathBuf {
-    installed_config_dir().map_or_else(|| PathBuf::from("appa.toml"), |dir| dir.join("appa.toml"))
+    match installed_config_dir() {
+        Ok(Some(directory)) => directory.join("appa.toml"),
+        Ok(None) => PathBuf::from("appa.toml"),
+        Err(error) => {
+            tracing::warn!(%error, "falling back to the working directory for the config path");
+            PathBuf::from("appa.toml")
+        }
+    }
 }
 
 /// Install the plugin belonging to this binary's own release into Claude Code,
@@ -180,7 +189,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     let source = PluginSource::resolve(explicit_source)?;
     let paths = deployment_paths()?;
     let installations = installed_plugin_installations(&paths.claude_dir)?;
-    let marketplaces = run_claude(["plugin", "marketplace", "list"])?;
+    let marketplaces = run_claude(["plugin", "marketplace", "list"], None)?;
 
     // 2. Directories, and the config that survives every upgrade.
     for directory in [&paths.install_dir, &paths.config_dir, &paths.data_dir] {
@@ -198,8 +207,8 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     })?;
     let config = paths.config_dir.join("appa.toml");
     let config_outcome = match create_default_config(&config)? {
-        true => ConfigOutcome::Created,
-        false => offer_config_rewrite(&config)?,
+        ConfigOutcome::Kept => offer_config_rewrite(&config)?,
+        created => created,
     };
     let composed_policy = verify_config(&config)?;
 
@@ -521,26 +530,21 @@ fn friendly_path(path: &Path) -> String {
     )
 }
 
-fn marketplace_manifest(path: &Path) -> PathBuf {
-    path.join(".claude-plugin/marketplace.json")
-}
-
 fn deployment_paths() -> Result<DeploymentPaths, InitError> {
     let home = user_home();
-    let config_dir = installed_config_dir().ok_or(InitError::MissingHome)?;
-    let data_dir = installed_data_dir().ok_or(InitError::MissingHome)?;
+    let config_dir = installed_config_dir()?.ok_or(InitError::MissingHome)?;
+    let data_dir = installed_data_dir()?.ok_or(InitError::MissingHome)?;
     let install_dir = if let Some(path) = env::var_os("APPA_INSTALL_DIR") {
-        absolute_directory(PathBuf::from(path))
+        absolute_directory(PathBuf::from(path))?
     } else if cfg!(windows) {
         data_dir.join("bin")
     } else {
         home.as_ref().ok_or(InitError::MissingHome)?.join(".local/bin")
     };
-    let claude_dir = env::var_os("CLAUDE_CONFIG_DIR")
-        .map(PathBuf::from)
-        .map(absolute_directory)
-        .or_else(|| home.map(|path| path.join(".claude")))
-        .ok_or(InitError::MissingHome)?;
+    let claude_dir = match env::var_os("CLAUDE_CONFIG_DIR") {
+        Some(path) => absolute_directory(PathBuf::from(path))?,
+        None => home.ok_or(InitError::MissingHome)?.join(".claude"),
+    };
     Ok(DeploymentPaths {
         install_dir,
         config_dir,
@@ -562,48 +566,48 @@ fn user_home() -> Option<PathBuf> {
     })
 }
 
-fn installed_config_dir() -> Option<PathBuf> {
+fn installed_config_dir() -> Result<Option<PathBuf>, InitError> {
     if let Some(path) = env::var_os("APPA_CONFIG_DIR") {
-        return Some(absolute_directory(PathBuf::from(path)));
+        return absolute_directory(PathBuf::from(path)).map(Some);
     }
     #[cfg(target_os = "macos")]
-    return env::var_os("HOME")
+    return Ok(env::var_os("HOME")
         .map(PathBuf::from)
-        .map(|home| home.join("Library/Application Support/appa"));
+        .map(|home| home.join("Library/Application Support/appa")));
     #[cfg(target_os = "windows")]
-    return env::var_os("APPDATA").map(PathBuf::from).map(|path| path.join("appa"));
+    return Ok(env::var_os("APPDATA").map(PathBuf::from).map(|path| path.join("appa")));
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    env::var_os("XDG_CONFIG_HOME")
+    Ok(env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
         .map(|path| path.join("appa"))
         .or_else(|| {
             env::var_os("HOME")
                 .map(PathBuf::from)
                 .map(|home| home.join(".config/appa"))
-        })
+        }))
 }
 
-fn installed_data_dir() -> Option<PathBuf> {
+fn installed_data_dir() -> Result<Option<PathBuf>, InitError> {
     if let Some(path) = env::var_os("APPA_DATA_DIR") {
-        return Some(absolute_directory(PathBuf::from(path)));
+        return absolute_directory(PathBuf::from(path)).map(Some);
     }
     #[cfg(target_os = "macos")]
-    return env::var_os("HOME")
+    return Ok(env::var_os("HOME")
         .map(PathBuf::from)
-        .map(|home| home.join("Library/Application Support/appa"));
+        .map(|home| home.join("Library/Application Support/appa")));
     #[cfg(target_os = "windows")]
-    return env::var_os("LOCALAPPDATA")
+    return Ok(env::var_os("LOCALAPPDATA")
         .map(PathBuf::from)
-        .map(|path| path.join("appa"));
+        .map(|path| path.join("appa")));
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    env::var_os("XDG_DATA_HOME")
+    Ok(env::var_os("XDG_DATA_HOME")
         .map(PathBuf::from)
         .map(|path| path.join("appa"))
         .or_else(|| {
             env::var_os("HOME")
                 .map(PathBuf::from)
                 .map(|home| home.join(".local/share/appa"))
-        })
+        }))
 }
 
 fn appa_filename() -> &'static str {
@@ -689,11 +693,11 @@ fn install_runtime(source: &Path, target: &Path, compensation: &mut Compensation
             source,
         });
     if let Err(error) = permissions {
-        let _ = fs::remove_file(&temporary);
+        discard_file(&temporary);
         return Err(error);
     }
     if let Err(source) = fs::rename(&temporary, target) {
-        let _ = fs::remove_file(&temporary);
+        discard_file(&temporary);
         return Err(InitError::InstallRuntime {
             path: target.to_path_buf(),
             source,
@@ -792,10 +796,19 @@ fn powershell<const N: usize>(command: &str, environment: [(&str, String); N]) -
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-fn create_default_config(path: &Path) -> Result<bool, InitError> {
+/// Remove a file this init wrote and abandons. Nothing it protects is lost
+/// with it, so a failure is noted beside the error being returned.
+fn discard_file(path: &Path) {
+    if let Err(error) = fs::remove_file(path) {
+        tracing::warn!(path = %path.display(), %error, "cannot remove a file init abandoned");
+    }
+}
+
+/// Seed the config from this build's default, or keep the one already there.
+fn create_default_config(path: &Path) -> Result<ConfigOutcome, InitError> {
     let mut file = match OpenOptions::new().write(true).create_new(true).open(path) {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(ConfigOutcome::Kept),
         Err(source) => {
             return Err(InitError::WriteFile {
                 path: path.to_path_buf(),
@@ -805,13 +818,13 @@ fn create_default_config(path: &Path) -> Result<bool, InitError> {
     };
     if let Err(source) = file.write_all(DEFAULT_CONFIG.as_bytes()).and_then(|()| file.sync_all()) {
         drop(file);
-        let _ = fs::remove_file(path);
+        discard_file(path);
         return Err(InitError::WriteFile {
             path: path.to_path_buf(),
             source,
         });
     }
-    Ok(true)
+    Ok(ConfigOutcome::Created)
 }
 
 /// The policy version this build's default config declares.
@@ -862,7 +875,21 @@ fn offer_config_rewrite_with(
         _ => return Ok(ConfigOutcome::Kept),
     }
     let backup = path.with_extension("toml.bak");
-    if !confirm_rewrite(path, &backup, input, output)? {
+    let rewrite = Confirmation {
+        question: format!(
+            "appa: {} was authored against an older policy model than this build writes.\n\
+             Rewrite it from this build's default? Your file, its include lines and every edit\n\
+             in it, is kept only at {}, replacing whatever is there.",
+            friendly_path(path),
+            friendly_path(&backup),
+        ),
+        default: Answer::No,
+    };
+    let prompt = |source| InitError::WriteFile {
+        path: path.to_path_buf(),
+        source,
+    };
+    if rewrite.ask(input, output).map_err(prompt)? == Answer::No {
         return Ok(ConfigOutcome::Kept);
     }
     // The original moves aside whole, so nothing here can leave a half-written
@@ -884,31 +911,40 @@ fn offer_config_rewrite_with(
     }
 }
 
-fn confirm_rewrite(
-    path: &Path,
-    backup: &Path,
-    input: &mut impl BufRead,
-    output: &mut impl Write,
-) -> Result<bool, InitError> {
-    let prompt = |source| InitError::WriteFile {
-        path: path.to_path_buf(),
-        source,
-    };
-    write!(
-        output,
-        "appa: {} was authored against an older policy model than this build writes.\n\
-         Rewrite it from this build's default? Your file, its include lines and every edit\n\
-         in it, is kept only at {}, replacing whatever is there. [y/N] ",
-        friendly_path(path),
-        friendly_path(backup),
-    )
-    .and_then(|()| output.flush())
-    .map_err(prompt)?;
-    let mut answer = String::new();
-    if input.read_line(&mut answer).map_err(prompt)? == 0 {
-        return Ok(false);
+/// What a yes-or-no question resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Answer {
+    Yes,
+    No,
+}
+
+/// A yes-or-no question put to the person running init, with the answer an
+/// empty line means; the prompt capitalizes that choice.
+struct Confirmation {
+    question: String,
+    default: Answer,
+}
+
+impl Confirmation {
+    /// Ask on `output` and read one line from `input`. End of input, where no
+    /// one is there to answer, is a no whatever the default.
+    fn ask(&self, input: &mut impl BufRead, output: &mut impl Write) -> std::io::Result<Answer> {
+        let choices = match self.default {
+            Answer::Yes => "[Y/n]",
+            Answer::No => "[y/N]",
+        };
+        write!(output, "{} {choices} ", self.question)?;
+        output.flush()?;
+        let mut answer = String::new();
+        if input.read_line(&mut answer)? == 0 {
+            return Ok(Answer::No);
+        }
+        Ok(match answer.trim().to_ascii_lowercase().as_str() {
+            "" => self.default,
+            "y" | "yes" => Answer::Yes,
+            _ => Answer::No,
+        })
     }
-    Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
 }
 
 /// The config the runtime will be started against, put through the runtime's
@@ -949,26 +985,20 @@ fn verify_config(path: &Path) -> Result<ComposedPolicy, InitError> {
     )))
 }
 
-fn run_claude<const N: usize>(arguments: [&str; N]) -> Result<Output, InitError> {
-    run_claude_in(arguments, None)
-}
-
-fn run_claude_in<const N: usize>(arguments: [&str; N], directory: Option<&Path>) -> Result<Output, InitError> {
-    run_claude_os_in(arguments.map(OsStr::new), directory)
-}
-
-fn run_claude_os<const N: usize>(arguments: [&OsStr; N]) -> Result<Output, InitError> {
-    run_claude_os_in(arguments, None)
-}
-
-fn run_claude_os_in<const N: usize>(arguments: [&OsStr; N], directory: Option<&Path>) -> Result<Output, InitError> {
+/// Run one `claude` command, from `directory` when a project-scoped plugin
+/// installation names one, and answer with its output only when it succeeded.
+fn run_claude<A: AsRef<OsStr>>(
+    arguments: impl IntoIterator<Item = A>,
+    directory: Option<&Path>,
+) -> Result<Output, InitError> {
+    let arguments: Vec<A> = arguments.into_iter().collect();
     let command = arguments
         .iter()
-        .map(|argument| argument.to_string_lossy())
+        .map(|argument| argument.as_ref().to_string_lossy())
         .collect::<Vec<_>>()
         .join(" ");
     let mut process = Command::new("claude");
-    process.args(arguments);
+    process.args(&arguments);
     if let Some(directory) = directory {
         process.current_dir(directory);
     }
@@ -982,14 +1012,6 @@ fn run_claude_os_in<const N: usize>(arguments: [&OsStr; N], directory: Option<&P
         command,
         message: if stderr.is_empty() { stdout } else { stderr },
     })
-}
-
-fn output_text(output: &Output) -> String {
-    format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    )
 }
 
 fn is_appa_marketplace_line(line: &str) -> bool {
@@ -1086,21 +1108,29 @@ fn replace_plugin(
     installations: &[PluginInstallation],
 ) -> Result<(), InitError> {
     for installation in installations {
-        run_claude_in(
+        run_claude(
             ["plugin", "uninstall", PLUGIN, "--scope", &installation.scope, "--yes"],
             installation.project_path.as_deref(),
         )?;
     }
-    if output_text(marketplaces).lines().any(is_appa_marketplace_line) {
-        run_claude(["plugin", "marketplace", "remove", MARKETPLACE])?;
+    let listed = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&marketplaces.stdout),
+        String::from_utf8_lossy(&marketplaces.stderr)
+    );
+    if listed.lines().any(is_appa_marketplace_line) {
+        run_claude(["plugin", "marketplace", "remove", MARKETPLACE], None)?;
     }
-    run_claude_os([
-        OsStr::new("plugin"),
-        OsStr::new("marketplace"),
-        OsStr::new("add"),
-        deployment.as_os_str(),
-    ])?;
-    run_claude(["plugin", "install", PLUGIN, "--scope", "user"])?;
+    run_claude(
+        [
+            OsStr::new("plugin"),
+            OsStr::new("marketplace"),
+            OsStr::new("add"),
+            deployment.as_os_str(),
+        ],
+        None,
+    )?;
+    run_claude(["plugin", "install", PLUGIN, "--scope", "user"], None)?;
     Ok(())
 }
 
@@ -1129,7 +1159,7 @@ fn prepare_plugin_recovery(
         "plugins": [{ "name": "appa-runtime", "source": "./plugin" }]
     }))
     .expect("the recovery marketplace is valid JSON");
-    let manifest_path = marketplace_manifest(&marketplace);
+    let manifest_path = marketplace.join(".claude-plugin/marketplace.json");
     fs::write(&manifest_path, manifest).map_err(|source| InitError::WriteFile {
         path: manifest_path,
         source,
@@ -1184,29 +1214,40 @@ fn undo_plugin_switch(recovery: Option<&PluginRecovery>, launcher_dir: &Path) ->
     match recovery {
         Some(recovery) => restore_plugin(recovery).and_then(|()| install_clappa(launcher_dir).map(drop)),
         None => {
-            run_claude(["plugin", "uninstall", PLUGIN, "--scope", "user", "--yes"])?;
-            run_claude(["plugin", "marketplace", "remove", MARKETPLACE])?;
+            run_claude(["plugin", "uninstall", PLUGIN, "--scope", "user", "--yes"], None)?;
+            run_claude(["plugin", "marketplace", "remove", MARKETPLACE], None)?;
             Ok(())
         }
     }
 }
 
+/// Put the installation this init replaced back from its rollback source.
+/// Clearing whatever the failed switch left registered is best effort: what
+/// matters is that the add and the installs that follow succeed.
 fn restore_plugin(recovery: &PluginRecovery) -> Result<(), InitError> {
     for installation in &recovery.installations {
-        let _ = run_claude_in(
+        let cleared = run_claude(
             ["plugin", "uninstall", PLUGIN, "--scope", &installation.scope, "--yes"],
             installation.project_path.as_deref(),
         );
+        if let Err(error) = cleared {
+            tracing::warn!(scope = %installation.scope, %error, "cannot clear the plugin before restoring it");
+        }
     }
-    let _ = run_claude(["plugin", "marketplace", "remove", MARKETPLACE]);
-    run_claude_os([
-        OsStr::new("plugin"),
-        OsStr::new("marketplace"),
-        OsStr::new("add"),
-        recovery.marketplace.as_os_str(),
-    ])?;
+    if let Err(error) = run_claude(["plugin", "marketplace", "remove", MARKETPLACE], None) {
+        tracing::warn!(%error, "cannot clear the marketplace before restoring it");
+    }
+    run_claude(
+        [
+            OsStr::new("plugin"),
+            OsStr::new("marketplace"),
+            OsStr::new("add"),
+            recovery.marketplace.as_os_str(),
+        ],
+        None,
+    )?;
     for installation in &recovery.installations {
-        run_claude_in(
+        run_claude(
             ["plugin", "install", PLUGIN, "--scope", &installation.scope],
             installation.project_path.as_deref(),
         )?;
@@ -1217,8 +1258,10 @@ fn restore_plugin(recovery: &PluginRecovery) -> Result<(), InitError> {
 /// Remove this invocation's rollback source. Another init's, live or crashed,
 /// is not this one's to judge.
 fn cleanup_plugin_recovery(recovery: Option<&PluginRecovery>) {
-    if let Some(recovery) = recovery {
-        let _ = fs::remove_dir_all(&recovery.marketplace);
+    if let Some(recovery) = recovery
+        && let Err(error) = fs::remove_dir_all(&recovery.marketplace)
+    {
+        tracing::warn!(path = %recovery.marketplace.display(), %error, "cannot remove the rollback source");
     }
 }
 
@@ -1698,40 +1741,21 @@ fn classify_endpoint_owner(
     }
 }
 
-fn confirm_stop(pid: i32, endpoint: &Endpoint) -> Result<bool, InitError> {
+fn confirm_stop(pid: i32, endpoint: &Endpoint) -> Result<Answer, InitError> {
+    let stop = Confirmation {
+        question: format!(
+            "appa: another appa deployment (pid {pid}) owns {}. Stop it and continue?",
+            endpoint.url()
+        ),
+        default: Answer::Yes,
+    };
     let stdin = std::io::stdin();
     let stderr = std::io::stderr();
-    confirm_stop_with(pid, endpoint, &mut stdin.lock(), &mut stderr.lock())
-}
-
-fn confirm_stop_with(
-    pid: i32,
-    endpoint: &Endpoint,
-    input: &mut impl BufRead,
-    output: &mut impl Write,
-) -> Result<bool, InitError> {
-    write!(
-        output,
-        "appa: another appa deployment (pid {pid}) owns {}. Stop it and continue? [Y/n] ",
-        endpoint.url()
-    )
-    .and_then(|()| output.flush())
-    .map_err(|source| InitError::RuntimeIdentity {
-        endpoint: endpoint.url().to_owned(),
-        message: format!("cannot ask permission to stop pid {pid}: {source}"),
-    })?;
-    let mut answer = String::new();
-    if input
-        .read_line(&mut answer)
+    stop.ask(&mut stdin.lock(), &mut stderr.lock())
         .map_err(|source| InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
-            message: format!("cannot read permission to stop pid {pid}: {source}"),
-        })?
-        == 0
-    {
-        return Ok(false);
-    }
-    Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes"))
+            message: format!("cannot ask permission to stop pid {pid}: {source}"),
+        })
 }
 
 /// Clear a foreign owner while Claude and the launcher are still untouched.
@@ -1752,7 +1776,7 @@ fn clear_confirmed_foreign_with(
     config: &Path,
     endpoint: &Endpoint,
     pid: i32,
-    confirm: impl FnOnce(i32, &Endpoint) -> Result<bool, InitError>,
+    confirm: impl FnOnce(i32, &Endpoint) -> Result<Answer, InitError>,
 ) -> Result<(), InitError> {
     if !is_owned_appa_runtime(pid)? {
         return Err(InitError::RuntimeIdentity {
@@ -1762,7 +1786,7 @@ fn clear_confirmed_foreign_with(
             ),
         });
     }
-    if !confirm(pid, endpoint)? {
+    if confirm(pid, endpoint)? == Answer::No {
         return Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
             message: format!("another appa deployment (pid {pid}) still owns this endpoint; init cancelled"),
@@ -1808,7 +1832,7 @@ fn reconcile_policy(
     let Some(divergence) = policy_divergence(composed, &serving_policy_key(endpoint)?) else {
         return Ok(RuntimeOutcome::Healthy);
     };
-    if !confirm_reload(config, divergence)? {
+    if confirm_reload(config, divergence)? == Answer::No {
         return Ok(RuntimeOutcome::OlderPolicy);
     }
     reload_policy(endpoint, config)?;
@@ -1875,21 +1899,11 @@ fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
 
 /// A terminal is asked; anything else reloads. A script that just wrote a config wants it
 /// serving, and there is no one there to answer.
-fn confirm_reload(config: &Path, divergence: Divergence) -> Result<bool, InitError> {
+fn confirm_reload(config: &Path, divergence: Divergence) -> Result<Answer, InitError> {
     let stdin = std::io::stdin();
     if !stdin.is_terminal() {
-        return Ok(true);
+        return Ok(Answer::Yes);
     }
-    let stderr = std::io::stderr();
-    confirm_reload_with(config, divergence, &mut stdin.lock(), &mut stderr.lock())
-}
-
-fn confirm_reload_with(
-    config: &Path,
-    divergence: Divergence,
-    input: &mut impl BufRead,
-    output: &mut impl Write,
-) -> Result<bool, InitError> {
     let prompt = |source| InitError::WriteFile {
         path: config.to_path_buf(),
         source,
@@ -1897,7 +1911,7 @@ fn confirm_reload_with(
     let config = friendly_path(config);
     // Each case states exactly what init established, and no more: one knows the running
     // runtime serves something else, the other knows only that it cannot tell.
-    let question = match divergence {
+    let established = match divergence {
         Divergence::Serving => {
             format!("appa: the running runtime still serves the policy it started with, not {config}.")
         }
@@ -1906,17 +1920,14 @@ fn confirm_reload_with(
              whether the running runtime already serves it."
         ),
     };
-    write!(
-        output,
-        "{question}\nReload it now? Sessions open right now keep the deployment they started with. [Y/n] ",
-    )
-    .and_then(|()| output.flush())
-    .map_err(prompt)?;
-    let mut answer = String::new();
-    if input.read_line(&mut answer).map_err(prompt)? == 0 {
-        return Ok(false);
-    }
-    Ok(matches!(answer.trim().to_ascii_lowercase().as_str(), "" | "y" | "yes"))
+    let reload = Confirmation {
+        question: format!(
+            "{established}\nReload it now? Sessions open right now keep the deployment they started with."
+        ),
+        default: Answer::Yes,
+    };
+    let stderr = std::io::stderr();
+    reload.ask(&mut stdin.lock(), &mut stderr.lock()).map_err(prompt)
 }
 
 /// The endpoint answers for this deployment: this build, serving this configuration.
@@ -2006,14 +2017,9 @@ mod tests {
         unsafe { libc::kill(pid, 0) == 0 }
     }
 
-    #[cfg(unix)]
-    fn health_answers(answers: Vec<String>) -> Endpoint {
-        recorded_answers(answers).0
-    }
-
-    /// The same loopback fixture, with the request lines it served. A probe's path is part
-    /// of the contract it has with the runtime, so a test that cares which endpoint init
-    /// asks reads them; one that only cares how an answer parses takes `health_answers`.
+    /// A loopback fixture serving `answers` in turn, with the request lines it served. A
+    /// probe's path is part of the contract it has with the runtime, so a test that cares
+    /// which endpoint init asks reads them.
     #[cfg(unix)]
     fn recorded_answers(answers: Vec<String>) -> (Endpoint, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
         use std::io::{Read, Write};
@@ -2115,25 +2121,24 @@ mod tests {
     }
 
     #[test]
-    fn stopping_a_foreign_runtime_requires_a_y_or_default_yes_answer() {
-        let endpoint = Endpoint::parse("http://127.0.0.1:8787").expect("the endpoint parses");
-        for answer in ["y\n", "YES\n", "\n"] {
-            let mut output = Vec::new();
-            assert!(
-                confirm_stop_with(42, &endpoint, &mut answer.as_bytes(), &mut output).expect("the answer reads"),
-                "{answer:?} approves"
-            );
-            assert!(
-                String::from_utf8(output)
-                    .unwrap()
-                    .contains("Stop it and continue? [Y/n]")
-            );
-        }
-        for answer in ["n\n", "no\n", "anything else\n", ""] {
-            assert!(
-                !confirm_stop_with(42, &endpoint, &mut answer.as_bytes(), &mut Vec::new()).expect("the answer reads"),
-                "{answer:?} refuses"
-            );
+    fn an_empty_answer_takes_the_default_and_end_of_input_refuses() {
+        let ask = |default: Answer, answer: &str| {
+            let confirmation = Confirmation {
+                question: "continue?".to_owned(),
+                default,
+            };
+            confirmation
+                .ask(&mut answer.as_bytes(), &mut Vec::new())
+                .expect("the answer reads")
+        };
+        for default in [Answer::Yes, Answer::No] {
+            for answer in ["y\n", "YES\n", " yes \n"] {
+                assert_eq!(ask(default, answer), Answer::Yes, "{answer:?} under {default:?}");
+            }
+            for answer in ["n\n", "no\n", "anything else\n", ""] {
+                assert_eq!(ask(default, answer), Answer::No, "{answer:?} under {default:?}");
+            }
+            assert_eq!(ask(default, "\n"), default);
         }
     }
 
@@ -2155,27 +2160,6 @@ mod tests {
     }
 
     #[test]
-    fn reloading_a_lagging_runtime_requires_a_y_or_default_yes_answer() {
-        let config = PathBuf::from("/home/user/config/appa.toml");
-        for divergence in [Divergence::Serving, Divergence::Unestablished] {
-            for answer in ["y\n", "YES\n", "\n"] {
-                assert!(
-                    confirm_reload_with(&config, divergence, &mut answer.as_bytes(), &mut Vec::new())
-                        .expect("the answer reads"),
-                    "{answer:?} approves under {divergence:?}"
-                );
-            }
-            for answer in ["n\n", "no\n", "anything else\n", ""] {
-                assert!(
-                    !confirm_reload_with(&config, divergence, &mut answer.as_bytes(), &mut Vec::new())
-                        .expect("the answer reads"),
-                    "{answer:?} refuses under {divergence:?}"
-                );
-            }
-        }
-    }
-
-    #[test]
     fn a_serving_policy_key_is_read_from_the_policy_route() {
         let (endpoint, asked) = recorded_answers(vec!["c54f1509".to_string()]);
         assert_eq!(serving_policy_key(&endpoint).expect("the key reads"), "c54f1509");
@@ -2191,7 +2175,7 @@ mod tests {
     /// the skew init exists to prevent.
     #[test]
     fn a_runtime_that_does_not_answer_for_its_policy_refuses_init() {
-        let blank = health_answers(vec![String::new()]);
+        let blank = recorded_answers(vec![String::new()]).0;
         assert!(matches!(serving_policy_key(&blank), Err(InitError::PolicyKey { .. })));
         let unbound = Endpoint::parse("http://127.0.0.1:1").expect("the endpoint parses");
         assert!(matches!(serving_policy_key(&unbound), Err(InitError::PolicyKey { .. })));
@@ -2201,7 +2185,7 @@ mod tests {
     fn a_matching_policy_key_reconciles_without_asking_or_reloading() {
         // One answer is served: the key probe. A reload would need a second connection,
         // so reaching one at all would hang rather than pass.
-        let endpoint = health_answers(vec!["agreed".to_string()]);
+        let endpoint = recorded_answers(vec!["agreed".to_string()]).0;
         let config = PathBuf::from("/home/user/config/appa.toml");
         assert_eq!(
             reconcile_policy(&endpoint, &config, &ComposedPolicy::Key("agreed".to_string()))
@@ -2234,12 +2218,12 @@ mod tests {
         };
         let candidate = directory.path().join("candidate-appa");
         fs::write(&candidate, "a different candidate build").expect("the candidate binary exists");
-        let endpoint = health_answers(vec![format!("different-fingerprint {pid}")]);
+        let endpoint = recorded_answers(vec![format!("different-fingerprint {pid}")]).0;
 
         let config = directory.path().join("appa.toml");
         clear_confirmed_foreign_with(&candidate, &config, &endpoint, pid, |approved_pid, _| {
             assert_eq!(approved_pid, pid);
-            Ok(true)
+            Ok(Answer::Yes)
         })
         .expect("the approved foreign runtime stops");
 
@@ -2255,7 +2239,7 @@ mod tests {
             return;
         };
         fs::remove_file(&replaced).expect("the installed binary is unlinked while its runtime remains");
-        let endpoint = health_answers(vec![format!("stale {pid}"), format!("stale {pid}")]);
+        let endpoint = recorded_answers(vec![format!("stale {pid}"), format!("stale {pid}")]).0;
 
         clear_stale_endpoint(&endpoint).expect("init stops its stale unlinked runtime");
 
@@ -2270,7 +2254,7 @@ mod tests {
         let Some(pid) = process_executing(&other, RUNTIME_ARGUMENTS) else {
             return;
         };
-        let endpoint = health_answers(vec![format!("stale {pid}")]);
+        let endpoint = recorded_answers(vec![format!("stale {pid}")]).0;
 
         let refused = clear_stale_endpoint(&endpoint);
 
@@ -2291,7 +2275,10 @@ mod tests {
         let directory = tempfile::tempdir().expect("temporary directory");
         let config = directory.path().join("appa.toml");
 
-        assert!(create_default_config(&config).expect("the default config is written"));
+        assert_eq!(
+            create_default_config(&config).expect("the default config is written"),
+            ConfigOutcome::Created
+        );
         verify_config(&config).expect("the config init writes composes");
 
         let ahead = template_policy_version() + 1;
@@ -2389,7 +2376,10 @@ mod tests {
     fn a_current_config_is_never_offered_for_rewrite() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let config = directory.path().join("appa.toml");
-        assert!(create_default_config(&config).expect("the default config is written"));
+        assert_eq!(
+            create_default_config(&config).expect("the default config is written"),
+            ConfigOutcome::Created
+        );
 
         let (outcome, prompt) = answer_rewrite(&config, "y\n");
         assert!(prompt.is_empty(), "no offer is made");

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -1483,7 +1483,7 @@ fn clear_stale_endpoint(endpoint: &Endpoint) -> Result<(), InitError> {
             });
         }
     }
-    terminate_appa_pid(pid)?;
+    terminate_owned_appa_runtime(pid, endpoint)?;
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while std::time::Instant::now() < deadline {
@@ -1779,13 +1779,7 @@ fn clear_confirmed_foreign_with(
             });
         }
     }
-    if !is_owned_appa_runtime(pid)? {
-        return Err(InitError::RuntimeIdentity {
-            endpoint: endpoint.url().to_owned(),
-            message: format!("pid {pid} changed identity after approval; not stopping it"),
-        });
-    }
-    terminate_appa_pid(pid)?;
+    terminate_owned_appa_runtime(pid, endpoint)?;
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     while std::time::Instant::now() < deadline {

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -303,7 +303,7 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     //    absent on a first install and disabled on an upgrade, so a session
     //    started against a half-installed bundle cannot be a protected one.
     install_clappa(launcher_dir)?;
-    cleanup_plugin_recoveries(&paths.data_dir);
+    cleanup_plugin_recovery(recovery.as_ref());
 
     Ok(render_receipt(
         &source_label(&source, &deployment),
@@ -1214,14 +1214,11 @@ fn restore_plugin(recovery: &PluginRecovery) -> Result<(), InitError> {
     Ok(())
 }
 
-fn cleanup_plugin_recoveries(data_dir: &Path) {
-    let Ok(entries) = fs::read_dir(data_dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        if entry.file_name().to_string_lossy().starts_with(RECOVERY_PREFIX) {
-            let _ = fs::remove_dir_all(entry.path());
-        }
+/// Remove this invocation's rollback source. Another init's, live or crashed,
+/// is not this one's to judge.
+fn cleanup_plugin_recovery(recovery: Option<&PluginRecovery>) {
+    if let Some(recovery) = recovery {
+        let _ = fs::remove_dir_all(&recovery.marketplace);
     }
 }
 

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -54,8 +54,10 @@ pub enum InitError {
     Starter(String),
     #[error("the runtime at {endpoint} is not this installed build: {message}")]
     RuntimeIdentity { endpoint: String, message: String },
-    #[error("a previous appa runtime (pid {pid}) is still executing {path}; stop it and rerun init")]
-    RuntimeSurvived { pid: i32, path: PathBuf },
+    #[error("the appa runtime (pid {pid}) still answers {endpoint} after being stopped; stop it and rerun init")]
+    RuntimeSurvived { pid: i32, endpoint: String },
+    #[error("the runtime at {endpoint} does not answer for its policy: {message}")]
+    PolicyKey { endpoint: String, message: String },
     #[error("the runtime at {endpoint} refused to serve {path}: {message}")]
     ReloadRefused {
         endpoint: String,
@@ -241,15 +243,12 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         })?,
     };
 
-    // 4. Clear the endpoint before anything is mutated. A verified runtime at a
-    //    retired install path that will not stop aborts init here, rather than
-    //    leaving a new plugin registered against an old runtime that a rerun
-    //    cannot dislodge.
+    // 4. Clear the endpoint before anything is mutated. A runtime that will not
+    //    stop aborts init here, rather than leaving a new plugin registered
+    //    against an old runtime that a rerun cannot dislodge.
     progress("checking the runtime endpoint");
-    clear_retired_runtime(&paths)?;
-    //    A previous install may have been unlinked before init ran. Its process
-    //    still owns the endpoint, and its authenticated health answer names the
-    //    stale pid even though no pathname remains for the retired-path scan.
+    //    A runtime whose binary an install replaced on disk still owns the
+    //    endpoint, and its health answer names the stale pid.
     clear_stale_endpoint(&endpoint)?;
     //    A healthy runtime from another build is stopped only after an explicit
     //    confirmation and only when it identifies a same-user appa pid.
@@ -269,7 +268,6 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     progress("updating the Claude Code plugin");
     let switch = replace_plugin(&deployment.root, &marketplaces, &installations)
         .and_then(|()| install_runtime(&appa, &deployed_appa))
-        .and_then(|()| remove_legacy_runtime(&appa, &paths))
         .and_then(|()| installed_plugin_root(&paths.claude_dir))
         .and_then(|plugin_root| {
             install_statusline(&plugin_root, &paths)?;
@@ -302,16 +300,11 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     install_clappa(launcher_dir)?;
     cleanup_plugin_recoveries(&paths.data_dir);
 
-    // 8. Anything left on PATH that this init did not deploy is named, never
-    //    removed: it is the user's file to keep or drop.
-    let stale_path_copy = stale_path_copy(&paths, &deployed_appa);
-
     Ok(render_receipt(
         &source_label(&source, &deployment),
         &config,
         config_outcome,
         runtime_outcome,
-        stale_path_copy.as_deref(),
         std::io::stdout().is_terminal() && env::var_os("NO_COLOR").is_none(),
     ))
 }
@@ -330,19 +323,11 @@ fn source_label(source: &PluginSource, deployment: &Deployment) -> String {
     format!("{origin} -> {}", friendly_path(&deployment.root))
 }
 
-/// A copy of `appa` at the retired install path, which earlier versions
-/// deployed to and which may still shadow this build on PATH.
-fn stale_path_copy(paths: &DeploymentPaths, deployed: &Path) -> Option<PathBuf> {
-    let retired = paths.install_dir.join(appa_filename());
-    (retired.is_file() && !same_file(&retired, deployed)).then_some(retired)
-}
-
 fn render_receipt(
     adapter: &str,
     config: &Path,
     config_outcome: ConfigOutcome,
     runtime_outcome: RuntimeOutcome,
-    stale_path_copy: Option<&Path>,
     color: bool,
 ) -> String {
     let title = if color {
@@ -372,12 +357,6 @@ fn render_receipt(
     // version, so a session running across an upgrade keeps talking to the
     // runtime it started with.
     receipt.push_str("\nRestart any running `clappa` session to pick this up.\n");
-    if let Some(stale) = stale_path_copy {
-        receipt.push_str(&format!(
-            "\nA previous appa remains at {}. It is not used any more and may shadow\nthis build on PATH; remove it when you are ready.\n",
-            friendly_path(stale),
-        ));
-    }
     receipt.push_str("\nNext: run `clappa`, then `/appa-guide init`.\n");
     receipt
 }
@@ -484,254 +463,6 @@ fn appa_filename() -> &'static str {
     if cfg!(windows) { "appa.exe" } else { "appa" }
 }
 
-fn legacy_runtime_filename() -> &'static str {
-    if cfg!(windows) {
-        "appa-runtime.exe"
-    } else {
-        "appa-runtime"
-    }
-}
-
-fn remove_legacy_runtime(appa: &Path, paths: &DeploymentPaths) -> Result<(), InitError> {
-    let mut targets = vec![paths.install_dir.join(legacy_runtime_filename())];
-    if let Some(parent) = appa.parent() {
-        let sibling = parent.join(legacy_runtime_filename());
-        if sibling != targets[0] {
-            targets.push(sibling);
-        }
-    }
-    for target in targets {
-        // A Unix process can keep running after Cargo has unlinked its executable. Scan the
-        // two exact retired install paths even when no directory entry remains, then remove any
-        // file that is left. Windows keeps the file present while the process is running, so a
-        // missing path cannot be a live legacy runtime.
-        if cfg!(windows) && !target.exists() {
-            continue;
-        }
-        stop_legacy_runtime_at(&target)?;
-        if !target.exists() {
-            continue;
-        }
-        #[cfg(unix)]
-        fs::remove_file(&target).map_err(|source| InitError::InstallRuntime {
-            path: target.clone(),
-            source,
-        })?;
-        #[cfg(windows)]
-        fs::remove_file(&target).map_err(|source| InitError::InstallRuntime { path: target, source })?;
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
-    let Ok(output) = Command::new("ps").args(["-axo", "pid=,command="]).output() else {
-        return Ok(());
-    };
-    if !output.status.success() {
-        // Process discovery is a migration convenience. Restricted environments may deny ps;
-        // continue the install and let runtime identity verification reject a surviving daemon.
-        return Ok(());
-    }
-    let written = target.to_string_lossy();
-    let mut stopped = Vec::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let line = line.trim_start();
-        let Some((pid, command)) = line.split_once(char::is_whitespace) else {
-            continue;
-        };
-        let command = command.trim_start();
-        let is_target =
-            |path: &str| command == path || command.strip_prefix(path).is_some_and(|rest| rest.starts_with(' '));
-        if !is_target(&written) {
-            continue;
-        }
-        let Ok(pid) = pid.parse::<i32>() else {
-            continue;
-        };
-        // The exact executable path is one of APPA's two retired install locations.
-        // A process owned by another user cannot be signalled by this process.
-        if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
-            let error = std::io::Error::last_os_error();
-            if error.kind() != std::io::ErrorKind::NotFound {
-                return Err(InitError::InstallRuntime {
-                    path: target.to_path_buf(),
-                    source: error,
-                });
-            }
-        }
-        stopped.push(pid);
-    }
-    if !stopped.is_empty() {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        while std::time::Instant::now() < deadline && stopped.iter().any(|pid| unsafe { libc::kill(*pid, 0) == 0 }) {
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-    }
-    Ok(())
-}
-
-#[cfg(windows)]
-fn stop_legacy_runtime_at(target: &Path) -> Result<(), InitError> {
-    // Legacy cleanup removes the file next, and a surviving process surfaces
-    // there as a failed removal.
-    stop_windows_processes_at(target, "appa-runtime").map(drop)
-}
-
-/// Stop any runtime executing the retired install path before anything is
-/// mutated.
-///
-/// The pathname stop set is exact: `<install_dir>/appa`, the path an init with
-/// the environment resolving as it does now would have deployed to. A runtime
-/// whose executable was already unlinked cannot match that path; the subsequent
-/// endpoint check reclaims it only when `/health` explicitly answers
-/// `stale <pid>` and the pid passes the starter's ownership/name check. A
-/// healthy runtime from another install remains foreign and is never stopped.
-///
-/// A verified target that survives termination aborts init, because the
-/// fingerprint backstop runs after the Claude switch: proceeding would register
-/// the new plugin against an old runtime, and a rerun would find the same
-/// surviving process and do the same thing again.
-fn clear_retired_runtime(paths: &DeploymentPaths) -> Result<(), InitError> {
-    let retired = paths.install_dir.join(appa_filename());
-    match stop_processes_executing(&retired)?.first() {
-        Some(&pid) => Err(InitError::RuntimeSurvived { pid, path: retired }),
-        None => Ok(()),
-    }
-}
-
-/// The subcommand a managed runtime is started with, by every starter and by
-/// init itself. It is what distinguishes a runtime from any other invocation of
-/// the same binary.
-#[cfg(unix)]
-const RUNTIME_SUBCOMMAND: &str = "runtime";
-
-/// Terminate every managed runtime whose executable *is* `target`, and return
-/// those still alive afterwards.
-///
-/// Two conditions, and a candidate needs both. The executable must be the
-/// retired path, verified against the operating system's own answer for that
-/// pid, because `ps` reports argv and argv is spoofable. And argv must name the
-/// `runtime` subcommand, because the retired binary is also what a concurrent
-/// `appa init` or an in-flight `appa hook` is executing, and terminating those
-/// would interrupt work that has nothing to do with the runtime being replaced.
-/// Argv is only ever narrowing here: it can excuse a process from the stop set,
-/// never admit one the executable check rejected.
-///
-/// Windows applies the executable condition alone. Reading another process's
-/// command line there needs a CIM query rather than `Get-Process`, and the same
-/// helper serves legacy cleanup, whose binary had no subcommand at all.
-#[cfg(unix)]
-fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
-    let Ok(output) = Command::new("ps").args(["-axo", "pid=,command="]).output() else {
-        return Ok(Vec::new());
-    };
-    if !output.status.success() {
-        // Restricted environments may deny ps. Continue, and let the fingerprint
-        // check report whatever is answering.
-        return Ok(Vec::new());
-    }
-    let Some(identity) = file_identity(target) else {
-        return Ok(Vec::new());
-    };
-
-    // init itself commonly runs from the retired path -- that is what a user
-    // typing `~/.local/bin/appa init claude-code` does -- and it is in the stop
-    // set by every other measure, so it is excluded by pid.
-    let own = std::process::id() as i32;
-    let mut signalled = Vec::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        let Some((pid, arguments)) = line.trim_start().split_once(char::is_whitespace) else {
-            continue;
-        };
-        let Ok(pid) = pid.parse::<i32>() else {
-            continue;
-        };
-        if pid == own {
-            continue;
-        }
-        // A whole token, so a path that merely contains the word does not match.
-        // The starter runs `<binary> runtime --listen <addr>`, and a binary path
-        // carrying spaces splits into tokens that are all still not `runtime`.
-        if !arguments.split_whitespace().any(|token| token == RUNTIME_SUBCOMMAND) {
-            continue;
-        }
-        match executable_of(pid) {
-            Some(executable) if file_identity(&executable) == Some(identity) => {}
-            // Not this executable, or unreadable: report and skip.
-            _ => continue,
-        }
-        if unsafe { libc::kill(pid, libc::SIGTERM) } != 0 {
-            let error = std::io::Error::last_os_error();
-            if error.kind() != std::io::ErrorKind::NotFound {
-                return Err(InitError::InstallRuntime {
-                    path: target.to_path_buf(),
-                    source: error,
-                });
-            }
-            continue;
-        }
-        signalled.push(pid);
-    }
-
-    if signalled.is_empty() {
-        return Ok(Vec::new());
-    }
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    while std::time::Instant::now() < deadline {
-        signalled.retain(|pid| unsafe { libc::kill(*pid, 0) == 0 });
-        if signalled.is_empty() {
-            return Ok(Vec::new());
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-    signalled.retain(|pid| unsafe { libc::kill(*pid, 0) == 0 });
-    Ok(signalled)
-}
-
-/// OS file identity, so a runtime launched through a symlinked install path is
-/// not wrongly excluded. On Unix `(dev, ino)` is exact, and it identifies hard
-/// links to one file as that file.
-#[cfg(unix)]
-fn file_identity(path: &Path) -> Option<(u64, u64)> {
-    use std::os::unix::fs::MetadataExt;
-
-    let metadata = fs::metadata(path).ok()?;
-    Some((metadata.dev(), metadata.ino()))
-}
-
-/// The executable a pid is actually running, from the operating system rather
-/// than from its own argv.
-#[cfg(target_os = "linux")]
-fn executable_of(pid: i32) -> Option<PathBuf> {
-    fs::read_link(format!("/proc/{pid}/exe")).ok()
-}
-
-#[cfg(target_os = "macos")]
-fn executable_of(pid: i32) -> Option<PathBuf> {
-    // PROC_PIDPATHINFO_MAXSIZE
-    const MAX: usize = 4 * libc::PATH_MAX as usize;
-
-    let mut buffer = vec![0u8; MAX];
-    let written = unsafe { libc::proc_pidpath(pid, buffer.as_mut_ptr().cast(), buffer.len() as u32) };
-    if written <= 0 {
-        return None;
-    }
-    buffer.truncate(written as usize);
-    Some(PathBuf::from(String::from_utf8(buffer).ok()?))
-}
-
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn executable_of(_pid: i32) -> Option<PathBuf> {
-    // No portable primitive here: report and skip rather than kill on argv.
-    None
-}
-
-#[cfg(windows)]
-fn stop_processes_executing(target: &Path) -> Result<Vec<i32>, InitError> {
-    stop_windows_processes_at(target, "appa")
-}
-
 /// The comparison operand on Windows: the fully resolved path, folded for the
 /// case-insensitive filesystem.
 ///
@@ -748,12 +479,14 @@ fn windows_identity(path: &Path) -> Option<String> {
     Some(text.strip_prefix(r"\\?\").unwrap_or(text).to_lowercase())
 }
 
-/// Whether two paths name the same file, resolving symlinks.
+/// Whether two paths name the same existing file, resolving symlinks. On Unix
+/// `(dev, ino)` identity also names hard links to one file as that file.
 fn same_file(left: &Path, right: &Path) -> bool {
     #[cfg(unix)]
     {
-        match (file_identity(left), file_identity(right)) {
-            (Some(left), Some(right)) => left == right,
+        use std::os::unix::fs::MetadataExt;
+        match (fs::metadata(left), fs::metadata(right)) {
+            (Ok(left), Ok(right)) => left.dev() == right.dev() && left.ino() == right.ino(),
             _ => false,
         }
     }
@@ -767,12 +500,12 @@ fn same_file(left: &Path, right: &Path) -> bool {
 }
 
 fn install_runtime(source: &Path, target: &Path) -> Result<(), InitError> {
-    if source.canonicalize().ok() == target.canonicalize().ok() && target.exists() {
+    if same_file(source, target) {
         return Ok(());
     }
     #[cfg(windows)]
     if target.exists() {
-        stop_windows_processes_at(target, "appa")?;
+        stop_windows_processes_at(target)?;
         fs::remove_file(target).map_err(|source| InitError::InstallRuntime {
             path: target.to_path_buf(),
             source,
@@ -806,23 +539,22 @@ fn install_runtime(source: &Path, target: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
-/// Terminate every `process_name` process whose resolved executable is
-/// `target`, and answer with those still alive afterwards.
+/// Terminate every `appa` process whose resolved executable is `target`, and
+/// answer with those still alive afterwards.
 ///
-/// PowerShell only enumerates and stops. The comparison happens here, so
-/// Windows and Unix apply the same rule and neither swallows a discovery or
-/// termination failure the way `-ErrorAction SilentlyContinue` did.
+/// PowerShell only enumerates and stops. The comparison happens here, so a
+/// discovery or termination failure surfaces instead of being swallowed.
 #[cfg(windows)]
-fn stop_windows_processes_at(target: &Path, process_name: &str) -> Result<Vec<i32>, InitError> {
+fn stop_windows_processes_at(target: &Path) -> Result<Vec<i32>, InitError> {
     let Some(identity) = windows_identity(target) else {
         // A path that will not resolve is reported and skipped, never killed.
         return Ok(Vec::new());
     };
 
     let listed = powershell(
-        "Get-Process -Name $env:APPA_STOP_NAME -ErrorAction SilentlyContinue | \
+        "Get-Process -Name appa -ErrorAction SilentlyContinue | \
          ForEach-Object { \"$($_.Id)`t$($_.Path)\" }",
-        [("APPA_STOP_NAME", process_name.to_owned())],
+        [],
     )?;
 
     let own = std::process::id() as i32;
@@ -834,7 +566,7 @@ fn stop_windows_processes_at(target: &Path, process_name: &str) -> Result<Vec<i3
         let Ok(pid) = pid.trim().parse::<i32>() else {
             continue;
         };
-        // init commonly runs from the retired path itself.
+        // init may itself be running from the target path.
         if pid == own {
             continue;
         }
@@ -937,7 +669,7 @@ fn policy_version(text: &str) -> Option<i64> {
 ///
 /// The config is the user's, and init keeps it across every upgrade. A policy
 /// version below this build's is the one mechanical signal that it was authored
-/// against a model this build no longer writes, so it is also the only drift
+/// against an older model than this build writes, so it is also the only drift
 /// init asks about. Only a terminal is asked, and the answer defaults to no: a
 /// rewrite discards every edit the file carries, the include lines that bind
 /// batteries included, and keeps them only in the backup.
@@ -1510,9 +1242,9 @@ enum EndpointOwner {
     Unidentified,
     /// The binary whose bytes were offered for comparison.
     Deployment,
-    /// A different build. New runtimes name their pid; an older runtime may
-    /// return only its digest and remains ineligible for automatic stopping.
-    Foreign { pid: Option<i32> },
+    /// A different build or a different configuration, naming the pid that
+    /// serves it.
+    Foreign { pid: i32 },
 }
 
 fn endpoint_health(endpoint: &Endpoint) -> Result<Option<String>, InitError> {
@@ -1544,11 +1276,10 @@ fn stale_pid(answer: &str) -> Option<i32> {
 /// Stop the exact stale APPA runtime named by the endpoint before classifying
 /// any remaining responder as foreign.
 ///
-/// This covers an unlinked Unix executable: pathname identity is unavailable,
-/// but the runtime's own health protocol still names its pid. The pid is not
-/// trusted by itself; init applies the same same-user/process-name check as the
-/// shipped starter before sending a signal. An `ok`, malformed, or absent
-/// health answer never grants shutdown authority.
+/// The runtime's own health protocol names its pid. The pid is not trusted by
+/// itself; init applies the same same-user/process-name check as the shipped
+/// starter before sending a signal. An `ok`, malformed, or absent health answer
+/// never grants shutdown authority.
 fn clear_stale_endpoint(endpoint: &Endpoint) -> Result<(), InitError> {
     let Some(answer) = endpoint_health(endpoint)? else {
         return Ok(());
@@ -1595,11 +1326,10 @@ fn clear_stale_endpoint(endpoint: &Endpoint) -> Result<(), InitError> {
             }
         }
     }
-    #[cfg(unix)]
-    let path = executable_of(pid).unwrap_or_else(|| PathBuf::from(format!("pid {pid} at {}", endpoint.url())));
-    #[cfg(windows)]
-    let path = PathBuf::from(format!("pid {pid} at {}", endpoint.url()));
-    Err(InitError::RuntimeSurvived { pid, path })
+    Err(InitError::RuntimeSurvived {
+        pid,
+        endpoint: endpoint.url().to_owned(),
+    })
 }
 
 #[cfg(unix)]
@@ -1642,7 +1372,7 @@ fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
         return Ok(());
     }
     Err(InitError::InstallRuntime {
-        path: executable_of(pid).unwrap_or_else(|| PathBuf::from(format!("pid {pid}"))),
+        path: PathBuf::from(format!("pid {pid}")),
         source,
     })
 }
@@ -1717,25 +1447,37 @@ fn endpoint_owner(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<E
         return Ok(EndpointOwner::Unidentified);
     }
     let answer = String::from_utf8_lossy(&output.stdout);
-    Ok(classify_endpoint_owner(&expected, config, &answer))
+    classify_endpoint_owner(&expected, config, endpoint, &answer)
 }
 
 /// A process is this deployment only when it names both this build and this configuration.
 /// Anything else — a different build, a different config, or an answer that names no
-/// config at all — is another deployment, to be stopped before this install proceeds.
-fn classify_endpoint_owner(expected: &str, config: &Path, answer: &str) -> EndpointOwner {
+/// config at all — is another deployment, to be stopped before this install proceeds,
+/// and one that names no pid cannot be stopped at all.
+fn classify_endpoint_owner(
+    expected: &str,
+    config: &Path,
+    endpoint: &Endpoint,
+    answer: &str,
+) -> Result<EndpointOwner, InitError> {
     let (identity, rest) = answer.split_once('\n').unwrap_or((answer, ""));
     let mut fields = identity.split_whitespace();
     let actual = fields.next().unwrap_or_default();
-    let pid = fields.next().and_then(positive_pid);
     // Everything after the first newline is the path, less the one the transport appends:
     // a config path may itself hold a newline, and splitting again would truncate it.
     let serves = rest.strip_suffix('\n').unwrap_or(rest);
     if actual == expected && !serves.is_empty() && Path::new(serves) == config {
-        EndpointOwner::Deployment
-    } else {
-        EndpointOwner::Foreign { pid }
+        return Ok(EndpointOwner::Deployment);
     }
+    let pid = fields
+        .next()
+        .and_then(positive_pid)
+        .ok_or_else(|| InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: "another appa deployment owns this endpoint, but its runtime does not identify its pid; stop it and rerun init"
+                .to_owned(),
+        })?;
+    Ok(EndpointOwner::Foreign { pid })
 }
 
 fn confirm_stop(pid: i32, endpoint: &Endpoint) -> Result<bool, InitError> {
@@ -1783,14 +1525,7 @@ fn confirm_stop_with(
 fn clear_foreign_endpoint(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     match endpoint_owner(binary, config, endpoint)? {
         EndpointOwner::Deployment | EndpointOwner::Unidentified => Ok(()),
-        EndpointOwner::Foreign { pid: None } => Err(InitError::RuntimeIdentity {
-            endpoint: endpoint.url().to_owned(),
-            message: "another appa deployment owns this endpoint, but that runtime does not identify its pid; stop it and rerun init"
-                .to_owned(),
-        }),
-        EndpointOwner::Foreign { pid: Some(pid) } => {
-            clear_confirmed_foreign_with(binary, config, endpoint, pid, confirm_stop)
-        }
+        EndpointOwner::Foreign { pid } => clear_confirmed_foreign_with(binary, config, endpoint, pid, confirm_stop),
     }
 }
 
@@ -1818,7 +1553,7 @@ fn clear_confirmed_foreign_with(
     match endpoint_owner(binary, config, endpoint)? {
         EndpointOwner::Unidentified => return Ok(()),
         EndpointOwner::Deployment => return Ok(()),
-        EndpointOwner::Foreign { pid: Some(current) } if current == pid => {}
+        EndpointOwner::Foreign { pid: current } if current == pid => {}
         EndpointOwner::Foreign { .. } => {
             return Err(InitError::RuntimeIdentity {
                 endpoint: endpoint.url().to_owned(),
@@ -1841,11 +1576,10 @@ fn clear_confirmed_foreign_with(
             Some(_) => std::thread::sleep(std::time::Duration::from_millis(50)),
         }
     }
-    #[cfg(unix)]
-    let path = executable_of(pid).unwrap_or_else(|| PathBuf::from(format!("pid {pid} at {}", endpoint.url())));
-    #[cfg(windows)]
-    let path = PathBuf::from(format!("pid {pid} at {}", endpoint.url()));
-    Err(InitError::RuntimeSurvived { pid, path })
+    Err(InitError::RuntimeSurvived {
+        pid,
+        endpoint: endpoint.url().to_owned(),
+    })
 }
 
 /// Reconcile the policy a surviving runtime serves with the file this init validated.
@@ -1859,7 +1593,7 @@ fn reconcile_policy(
     config: &Path,
     composed: &ComposedPolicy,
 ) -> Result<RuntimeOutcome, InitError> {
-    let Some(divergence) = policy_divergence(composed, serving_policy_key(endpoint).as_deref()) else {
+    let Some(divergence) = policy_divergence(composed, &serving_policy_key(endpoint)?) else {
         return Ok(RuntimeOutcome::Healthy);
     };
     if !confirm_reload(config, divergence)? {
@@ -1872,13 +1606,10 @@ fn reconcile_policy(
 /// Why a serving runtime may not be answering under the file this init validated, or
 /// `None` when it demonstrably is.
 ///
-/// A runtime that does not answer for its policy leaves nothing to reconcile at all: init
-/// cannot reach it to compare or to reload, so it stays quiet. A config init cannot compose
-/// is the opposite case — the runtime can be asked, and only a person can decide, so the
-/// question is put rather than answered by assumption. The reload itself resolves the
+/// A config init cannot compose is not settled by assumption: the runtime can be asked,
+/// and only a person can decide, so the question is put. The reload itself resolves the
 /// secret where the runtime runs, which is the environment that has it.
-fn policy_divergence(composed: &ComposedPolicy, serving: Option<&str>) -> Option<Divergence> {
-    let serving = serving?;
+fn policy_divergence(composed: &ComposedPolicy, serving: &str) -> Option<Divergence> {
     match composed {
         ComposedPolicy::Key(key) if key == serving => None,
         ComposedPolicy::Key(_) => Some(Divergence::Serving),
@@ -1886,18 +1617,26 @@ fn policy_divergence(composed: &ComposedPolicy, serving: Option<&str>) -> Option
     }
 }
 
-/// The policy key the endpoint answers under, or `None` when it does not answer for one.
-fn serving_policy_key(endpoint: &Endpoint) -> Option<String> {
+/// The policy key the endpoint answers under. A runtime that does not answer for one
+/// cannot be reconciled, and a plugin bound to it is the skew init exists to prevent.
+fn serving_policy_key(endpoint: &Endpoint) -> Result<String, InitError> {
+    let refused = |message: String| InitError::PolicyKey {
+        endpoint: endpoint.url().to_owned(),
+        message,
+    };
     let output = Command::new("curl")
-        .args(["--fail", "--silent", "--max-time", "2"])
+        .args(["--fail", "--silent", "--show-error", "--max-time", "2"])
         .arg(endpoint.join("/policy-key"))
         .output()
-        .ok()?;
+        .map_err(|error| refused(error.to_string()))?;
     if !output.status.success() {
-        return None;
+        return Err(refused(String::from_utf8_lossy(&output.stderr).trim().to_owned()));
     }
     let key = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    (!key.is_empty()).then_some(key)
+    if key.is_empty() {
+        return Err(refused("the answer names no policy key".to_owned()));
+    }
+    Ok(key)
 }
 
 /// Ask the running runtime to serve the configuration on disk.
@@ -1987,14 +1726,12 @@ fn verify_runtime_deployment(runtime: &Path, config: &Path, endpoint: &Endpoint)
 mod tests {
     use super::*;
 
-    /// A stand-in the stop set can actually find and signal.
+    /// A stand-in the ownership check can find and the signal can reach.
     ///
     /// macOS kills a copied platform binary outright -- a copy of `/bin/sh` or
     /// `/bin/sleep` dies with SIGKILL before it runs a single instruction -- so
-    /// a test built on one would pass without ever exercising the stop set,
-    /// because a killed process is also a stopped one. `perl` copies and runs,
-    /// and can be told to ignore SIGTERM, which is the case that must abort
-    /// init rather than be assumed gone.
+    /// a test built on one would pass without ever exercising the stop,
+    /// because a killed process is also a stopped one. `perl` copies and runs.
     #[cfg(unix)]
     const STAND_IN: &str = "/usr/bin/perl";
 
@@ -2003,15 +1740,14 @@ mod tests {
     const RUNTIME_ARGUMENTS: &[&str] = &["runtime", "--listen", "127.0.0.1:8787"];
 
     /// A process whose executable really *is* `at`, started with `arguments`, so
-    /// verification finds it there rather than taking a spoofable argv on trust
-    /// and the stop set sees the argv it decides on.
+    /// the ownership check sees the process name it decides on.
     ///
     /// The stand-in is reaped on its own thread. A dead child that nobody has
     /// waited for is a zombie, and `kill(pid, 0)` still succeeds on one, so
     /// without the reaper these tests could not tell a stopped process from a
-    /// running one. In production the retired runtime is never init's child.
+    /// running one. In production a stopped runtime is never init's child.
     #[cfg(unix)]
-    fn process_executing(at: &Path, ignores_sigterm: bool, arguments: &[&str]) -> Option<i32> {
+    fn process_executing(at: &Path, arguments: &[&str]) -> Option<i32> {
         use std::os::unix::fs::PermissionsExt;
 
         if !Path::new(STAND_IN).is_file() {
@@ -2027,10 +1763,9 @@ mod tests {
         // reports as alive, so checking the pid would accept a process that
         // never ran.
         let ready = at.with_extension("ready");
-        let disposition = if ignores_sigterm { "$SIG{TERM} = 'IGNORE'; " } else { "" };
-        let script = format!("{disposition}open(my $f, '>', $ARGV[0]) or die; close $f; sleep 30");
+        let script = "open(my $f, '>', $ARGV[0]) or die; close $f; sleep 30";
         let mut child = Command::new(at)
-            .args(["-e", &script])
+            .args(["-e", script])
             .arg(&ready)
             .args(arguments)
             .spawn()
@@ -2120,21 +1855,25 @@ mod tests {
 
     #[test]
     fn only_this_build_serving_this_config_is_this_deployment() {
+        let endpoint = Endpoint::parse("http://127.0.0.1:8787").expect("the endpoint parses");
+        let classify = |expected: &str, config: &Path, answer: &str| {
+            classify_endpoint_owner(expected, config, &endpoint, answer).expect("the answer classifies")
+        };
         let mine = Path::new("/home/user/config/appa.toml");
         assert_eq!(
-            classify_endpoint_owner("same", mine, "same 42\n/home/user/config/appa.toml"),
+            classify("same", mine, "same 42\n/home/user/config/appa.toml"),
             EndpointOwner::Deployment
         );
         // The build alone never settles it: one build serves as many deployments as there
         // are configurations, and each is a stranger to the others.
         assert_eq!(
-            classify_endpoint_owner("same", mine, "same 42\n/home/other/config/appa.toml"),
-            EndpointOwner::Foreign { pid: Some(42) }
+            classify("same", mine, "same 42\n/home/other/config/appa.toml"),
+            EndpointOwner::Foreign { pid: 42 }
         );
         // A path with spaces is one path, not two fields.
         let spaced = Path::new("/home/user/Application Support/appa.toml");
         assert_eq!(
-            classify_endpoint_owner("same", spaced, "same 42\n/home/user/Application Support/appa.toml"),
+            classify("same", spaced, "same 42\n/home/user/Application Support/appa.toml"),
             EndpointOwner::Deployment
         );
         // On Unix a directory name may hold a newline, so the path is read as the whole
@@ -2142,27 +1881,24 @@ mod tests {
         // newline of its own does not turn one deployment into a stranger.
         let newlined = Path::new("/home/user/two\nlines/appa.toml");
         assert_eq!(
-            classify_endpoint_owner("same", newlined, "same 42\n/home/user/two\nlines/appa.toml"),
+            classify("same", newlined, "same 42\n/home/user/two\nlines/appa.toml"),
             EndpointOwner::Deployment
         );
         assert_eq!(
-            classify_endpoint_owner("same", mine, "same 42\n/home/user/config/appa.toml\n"),
+            classify("same", mine, "same 42\n/home/user/config/appa.toml\n"),
             EndpointOwner::Deployment
         );
         assert_eq!(
-            classify_endpoint_owner("same", mine, "different 42\n/home/user/config/appa.toml"),
-            EndpointOwner::Foreign { pid: Some(42) }
+            classify("same", mine, "different 42\n/home/user/config/appa.toml"),
+            EndpointOwner::Foreign { pid: 42 }
         );
         // An answer that names no configuration cannot claim to be this deployment, and
-        // one that names no pid cannot be stopped without one.
-        assert_eq!(
-            classify_endpoint_owner("same", mine, "same 42"),
-            EndpointOwner::Foreign { pid: Some(42) }
-        );
-        assert_eq!(
-            classify_endpoint_owner("same", mine, "different"),
-            EndpointOwner::Foreign { pid: None }
-        );
+        // one that names no pid cannot be stopped, so it is refused outright.
+        assert_eq!(classify("same", mine, "same 42"), EndpointOwner::Foreign { pid: 42 });
+        assert!(matches!(
+            classify_endpoint_owner("same", mine, &endpoint, "different"),
+            Err(InitError::RuntimeIdentity { .. })
+        ));
     }
 
     #[test]
@@ -2192,21 +1928,17 @@ mod tests {
     fn a_serving_runtime_is_reconciled_only_when_agreement_is_not_established() {
         let key = |key: &str| ComposedPolicy::Key(key.to_string());
         assert_eq!(
-            policy_divergence(&key("composed"), Some("serving")),
+            policy_divergence(&key("composed"), "serving"),
             Some(Divergence::Serving)
         );
         // An install that changed nothing must ask nothing.
-        assert_eq!(policy_divergence(&key("same"), Some("same")), None);
+        assert_eq!(policy_divergence(&key("same"), "same"), None);
         // A config this process cannot compose is unsettled, never settled: assuming
         // agreement here is what would leave an older policy serving unremarked.
         assert_eq!(
-            policy_divergence(&ComposedPolicy::Unknowable, Some("serving")),
+            policy_divergence(&ComposedPolicy::Unknowable, "serving"),
             Some(Divergence::Unestablished)
         );
-        // A runtime that answers for no policy cannot be compared or reloaded, so there
-        // is nothing to put to the user either way.
-        assert_eq!(policy_divergence(&key("composed"), None), None);
-        assert_eq!(policy_divergence(&ComposedPolicy::Unknowable, None), None);
     }
 
     #[test]
@@ -2231,21 +1963,25 @@ mod tests {
     }
 
     #[test]
-    fn a_serving_policy_key_is_read_only_when_the_endpoint_answers_one() {
+    fn a_serving_policy_key_is_read_from_the_policy_route() {
         let (endpoint, asked) = recorded_answers(vec!["c54f1509".to_string()]);
-        assert_eq!(serving_policy_key(&endpoint).as_deref(), Some("c54f1509"));
+        assert_eq!(serving_policy_key(&endpoint).expect("the key reads"), "c54f1509");
         assert_eq!(
             asked.lock().expect("the request recorder is never poisoned").as_slice(),
             ["GET /policy-key HTTP/1.1".to_string()],
             "the probe reads the policy route, and reads it without mutating"
         );
+    }
 
-        // A runtime predating the route answers nothing usable, and an unbound port
-        // answers not at all. Both leave init with no key rather than a wrong one.
+    /// A runtime that answers nothing usable, and a port nothing answers on, both
+    /// refuse init: a plugin bound to a runtime whose policy cannot be established is
+    /// the skew init exists to prevent.
+    #[test]
+    fn a_runtime_that_does_not_answer_for_its_policy_refuses_init() {
         let blank = health_answers(vec![String::new()]);
-        assert_eq!(serving_policy_key(&blank), None);
+        assert!(matches!(serving_policy_key(&blank), Err(InitError::PolicyKey { .. })));
         let unbound = Endpoint::parse("http://127.0.0.1:1").expect("the endpoint parses");
-        assert_eq!(serving_policy_key(&unbound), None);
+        assert!(matches!(serving_policy_key(&unbound), Err(InitError::PolicyKey { .. })));
     }
 
     #[test]
@@ -2280,7 +2016,7 @@ mod tests {
     fn an_approved_foreign_appa_runtime_is_stopped() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let foreign = directory.path().join("foreign/appa");
-        let Some(pid) = process_executing(&foreign, false, RUNTIME_ARGUMENTS) else {
+        let Some(pid) = process_executing(&foreign, RUNTIME_ARGUMENTS) else {
             return;
         };
         let candidate = directory.path().join("candidate-appa");
@@ -2301,11 +2037,11 @@ mod tests {
     #[test]
     fn init_reclaims_an_unlinked_runtime_named_by_its_stale_health_answer() {
         let directory = tempfile::tempdir().expect("temporary directory");
-        let retired = directory.path().join("bin/appa");
-        let Some(pid) = process_executing(&retired, false, RUNTIME_ARGUMENTS) else {
+        let replaced = directory.path().join("bin/appa");
+        let Some(pid) = process_executing(&replaced, RUNTIME_ARGUMENTS) else {
             return;
         };
-        fs::remove_file(&retired).expect("the installed binary is unlinked while its runtime remains");
+        fs::remove_file(&replaced).expect("the installed binary is unlinked while its runtime remains");
         let endpoint = health_answers(vec![format!("stale {pid}"), format!("stale {pid}")]);
 
         clear_stale_endpoint(&endpoint).expect("init stops its stale unlinked runtime");
@@ -2318,7 +2054,7 @@ mod tests {
     fn a_spoofed_stale_pid_does_not_grant_process_shutdown() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let other = directory.path().join("bin/not-appa");
-        let Some(pid) = process_executing(&other, false, RUNTIME_ARGUMENTS) else {
+        let Some(pid) = process_executing(&other, RUNTIME_ARGUMENTS) else {
             return;
         };
         let endpoint = health_answers(vec![format!("stale {pid}")]);
@@ -2328,109 +2064,6 @@ mod tests {
         assert!(matches!(refused, Err(InitError::RuntimeIdentity { .. })));
         assert!(still_running(pid), "a non-appa process was terminated");
         unsafe { libc::kill(pid, libc::SIGKILL) };
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn a_runtime_at_the_retired_path_is_stopped() {
-        let directory = tempfile::tempdir().expect("temporary directory");
-        let retired = directory.path().join("bin/appa");
-        let Some(pid) = process_executing(&retired, false, RUNTIME_ARGUMENTS) else {
-            return;
-        };
-
-        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
-
-        assert!(survivors.is_empty(), "a stoppable runtime was reported as surviving");
-        assert!(!still_running(pid), "the runtime at the retired path is still running",);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn a_runtime_at_another_path_is_left_alone() {
-        let directory = tempfile::tempdir().expect("temporary directory");
-        // What an init run under a different APPA_INSTALL_DIR or APPA_DATA_DIR
-        // leaves behind: a path this environment never computes.
-        let elsewhere = directory.path().join("other-install/appa");
-        let Some(pid) = process_executing(&elsewhere, false, RUNTIME_ARGUMENTS) else {
-            return;
-        };
-        let retired = directory.path().join("bin/appa");
-        fs::create_dir_all(retired.parent().expect("a parent")).expect("the retired directory");
-        fs::copy(STAND_IN, &retired).expect("the retired binary exists but runs nothing");
-
-        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
-
-        assert!(survivors.is_empty());
-        assert!(
-            still_running(pid),
-            "a runtime outside the stop set must be left running, not killed",
-        );
-        unsafe { libc::kill(pid, libc::SIGKILL) };
-    }
-
-    /// What a second `appa init`, or an `appa hook` in flight, looks like: the
-    /// retired executable, doing something that is not serving the endpoint.
-    /// Terminating it would interrupt work unrelated to the runtime being
-    /// replaced -- and killing a concurrent init mid-switch is the worst of
-    /// them, because the Claude plugin replacement it is performing is not
-    /// atomic.
-    #[cfg(unix)]
-    #[test]
-    fn another_invocation_of_the_retired_binary_is_left_alone() {
-        let directory = tempfile::tempdir().expect("temporary directory");
-        let retired = directory.path().join("bin/appa");
-        let Some(pid) = process_executing(&retired, false, &["init", "claude-code"]) else {
-            return;
-        };
-
-        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
-
-        assert!(survivors.is_empty());
-        assert!(
-            still_running(pid),
-            "the stop set signalled a process that is not a runtime",
-        );
-        unsafe { libc::kill(pid, libc::SIGKILL) };
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn a_verified_runtime_that_refuses_to_die_is_reported() {
-        let directory = tempfile::tempdir().expect("temporary directory");
-        let retired = directory.path().join("bin/appa");
-        // Ignores SIGTERM, which is exactly the case that must abort init
-        // rather than let a new plugin bind to an old runtime.
-        let Some(pid) = process_executing(&retired, true, RUNTIME_ARGUMENTS) else {
-            return;
-        };
-
-        let survivors = stop_processes_executing(&retired).expect("the stop set runs");
-
-        assert_eq!(
-            survivors,
-            vec![pid],
-            "a verified target that outlived SIGTERM must be reported, not assumed gone",
-        );
-        unsafe { libc::kill(pid, libc::SIGKILL) };
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn cleanup_stops_an_unlinked_legacy_runtime() {
-        let directory = tempfile::tempdir().expect("temporary directory");
-        // The retired daemon was its own binary and took no subcommand; legacy
-        // cleanup matches on the executable path alone.
-        let target = directory.path().join("appa-runtime");
-        let Some(pid) = process_executing(&target, false, &[]) else {
-            return;
-        };
-        fs::remove_file(target.with_extension("ready")).expect("the readiness marker is removed");
-        fs::remove_file(&target).expect("Cargo unlinks the installed legacy executable");
-
-        stop_legacy_runtime_at(&target).expect("legacy cleanup succeeds");
-
-        assert!(!still_running(pid), "cleanup must stop the unlinked process");
     }
 
     #[test]
@@ -2562,7 +2195,6 @@ mod tests {
             &config,
             ConfigOutcome::Kept,
             RuntimeOutcome::Healthy,
-            None,
             false,
         );
 
@@ -2580,7 +2212,6 @@ mod tests {
             &config,
             ConfigOutcome::Kept,
             RuntimeOutcome::Healthy,
-            None,
             true,
         );
         assert!(colored.starts_with("\u{1b}[1;32m✓ OpenAPPA initialized\u{1b}[0m"));

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -66,7 +66,7 @@ pub enum InitError {
     },
     #[error(transparent)]
     PluginBundle(#[from] PluginBundleError),
-    #[error("{operation}; restoring the previous Claude Code plugin also failed: {recovery}")]
+    #[error("{operation}; restoring the previous installation also failed: {recovery}")]
     PluginRecovery {
         operation: Box<InitError>,
         recovery: Box<InitError>,
@@ -264,27 +264,32 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
     // 6. The Claude switch, the binary, and the runtime this plugin is being
     //    bound to: one transaction. Verification is inside it, because a plugin
     //    left registered against a runtime that failed verification is exactly
-    //    the skew this bundle exists to prevent.
+    //    the skew this bundle exists to prevent. Every step records what it
+    //    changed, and a failure unwinds those changes in reverse before the
+    //    plugin switch itself is undone.
     progress("updating the Claude Code plugin");
-    let switch = replace_plugin(&deployment.root, &marketplaces, &installations)
-        .and_then(|()| install_runtime(&appa, &deployed_appa))
-        .and_then(|()| installed_plugin_root(&paths.claude_dir))
-        .and_then(|plugin_root| {
-            install_statusline(&plugin_root, &paths)?;
-            progress("starting the runtime");
-            start_runtime(&plugin_root, &deployed_appa, &config, &endpoint)
-        })
-        //    The runtime this plugin is bound to must also be serving this
-        //    deployment's policy, so the reconcile is inside the transaction:
-        //    a refusal here means the endpoint belongs to someone else, and a
-        //    plugin left registered against it is the same skew as a plugin left
-        //    registered against a runtime that failed verification. A decline is
-        //    not a refusal — it answers `Ok` and the install stands.
-        .and_then(|()| reconcile_policy(&endpoint, &config, &composed_policy));
+    let mut compensation = Compensation::default();
+    let switch = replace_plugin(&deployment.root, &marketplaces, &installations).and_then(|()| {
+        switch_over(
+            &appa,
+            &deployed_appa,
+            &config,
+            &composed_policy,
+            &endpoint,
+            &paths,
+            &mut compensation,
+        )
+    });
     let runtime_outcome = match switch {
-        Ok(outcome) => outcome,
+        Ok(outcome) => {
+            compensation.commit();
+            outcome
+        }
         Err(operation) => {
-            if let Err(recovery_error) = undo_plugin_switch(recovery.as_ref(), launcher_dir) {
+            let unwound = compensation
+                .unwind()
+                .and_then(|()| undo_plugin_switch(recovery.as_ref(), launcher_dir));
+            if let Err(recovery_error) = unwound {
                 return Err(InitError::PluginRecovery {
                     operation: Box::new(operation),
                     recovery: Box::new(recovery_error),
@@ -307,6 +312,148 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         runtime_outcome,
         std::io::stdout().is_terminal() && env::var_os("NO_COLOR").is_none(),
     ))
+}
+
+/// The steps after the Claude switch, each recording what it changed.
+///
+/// The runtime this plugin is bound to must also be serving this deployment's
+/// policy, so the reconcile is inside the transaction: a refusal there means the
+/// endpoint belongs to someone else, and a plugin left registered against it is
+/// the same skew as a plugin left registered against a runtime that failed
+/// verification. A decline is not a refusal: it answers `Ok` and the install
+/// stands.
+fn switch_over(
+    appa: &Path,
+    deployed_appa: &Path,
+    config: &Path,
+    composed_policy: &ComposedPolicy,
+    endpoint: &Endpoint,
+    paths: &DeploymentPaths,
+    compensation: &mut Compensation,
+) -> Result<RuntimeOutcome, InitError> {
+    install_runtime(appa, deployed_appa, compensation)?;
+    let plugin_root = installed_plugin_root(&paths.claude_dir)?;
+    install_statusline(&plugin_root, paths, compensation)?;
+    progress("starting the runtime");
+    // A runtime answering `ok` here was running before this init and stays the
+    // user's; anything the starter brings up after silence is init's to stop.
+    let running_before = endpoint_health(endpoint)?.is_some_and(|answer| answer == "ok");
+    start_runtime(&plugin_root)?;
+    let pid = verify_runtime_deployment(deployed_appa, config, endpoint)?;
+    if !running_before {
+        compensation.record(Undo::Runtime {
+            pid,
+            endpoint: endpoint.clone(),
+        });
+    }
+    reconcile_policy(endpoint, config, composed_policy)
+}
+
+/// What the switch has changed on disk and in process state, so a failure can
+/// put each change back in reverse order. The plugin registration itself is
+/// undone separately by [`undo_plugin_switch`].
+#[derive(Default)]
+struct Compensation {
+    done: Vec<Undo>,
+}
+
+enum Undo {
+    /// The deployed binary's bytes before install_runtime replaced them, copied
+    /// aside to `previous`; `None` when no binary was deployed.
+    Binary { target: PathBuf, previous: Option<PathBuf> },
+    /// A file the statusline install rewrote, with its bytes from before; `None`
+    /// when it did not exist.
+    File { path: PathBuf, before: Option<Vec<u8>> },
+    /// A runtime this init started and verified as this deployment's.
+    Runtime { pid: i32, endpoint: Endpoint },
+}
+
+impl Compensation {
+    fn record(&mut self, undo: Undo) {
+        self.done.push(undo);
+    }
+
+    /// Put back every recorded change, last first. Every step is attempted; the
+    /// first failure is the one reported.
+    fn unwind(self) -> Result<(), InitError> {
+        let mut first_failure = None;
+        for undo in self.done.into_iter().rev() {
+            if let Err(error) = undo.apply() {
+                tracing::warn!(%error, "an init rollback step failed");
+                first_failure.get_or_insert(error);
+            }
+        }
+        first_failure.map_or(Ok(()), Err)
+    }
+
+    /// The install stands: drop the binary snapshot.
+    fn commit(self) {
+        for undo in self.done {
+            if let Undo::Binary {
+                previous: Some(previous),
+                ..
+            } = undo
+                && let Err(error) = fs::remove_file(&previous)
+            {
+                tracing::warn!(path = %previous.display(), %error, "cannot remove the binary snapshot");
+            }
+        }
+    }
+}
+
+impl Undo {
+    fn apply(self) -> Result<(), InitError> {
+        match self {
+            Undo::Binary { target, previous } => {
+                let install = |source| InitError::InstallRuntime {
+                    path: target.clone(),
+                    source,
+                };
+                match previous {
+                    Some(previous) => {
+                        #[cfg(windows)]
+                        if target.exists() {
+                            stop_windows_processes_at(&target)?;
+                            fs::remove_file(&target).map_err(install)?;
+                        }
+                        fs::rename(&previous, &target).map_err(install)
+                    }
+                    None => remove_if_present(&target).map_err(install),
+                }
+            }
+            Undo::File { path, before } => {
+                let write = |source| InitError::WriteFile {
+                    path: path.clone(),
+                    source,
+                };
+                match before {
+                    Some(bytes) => fs::write(&path, bytes).map_err(write),
+                    None => remove_if_present(&path).map_err(write),
+                }
+            }
+            Undo::Runtime { pid, endpoint } => stop_owned_appa_runtime(pid, &endpoint),
+        }
+    }
+}
+
+fn remove_if_present(path: &Path) -> std::io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// The bytes at `path` before init rewrites it, or `None` when it is absent.
+fn file_before(path: &Path) -> Result<Option<Vec<u8>>, InitError> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(InitError::WriteFile {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 fn progress(message: &str) {
@@ -499,10 +646,26 @@ fn same_file(left: &Path, right: &Path) -> bool {
     }
 }
 
-fn install_runtime(source: &Path, target: &Path) -> Result<(), InitError> {
+/// Copy the binary to its deployed path, keeping the bytes it replaces beside it
+/// as `appa.prev` until the install stands.
+fn install_runtime(source: &Path, target: &Path, compensation: &mut Compensation) -> Result<(), InitError> {
     if same_file(source, target) {
         return Ok(());
     }
+    let previous = if target.exists() {
+        let snapshot = target.with_extension("prev");
+        fs::copy(target, &snapshot).map_err(|source| InitError::InstallRuntime {
+            path: snapshot.clone(),
+            source,
+        })?;
+        Some(snapshot)
+    } else {
+        None
+    };
+    compensation.record(Undo::Binary {
+        target: target.to_path_buf(),
+        previous,
+    });
     #[cfg(windows)]
     if target.exists() {
         stop_windows_processes_at(target)?;
@@ -1112,7 +1275,13 @@ fn install_disabled_clappa(install_dir: &Path) -> Result<(), InitError> {
     Ok(())
 }
 
-fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(), InitError> {
+/// Install the platform statusline and point Claude's settings at it, unless a
+/// statusline that is not APPA's is configured, which is left alone.
+fn install_statusline(
+    plugin_root: &Path,
+    paths: &DeploymentPaths,
+    compensation: &mut Compensation,
+) -> Result<(), InitError> {
     #[cfg(windows)]
     let (source, target) = (
         plugin_root.join("statusline.ps1"),
@@ -1146,6 +1315,12 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(),
         .and_then(Value::as_str);
     if existing.is_some_and(|command| !command.contains("appa-statusline")) {
         return Ok(());
+    }
+    for path in [&target, &settings_path] {
+        compensation.record(Undo::File {
+            path: path.clone(),
+            before: file_before(path)?,
+        });
     }
 
     fs::copy(&source, &target).map_err(|source| InitError::WriteFile {
@@ -1188,7 +1363,9 @@ fn install_statusline(plugin_root: &Path, paths: &DeploymentPaths) -> Result<(),
     Ok(())
 }
 
-fn start_runtime(plugin_root: &Path, runtime: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+/// Run the installed plugin's starter, which brings up the deployed runtime
+/// when nothing healthy answers the endpoint.
+fn start_runtime(plugin_root: &Path) -> Result<(), InitError> {
     #[cfg(windows)]
     let mut command = {
         let starter = plugin_root.join("hooks/hook.ps1");
@@ -1220,7 +1397,7 @@ fn start_runtime(plugin_root: &Path, runtime: &Path, config: &Path, endpoint: &E
         .output()
         .map_err(|error| InitError::Starter(error.to_string()))?;
     if output.status.success() {
-        return verify_runtime_deployment(runtime, config, endpoint);
+        return Ok(());
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
     Err(InitError::Starter(if stderr.is_empty() {
@@ -1240,8 +1417,9 @@ enum EndpointOwner {
     /// Nothing answered, or what answered serves no fingerprint. Before the
     /// start this is the ordinary case; after it, it is a failure.
     Unidentified,
-    /// The binary whose bytes were offered for comparison.
-    Deployment,
+    /// The binary whose bytes were offered for comparison, serving this
+    /// configuration, in the process it names.
+    Deployment { pid: i32 },
     /// A different build or a different configuration, naming the pid that
     /// serves it.
     Foreign { pid: i32 },
@@ -1330,6 +1508,48 @@ fn clear_stale_endpoint(endpoint: &Endpoint) -> Result<(), InitError> {
         pid,
         endpoint: endpoint.url().to_owned(),
     })
+}
+
+/// Signal `pid`, confirming immediately before that it is still this user's
+/// appa runtime: the check-to-signal window is what a forged answer would use.
+fn terminate_owned_appa_runtime(pid: i32, endpoint: &Endpoint) -> Result<(), InitError> {
+    if !is_owned_appa_runtime(pid)? {
+        return Err(InitError::RuntimeIdentity {
+            endpoint: endpoint.url().to_owned(),
+            message: format!("pid {pid} is not this user's appa runtime; not stopping it"),
+        });
+    }
+    terminate_appa_pid(pid)
+}
+
+/// Stop a runtime this init started, and wait for its process to go.
+fn stop_owned_appa_runtime(pid: i32, endpoint: &Endpoint) -> Result<(), InitError> {
+    terminate_owned_appa_runtime(pid, endpoint)?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
+        if !process_exists(pid) {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    Err(InitError::RuntimeSurvived {
+        pid,
+        endpoint: endpoint.url().to_owned(),
+    })
+}
+
+#[cfg(unix)]
+fn process_exists(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+#[cfg(windows)]
+fn process_exists(pid: i32) -> bool {
+    powershell(
+        "if (Get-Process -Id $env:APPA_STALE_PID -ErrorAction SilentlyContinue) { 'alive' }",
+        [("APPA_STALE_PID", pid.to_string())],
+    )
+    .is_ok_and(|answer| answer.trim() == "alive")
 }
 
 #[cfg(unix)]
@@ -1452,8 +1672,9 @@ fn endpoint_owner(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<E
 
 /// A process is this deployment only when it names both this build and this configuration.
 /// Anything else — a different build, a different config, or an answer that names no
-/// config at all — is another deployment, to be stopped before this install proceeds,
-/// and one that names no pid cannot be stopped at all.
+/// config at all — is another deployment, to be stopped before this install proceeds.
+/// Either way the answer must name the pid that serves it: a runtime that cannot be
+/// stopped by pid can be neither cleared nor rolled back.
 fn classify_endpoint_owner(
     expected: &str,
     config: &Path,
@@ -1463,21 +1684,21 @@ fn classify_endpoint_owner(
     let (identity, rest) = answer.split_once('\n').unwrap_or((answer, ""));
     let mut fields = identity.split_whitespace();
     let actual = fields.next().unwrap_or_default();
-    // Everything after the first newline is the path, less the one the transport appends:
-    // a config path may itself hold a newline, and splitting again would truncate it.
-    let serves = rest.strip_suffix('\n').unwrap_or(rest);
-    if actual == expected && !serves.is_empty() && Path::new(serves) == config {
-        return Ok(EndpointOwner::Deployment);
-    }
     let pid = fields
         .next()
         .and_then(positive_pid)
         .ok_or_else(|| InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
-            message: "another appa deployment owns this endpoint, but its runtime does not identify its pid; stop it and rerun init"
-                .to_owned(),
+            message: "the answering runtime does not identify its pid; stop it and rerun init".to_owned(),
         })?;
-    Ok(EndpointOwner::Foreign { pid })
+    // Everything after the first newline is the path, less the one the transport appends:
+    // a config path may itself hold a newline, and splitting again would truncate it.
+    let serves = rest.strip_suffix('\n').unwrap_or(rest);
+    if actual == expected && !serves.is_empty() && Path::new(serves) == config {
+        Ok(EndpointOwner::Deployment { pid })
+    } else {
+        Ok(EndpointOwner::Foreign { pid })
+    }
 }
 
 fn confirm_stop(pid: i32, endpoint: &Endpoint) -> Result<bool, InitError> {
@@ -1524,7 +1745,7 @@ fn confirm_stop_with(
 /// immediately before signalling to close the prompt-to-kill race.
 fn clear_foreign_endpoint(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
     match endpoint_owner(binary, config, endpoint)? {
-        EndpointOwner::Deployment | EndpointOwner::Unidentified => Ok(()),
+        EndpointOwner::Deployment { .. } | EndpointOwner::Unidentified => Ok(()),
         EndpointOwner::Foreign { pid } => clear_confirmed_foreign_with(binary, config, endpoint, pid, confirm_stop),
     }
 }
@@ -1552,7 +1773,7 @@ fn clear_confirmed_foreign_with(
     }
     match endpoint_owner(binary, config, endpoint)? {
         EndpointOwner::Unidentified => return Ok(()),
-        EndpointOwner::Deployment => return Ok(()),
+        EndpointOwner::Deployment { .. } => return Ok(()),
         EndpointOwner::Foreign { pid: current } if current == pid => {}
         EndpointOwner::Foreign { .. } => {
             return Err(InitError::RuntimeIdentity {
@@ -1708,9 +1929,10 @@ fn confirm_reload_with(
 }
 
 /// The endpoint answers for this deployment: this build, serving this configuration.
-fn verify_runtime_deployment(runtime: &Path, config: &Path, endpoint: &Endpoint) -> Result<(), InitError> {
+/// Answers with the pid of the process serving it.
+fn verify_runtime_deployment(runtime: &Path, config: &Path, endpoint: &Endpoint) -> Result<i32, InitError> {
     match endpoint_owner(runtime, config, endpoint)? {
-        EndpointOwner::Deployment => Ok(()),
+        EndpointOwner::Deployment { pid } => Ok(pid),
         EndpointOwner::Unidentified => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
             message: "the answering process exposes no binary fingerprint; stop it and rerun init".to_owned(),
@@ -1862,7 +2084,7 @@ mod tests {
         let mine = Path::new("/home/user/config/appa.toml");
         assert_eq!(
             classify("same", mine, "same 42\n/home/user/config/appa.toml"),
-            EndpointOwner::Deployment
+            EndpointOwner::Deployment { pid: 42 }
         );
         // The build alone never settles it: one build serves as many deployments as there
         // are configurations, and each is a stranger to the others.
@@ -1874,7 +2096,7 @@ mod tests {
         let spaced = Path::new("/home/user/Application Support/appa.toml");
         assert_eq!(
             classify("same", spaced, "same 42\n/home/user/Application Support/appa.toml"),
-            EndpointOwner::Deployment
+            EndpointOwner::Deployment { pid: 42 }
         );
         // On Unix a directory name may hold a newline, so the path is read as the whole
         // remainder of the answer the runtime composes — and a transport that appends a
@@ -1882,11 +2104,11 @@ mod tests {
         let newlined = Path::new("/home/user/two\nlines/appa.toml");
         assert_eq!(
             classify("same", newlined, "same 42\n/home/user/two\nlines/appa.toml"),
-            EndpointOwner::Deployment
+            EndpointOwner::Deployment { pid: 42 }
         );
         assert_eq!(
             classify("same", mine, "same 42\n/home/user/config/appa.toml\n"),
-            EndpointOwner::Deployment
+            EndpointOwner::Deployment { pid: 42 }
         );
         assert_eq!(
             classify("same", mine, "different 42\n/home/user/config/appa.toml"),

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -385,12 +385,6 @@ mod tests {
             DEFAULT_CONFIG
         );
         Config::load(&path).expect("the embedded default config validates");
-        assert!(
-            DEFAULT_CONFIG.contains("name = \"claude-code.undeclared-tool\"")
-                && DEFAULT_CONFIG.contains("name = \"*\"")
-                && DEFAULT_CONFIG.contains("annotator = \"claude-code.undeclared-tool\""),
-            "a fresh Claude Code deployment carries its explicit compatibility fallback"
-        );
 
         fs::write(&path, "existing deployment").expect("existing config is replaced by the test");
         assert!(!ensure_default_config(&path).expect("existing config is preserved"));

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -588,10 +588,6 @@ pub enum Population<'a> {
 #[derive(Debug, Clone)]
 pub struct Deployment {
     pub root: PathBuf,
-    /// Whether an existing deployment was validated and reused, rather than
-    /// materialized afresh. This is the convergence property: a rerun that
-    /// changes nothing reuses, and one that finds drift does not.
-    pub reused: bool,
 }
 
 /// Materialize the deployment for this source and these paths, or reuse the
@@ -671,10 +667,7 @@ pub fn materialize(
         match reusable(&published, &plan) {
             Ok(()) => {
                 let _ = fs::remove_dir_all(&incoming);
-                return Ok(Deployment {
-                    root: published,
-                    reused: true,
-                });
+                return Ok(Deployment { root: published });
             }
             Err(reason) => {
                 tracing::debug!(path = %published.display(), %reason, "quarantining a damaged deployment");
@@ -711,7 +704,6 @@ pub fn materialize(
 
     Ok(Deployment {
         root: deployments_dir.join(digest.to_string()),
-        reused: false,
     })
 }
 
@@ -922,7 +914,7 @@ fn safe_relative(path: &Path) -> EntryPath {
 // ---------------------------------------------------------------------------
 
 /// Turn the staged tree into a deployment for these exact paths: select the
-/// platform hook map, write the generated paths files, and replace the legacy
+/// platform hook map, write the generated paths files, and replace the default
 /// endpoint literal everywhere it appears.
 fn render(root: &Path, plan: &DeploymentPlan) -> Result<(), PluginBundleError> {
     select_platform_hooks(root)?;
@@ -944,12 +936,11 @@ fn select_platform_hooks(root: &Path) -> Result<(), PluginBundleError> {
     }
 }
 
-/// Replace the legacy endpoint literal in every text file of the deployment.
+/// Replace the default endpoint literal in every text file of the deployment.
 ///
-/// Three successive drafts of this change each missed a consumer, so the
-/// substitution is total over the tree rather than driven by a hand-written list
-/// of files. A file that does not contain the literal is left untouched, and
-/// binary files cannot contain it.
+/// The substitution is total over the tree rather than driven by a list of
+/// files, so no consumer of the literal can be missed. A file that does not
+/// contain the literal is left untouched, and binary files cannot contain it.
 fn render_endpoint(root: &Path, endpoint_url: &str) -> Result<(), PluginBundleError> {
     if endpoint_url == DEFAULT_ENDPOINT_URL {
         return Ok(());
@@ -1496,21 +1487,21 @@ mod tests {
         sample_tree(source.path());
 
         let first = deploy(source.path(), deployments.path(), "http://127.0.0.1:9999");
-        assert!(!first.reused);
 
         let paths = fs::read_to_string(first.root.join(PATHS_SH)).unwrap();
         assert!(paths.contains("APPA_BIN='/data/bin/appa'"));
         assert!(paths.contains("APPA_ENDPOINT='http://127.0.0.1:9999'"));
 
-        // Every consumer carrying the legacy literal is rendered, without a
-        // hand-written list of files.
+        // Every consumer carrying the default literal is rendered.
         let statusline = fs::read_to_string(first.root.join("plugin/statusline.sh")).unwrap();
         assert!(statusline.contains("http://127.0.0.1:9999"));
         assert!(!statusline.contains(DEFAULT_ENDPOINT_URL));
 
+        // A rerun that changes nothing converges on the same directory and moves
+        // nothing aside.
         let second = deploy(source.path(), deployments.path(), "http://127.0.0.1:9999");
-        assert!(second.reused);
         assert_eq!(second.root, first.root);
+        assert_eq!(fs::read_dir(deployments.path()).unwrap().count(), 1);
     }
 
     #[test]
@@ -1570,7 +1561,6 @@ mod tests {
             fs::write(first.root.join(name), damaged).unwrap();
 
             let repaired = deploy(source.path(), deployments.path(), DEFAULT_ENDPOINT_URL);
-            assert!(!repaired.reused, "{name} was reused while stale");
             assert!(
                 fs::read_to_string(repaired.root.join(name)).unwrap().contains(restored),
                 "{name} was not restored",

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -17,8 +17,13 @@ use std::time::Duration;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+pub use crate::plugin_layout::stage_repository;
+use crate::plugin_layout::{
+    EntryKind, MAX_ENTRIES, MAX_UNCOMPRESSED_BYTES, TreeDigestError, absorb_field, canonical_tree_digest, walk,
+};
+
 /// Files and directories every plugin source must carry, in the marketplace-root
-/// shape `scripts/appa-stage-plugin-bundle.sh` produces. One validator serves
+/// shape `plugin_layout::stage_repository` produces. One validator serves
 /// both source resolution and the reuse check on an existing deployment.
 const REQUIRED_FILES: [&str; 8] = [
     ".claude-plugin/marketplace.json",
@@ -410,140 +415,24 @@ impl Endpoint {
 // Canonical digests
 // ---------------------------------------------------------------------------
 
-/// Every length prefix in both digests is an unsigned 64-bit big-endian integer
-/// followed immediately by exactly that many bytes. Naive concatenation would be
-/// ambiguous, and both digests name deployment directories, so the encoding is
-/// observable identity and is pinned rather than left to the implementation.
-fn absorb_field(hasher: &mut Sha256, bytes: &[u8]) {
-    hasher.update((bytes.len() as u64).to_be_bytes());
-    hasher.update(bytes);
-}
-
-const KIND_FILE: u8 = b'f';
-const KIND_DIRECTORY: u8 = b'd';
-
-type StagedEntry = (String, u8, PathBuf);
-
-/// The identity of a plugin source that has no release digest of its own.
-///
-/// Computed over the staged tree after staging and **before** rendering, so it
-/// never depends on the paths being rendered into it. Without this, editing a
-/// file in a `--plugin-source` tree and re-running init would reuse the
-/// existing deployment and never reach Claude.
+/// The identity of a plugin source that has no release digest of its own:
+/// the canonical tree digest `build.rs` bakes in, over the staged tree and
+/// before rendering. Without this, editing a file in a `--plugin-source` tree
+/// and re-running init would reuse the existing deployment and never reach
+/// Claude.
 pub fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundleError> {
-    let entries = walk(root)?;
-
-    let mut hasher = Sha256::new();
-    for (relative, kind, absolute) in entries {
-        absorb_field(&mut hasher, relative.as_bytes());
-        hasher.update([kind]);
-        if kind == KIND_DIRECTORY {
-            absorb_field(&mut hasher, &[]);
-        } else {
-            absorb_file(&mut hasher, &absolute)?;
-        }
-    }
-    Ok(PluginDigest::from_hasher(hasher))
+    Ok(PluginDigest(canonical_tree_digest(root)?))
 }
 
-/// The tree in canonical order, refused if it exceeds the source bounds.
-fn walk(root: &Path) -> Result<Vec<StagedEntry>, PluginBundleError> {
-    let mut entries = Vec::new();
-    collect_entries(root, root, &mut entries)?;
-    if entries.len() > MAX_ENTRIES {
-        return Err(PluginBundleError::OversizedSource {
-            path: root.to_path_buf(),
-            reason: format!("it holds more than {MAX_ENTRIES} entries"),
-        });
-    }
-    let mut total = 0u64;
-    for (_, kind, absolute) in &entries {
-        if *kind != KIND_FILE {
-            continue;
-        }
-        let length = fs::metadata(absolute)
-            .map_err(|source| PluginBundleError::ReadSource {
-                path: absolute.clone(),
-                source,
-            })?
-            .len();
-        total = total.saturating_add(length);
-        if total > MAX_UNCOMPRESSED_BYTES {
-            return Err(PluginBundleError::OversizedSource {
-                path: root.to_path_buf(),
-                reason: format!("it holds more than {MAX_UNCOMPRESSED_BYTES} bytes"),
-            });
+impl From<TreeDigestError> for PluginBundleError {
+    fn from(error: TreeDigestError) -> Self {
+        match error {
+            TreeDigestError::Read { path, source } => Self::ReadSource { path, source },
+            TreeDigestError::UnportablePath { path } => Self::UnportablePath { path },
+            TreeDigestError::UnsupportedEntry { path } => Self::UnsupportedEntry { path },
+            TreeDigestError::Oversized { path, reason } => Self::OversizedSource { path, reason },
         }
     }
-    // Bytewise on the UTF-8 path bytes, never locale collation.
-    entries.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
-    Ok(entries)
-}
-
-/// A file's length prefix and then its bytes, streamed.
-///
-/// The length comes from the file's own metadata and exactly that many bytes are
-/// absorbed, so the encoding stays the length-prefixed one the digest is defined
-/// as, without holding a whole file in memory.
-fn absorb_file(hasher: &mut Sha256, path: &Path) -> Result<(), PluginBundleError> {
-    use std::io::Read;
-
-    let read = |source: std::io::Error| PluginBundleError::ReadSource {
-        path: path.to_path_buf(),
-        source,
-    };
-    let mut file = fs::File::open(path).map_err(read)?;
-    let length = file.metadata().map_err(read)?.len();
-    hasher.update(length.to_be_bytes());
-
-    let mut remaining = length;
-    let mut buffer = [0u8; 64 * 1024];
-    while remaining > 0 {
-        let wanted = remaining.min(buffer.len() as u64) as usize;
-        let filled = file.read(&mut buffer[..wanted]).map_err(read)?;
-        if filled == 0 {
-            return Err(PluginBundleError::OversizedSource {
-                path: path.to_path_buf(),
-                reason: "it changed size while being read".to_owned(),
-            });
-        }
-        hasher.update(&buffer[..filled]);
-        remaining -= filled as u64;
-    }
-    Ok(())
-}
-
-fn collect_entries(root: &Path, directory: &Path, entries: &mut Vec<StagedEntry>) -> Result<(), PluginBundleError> {
-    let read = fs::read_dir(directory).map_err(|source| PluginBundleError::ReadSource {
-        path: directory.to_path_buf(),
-        source,
-    })?;
-    for entry in read {
-        let entry = entry.map_err(|source| PluginBundleError::ReadSource {
-            path: directory.to_path_buf(),
-            source,
-        })?;
-        let absolute = entry.path();
-        let relative = absolute
-            .strip_prefix(root)
-            .map_err(|_| PluginBundleError::UnportablePath { path: absolute.clone() })?;
-        let portable = portable_relative_path(relative)?;
-        // Symlinks and special files are refused here exactly as in extraction:
-        // the bundle is regular files and directories.
-        let kind = entry.file_type().map_err(|source| PluginBundleError::ReadSource {
-            path: absolute.clone(),
-            source,
-        })?;
-        if kind.is_dir() {
-            entries.push((portable, KIND_DIRECTORY, absolute.clone()));
-            collect_entries(root, &absolute, entries)?;
-        } else if kind.is_file() {
-            entries.push((portable, KIND_FILE, absolute));
-        } else {
-            return Err(PluginBundleError::UnsupportedEntry { path: absolute });
-        }
-    }
-    Ok(())
 }
 
 /// Everything a deployment's identity depends on beyond the source bytes.
@@ -585,13 +474,6 @@ fn path_identity(path: &Path) -> Result<&str, PluginBundleError> {
 // ---------------------------------------------------------------------------
 // Materialization
 // ---------------------------------------------------------------------------
-
-/// Caps on what a plugin source may be, whichever way it arrives. The bundle is
-/// a few hundred small text files; these bound a hostile archive or a
-/// development checkout that has accumulated a large generated directory,
-/// without being tight enough to constrain the real one.
-const MAX_ENTRIES: usize = 4096;
-const MAX_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 
 /// The generated file every deployed shell surface sources.
 const PATHS_SH: &str = "plugin/hooks/appa-paths.sh";
@@ -645,11 +527,9 @@ pub fn materialize(
                 copy_tree(source, &incoming)?
             }
             Population::Repository { root, .. } => {
-                crate::plugin_layout::stage_repository(root, &incoming).map_err(|error| {
-                    PluginBundleError::StageRepository {
-                        path: root.to_path_buf(),
-                        reason: error.to_string(),
-                    }
+                stage_repository(root, &incoming).map_err(|error| PluginBundleError::StageRepository {
+                    path: root.to_path_buf(),
+                    reason: error.to_string(),
                 })?;
             }
             Population::Archive(archive) => extract_archive(archive, &incoming)?,
@@ -971,10 +851,11 @@ fn render_endpoint(root: &Path, endpoint_url: &str) -> Result<(), PluginBundleEr
     if endpoint_url == DEFAULT_ENDPOINT_URL {
         return Ok(());
     }
-    for (_, kind, absolute) in walk(root)? {
-        if kind != KIND_FILE {
+    for entry in walk(root)? {
+        if entry.kind != EntryKind::File {
             continue;
         }
+        let absolute = entry.absolute;
         let bytes = fs::read(&absolute).map_err(|source| PluginBundleError::ReadSource {
             path: absolute.clone(),
             source,
@@ -1215,11 +1096,9 @@ pub fn ensure_commit_archive(
     extract_archive(source.path(), &repository_container)?;
     let repository = single_directory(&repository_container)?;
     let bundle = workspace.path().join("bundle");
-    crate::plugin_layout::stage_repository(&repository, &bundle).map_err(|error| {
-        PluginBundleError::StageRepository {
-            path: repository.clone(),
-            reason: error.to_string(),
-        }
+    stage_repository(&repository, &bundle).map_err(|error| PluginBundleError::StageRepository {
+        path: repository.clone(),
+        reason: error.to_string(),
     })?;
     validate_tree(&bundle, TreeShape::Source)?;
     let actual = canonical_source_digest(&bundle)?;
@@ -1418,17 +1297,6 @@ mod tests {
         for value in ["", "abc", &"z".repeat(64), &"a".repeat(63), &"a".repeat(65)] {
             assert!(PluginDigest::parse(value).is_err(), "accepted {value:?}");
         }
-    }
-
-    #[test]
-    fn portable_path_uses_forward_slashes() {
-        let relative: PathBuf = ["plugin", "hooks", "hooks.json"].iter().collect();
-        assert_eq!(portable_relative_path(&relative).unwrap(), "plugin/hooks/hooks.json");
-    }
-
-    #[test]
-    fn portable_path_refuses_traversal_components() {
-        assert!(portable_relative_path(Path::new("../escape")).is_err());
     }
 
     fn sample_tree(root: &Path) {
@@ -1694,7 +1562,7 @@ mod tests {
     fn build_time_and_runtime_repository_staging_have_one_tree_identity() {
         let repository = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
         let staged = tempfile::tempdir().unwrap();
-        crate::plugin_layout::stage_repository(repository, staged.path()).unwrap();
+        stage_repository(repository, staged.path()).unwrap();
 
         let runtime = canonical_source_digest(staged.path()).unwrap();
         let compiled = PluginDigest::parse(env!("APPA_PLUGIN_TREE_SHA256")).unwrap();
@@ -1714,7 +1582,7 @@ mod tests {
             .status()
             .unwrap();
         assert!(status.success());
-        crate::plugin_layout::stage_repository(repository, &mapped).unwrap();
+        stage_repository(repository, &mapped).unwrap();
 
         assert_eq!(
             canonical_source_digest(&scripted).unwrap(),

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -730,7 +730,7 @@ fn reusable(published: &Path, plan: &DeploymentPlan) -> Result<(), String> {
 /// Move a damaged deployment aside. Nothing is ever deleted, and the
 /// destination never pre-exists, so `rename` cannot silently replace a
 /// directory. The namespace is deliberately distinct from the
-/// `.appa-init-recovery-` prefix that init sweeps globally.
+/// `.appa-init-recovery-` prefix init names its rollback source with.
 fn quarantine(deployments_dir: &Path, published: &Path) -> Result<(), PluginBundleError> {
     let name = published
         .file_name()

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -56,6 +56,8 @@ pub enum PluginBundleError {
     MissingReleaseRef,
     #[error("this appa build carries an invalid plugin tree digest: {value}")]
     MalformedBuildDigest { value: String },
+    #[error("this appa build carries an unknown plugin source kind: {value}")]
+    MalformedBuildSourceKind { value: String },
     #[error("{value} is not a SHA-256 digest")]
     MalformedDigest { value: String },
     #[error("the plugin source at {path} is not a marketplace root: {reason}")]
@@ -144,6 +146,28 @@ impl fmt::Debug for PluginDigest {
     }
 }
 
+/// How a build without a release digest identifies its plugin source, as
+/// `build.rs` stamps it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceKind {
+    /// A clean checkout: the plugin is the tree at the build's Git commit.
+    Commit,
+    /// A dirty checkout: the plugin is the tree in the repository itself.
+    Local,
+}
+
+impl SourceKind {
+    fn parse(value: &str) -> Result<Self, PluginBundleError> {
+        match value {
+            "commit" => Ok(Self::Commit),
+            "local" => Ok(Self::Local),
+            other => Err(PluginBundleError::MalformedBuildSourceKind {
+                value: other.to_owned(),
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct BuildIdentity<'a> {
     pub release_digest: Option<PluginDigest>,
@@ -151,7 +175,7 @@ struct BuildIdentity<'a> {
     pub commit: Option<&'a str>,
     pub tree_digest: Option<PluginDigest>,
     pub local_root: Option<&'a str>,
-    pub source_kind: Option<&'a str>,
+    pub source_kind: Option<SourceKind>,
 }
 
 impl BuildIdentity<'static> {
@@ -174,7 +198,9 @@ impl BuildIdentity<'static> {
             commit: option_env!("APPA_BUILD_COMMIT"),
             tree_digest: Some(tree_digest),
             local_root: option_env!("APPA_PLUGIN_SOURCE_ROOT"),
-            source_kind: option_env!("APPA_PLUGIN_SOURCE_KIND"),
+            source_kind: option_env!("APPA_PLUGIN_SOURCE_KIND")
+                .map(SourceKind::parse)
+                .transpose()?,
         })
     }
 }
@@ -210,21 +236,21 @@ impl PluginSource {
         }
         let digest = build.tree_digest.ok_or(PluginBundleError::MissingBuildIdentity)?;
         match build.source_kind {
-            Some("commit") => {
+            Some(SourceKind::Commit) => {
                 let commit = build.commit.ok_or(PluginBundleError::MissingBuildIdentity)?;
                 Ok(Self::Commit {
                     commit: commit.to_owned(),
                     digest,
                 })
             }
-            Some("local") => {
+            Some(SourceKind::Local) => {
                 let root = build.local_root.ok_or(PluginBundleError::MissingBuildIdentity)?;
                 Ok(Self::Local {
                     root: PathBuf::from(root),
                     digest,
                 })
             }
-            _ => Err(PluginBundleError::MissingBuildIdentity),
+            None => Err(PluginBundleError::MissingBuildIdentity),
         }
     }
 }
@@ -1373,6 +1399,21 @@ mod tests {
     }
 
     #[test]
+    fn a_build_stamped_with_an_unknown_source_kind_is_refused() {
+        assert_eq!(SourceKind::parse("commit").unwrap(), SourceKind::Commit);
+        assert_eq!(SourceKind::parse("local").unwrap(), SourceKind::Local);
+        for value in ["", "release", "Commit", "git"] {
+            assert!(
+                matches!(
+                    SourceKind::parse(value),
+                    Err(PluginBundleError::MalformedBuildSourceKind { .. })
+                ),
+                "accepted {value:?}"
+            );
+        }
+    }
+
+    #[test]
     fn digest_rejects_malformed_hex() {
         for value in ["", "abc", &"z".repeat(64), &"a".repeat(63), &"a".repeat(65)] {
             assert!(PluginDigest::parse(value).is_err(), "accepted {value:?}");
@@ -1780,7 +1821,7 @@ mod tests {
                 commit: Some("71b5080ad2a49e21493887c5bf71a45c620e924f"),
                 tree_digest: Some(digest),
                 local_root: None,
-                source_kind: Some("commit"),
+                source_kind: Some(SourceKind::Commit),
             },
         )
         .unwrap();
@@ -1808,7 +1849,7 @@ mod tests {
                 commit: Some("ignored"),
                 tree_digest: Some(PluginDigest::of(b"tree")),
                 local_root: None,
-                source_kind: Some("release"),
+                source_kind: None,
             },
         )
         .unwrap();

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -48,7 +48,7 @@ const REQUIRED_DIRS: [&str; 2] = ["plugin", "batteries"];
 /// platform and removes the other, so a deployment carries exactly one. The same
 /// validator serves both, and this is the only thing it varies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TreeShape {
+enum TreeShape {
     Source,
     Deployment,
 }
@@ -107,7 +107,7 @@ pub enum PluginBundleError {
 pub struct PluginDigest([u8; 32]);
 
 impl PluginDigest {
-    pub fn parse(value: &str) -> Result<Self, PluginBundleError> {
+    fn parse(value: &str) -> Result<Self, PluginBundleError> {
         let trimmed = value.trim();
         let malformed = || PluginBundleError::MalformedDigest {
             value: trimmed.to_owned(),
@@ -125,13 +125,14 @@ impl PluginDigest {
         Ok(Self(bytes))
     }
 
-    pub fn of(bytes: &[u8]) -> Self {
+    #[cfg(test)]
+    fn of(bytes: &[u8]) -> Self {
         let mut digest = Sha256::new();
         digest.update(bytes);
         Self(digest.finalize().into())
     }
 
-    pub fn from_hasher(hasher: Sha256) -> Self {
+    fn from_hasher(hasher: Sha256) -> Self {
         Self(hasher.finalize().into())
     }
 }
@@ -214,7 +215,7 @@ impl BuildIdentity<'static> {
 /// development override; normal init resolves the identity baked into this
 /// binary without consulting PATH, the working directory, or mutable refs.
 #[derive(Debug, Clone)]
-pub enum PluginSource {
+pub(crate) enum PluginSource {
     Explicit(PathBuf),
     Release { reference: String, digest: PluginDigest },
     Commit { commit: String, digest: PluginDigest },
@@ -290,7 +291,7 @@ fn strip_extended_prefix(path: &Path) -> PathBuf {
 ///
 /// This checks shape, not content: a tree whose `batteries/` files were edited in
 /// place passes. Reuse pairs it with a byte comparison of the one generated file.
-pub fn validate_tree(root: &Path, shape: TreeShape) -> Result<(), PluginBundleError> {
+fn validate_tree(root: &Path, shape: TreeShape) -> Result<(), PluginBundleError> {
     let invalid = |reason: String| PluginBundleError::InvalidSource {
         path: root.to_path_buf(),
         reason,
@@ -312,31 +313,6 @@ pub fn validate_tree(root: &Path, shape: TreeShape) -> Result<(), PluginBundleEr
         return Err(invalid(format!("{WINDOWS_HOOKS} is missing")));
     }
     Ok(())
-}
-
-/// A staged relative path as the canonical digest encodes it: UTF-8 with `/`
-/// separators on every platform. The bundle is ASCII filenames, so a path that
-/// cannot be spelled this way is refused rather than normalized.
-pub fn portable_relative_path(relative: &Path) -> Result<String, PluginBundleError> {
-    let mut parts = Vec::new();
-    for component in relative.components() {
-        match component {
-            std::path::Component::Normal(part) => match part.to_str() {
-                Some(text) => parts.push(text),
-                None => {
-                    return Err(PluginBundleError::UnportablePath {
-                        path: relative.to_path_buf(),
-                    });
-                }
-            },
-            _ => {
-                return Err(PluginBundleError::UnportablePath {
-                    path: relative.to_path_buf(),
-                });
-            }
-        }
-    }
-    Ok(parts.join("/"))
 }
 
 // ---------------------------------------------------------------------------
@@ -401,7 +377,7 @@ impl Endpoint {
         &self.url
     }
 
-    pub fn listen(&self) -> SocketAddr {
+    fn listen(&self) -> SocketAddr {
         self.listen
     }
 
@@ -420,7 +396,7 @@ impl Endpoint {
 /// before rendering. Without this, editing a file in a `--plugin-source` tree
 /// and re-running init would reuse the existing deployment and never reach
 /// Claude.
-pub fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundleError> {
+fn canonical_source_digest(root: &Path) -> Result<PluginDigest, PluginBundleError> {
     Ok(PluginDigest(canonical_tree_digest(root)?))
 }
 
@@ -437,18 +413,18 @@ impl From<TreeDigestError> for PluginBundleError {
 
 /// Everything a deployment's identity depends on beyond the source bytes.
 #[derive(Debug, Clone)]
-pub struct DeploymentPlan {
-    pub source_digest: PluginDigest,
-    pub binary_path: PathBuf,
-    pub config_path: PathBuf,
-    pub data_dir: PathBuf,
-    pub endpoint: Endpoint,
+struct DeploymentPlan {
+    source_digest: PluginDigest,
+    binary_path: PathBuf,
+    config_path: PathBuf,
+    data_dir: PathBuf,
+    endpoint: Endpoint,
 }
 
 /// The name of the deployment directory: the source identity plus every path and
 /// platform detail rendered into it, so a deployment can never be reused for a
 /// different binary, config, data directory, endpoint or platform.
-pub fn deployment_digest(plan: &DeploymentPlan) -> Result<PluginDigest, PluginBundleError> {
+fn deployment_digest(plan: &DeploymentPlan) -> Result<PluginDigest, PluginBundleError> {
     let mut hasher = Sha256::new();
     absorb_field(&mut hasher, plan.source_digest.to_string().as_bytes());
     absorb_field(&mut hasher, path_identity(&plan.binary_path)?.as_bytes());
@@ -563,7 +539,7 @@ pub fn materialize(
         Err(error) => {
             // Our own unpublished reservation: removing it deletes no
             // registered state.
-            let _ = fs::remove_dir_all(&incoming);
+            discard_reservation(&incoming);
             return Err(error);
         }
     };
@@ -572,7 +548,7 @@ pub fn materialize(
     if published.is_dir() {
         match reusable(&published, &plan) {
             Ok(()) => {
-                let _ = fs::remove_dir_all(&incoming);
+                discard_reservation(&incoming);
                 return Ok(Deployment { root: published });
             }
             Err(reason) => {
@@ -583,7 +559,7 @@ pub fn materialize(
     }
 
     if let Err(error) = render(&incoming, &plan) {
-        let _ = fs::remove_dir_all(&incoming);
+        discard_reservation(&incoming);
         return Err(error);
     }
 
@@ -597,10 +573,10 @@ pub fn materialize(
                 std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::DirectoryNotEmpty
             ) =>
         {
-            let _ = fs::remove_dir_all(&incoming);
+            discard_reservation(&incoming);
         }
         Err(source) => {
-            let _ = fs::remove_dir_all(&incoming);
+            discard_reservation(&incoming);
             return Err(PluginBundleError::WriteDeployment {
                 path: published,
                 source,
@@ -622,6 +598,15 @@ pub fn materialize(
 /// deliberately not a content hash of every file: a tree whose `batteries/`
 /// contents were edited in place is not detected, and init's convergence claim
 /// is scoped to match.
+/// Remove this init's own unpublished reservation. No registered state is
+/// lost with it, so a failure is noted rather than reported over the error
+/// or the deployment the caller is already returning.
+fn discard_reservation(incoming: &Path) {
+    if let Err(error) = fs::remove_dir_all(incoming) {
+        tracing::warn!(path = %incoming.display(), %error, "cannot remove an unpublished deployment");
+    }
+}
+
 fn reusable(published: &Path, plan: &DeploymentPlan) -> Result<(), String> {
     validate_tree(published, TreeShape::Deployment).map_err(|error| error.to_string())?;
     for (name, expected) in [(PATHS_SH, paths_sh(plan)), (PATHS_PS1, paths_ps1(plan))] {
@@ -972,7 +957,7 @@ fn cached_archive_path(cache_dir: &Path, version: &str, digest: PluginDigest) ->
 /// The release download base. `APPA_RELEASE_BASE_URL` overrides it in debug
 /// builds only, and init reads it once at the boundary rather than leaving the
 /// fetch to consult the environment underneath its caller.
-pub fn release_base_url() -> String {
+pub(crate) fn release_base_url() -> String {
     let configured = if cfg!(debug_assertions) {
         env::var("APPA_RELEASE_BASE_URL").ok()
     } else {
@@ -983,7 +968,7 @@ pub fn release_base_url() -> String {
 
 /// The immutable GitHub source-archive base. Like the release test seam, the
 /// override exists only in debug builds and cannot redirect a shipped binary.
-pub fn source_archive_base_url() -> String {
+pub(crate) fn source_archive_base_url() -> String {
     let configured = if cfg!(debug_assertions) {
         env::var("APPA_SOURCE_ARCHIVE_BASE_URL").ok()
     } else {
@@ -997,7 +982,7 @@ pub fn source_archive_base_url() -> String {
 ///
 /// Every path ends in the same check against the digest this binary was built
 /// with, so the cache cannot be used to bypass a refusal.
-pub fn ensure_archive(
+pub(crate) fn ensure_archive(
     digest: PluginDigest,
     reference: &str,
     version: &str,
@@ -1057,7 +1042,7 @@ fn commit_archive_name(commit: &str, digest: PluginDigest) -> String {
 /// GitHub's repository archive is transport only. It is staged into the same
 /// marketplace shape as a release and checked against the canonical tree
 /// digest baked into the binary before entering the cache.
-pub fn ensure_commit_archive(
+pub(crate) fn ensure_commit_archive(
     commit: &str,
     expected: PluginDigest,
     cache_dir: &Path,

--- a/appa-runtime/src/plugin_layout.rs
+++ b/appa-runtime/src/plugin_layout.rs
@@ -1,12 +1,16 @@
-//! The repository paths that make up the distributable Claude Code plugin.
+//! The repository paths that make up the distributable Claude Code plugin,
+//! and the canonical identity of a staged plugin tree.
 //!
-//! This module is also compiled by `build.rs`, so keep it limited to `std`.
-//! One mapping drives build-time identity and runtime staging from a GitHub
-//! source archive.
+//! This module is also compiled by `build.rs`, so keep it limited to `std`
+//! and `sha2`. One mapping drives build-time identity and runtime staging
+//! from a GitHub source archive, and one digest names both.
 
+use std::fmt;
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
 
 pub const REPOSITORY_MAPPINGS: [(&str, &str); 7] = [
     ("integrations/claude-code/.claude-plugin", ".claude-plugin"),
@@ -17,6 +21,13 @@ pub const REPOSITORY_MAPPINGS: [(&str, &str); 7] = [
     ("integrations/claude-code/live-gate-check.py", "live-gate-check.py"),
     ("website/content/docs/contracts.md", "website/content/docs/contracts.md"),
 ];
+
+/// Caps on what a plugin source may be, whichever way it arrives. The bundle is
+/// a few hundred small text files; these bound a hostile archive or a
+/// development checkout that has accumulated a large generated directory,
+/// without being tight enough to constrain the real one.
+pub const MAX_ENTRIES: usize = 4096;
+pub const MAX_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Stage the plugin marketplace tree from an OpenAPPA repository checkout.
 pub fn stage_repository(repository: &Path, destination: &Path) -> io::Result<()> {
@@ -65,4 +76,217 @@ fn copy_entry(source: &Path, destination: &Path) -> io::Result<()> {
 fn ignored_generated_entry(name: &std::ffi::OsStr) -> bool {
     let name = name.to_string_lossy();
     name == "__pycache__" || name.ends_with(".pyc") || name.ends_with(".pyo")
+}
+
+// ---------------------------------------------------------------------------
+// Canonical tree digest
+// ---------------------------------------------------------------------------
+
+/// Why a staged tree has no canonical identity.
+#[derive(Debug)]
+pub enum TreeDigestError {
+    Read { path: PathBuf, source: io::Error },
+    UnportablePath { path: PathBuf },
+    UnsupportedEntry { path: PathBuf },
+    Oversized { path: PathBuf, reason: String },
+}
+
+impl fmt::Display for TreeDigestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read { path, source } => write!(formatter, "cannot read {}: {source}", path.display()),
+            Self::UnportablePath { path } => write!(formatter, "{} is not a portable path", path.display()),
+            Self::UnsupportedEntry { path } => {
+                write!(
+                    formatter,
+                    "{} is neither a regular file nor a directory",
+                    path.display()
+                )
+            }
+            Self::Oversized { path, reason } => write!(formatter, "{} is too large: {reason}", path.display()),
+        }
+    }
+}
+
+/// Every length prefix in the canonical digests is an unsigned 64-bit
+/// big-endian integer followed immediately by exactly that many bytes. Naive
+/// concatenation would be ambiguous, and the digests name deployment
+/// directories, so the encoding is observable identity and is pinned rather
+/// than left to the implementation.
+pub fn absorb_field(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    File,
+    Directory,
+}
+
+impl EntryKind {
+    fn tag(self) -> u8 {
+        match self {
+            Self::File => b'f',
+            Self::Directory => b'd',
+        }
+    }
+}
+
+/// One entry of a staged tree, in the spelling the digest encodes it under.
+pub struct StagedEntry {
+    pub portable: String,
+    pub kind: EntryKind,
+    pub absolute: PathBuf,
+}
+
+/// The identity of a staged plugin tree: its portable paths, kinds and file
+/// bytes in canonical order. Computed after staging and before rendering, so
+/// it never depends on the paths rendered into the tree.
+pub fn canonical_tree_digest(root: &Path) -> Result<[u8; 32], TreeDigestError> {
+    let mut hasher = Sha256::new();
+    for entry in walk(root)? {
+        absorb_field(&mut hasher, entry.portable.as_bytes());
+        hasher.update([entry.kind.tag()]);
+        match entry.kind {
+            EntryKind::Directory => absorb_field(&mut hasher, &[]),
+            EntryKind::File => absorb_file(&mut hasher, &entry.absolute)?,
+        }
+    }
+    Ok(hasher.finalize().into())
+}
+
+/// The tree in canonical order, refused if it exceeds the source bounds.
+pub fn walk(root: &Path) -> Result<Vec<StagedEntry>, TreeDigestError> {
+    let mut entries = Vec::new();
+    collect(root, root, &mut entries)?;
+    if entries.len() > MAX_ENTRIES {
+        return Err(TreeDigestError::Oversized {
+            path: root.to_path_buf(),
+            reason: format!("it holds more than {MAX_ENTRIES} entries"),
+        });
+    }
+    let mut total = 0u64;
+    for entry in entries.iter().filter(|entry| entry.kind == EntryKind::File) {
+        let length = fs::metadata(&entry.absolute)
+            .map_err(|source| TreeDigestError::Read {
+                path: entry.absolute.clone(),
+                source,
+            })?
+            .len();
+        total = total.saturating_add(length);
+        if total > MAX_UNCOMPRESSED_BYTES {
+            return Err(TreeDigestError::Oversized {
+                path: root.to_path_buf(),
+                reason: format!("it holds more than {MAX_UNCOMPRESSED_BYTES} bytes"),
+            });
+        }
+    }
+    // Bytewise on the UTF-8 path bytes, never locale collation.
+    entries.sort_by(|left, right| left.portable.as_bytes().cmp(right.portable.as_bytes()));
+    Ok(entries)
+}
+
+/// A staged relative path as the canonical digest encodes it: UTF-8 with `/`
+/// separators on every platform. The bundle is ASCII filenames, so a path that
+/// cannot be spelled this way is refused rather than normalized.
+pub fn portable_relative_path(relative: &Path) -> Result<String, TreeDigestError> {
+    let unportable = || TreeDigestError::UnportablePath {
+        path: relative.to_path_buf(),
+    };
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        match component {
+            std::path::Component::Normal(part) => parts.push(part.to_str().ok_or_else(unportable)?),
+            _ => return Err(unportable()),
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+/// A file's length prefix and then its bytes, streamed.
+///
+/// The length comes from the file's own metadata and exactly that many bytes are
+/// absorbed, so the encoding stays the length-prefixed one the digest is defined
+/// as, without holding a whole file in memory.
+fn absorb_file(hasher: &mut Sha256, path: &Path) -> Result<(), TreeDigestError> {
+    use std::io::Read;
+
+    let read = |source: io::Error| TreeDigestError::Read {
+        path: path.to_path_buf(),
+        source,
+    };
+    let mut file = fs::File::open(path).map_err(read)?;
+    let length = file.metadata().map_err(read)?.len();
+    hasher.update(length.to_be_bytes());
+
+    let mut remaining = length;
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let wanted = remaining.min(buffer.len() as u64) as usize;
+        let filled = file.read(&mut buffer[..wanted]).map_err(read)?;
+        if filled == 0 {
+            return Err(TreeDigestError::Oversized {
+                path: path.to_path_buf(),
+                reason: "it changed size while being read".to_owned(),
+            });
+        }
+        hasher.update(&buffer[..filled]);
+        remaining -= filled as u64;
+    }
+    Ok(())
+}
+
+fn collect(root: &Path, directory: &Path, entries: &mut Vec<StagedEntry>) -> Result<(), TreeDigestError> {
+    let read = |source: io::Error| TreeDigestError::Read {
+        path: directory.to_path_buf(),
+        source,
+    };
+    for entry in fs::read_dir(directory).map_err(read)? {
+        let entry = entry.map_err(read)?;
+        let absolute = entry.path();
+        let relative = absolute
+            .strip_prefix(root)
+            .map_err(|_| TreeDigestError::UnportablePath { path: absolute.clone() })?;
+        let portable = portable_relative_path(relative)?;
+        // Symlinks and special files are refused here exactly as in extraction:
+        // the bundle is regular files and directories.
+        let kind = entry.file_type().map_err(|source| TreeDigestError::Read {
+            path: absolute.clone(),
+            source,
+        })?;
+        if kind.is_dir() {
+            entries.push(StagedEntry {
+                portable,
+                kind: EntryKind::Directory,
+                absolute: absolute.clone(),
+            });
+            collect(root, &absolute, entries)?;
+        } else if kind.is_file() {
+            entries.push(StagedEntry {
+                portable,
+                kind: EntryKind::File,
+                absolute,
+            });
+        } else {
+            return Err(TreeDigestError::UnsupportedEntry { path: absolute });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portable_path_uses_forward_slashes() {
+        let relative: PathBuf = ["plugin", "hooks", "hooks.json"].iter().collect();
+        assert_eq!(portable_relative_path(&relative).unwrap(), "plugin/hooks/hooks.json");
+    }
+
+    #[test]
+    fn portable_path_refuses_traversal_components() {
+        assert!(portable_relative_path(Path::new("../escape")).is_err());
+    }
 }

--- a/appa-runtime/tests/annotators.rs
+++ b/appa-runtime/tests/annotators.rs
@@ -2,14 +2,14 @@
 //! executable behind the command override, a real store, the real hook path.
 
 mod common;
-use common::{raw, serve};
+use common::{audit_len, propose, ran, raw, root, serve};
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use appa_runtime::api::{AuditEvent, Runtime};
 use appa_runtime::{config::Config, hooks};
-use appa_runtime_api::{Actor, HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome, TrajectoryId};
+use appa_runtime_api::{Actor, HookDecision, HookEvent, ProposedCall, TrajectoryId};
 use axum::Router;
 use axum::extract::State;
 use axum::routing::post;
@@ -73,51 +73,11 @@ fn produced(delta_trust: &str) -> serde_json::Value {
     })
 }
 
-fn root() -> TrajectoryId {
-    TrajectoryId("annotators-test".to_string())
-}
-
-fn actor() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
-}
-
 fn fetch(url: &str) -> ProposedCall {
     ProposedCall {
         tool: "fetch".to_string(),
         arguments: raw(serde_json::json!({ "url": url })),
     }
-}
-
-async fn propose(runtime: &Arc<Runtime>, call: ProposedCall) -> HookDecision {
-    hooks::handle(
-        runtime,
-        HookEvent::ToolCall {
-            actor: actor(),
-            call,
-            spawn: false,
-        },
-    )
-    .await
-}
-
-async fn ran(runtime: &Arc<Runtime>, call: ProposedCall) {
-    assert_eq!(
-        hooks::handle(
-            runtime,
-            HookEvent::ToolResult {
-                actor: actor(),
-                call,
-                outcome: ToolOutcome::Success {
-                    body: OutcomeBody::Available("done".to_string()),
-                },
-            },
-        )
-        .await,
-        HookDecision::Ack
-    );
 }
 
 async fn open_runtime(dir: &tempfile::TempDir, config_toml: &str) -> Arc<Runtime> {
@@ -130,10 +90,6 @@ async fn open_runtime(dir: &tempfile::TempDir, config_toml: &str) -> Arc<Runtime
         HookDecision::Ack
     );
     runtime
-}
-
-fn audit_len(runtime: &Runtime) -> usize {
-    runtime.audit(&root()).expect("the audit reads").len()
 }
 
 fn http_policy(url: &str) -> String {

--- a/appa-runtime/tests/audience.rs
+++ b/appa-runtime/tests/audience.rs
@@ -1,11 +1,11 @@
 mod common;
-use common::{offers, raw, serve};
+use common::{actor, audit_len, last_offer, propose, ran, raw, root, serve};
 
 use std::sync::{Arc, Mutex};
 
 use appa_runtime::api::{RemedyOutcome, Runtime};
 use appa_runtime::{config::Config, hooks};
-use appa_runtime_api::{Actor, HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome, TrajectoryId};
+use appa_runtime_api::{HookDecision, HookEvent, ProposedCall};
 use axum::Router;
 use axum::extract::State;
 use axum::routing::post;
@@ -119,17 +119,6 @@ async fn serve_source() -> (String, Source) {
     (format!("{}/audience", serve(router).await), source)
 }
 
-fn root() -> TrajectoryId {
-    TrajectoryId("audience-test".to_string())
-}
-
-fn actor() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
-}
-
 fn read_hr() -> ProposedCall {
     ProposedCall {
         tool: "read_hr".to_string(),
@@ -142,42 +131,6 @@ fn send(to: &str) -> ProposedCall {
         tool: "send".to_string(),
         arguments: raw(serde_json::json!({ "to": to })),
     }
-}
-
-async fn propose(runtime: &Arc<Runtime>, call: ProposedCall) -> HookDecision {
-    hooks::handle(
-        runtime,
-        HookEvent::ToolCall {
-            actor: actor(),
-            call,
-            spawn: false,
-        },
-    )
-    .await
-}
-
-async fn ran(runtime: &Arc<Runtime>, call: ProposedCall) {
-    assert_eq!(
-        hooks::handle(
-            runtime,
-            HookEvent::ToolResult {
-                actor: actor(),
-                call,
-                outcome: ToolOutcome::Success {
-                    body: OutcomeBody::Available("done".to_string()),
-                },
-            },
-        )
-        .await,
-        HookDecision::Ack
-    );
-}
-
-fn last_offer(feedback: &str) -> appa_runtime::api::OfferId {
-    offers(feedback)
-        .last()
-        .cloned()
-        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 
 async fn narrowed(dir: &tempfile::TempDir, audience_url: &str) -> Arc<Runtime> {
@@ -203,10 +156,6 @@ async fn narrowed(dir: &tempfile::TempDir, audience_url: &str) -> Arc<Runtime> {
     );
     ran(&runtime, read_hr()).await;
     runtime
-}
-
-fn audit_len(runtime: &Runtime) -> usize {
-    runtime.audit(&root()).expect("the audit reads").len()
 }
 
 #[tokio::test]

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -5,6 +5,11 @@
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use appa_runtime::api::{OfferId, Runtime};
+use appa_runtime::hooks;
+use appa_runtime_api::{Actor, HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome, TrajectoryId};
 
 /// Fixture arguments, from a `json!` value to the bytes a harness would
 /// have sent. The adapter holds the harness's bytes already, so
@@ -33,15 +38,80 @@ pub fn stage_bundle(into: &Path) -> PathBuf {
 /// Every offer a feedback body names, in the order the feedback lists
 /// them. Which end a suite takes is its own assertion: a remedy plan
 /// that stages several offers surfaces one line each.
-pub fn offers(feedback: &str) -> Vec<appa_runtime::api::OfferId> {
+pub fn offers(feedback: &str) -> Vec<OfferId> {
     feedback
         .lines()
         .filter_map(|line| {
             let after = line.split("offer_id:").nth(1)?;
             let rest = after.trim_start().strip_prefix('"')?;
-            Some(appa_runtime::api::OfferId(rest[..rest.find('"')?].to_string()))
+            Some(OfferId(rest[..rest.find('"')?].to_string()))
         })
         .collect()
+}
+
+/// The last offer a feedback body names.
+pub fn last_offer(feedback: &str) -> OfferId {
+    offers(feedback)
+        .last()
+        .cloned()
+        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
+}
+
+/// The last offer a denial's feedback names.
+pub fn offer_of(decision: &HookDecision) -> OfferId {
+    let HookDecision::DenyCall { feedback, .. } = decision else {
+        panic!("expected a deny carrying feedback, got {decision:?}")
+    };
+    last_offer(feedback)
+}
+
+/// The one root trajectory a suite's session runs as. Every suite opens
+/// its own database, so the id needs no suite-specific spelling.
+pub fn root() -> TrajectoryId {
+    TrajectoryId("test-root".to_string())
+}
+
+pub fn actor() -> Actor {
+    Actor {
+        root: root(),
+        child: None,
+    }
+}
+
+/// The root actor proposes one call.
+pub async fn propose(runtime: &Arc<Runtime>, call: ProposedCall) -> HookDecision {
+    hooks::handle(
+        runtime,
+        HookEvent::ToolCall {
+            actor: actor(),
+            call,
+            spawn: false,
+        },
+    )
+    .await
+}
+
+/// The root actor reports one call as run with a plain body, and the
+/// runtime acknowledges it.
+pub async fn ran(runtime: &Arc<Runtime>, call: ProposedCall) {
+    assert_eq!(
+        hooks::handle(
+            runtime,
+            HookEvent::ToolResult {
+                actor: actor(),
+                call,
+                outcome: ToolOutcome::Success {
+                    body: OutcomeBody::Available("done".to_string()),
+                },
+            },
+        )
+        .await,
+        HookDecision::Ack
+    );
+}
+
+pub fn audit_len(runtime: &Runtime) -> usize {
+    runtime.audit(&root()).expect("the audit reads").len()
 }
 
 /// Serve one router on an ephemeral loopback port for the rest of the

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -23,15 +23,10 @@ pub fn repo_root() -> PathBuf {
 }
 
 /// The marketplace root a developer passes to `--plugin-source`, staged into
-/// `into` by the same script the release runs.
+/// `into` by the same mapping the build and init use.
 pub fn stage_bundle(into: &Path) -> PathBuf {
     let staged = into.join("plugin-source");
-    let status = std::process::Command::new("sh")
-        .arg(repo_root().join("scripts/appa-stage-plugin-bundle.sh"))
-        .arg(&staged)
-        .status()
-        .expect("the staging script runs");
-    assert!(status.success(), "the staging script failed");
+    appa_runtime::plugin_bundle::stage_repository(&repo_root(), &staged).expect("the checkout stages");
     staged
 }
 

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -31,6 +31,12 @@ case "$*" in
   *"/policy-key"*)
     # FAKE_POLICY_KEY is the policy the endpoint serves. Unset, the route is
     # missing, which curl --fail reports as a failure and init refuses.
+    # FAKE_POLICY_KEY_TIMEOUT is a runtime that never answers the route inside
+    # curl's deadline.
+    if [ -n "${FAKE_POLICY_KEY_TIMEOUT:-}" ]; then
+      printf 'curl: (28) Operation timed out after 2000 milliseconds\n' >&2
+      exit 28
+    fi
     if [ -z "${FAKE_POLICY_KEY:-}" ]; then
       printf 'curl: (22) The requested URL returned error: 404\n' >&2
       exit 22

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -11,10 +11,10 @@ case "$*" in
     exit 0
     ;;
   *"/policy-key"*)
-    # A runtime that does not answer for its policy, which is what curl --fail
-    # reports as a failure and init reads as nothing to reconcile. Set
-    # FAKE_POLICY_KEY to give the endpoint a policy to serve instead.
+    # FAKE_POLICY_KEY is the policy the endpoint serves. Unset, the route is
+    # missing, which curl --fail reports as a failure and init refuses.
     if [ -z "${FAKE_POLICY_KEY:-}" ]; then
+      printf 'curl: (22) The requested URL returned error: 404\n' >&2
       exit 22
     fi
     printf '%s\n' "$FAKE_POLICY_KEY"

--- a/appa-runtime/tests/fixtures/fake-curl.sh
+++ b/appa-runtime/tests/fixtures/fake-curl.sh
@@ -3,7 +3,25 @@
 # what every /binary-fingerprint call after the first reports: init probes the
 # endpoint once before it mutates anything and once after the start, and the two
 # answers differing is how a foreign runtime arriving mid-install is reproduced.
+#
+# FAKE_RUNTIME_STAND_IN, when set, names the directory fake-ensure-runtime.sh
+# starts a stand-in process in: until its pid file exists nothing answers, and
+# afterwards the stand-in's pid is the one every identity answer names. Without
+# it the answering pid is this shell's own, which no ownership check accepts.
 set -eu
+
+runtime_pid() {
+  if [ -n "${FAKE_RUNTIME_STAND_IN:-}" ]; then
+    cat "$FAKE_RUNTIME_STAND_IN/pid"
+  else
+    printf '%s' "$$"
+  fi
+}
+
+if [ -n "${FAKE_RUNTIME_STAND_IN:-}" ] && [ ! -f "$FAKE_RUNTIME_STAND_IN/pid" ]; then
+  printf 'curl: (7) Failed to connect\n' >&2
+  exit 7
+fi
 
 case "$*" in
   *"/health"*)
@@ -35,12 +53,13 @@ if [ -n "${FAKE_CURL_CALLS:-}" ]; then
   count=$(( $(cat "$FAKE_CURL_CALLS" 2>/dev/null || echo 0) + 1 ))
   printf '%s' "$count" >"$FAKE_CURL_CALLS"
   if [ -n "${FAKE_RUNTIME_FINGERPRINT_LATER:-}" ] && [ "$count" -gt 1 ]; then
-    printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER" "$FAKE_RUNTIME_CONFIG"
+    printf '%s %s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT_LATER" "$(runtime_pid)" "$FAKE_RUNTIME_CONFIG"
     exit 0
   fi
 fi
 
-# A deployment is the build and the configuration it serves, each on its own
-# line. Both are mandatory: a caller that names only the build has not said which
-# deployment answers, and `set -u` refuses rather than answering for a nameless one.
-printf '%s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT" "$FAKE_RUNTIME_CONFIG"
+# A deployment is the build, the process serving it, and the configuration it
+# serves, the last on its own line. All are mandatory: a caller that names only
+# the build has not said which deployment answers, and `set -u` refuses rather
+# than answering for a nameless one.
+printf '%s %s\n%s\n' "$FAKE_RUNTIME_FINGERPRINT" "$(runtime_pid)" "$FAKE_RUNTIME_CONFIG"

--- a/appa-runtime/tests/fixtures/fake-ensure-runtime.sh
+++ b/appa-runtime/tests/fixtures/fake-ensure-runtime.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# The installed plugin's starter, as init runs it. Exits 0 with nothing started
+# by default, because fake-curl answers as a healthy runtime anyway.
+#
+# FAKE_STARTER_FAILS makes the start fail, which is what a runtime that never
+# became healthy looks like to init.
+#
+# FAKE_RUNTIME_STAND_IN names a directory: a perl copy named `appa` is started
+# there, sleeping, detached from this script's pipes so init's wait on the
+# starter returns, and its pid is written to `$FAKE_RUNTIME_STAND_IN/pid` for
+# fake-curl to report. It passes init's same-user, process-name ownership check,
+# so it is what init stops when it rolls a failed install back.
+set -eu
+
+if [ -n "${FAKE_STARTER_FAILS:-}" ]; then
+  printf 'deliberate fake starter failure\n' >&2
+  exit 1
+fi
+
+if [ -n "${FAKE_RUNTIME_STAND_IN:-}" ] && [ ! -f "$FAKE_RUNTIME_STAND_IN/pid" ]; then
+  perl=$(command -v perl) || {
+    printf 'the runtime stand-in needs perl\n' >&2
+    exit 1
+  }
+  mkdir -p "$FAKE_RUNTIME_STAND_IN"
+  cp "$perl" "$FAKE_RUNTIME_STAND_IN/appa"
+  chmod 755 "$FAKE_RUNTIME_STAND_IN/appa"
+  "$FAKE_RUNTIME_STAND_IN/appa" -e 'sleep 300' </dev/null >/dev/null 2>&1 &
+  printf '%s\n' "$!" >"$FAKE_RUNTIME_STAND_IN/pid"
+fi
+exit 0

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use appa_engine::profile::PolicyFileKey;
@@ -51,6 +51,220 @@ fn runtime_fingerprint(deployed: &Path) -> String {
 /// Where init deploys the harness binary: private to appa, never on PATH.
 fn deployed_binary(data: &Path) -> std::path::PathBuf {
     data.join("bin/appa")
+}
+
+/// One isolated install: private home, install, config, data and Claude
+/// directories, fake `claude` and `curl` first on PATH, and the installed-plugin
+/// directory the fake registry points at, carrying the fixture starter.
+struct Fixture {
+    _directory: tempfile::TempDir,
+    root: PathBuf,
+    bin: PathBuf,
+    config: PathBuf,
+    data: PathBuf,
+    claude: PathBuf,
+    plugin: PathBuf,
+    appa: PathBuf,
+    source: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let root = directory.path().canonicalize().expect("a resolved root");
+        let bin = root.join("bin");
+        let claude = root.join("claude");
+        let plugin = root.join("installed-plugin");
+        fs::create_dir_all(&bin).expect("bin directory");
+        fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
+        fs::create_dir_all(&claude).expect("Claude directory");
+        let appa = install_test_binaries(&bin);
+        install_fake_curl(&bin);
+        let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+        for (fixture, target) in [
+            ("fake-claude.sh", bin.join("claude")),
+            ("fake-ensure-runtime.sh", plugin.join("hooks/ensure-runtime.sh")),
+        ] {
+            fs::copy(fixtures.join(fixture), &target).expect("the fixture is copied");
+            executable(&target);
+        }
+        fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
+        let source = stage_bundle(&root);
+        Self {
+            _directory: directory,
+            config: root.join("config"),
+            data: root.join("data"),
+            root,
+            bin,
+            claude,
+            plugin,
+            appa,
+            source,
+        }
+    }
+
+    /// `appa init claude-code` against this fixture, with the endpoint answering
+    /// as this deployment's own healthy runtime serving the policy init writes.
+    /// A test overrides the `FAKE_*` variables for the case it reproduces.
+    fn init(&self) -> Command {
+        let mut command = Command::new(&self.appa);
+        command
+            .current_dir(&self.root)
+            .args(["init", "claude-code", "--plugin-source"])
+            .arg(&self.source)
+            .env(
+                "PATH",
+                format!("{}:{}", self.bin.display(), std::env::var("PATH").unwrap_or_default()),
+            )
+            .env("HOME", &self.root)
+            .env("APPA_INSTALL_DIR", &self.bin)
+            .env("APPA_CONFIG_DIR", &self.config)
+            .env("APPA_DATA_DIR", &self.data)
+            .env("CLAUDE_CONFIG_DIR", &self.claude)
+            .env("FAKE_CLAUDE_HOME", &self.claude)
+            .env("FAKE_CLAUDE_LOG", self.root.join("claude.log"))
+            .env("FAKE_PLUGIN_ROOT", &self.plugin)
+            .env("FAKE_RUNTIME_FINGERPRINT", runtime_fingerprint(&self.appa))
+            .env("FAKE_RUNTIME_CONFIG", self.config.join("appa.toml"))
+            .env("FAKE_POLICY_KEY", default_policy_key());
+        command
+    }
+
+    fn deployed_binary(&self) -> PathBuf {
+        deployed_binary(&self.data)
+    }
+
+    fn statusline(&self) -> PathBuf {
+        self.bin.join("appa-statusline.sh")
+    }
+
+    fn settings(&self) -> PathBuf {
+        self.claude.join("settings.json")
+    }
+
+    fn registry(&self) -> Option<serde_json::Value> {
+        let bytes = fs::read(self.claude.join("plugins/installed_plugins.json")).ok()?;
+        Some(serde_json::from_slice(&bytes).expect("the registry is JSON"))
+    }
+}
+
+/// Everything a failed upgrade must leave as it found it.
+#[derive(Debug, PartialEq, Eq)]
+struct Installed {
+    binary: Option<Vec<u8>>,
+    statusline: Option<Vec<u8>>,
+    settings: Option<Vec<u8>>,
+    registry: Option<serde_json::Value>,
+}
+
+impl Installed {
+    fn of(fixture: &Fixture) -> Self {
+        Self {
+            binary: fs::read(fixture.deployed_binary()).ok(),
+            statusline: fs::read(fixture.statusline()).ok(),
+            settings: fs::read(fixture.settings()).ok(),
+            registry: fixture.registry(),
+        }
+    }
+}
+
+/// An install a previous init left, with bytes of its own in every file a later
+/// init rewrites, so a restore that merely reinstalls this build is told apart
+/// from one that puts the previous files back.
+fn previous_install(fixture: &Fixture) -> Installed {
+    assert!(fixture.init().output().expect("appa init runs").status.success());
+    fs::write(fixture.deployed_binary(), b"the previous build").expect("the previous binary is written");
+    fs::write(fixture.statusline(), b"the previous statusline").expect("the previous statusline is written");
+    let settings = fs::read_to_string(fixture.settings()).expect("settings are readable");
+    fs::write(fixture.settings(), settings.replacen('{', "{\"userSetting\": true,", 1))
+        .expect("the previous settings are written");
+    Installed::of(fixture)
+}
+
+fn launcher_is_armed(fixture: &Fixture) -> bool {
+    fs::read_to_string(fixture.bin.join("clappa")).is_ok_and(|launcher| !launcher.contains("init did not complete"))
+}
+
+#[test]
+fn a_failure_before_the_statusline_puts_the_previous_binary_back() {
+    let fixture = Fixture::new();
+    let before = previous_install(&fixture);
+    // The statusline install refuses a plugin without its statusline, after the
+    // binary has already been replaced.
+    fs::remove_file(fixture.plugin.join("statusline.sh")).expect("the plugin statusline is removed");
+
+    let failed = fixture.init().output().expect("appa init runs");
+
+    assert!(!failed.status.success());
+    assert_eq!(Installed::of(&fixture), before);
+    assert!(!fixture.deployed_binary().with_extension("prev").exists());
+    assert!(
+        launcher_is_armed(&fixture),
+        "the previous install's launcher is re-armed"
+    );
+}
+
+#[test]
+fn a_failure_at_the_start_puts_the_previous_statusline_back() {
+    let fixture = Fixture::new();
+    let before = previous_install(&fixture);
+
+    let failed = fixture
+        .init()
+        .env("FAKE_STARTER_FAILS", "1")
+        .output()
+        .expect("appa init runs");
+
+    assert!(!failed.status.success());
+    assert_eq!(Installed::of(&fixture), before);
+    assert!(!fixture.deployed_binary().with_extension("prev").exists());
+    assert!(
+        launcher_is_armed(&fixture),
+        "the previous install's launcher is re-armed"
+    );
+}
+
+/// A first install that fails after its runtime is up leaves nothing behind:
+/// the runtime it started is stopped, and no file or registration it wrote
+/// survives to bind a session to a runtime whose policy init could not settle.
+#[test]
+fn a_failure_after_the_start_stops_the_runtime_init_started() {
+    let fixture = Fixture::new();
+    let stand_in = fixture.root.join("stand-in");
+
+    let failed = fixture
+        .init()
+        .env("FAKE_RUNTIME_STAND_IN", &stand_in)
+        .env_remove("FAKE_POLICY_KEY")
+        .output()
+        .expect("appa init runs");
+
+    assert!(!failed.status.success());
+    let pid: i32 = fs::read_to_string(stand_in.join("pid"))
+        .expect("the starter recorded the runtime it started")
+        .trim()
+        .parse()
+        .expect("the recorded pid parses");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline && unsafe { libc::kill(pid, 0) } == 0 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert_ne!(
+        unsafe { libc::kill(pid, 0) },
+        0,
+        "the runtime init started is still running"
+    );
+    assert_eq!(
+        Installed::of(&fixture),
+        Installed {
+            binary: None,
+            statusline: None,
+            settings: None,
+            registry: Some(serde_json::json!({"version": 2, "plugins": {}})),
+        }
+    );
+    assert!(!fixture.claude.join("marketplace-appa").exists());
+    assert!(!fixture.bin.join("clappa").exists());
 }
 
 #[test]
@@ -246,7 +460,6 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
 
     let unrecoverable = run(&fingerprint, &mine, Some("plugin-install-always"));
     assert!(!unrecoverable.status.success());
-    assert!(String::from_utf8_lossy(&unrecoverable.stderr).contains("restoring the previous Claude Code plugin"));
     assert!(
         fs::read_to_string(bin.join("clappa"))
             .expect("fail-closed launcher")

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -224,6 +224,35 @@ fn a_failure_at_the_start_puts_the_previous_statusline_back() {
     );
 }
 
+/// The rollback source under the data directory belongs to the init that wrote
+/// it. A concurrent init, or one that crashed mid-switch, may still need its own,
+/// so a successful init removes only the one it made.
+#[test]
+fn another_inits_rollback_source_survives_a_successful_init() {
+    let fixture = Fixture::new();
+    let other = fixture.data.join(".appa-init-recovery-424242");
+    fs::create_dir_all(other.join("plugin")).expect("the other rollback source is written");
+    assert!(fixture.init().output().expect("appa init runs").status.success());
+    let upgrade = fixture.init().output().expect("appa init runs");
+    assert!(upgrade.status.success(), "{}", String::from_utf8_lossy(&upgrade.stderr));
+
+    assert!(
+        other.join("plugin").is_dir(),
+        "the other init's rollback source was removed"
+    );
+    let leftovers: Vec<_> = fs::read_dir(&fixture.data)
+        .expect("the data directory is readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(".appa-init-recovery-"))
+        .collect();
+    assert_eq!(
+        leftovers,
+        [".appa-init-recovery-424242"],
+        "this init's own rollback source was left"
+    );
+}
+
 /// A first install that fails after its runtime is up leaves nothing behind:
 /// the runtime it started is stopped, and no file or registration it wrote
 /// survives to bind a session to a runtime whose policy init could not settle.

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -5,10 +5,20 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Command;
 
+use appa_engine::profile::PolicyFileKey;
+use appa_runtime::config::Config;
 use sha2::{Digest, Sha256};
 
 mod common;
-use common::stage_bundle;
+use common::{repo_root, stage_bundle};
+
+/// The key of the policy a first install writes: the shipped default, which
+/// composes to the same bytes wherever it is loaded from.
+fn default_policy_key() -> String {
+    let example = repo_root().join("integrations/claude-code/examples/claude-code.appa.toml");
+    let config = Config::load(&example).expect("the shipped default loads");
+    PolicyFileKey::of(config.policy_file().bytes()).as_str().to_owned()
+}
 
 fn executable(path: &Path) {
     let mut permissions = fs::metadata(path).expect("fixture metadata").permissions();
@@ -64,11 +74,10 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     fs::create_dir_all(&bin).expect("bin directory");
     fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
     let appa = install_test_binaries(&bin);
-    fs::copy(&appa, bin.join("appa-runtime")).expect("legacy runtime fixture is copied");
-    executable(&bin.join("appa-runtime"));
     install_fake_curl(&bin);
     let source = stage_bundle(directory.path());
     let fingerprint = runtime_fingerprint(&appa);
+    let policy_key = default_policy_key();
 
     let fake_claude = bin.join("claude");
     fs::copy(
@@ -107,7 +116,8 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
             .env("FAKE_CLAUDE_LOG", &log)
             .env("FAKE_PLUGIN_ROOT", &plugin)
             .env("FAKE_RUNTIME_FINGERPRINT", reported_fingerprint)
-            .env("FAKE_RUNTIME_CONFIG", reported_config);
+            .env("FAKE_RUNTIME_CONFIG", reported_config)
+            .env("FAKE_POLICY_KEY", &policy_key);
         if let Some(failure) = fail_once {
             command.env("FAKE_CLAUDE_FAIL_ONCE", failure);
         }
@@ -134,11 +144,9 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
     assert!(first_stdout.contains("development source"));
     assert!(first_stdout.contains("(created)"));
     // The harness binary lands on an appa-private path, not on PATH, and the
-    // copy that is on PATH is named rather than removed.
+    // copy that is on PATH is left alone.
     assert!(deployed_binary(&data).is_file());
     assert!(bin.join("appa").is_file());
-    assert!(first_stdout.contains("A previous appa remains at"));
-    assert!(!bin.join("appa-runtime").exists());
     assert!(bin.join("clappa").is_file());
     assert!(bin.join("appa-statusline.sh").is_file());
     assert!(config.join("appa.toml").is_file());
@@ -177,8 +185,6 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
         Some(1)
     );
 
-    fs::copy(&appa, bin.join("appa-runtime")).expect("legacy runtime is restored for the failed-upgrade fixture");
-    executable(&bin.join("appa-runtime"));
     for failure in ["marketplace-add", "plugin-install"] {
         let failed = run(&fingerprint, &mine, Some(failure));
         assert!(!failed.status.success(), "the injected {failure} failure must surface");
@@ -194,10 +200,6 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
         assert!(
             claude.join("marketplace-appa").is_file(),
             "{failure} must restore the marketplace"
-        );
-        assert!(
-            bin.join("appa-runtime").is_file(),
-            "{failure} must leave the previous runtime available",
         );
         assert!(
             !fs::read_to_string(bin.join("clappa"))
@@ -375,6 +377,7 @@ fn init_keeps_a_custom_statusline() {
         .env("FAKE_PLUGIN_ROOT", &plugin)
         .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
         .env("FAKE_RUNTIME_CONFIG", config.join("appa.toml"))
+        .env("FAKE_POLICY_KEY", default_policy_key())
         .output()
         .expect("appa init runs");
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
@@ -435,6 +438,7 @@ fn relative_directory_overrides_are_rendered_absolute() {
         .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
         // The deployment the answering runtime claims: this init's own config.
         .env("FAKE_RUNTIME_CONFIG", root.join("config/appa.toml"))
+        .env("FAKE_POLICY_KEY", default_policy_key())
         .output()
         .expect("appa init runs");
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -332,108 +332,84 @@ fn the_plugin_source_override_is_hidden_from_normal_help() {
     assert!(!String::from_utf8_lossy(&output.stdout).contains("plugin-source"));
 }
 
+/// The shipped default config, byte for byte: what a first init seeds.
+fn shipped_default_config() -> String {
+    fs::read_to_string(repo_root().join("integrations/claude-code/examples/claude-code.appa.toml"))
+        .expect("the shipped default is readable")
+}
+
+/// Every `claude` invocation the fixture answered, one line each, in order.
+fn claude_calls(fixture: &Fixture) -> String {
+    fs::read_to_string(fixture.root.join("claude.log")).expect("the Claude invocation log is readable")
+}
+
+/// How many copies of the plugin Claude's registry holds, or `None` when it
+/// holds no entry for it at all.
+fn registered_copies(fixture: &Fixture) -> Option<usize> {
+    fixture.registry()?["plugins"]["appa-runtime@appa"]
+        .as_array()
+        .map(Vec::len)
+}
+
+fn successful_init(fixture: &Fixture) {
+    let output = fixture.init().output().expect("appa init runs");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+}
+
 #[test]
-fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
-    let directory = tempfile::tempdir().expect("temporary directory");
-    let bin = directory.path().join("bin");
-    let config = directory.path().join("config");
-    let data = directory.path().join("data");
-    let claude = directory.path().join("claude");
-    let plugin = directory.path().join("installed-plugin");
-    fs::create_dir_all(&bin).expect("bin directory");
-    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
-    let appa = install_test_binaries(&bin);
-    install_fake_curl(&bin);
-    let source = stage_bundle(directory.path());
-    let fingerprint = runtime_fingerprint(&appa);
-    let policy_key = default_policy_key();
+fn a_first_init_installs_the_bundle_and_registers_one_plugin() {
+    let fixture = Fixture::new();
+    let reloads = fixture.root.join("reloads");
+    let output = fixture
+        .init()
+        .env("FAKE_RELOADS", &reloads)
+        .output()
+        .expect("appa init runs");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
 
-    let fake_claude = bin.join("claude");
-    fs::copy(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
-        &fake_claude,
-    )
-    .expect("fake claude is copied");
-    executable(&fake_claude);
-
-    let starter = plugin.join("hooks/ensure-runtime.sh");
-    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
-    executable(&starter);
-    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nprintf APPA\n").expect("statusline");
-
-    let log = directory.path().join("claude.log");
-    let path = format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default());
-    let mine = config.join("appa.toml");
-    // What the runtime already owning the endpoint claims to be: a build, and the
-    // configuration it serves. Either one differing makes it another deployment.
-    let run = |reported_fingerprint: &str, reported_config: &Path, fail_once: Option<&str>| {
-        let mut command = Command::new(&appa);
-        // Run from a directory that holds no marketplace: default resolution
-        // must not consult the working directory, and an explicit source is an
-        // ordinary path argument.
-        command
-            .current_dir(directory.path())
-            .args(["init", "claude-code", "--plugin-source"])
-            .arg(&source)
-            .env("PATH", &path)
-            .env("HOME", directory.path())
-            .env("APPA_INSTALL_DIR", &bin)
-            .env("APPA_CONFIG_DIR", &config)
-            .env("APPA_DATA_DIR", &data)
-            .env("CLAUDE_CONFIG_DIR", &claude)
-            .env("FAKE_CLAUDE_HOME", &claude)
-            .env("FAKE_CLAUDE_LOG", &log)
-            .env("FAKE_PLUGIN_ROOT", &plugin)
-            .env("FAKE_RUNTIME_FINGERPRINT", reported_fingerprint)
-            .env("FAKE_RUNTIME_CONFIG", reported_config)
-            .env("FAKE_POLICY_KEY", &policy_key);
-        if let Some(failure) = fail_once {
-            command.env("FAKE_CLAUDE_FAIL_ONCE", failure);
-        }
-        command.output().expect("appa init runs")
-    };
-
-    let first = run(&fingerprint, &mine, None);
-    assert!(first.status.success(), "{}", String::from_utf8_lossy(&first.stderr));
-    let first_stderr = String::from_utf8_lossy(&first.stderr);
-    for phase in [
-        "resolving the matching plugin",
-        "preparing the plugin bundle",
-        "checking the runtime endpoint",
-        "updating the Claude Code plugin",
-        "starting the runtime",
-    ] {
-        assert!(
-            first_stderr.contains(phase),
-            "missing progress phase {phase:?}: {first_stderr}"
-        );
-    }
-    let first_stdout = String::from_utf8(first.stdout).expect("UTF-8 output");
-    assert!(first_stdout.starts_with("OpenAPPA initialized for Claude Code"));
-    assert!(first_stdout.contains("development source"));
-    assert!(first_stdout.contains("(created)"));
     // The harness binary lands on an appa-private path, not on PATH, and the
     // copy that is on PATH is left alone.
-    assert!(deployed_binary(&data).is_file());
-    assert!(bin.join("appa").is_file());
-    assert!(bin.join("clappa").is_file());
-    assert!(bin.join("appa-statusline.sh").is_file());
-    assert!(config.join("appa.toml").is_file());
+    assert!(fixture.deployed_binary().is_file());
+    assert!(fixture.bin.join("appa").is_file());
+    assert!(launcher_is_armed(&fixture));
+    assert!(fixture.statusline().is_file());
+    assert_eq!(
+        fs::read_to_string(fixture.config.join("appa.toml")).ok(),
+        Some(shipped_default_config())
+    );
 
     let settings: serde_json::Value =
-        serde_json::from_slice(&fs::read(claude.join("settings.json")).expect("Claude settings"))
-            .expect("settings JSON");
+        serde_json::from_slice(&fs::read(fixture.settings()).expect("Claude settings")).expect("settings JSON");
     assert!(
         settings["statusLine"]["command"]
             .as_str()
             .is_some_and(|command| command.ends_with("appa-statusline.sh"))
     );
+    assert_eq!(registered_copies(&fixture), Some(1));
+    // The runtime reports serving the key the fixture computed for the shipped
+    // default, and init found nothing to reconcile: that key is the real one.
+    assert!(
+        !reloads.exists(),
+        "a first install reloaded a runtime already serving its policy"
+    );
+}
 
-    let second = run(&fingerprint, &mine, None);
-    assert!(second.status.success(), "{}", String::from_utf8_lossy(&second.stderr));
-    assert!(String::from_utf8_lossy(&second.stdout).contains("(kept)"));
+#[test]
+fn a_rerun_keeps_the_config_and_replaces_the_plugin_once() {
+    let fixture = Fixture::new();
+    successful_init(&fixture);
+    let config = fixture.config.join("appa.toml");
+    let authored = format!(
+        "{}\n# an edit init keeps\n",
+        fs::read_to_string(&config).expect("the config is readable")
+    );
+    fs::write(&config, &authored).expect("the edit is written");
 
-    let calls = fs::read_to_string(&log).expect("Claude invocation log");
+    successful_init(&fixture);
+
+    assert_eq!(fs::read_to_string(&config).ok(), Some(authored));
+    assert_eq!(registered_copies(&fixture), Some(1));
+    let calls = claude_calls(&fixture);
     assert_eq!(
         calls.matches("plugin install appa-runtime@appa --scope user").count(),
         2
@@ -445,89 +421,100 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
         1
     );
     assert_eq!(calls.matches("plugin marketplace remove appa").count(), 1);
+}
 
-    let registry: serde_json::Value =
-        serde_json::from_slice(&fs::read(claude.join("plugins/installed_plugins.json")).expect("plugin registry"))
-            .expect("registry JSON");
-    assert_eq!(
-        registry["plugins"]["appa-runtime@appa"].as_array().map(Vec::len),
-        Some(1)
-    );
+#[test]
+fn a_failed_switch_restores_the_registered_plugin_and_the_launcher() {
+    let fixture = Fixture::new();
+    successful_init(&fixture);
+    let before = Installed::of(&fixture);
 
     for failure in ["marketplace-add", "plugin-install"] {
-        let failed = run(&fingerprint, &mine, Some(failure));
+        let failed = fixture
+            .init()
+            .env("FAKE_CLAUDE_FAIL_ONCE", failure)
+            .output()
+            .expect("appa init runs");
         assert!(!failed.status.success(), "the injected {failure} failure must surface");
-        let registry: serde_json::Value = serde_json::from_slice(
-            &fs::read(claude.join("plugins/installed_plugins.json")).expect("restored plugin registry"),
-        )
-        .expect("restored registry JSON");
         assert_eq!(
-            registry["plugins"]["appa-runtime@appa"].as_array().map(Vec::len),
-            Some(1),
-            "{failure} must restore the prior plugin",
+            Installed::of(&fixture),
+            before,
+            "{failure} must restore the prior installation"
         );
         assert!(
-            claude.join("marketplace-appa").is_file(),
+            fixture.claude.join("marketplace-appa").is_file(),
             "{failure} must restore the marketplace"
         );
         assert!(
-            !fs::read_to_string(bin.join("clappa"))
-                .expect("restored launcher")
-                .contains("init did not complete"),
-            "{failure} must restore the protected launcher",
+            launcher_is_armed(&fixture),
+            "{failure} must restore the protected launcher"
         );
     }
+}
 
-    // A foreign runtime already owning the endpoint is refused before Claude is
-    // touched at all, so the installation it would have replaced is still the one
-    // that is registered and running. Another build is one way to be foreign; this
-    // build serving another deployment's configuration is the other, and it is the
-    // one a digest alone cannot see.
+/// A foreign runtime already owning the endpoint is refused before Claude is
+/// touched at all, so the installation it would have replaced is still the one
+/// that is registered and running. Another build is one way to be foreign; this
+/// build serving another deployment's configuration is the other, and it is the
+/// one a digest alone cannot see.
+#[test]
+fn a_foreign_runtime_is_refused_before_claude_is_touched() {
+    let fixture = Fixture::new();
+    successful_init(&fixture);
+    let fingerprint = runtime_fingerprint(&fixture.appa);
+    let mine = fixture.config.join("appa.toml");
+
     for (build, serving) in [
         ("not-this-build", mine.as_path()),
         (fingerprint.as_str(), Path::new("/somewhere/else/appa.toml")),
     ] {
-        let before = fs::read_to_string(&log).expect("Claude invocation log");
-        let refused = run(build, serving, None);
+        let before = claude_calls(&fixture).lines().count();
+        let refused = fixture
+            .init()
+            .env("FAKE_RUNTIME_FINGERPRINT", build)
+            .env("FAKE_RUNTIME_CONFIG", serving)
+            .output()
+            .expect("appa init runs");
         assert!(
             !refused.status.success(),
             "a runtime claiming build {build} at {} must be refused",
             serving.display()
         );
-        let after = fs::read_to_string(&log).expect("Claude invocation log");
-        assert_eq!(
-            after.lines().count() - before.lines().count(),
-            after
-                .lines()
-                .skip(before.lines().count())
-                .filter(|line| line.starts_with("plugin marketplace list"))
-                .count(),
-            "a refused endpoint must not reach a single mutating claude call: {}",
-            &after[before.len()..],
+        let mutating: Vec<String> = claude_calls(&fixture)
+            .lines()
+            .skip(before)
+            .filter(|line| !line.starts_with("plugin marketplace list"))
+            .map(str::to_owned)
+            .collect();
+        assert!(
+            mutating.is_empty(),
+            "a refused endpoint must not reach a single mutating claude call: {mutating:?}",
         );
         assert!(
-            !fs::read_to_string(bin.join("clappa"))
-                .expect("launcher")
-                .contains("init did not complete"),
-            "a refused endpoint must leave the working launcher armed",
+            launcher_is_armed(&fixture),
+            "a refused endpoint must leave the working launcher armed"
         );
     }
+}
 
-    let unrecoverable = run(&fingerprint, &mine, Some("plugin-install-always"));
+#[test]
+fn a_failed_rollback_disarms_the_launcher_until_an_init_completes() {
+    let fixture = Fixture::new();
+    successful_init(&fixture);
+
+    let unrecoverable = fixture
+        .init()
+        .env("FAKE_CLAUDE_FAIL_ONCE", "plugin-install-always")
+        .output()
+        .expect("appa init runs");
     assert!(!unrecoverable.status.success());
     assert!(
-        fs::read_to_string(bin.join("clappa"))
-            .expect("fail-closed launcher")
-            .contains("init did not complete"),
+        !launcher_is_armed(&fixture),
         "a failed rollback must leave clappa refusing to launch an unprotected session",
     );
 
-    let repaired = run(&fingerprint, &mine, None);
-    assert!(
-        repaired.status.success(),
-        "{}",
-        String::from_utf8_lossy(&repaired.stderr)
-    );
+    successful_init(&fixture);
+    assert!(launcher_is_armed(&fixture));
 }
 
 /// A runtime of this deployment that survived the install keeps serving the policy it
@@ -535,51 +522,10 @@ fn init_installs_one_local_adapter_and_is_safe_to_run_again() {
 /// reconcile reloads rather than asks.
 #[test]
 fn init_reloads_a_surviving_runtime_that_serves_an_older_policy() {
-    let directory = tempfile::tempdir().expect("temporary directory");
-    let bin = directory.path().join("bin");
-    let config = directory.path().join("config");
-    let data = directory.path().join("data");
-    let claude = directory.path().join("claude");
-    let plugin = directory.path().join("installed-plugin");
-    fs::create_dir_all(&bin).expect("bin directory");
-    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
-    fs::create_dir_all(&claude).expect("Claude directory");
-    let appa = install_test_binaries(&bin);
-    install_fake_curl(&bin);
-    let source = stage_bundle(directory.path());
-    let fingerprint = runtime_fingerprint(&appa);
-
-    let fake_claude = bin.join("claude");
-    fs::copy(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
-        &fake_claude,
-    )
-    .expect("fake claude is copied");
-    executable(&fake_claude);
-    let starter = plugin.join("hooks/ensure-runtime.sh");
-    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
-    executable(&starter);
-    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
-
-    let reloads = directory.path().join("reloads");
-    let output = Command::new(appa)
-        .current_dir(directory.path())
-        .args(["init", "claude-code", "--plugin-source"])
-        .arg(&source)
-        .env(
-            "PATH",
-            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
-        )
-        .env("HOME", directory.path())
-        .env("APPA_INSTALL_DIR", &bin)
-        .env("APPA_CONFIG_DIR", &config)
-        .env("APPA_DATA_DIR", &data)
-        .env("CLAUDE_CONFIG_DIR", &claude)
-        .env("FAKE_CLAUDE_HOME", &claude)
-        .env("FAKE_CLAUDE_LOG", directory.path().join("claude.log"))
-        .env("FAKE_PLUGIN_ROOT", &plugin)
-        .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
-        .env("FAKE_RUNTIME_CONFIG", config.join("appa.toml"))
+    let fixture = Fixture::new();
+    let reloads = fixture.root.join("reloads");
+    let output = fixture
+        .init()
         // This deployment's own runtime, serving a policy that is not the file init
         // wrote: the one state a reload is for.
         .env("FAKE_POLICY_KEY", "a-policy-this-init-did-not-compose")
@@ -596,63 +542,16 @@ fn init_reloads_a_surviving_runtime_that_serves_an_older_policy() {
 
 #[test]
 fn init_keeps_a_custom_statusline() {
-    let directory = tempfile::tempdir().expect("temporary directory");
-    let bin = directory.path().join("bin");
-    let config = directory.path().join("config");
-    let data = directory.path().join("data");
-    let claude = directory.path().join("claude");
-    let plugin = directory.path().join("installed-plugin");
-    fs::create_dir_all(&bin).expect("bin directory");
-    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
-    fs::create_dir_all(&claude).expect("Claude directory");
-    let appa = install_test_binaries(&bin);
-    install_fake_curl(&bin);
-    let source = stage_bundle(directory.path());
-    let fingerprint = runtime_fingerprint(&appa);
+    let fixture = Fixture::new();
+    let custom = serde_json::json!({"statusLine": {"type": "command", "command": "my-status"}});
+    fs::write(fixture.settings(), custom.to_string()).expect("custom settings");
 
-    let fake_claude = bin.join("claude");
-    fs::copy(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
-        &fake_claude,
-    )
-    .expect("fake claude is copied");
-    executable(&fake_claude);
-    let starter = plugin.join("hooks/ensure-runtime.sh");
-    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
-    executable(&starter);
-    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
-    fs::write(
-        claude.join("settings.json"),
-        r#"{"statusLine":{"type":"command","command":"my-status"}}"#,
-    )
-    .expect("custom settings");
+    successful_init(&fixture);
 
-    let output = Command::new(appa)
-        .current_dir(directory.path())
-        .args(["init", "claude-code", "--plugin-source"])
-        .arg(&source)
-        .env(
-            "PATH",
-            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
-        )
-        .env("HOME", directory.path())
-        .env("APPA_INSTALL_DIR", &bin)
-        .env("APPA_CONFIG_DIR", &config)
-        .env("APPA_DATA_DIR", &data)
-        .env("CLAUDE_CONFIG_DIR", &claude)
-        .env("FAKE_CLAUDE_HOME", &claude)
-        .env("FAKE_CLAUDE_LOG", directory.path().join("claude.log"))
-        .env("FAKE_PLUGIN_ROOT", &plugin)
-        .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
-        .env("FAKE_RUNTIME_CONFIG", config.join("appa.toml"))
-        .env("FAKE_POLICY_KEY", default_policy_key())
-        .output()
-        .expect("appa init runs");
-    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
-    assert!(!String::from_utf8_lossy(&output.stdout).contains("Statusline"));
-    let settings = fs::read_to_string(claude.join("settings.json")).expect("settings remain");
-    assert!(settings.contains("my-status"));
-    assert!(!bin.join("appa-statusline.sh").exists());
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(fixture.settings()).expect("settings remain")).expect("settings JSON");
+    assert_eq!(settings, custom);
+    assert!(!fixture.statusline().exists());
 }
 
 /// A relative directory override must not reach the rendered hooks as written.
@@ -662,57 +561,21 @@ fn init_keeps_a_custom_statusline() {
 /// and find no binary, config or database.
 #[test]
 fn relative_directory_overrides_are_rendered_absolute() {
-    let directory = tempfile::tempdir().expect("temporary directory");
-    let root = directory.path().canonicalize().expect("a resolved root");
-    let bin = root.join("bin");
-    let claude = root.join("claude");
-    let plugin = root.join("installed-plugin");
-    fs::create_dir_all(&bin).expect("bin directory");
-    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
-    let appa = install_test_binaries(&bin);
-    install_fake_curl(&bin);
-    let source = stage_bundle(&root);
-    let fingerprint = runtime_fingerprint(&appa);
-
-    let fake_claude = bin.join("claude");
-    fs::copy(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
-        &fake_claude,
-    )
-    .expect("fake claude is copied");
-    executable(&fake_claude);
-    let starter = plugin.join("hooks/ensure-runtime.sh");
-    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
-    executable(&starter);
-    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
-
-    let output = Command::new(&appa)
-        .current_dir(&root)
-        .args(["init", "claude-code", "--plugin-source"])
-        .arg(&source)
-        .env(
-            "PATH",
-            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
-        )
-        .env("HOME", &root)
-        // Relative, resolved against this working directory and no other.
+    let fixture = Fixture::new();
+    let root = &fixture.root;
+    let output = fixture
+        .init()
+        // Relative, resolved against the fixture's working directory and no other.
         .env("APPA_INSTALL_DIR", "bin")
         .env("APPA_CONFIG_DIR", "config")
         .env("APPA_DATA_DIR", "state")
-        .env("CLAUDE_CONFIG_DIR", &claude)
-        .env("FAKE_CLAUDE_HOME", &claude)
-        .env("FAKE_CLAUDE_LOG", root.join("claude.log"))
-        .env("FAKE_PLUGIN_ROOT", &plugin)
-        .env("FAKE_RUNTIME_FINGERPRINT", fingerprint)
         // The deployment the answering runtime claims: this init's own config.
         .env("FAKE_RUNTIME_CONFIG", root.join("config/appa.toml"))
-        .env("FAKE_POLICY_KEY", default_policy_key())
         .output()
         .expect("appa init runs");
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
 
-    let deployments = root.join("state/deployments");
-    let deployment = fs::read_dir(&deployments)
+    let deployment = fs::read_dir(root.join("state/deployments"))
         .expect("the deployment directory exists")
         .filter_map(Result::ok)
         .map(|entry| entry.path())
@@ -729,7 +592,7 @@ fn relative_directory_overrides_are_rendered_absolute() {
             .unwrap_or_else(|| panic!("{name} is missing from {rendered}"));
         assert!(Path::new(value).is_absolute(), "{name} was rendered relative: {value}",);
         assert!(
-            Path::new(value).starts_with(&root),
+            Path::new(value).starts_with(root),
             "{name} does not resolve under the working directory it was given: {value}",
         );
     }
@@ -746,49 +609,11 @@ fn relative_directory_overrides_are_rendered_absolute() {
 /// the one just installed rather than restoring a predecessor.
 #[test]
 fn a_runtime_that_fails_verification_after_the_switch_undoes_it() {
-    let directory = tempfile::tempdir().expect("temporary directory");
-    let root = directory.path();
-    let bin = root.join("bin");
-    let claude = root.join("claude");
-    let plugin = root.join("installed-plugin");
-    fs::create_dir_all(&bin).expect("bin directory");
-    fs::create_dir_all(plugin.join("hooks")).expect("plugin hooks");
-    let appa = install_test_binaries(&bin);
-    install_fake_curl(&bin);
-    let source = stage_bundle(root);
-
-    let fake_claude = bin.join("claude");
-    fs::copy(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-claude.sh"),
-        &fake_claude,
-    )
-    .expect("fake claude is copied");
-    executable(&fake_claude);
-    let starter = plugin.join("hooks/ensure-runtime.sh");
-    fs::write(&starter, "#!/bin/sh\nexit 0\n").expect("fake starter");
-    executable(&starter);
-    fs::write(plugin.join("statusline.sh"), "#!/bin/sh\nexit 0\n").expect("statusline");
-
-    let output = Command::new(&appa)
-        .current_dir(root)
-        .args(["init", "claude-code", "--plugin-source"])
-        .arg(&source)
-        .env(
-            "PATH",
-            format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default()),
-        )
-        .env("HOME", root)
-        .env("APPA_INSTALL_DIR", &bin)
-        .env("APPA_CONFIG_DIR", root.join("config"))
-        .env("APPA_DATA_DIR", root.join("data"))
-        .env("CLAUDE_CONFIG_DIR", &claude)
-        .env("FAKE_CLAUDE_HOME", &claude)
-        .env("FAKE_CLAUDE_LOG", root.join("claude.log"))
-        .env("FAKE_PLUGIN_ROOT", &plugin)
+    let fixture = Fixture::new();
+    let output = fixture
+        .init()
         // The preflight sees this build; everything after it sees a stranger.
-        .env("FAKE_CURL_CALLS", root.join("curl-calls"))
-        .env("FAKE_RUNTIME_FINGERPRINT", runtime_fingerprint(&appa))
-        .env("FAKE_RUNTIME_CONFIG", root.join("config/appa.toml"))
+        .env("FAKE_CURL_CALLS", fixture.root.join("curl-calls"))
         .env("FAKE_RUNTIME_FINGERPRINT_LATER", "not-this-build")
         .output()
         .expect("appa init runs");
@@ -798,21 +623,17 @@ fn a_runtime_that_fails_verification_after_the_switch_undoes_it() {
         "verification against a foreign runtime must fail init: {}",
         String::from_utf8_lossy(&output.stderr),
     );
-
-    let registry: serde_json::Value =
-        serde_json::from_slice(&fs::read(claude.join("plugins/installed_plugins.json")).expect("plugin registry"))
-            .expect("registry JSON");
     assert_eq!(
-        registry["plugins"]["appa-runtime@appa"].as_array().map(Vec::len),
+        registered_copies(&fixture),
         None,
         "the plugin must not stay registered against a runtime that failed verification",
     );
     assert!(
-        !claude.join("marketplace-appa").is_file(),
+        !fixture.claude.join("marketplace-appa").is_file(),
         "the marketplace must not stay registered either",
     );
     assert!(
-        !bin.join("clappa").exists(),
+        !fixture.bin.join("clappa").exists(),
         "the launcher must not be armed for a bundle whose runtime failed verification",
     );
 }

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -253,6 +253,32 @@ fn another_inits_rollback_source_survives_a_successful_init() {
     );
 }
 
+/// A runtime that does not answer for its policy inside the probe's deadline
+/// cannot be reconciled, so init fails and binds nothing to it rather than
+/// reporting it healthy.
+#[test]
+fn a_policy_key_timeout_fails_init() {
+    let fixture = Fixture::new();
+
+    let failed = fixture
+        .init()
+        .env("FAKE_POLICY_KEY_TIMEOUT", "1")
+        .output()
+        .expect("appa init runs");
+
+    assert!(!failed.status.success());
+    assert_eq!(
+        Installed::of(&fixture),
+        Installed {
+            binary: None,
+            statusline: None,
+            settings: None,
+            registry: Some(serde_json::json!({"version": 2, "plugins": {}})),
+        }
+    );
+    assert!(!fixture.bin.join("clappa").exists());
+}
+
 /// A first install that fails after its runtime is up leaves nothing behind:
 /// the runtime it started is stopped, and no file or registration it wrote
 /// survives to bind a session to a runtime whose policy init could not settle.

--- a/appa-runtime/tests/input_substitution.rs
+++ b/appa-runtime/tests/input_substitution.rs
@@ -1,11 +1,11 @@
 mod common;
-use common::{offers, raw};
+use common::{actor, last_offer, propose, raw, root};
 
 use std::sync::Arc;
 
 use appa_runtime::api::{AuditEvent, DispatchOutcome, OfferId, RemedyOutcome, Runtime};
 use appa_runtime::{config::Config, hooks};
-use appa_runtime_api::{Actor, HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome, TrajectoryId};
+use appa_runtime_api::{HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome};
 
 const POLICY: &str = r#"
 [policy]
@@ -38,17 +38,6 @@ builtin = "redact-email"
 const RAW_BODY: &str = "mail alice@corp.example today";
 const REDACTED_BODY: &str = "mail [redacted-email] today";
 
-fn root() -> TrajectoryId {
-    TrajectoryId("substitution-test".to_string())
-}
-
-fn actor() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
-}
-
 fn read_hr() -> ProposedCall {
     ProposedCall {
         tool: "read_hr".to_string(),
@@ -61,18 +50,6 @@ fn send(body: &str) -> ProposedCall {
         tool: "send".to_string(),
         arguments: raw(serde_json::json!({"body": body})),
     }
-}
-
-async fn propose(runtime: &Arc<Runtime>, call: ProposedCall) -> HookDecision {
-    hooks::handle(
-        runtime,
-        HookEvent::ToolCall {
-            actor: actor(),
-            call,
-            spawn: false,
-        },
-    )
-    .await
 }
 
 async fn report(runtime: &Arc<Runtime>, call: ProposedCall, body: &str) -> HookDecision {
@@ -94,13 +71,6 @@ fn feedback_of(decision: &HookDecision) -> String {
         HookDecision::DenyCall { feedback, .. } => feedback.clone(),
         other => panic!("expected a deny carrying feedback, got {other:?}"),
     }
-}
-
-fn last_offer(feedback: &str) -> OfferId {
-    offers(feedback)
-        .last()
-        .cloned()
-        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 
 async fn narrowed_and_blocked(dir: &tempfile::TempDir) -> (Arc<Runtime>, OfferId) {

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -89,6 +89,53 @@ fn both_shipped_hook_maps_gate_the_same_events() {
     }
 }
 
+/// The events each shipped map marks as turn ends, from the flag its hook
+/// command carries: `--turn-end` to hook.sh, `-TurnEnd` to hook.ps1. Nothing in
+/// the shipped scripts reads the event name for this, so the map is the only
+/// place the marking lives.
+fn turn_end_events(map: &serde_json::Value) -> Vec<String> {
+    let mut events: Vec<String> = map["hooks"]
+        .as_object()
+        .expect("the hook map is an object")
+        .iter()
+        .filter(|(_, groups)| {
+            groups
+                .as_array()
+                .expect("each event carries groups")
+                .iter()
+                .flat_map(|group| group["hooks"].as_array().expect("each group carries hooks"))
+                .any(|hook| {
+                    let command_words = hook["command"]
+                        .as_str()
+                        .map(str::split_whitespace)
+                        .into_iter()
+                        .flatten();
+                    let args = hook["args"]
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .filter_map(|arg| arg.as_str());
+                    command_words
+                        .chain(args)
+                        .any(|word| word == "--turn-end" || word == "-TurnEnd")
+                })
+        })
+        .map(|(event, _)| event.clone())
+        .collect();
+    events.sort();
+    events
+}
+
+/// Both shipped maps mark the same events as turn ends. A turn end marked on one
+/// platform and not the other would block, or fail to, on that platform alone.
+#[test]
+fn both_shipped_hook_maps_mark_the_same_turn_ends() {
+    let mut expected: Vec<String> = TURN_ENDS.iter().map(|event| (*event).to_owned()).collect();
+    expected.sort();
+    assert_eq!(turn_end_events(&shipped("hooks.json")), expected);
+    assert_eq!(turn_end_events(&shipped("hooks.windows.json")), expected);
+}
+
 /// Both shipped maps inject the same session context, and nothing else reaches
 /// the second SessionStart entry: a rename or a drift on one platform would
 /// leave that platform's sessions without the context the other one gets. The

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -51,12 +51,6 @@ fn an_ungated_session_has_no_appa_statusline() {
         .expect("the POSIX statusline runs");
     assert!(output.status.success());
     assert_eq!(output.stdout, b"", "plain Claude must have no APPA statusline");
-
-    let windows = std::fs::read_to_string(plugin_file("statusline.ps1")).expect("the Windows statusline is readable");
-    assert!(
-        windows.contains("if ($env:APPA_GATE -ne \"1\") {\n        exit 0\n    }"),
-        "the Windows statusline must also be silent outside clappa",
-    );
 }
 
 /// The two shipped hook maps gate the same events. Nothing else compares
@@ -166,13 +160,11 @@ fn both_shipped_hook_maps_inject_the_same_session_context() {
         args.contains(&"-SessionContext"),
         "the Windows SessionStart hook no longer asks hook.ps1 for the session context",
     );
-    let script = std::fs::read_to_string(hooks_dir.join("hook.ps1")).expect("the shipped hook.ps1 is readable");
-    assert!(
-        script.contains(CONTEXT),
-        "hook.ps1 no longer reads {CONTEXT}, so the two platforms inject different context",
-    );
 }
 
+/// The one command every posting hook in the shipped POSIX map registers,
+/// read from the map itself. SessionStart is that command with the runtime
+/// start chained in between its gate and its hook: `<gate>; <starter> && <hook>`.
 fn shipped_command() -> String {
     let hooks = shipped("hooks.json");
     let command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
@@ -200,16 +192,13 @@ fn shipped_command() -> String {
             "the {event} hook is no longer the non-blocking turn-end command",
         );
     }
+    let (gate, hook) = command
+        .split_once("; ")
+        .expect("the shared command is a gate followed by the hook");
+    let starter = "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null";
     assert_eq!(
         hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
-        Some(
-            command
-                .replace(
-                    "; sh",
-                    "; sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-runtime.sh\" </dev/null && sh",
-                )
-                .as_str()
-        ),
+        Some(format!("{gate}; {starter} && {hook}").as_str()),
         "the SessionStart hook is no longer the shared command plus its runtime start",
     );
     command

--- a/appa-runtime/tests/rendered_hooks.rs
+++ b/appa-runtime/tests/rendered_hooks.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 
-use appa_runtime::plugin_bundle::{Endpoint, Population, materialize};
+use appa_runtime::plugin_bundle::{DEFAULT_ENDPOINT_URL, Endpoint, Population, materialize};
 
 mod common;
 use common::stage_bundle;
@@ -251,4 +251,70 @@ fn the_session_start_starter_starts_the_binary_its_deployment_installed() {
         started.is_file(),
         "the starter did not execute the binary its paths file names",
     );
+}
+
+/// Every UTF-8 file under `root`, with its path, so an assertion can sweep the
+/// whole deployment rather than a list of files someone remembered.
+fn text_files(root: &Path) -> Vec<(std::path::PathBuf, String)> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory).expect("the deployment is readable") {
+            let path = entry.expect("the entry is readable").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if let Ok(text) = fs::read_to_string(&path) {
+                files.push((path, text));
+            }
+        }
+    }
+    files
+}
+
+#[test]
+fn a_materialized_endpoint_reaches_every_consumer_of_the_default_literal() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let root = directory.path();
+    let source = stage_bundle(root);
+    let endpoint = dead_endpoint();
+    assert_ne!(endpoint.url(), DEFAULT_ENDPOINT_URL);
+
+    let deployment = materialize(
+        Population::Tree(&source),
+        &root.join("data/deployments"),
+        &root.join("data/bin/appa"),
+        &root.join("config/appa.toml"),
+        &root.join("data"),
+        &endpoint,
+    )
+    .expect("the deployment materializes");
+
+    // The hooks learn the endpoint by sourcing the rendered paths file.
+    let sourced = Command::new("sh")
+        .arg("-c")
+        .arg(". \"$1\" && printf '%s' \"$APPA_ENDPOINT\"")
+        .arg("sh")
+        .arg(deployment.root.join("plugin/hooks/appa-paths.sh"))
+        .env("APPA_ENDPOINT", DEFAULT_ENDPOINT_URL)
+        .output()
+        .expect("the paths file sources");
+    assert_eq!(String::from_utf8_lossy(&sourced.stdout), endpoint.url());
+
+    // The MCP registration and the statusline read the literal themselves.
+    let mcp: serde_json::Value =
+        serde_json::from_slice(&fs::read(deployment.root.join("plugin/.mcp.json")).expect("the MCP registration"))
+            .expect("the MCP registration parses");
+    assert_eq!(
+        mcp["mcpServers"]["appa"]["url"],
+        format!("${{APPA_RUNTIME_URL:-{}}}/mcp", endpoint.url())
+    );
+    let statusline = fs::read_to_string(deployment.root.join("plugin/statusline.sh")).expect("the statusline");
+    assert!(statusline.contains(endpoint.url()));
+
+    let stale: Vec<_> = text_files(&deployment.root)
+        .into_iter()
+        .filter(|(_, text)| text.contains(DEFAULT_ENDPOINT_URL))
+        .map(|(path, _)| path)
+        .collect();
+    assert!(stale.is_empty(), "the default endpoint survived rendering in {stale:?}");
 }

--- a/appa-runtime/tests/rewrite_selects_contract.rs
+++ b/appa-runtime/tests/rewrite_selects_contract.rs
@@ -3,13 +3,13 @@
 //! path.
 
 mod common;
-use common::{offers, raw, serve};
+use common::{actor, offer_of, propose, ran, raw, root, serve};
 
 use std::sync::{Arc, Mutex};
 
-use appa_runtime::api::{AuditEvent, OfferId, RemedyOutcome, Runtime};
+use appa_runtime::api::{AuditEvent, RemedyOutcome, Runtime};
 use appa_runtime::{config::Config, hooks};
-use appa_runtime_api::{Actor, HookDecision, HookEvent, OutcomeBody, ProposedCall, ToolOutcome, TrajectoryId};
+use appa_runtime_api::{HookDecision, HookEvent, ProposedCall};
 use axum::Router;
 use axum::extract::State;
 use axum::routing::post;
@@ -111,17 +111,6 @@ async fn serve_stubs(rewrite: serde_json::Value) -> (String, Stubs) {
     (serve(router).await, stubs)
 }
 
-fn root() -> TrajectoryId {
-    TrajectoryId("rewrite-selects-contract".to_string())
-}
-
-fn actor() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
-}
-
 fn read_hr() -> ProposedCall {
     ProposedCall {
         tool: "read_hr".to_string(),
@@ -136,45 +125,6 @@ fn read_file(path: &str) -> ProposedCall {
     }
 }
 
-async fn propose(runtime: &Arc<Runtime>, call: ProposedCall) -> HookDecision {
-    hooks::handle(
-        runtime,
-        HookEvent::ToolCall {
-            actor: actor(),
-            call,
-            spawn: false,
-        },
-    )
-    .await
-}
-
-async fn ran(runtime: &Arc<Runtime>, call: ProposedCall) {
-    assert_eq!(
-        hooks::handle(
-            runtime,
-            HookEvent::ToolResult {
-                actor: actor(),
-                call,
-                outcome: ToolOutcome::Success {
-                    body: OutcomeBody::Available("done".to_string()),
-                },
-            },
-        )
-        .await,
-        HookDecision::Ack
-    );
-}
-
-fn last_offer(decision: &HookDecision) -> OfferId {
-    let HookDecision::DenyCall { feedback, .. } = decision else {
-        panic!("expected a deny carrying feedback, got {decision:?}")
-    };
-    offers(feedback)
-        .last()
-        .cloned()
-        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
-}
-
 /// A runtime whose audience is narrowed to `hr`, with the sanitizer answering `rewrite`.
 async fn narrowed(dir: &tempfile::TempDir, rewrite: serde_json::Value) -> (Arc<Runtime>, Stubs) {
     let (base, stubs) = serve_stubs(rewrite).await;
@@ -186,7 +136,7 @@ async fn narrowed(dir: &tempfile::TempDir, rewrite: serde_json::Value) -> (Arc<R
         hooks::handle(&runtime, HookEvent::SessionStart { root: root() }).await,
         HookDecision::Ack
     );
-    let accept = last_offer(&propose(&runtime, read_hr()).await);
+    let accept = offer_of(&propose(&runtime, read_hr()).await);
     assert!(matches!(
         runtime.execute_remedy(&actor(), accept).await,
         RemedyOutcome::Authorized { .. }
@@ -232,7 +182,7 @@ async fn a_rewrite_into_the_public_contract_consults_its_annotator_about_the_rew
         stubs.consults.lock().unwrap().is_empty(),
         "the private contract is static and owes no annotation"
     );
-    let hop = last_offer(&blocked);
+    let hop = offer_of(&blocked);
 
     assert_eq!(
         rewritten_path(runtime.execute_remedy(&actor(), hop).await),
@@ -268,7 +218,7 @@ async fn a_rewrite_into_the_private_contract_records_the_classified_read_and_con
 
     let blocked = propose(&runtime, read_file("public/q3.md")).await;
     assert_eq!(stubs.consults.lock().unwrap().len(), 1, "the proposal is classified");
-    let hop = last_offer(&blocked);
+    let hop = offer_of(&blocked);
 
     assert_eq!(
         rewritten_path(runtime.execute_remedy(&actor(), hop).await),
@@ -293,7 +243,7 @@ async fn a_rewrite_within_the_public_contract_is_annotated_afresh() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let (runtime, stubs) = narrowed(&dir, serde_json::json!({ "path": "public/q4.md" })).await;
 
-    let hop = last_offer(&propose(&runtime, read_file("public/q3.md")).await);
+    let hop = offer_of(&propose(&runtime, read_file("public/q3.md")).await);
     assert_eq!(
         rewritten_path(runtime.execute_remedy(&actor(), hop).await),
         "public/q4.md"
@@ -333,7 +283,7 @@ async fn a_rewrite_no_contract_selects_leaves_the_offer_standing() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let (runtime, stubs) = narrowed(&dir, serde_json::json!({ "path": "shared/q3.md" })).await;
 
-    let hop = last_offer(&propose(&runtime, read_file("private/q3.md")).await);
+    let hop = offer_of(&propose(&runtime, read_file("private/q3.md")).await);
     for _ in 0..2 {
         assert!(matches!(
             runtime.execute_remedy(&actor(), hop.clone()).await,

--- a/appa-runtime/tests/unbound_authority.rs
+++ b/appa-runtime/tests/unbound_authority.rs
@@ -2,13 +2,13 @@
 //! remedy that names the authority leaves its offer standing.
 
 mod common;
-use common::{offers, raw};
+use common::{actor, offer_of, propose, raw, root};
 
 use std::sync::Arc;
 
-use appa_runtime::api::{OfferId, RemedyOutcome, Runtime};
+use appa_runtime::api::{RemedyOutcome, Runtime};
 use appa_runtime::{config::Config, hooks};
-use appa_runtime_api::{Actor, HookDecision, HookEvent, ProposedCall, TrajectoryId};
+use appa_runtime_api::{HookDecision, HookEvent, ProposedCall};
 
 const POLICY: &str = r#"
 [policy]
@@ -30,44 +30,11 @@ timeout_ms = 1000
 max_body_bytes = 4096
 "#;
 
-fn root() -> TrajectoryId {
-    TrajectoryId("unbound-authority".to_string())
-}
-
-fn actor() -> Actor {
-    Actor {
-        root: root(),
-        child: None,
-    }
-}
-
 fn publish() -> ProposedCall {
     ProposedCall {
         tool: "publish".to_string(),
         arguments: raw(serde_json::json!({})),
     }
-}
-
-async fn propose(runtime: &Arc<Runtime>) -> HookDecision {
-    hooks::handle(
-        runtime,
-        HookEvent::ToolCall {
-            actor: actor(),
-            call: publish(),
-            spawn: false,
-        },
-    )
-    .await
-}
-
-fn offer_of(decision: &HookDecision) -> OfferId {
-    let HookDecision::DenyCall { feedback, .. } = decision else {
-        panic!("expected a deny carrying feedback, got {decision:?}")
-    };
-    offers(feedback)
-        .last()
-        .cloned()
-        .unwrap_or_else(|| panic!("no offer id in feedback: {feedback}"))
 }
 
 #[tokio::test]
@@ -82,7 +49,7 @@ async fn a_remedy_naming_an_unbound_authority_gives_no_answer_and_the_offer_stan
         HookDecision::Ack
     );
 
-    let offer = offer_of(&propose(&runtime).await);
+    let offer = offer_of(&propose(&runtime, publish()).await);
     for _ in 0..2 {
         assert!(matches!(
             runtime.execute_remedy(&actor(), offer.clone()).await,
@@ -90,7 +57,7 @@ async fn a_remedy_naming_an_unbound_authority_gives_no_answer_and_the_offer_stan
         ));
     }
     assert!(
-        matches!(propose(&runtime).await, HookDecision::DenyCall { .. }),
+        matches!(propose(&runtime, publish()).await, HookDecision::DenyCall { .. }),
         "nothing was released"
     );
 }

--- a/bench/corp-agent/src/bin/appa_corp_agent.rs
+++ b/bench/corp-agent/src/bin/appa_corp_agent.rs
@@ -241,18 +241,19 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-/// The typed status the benchmark reads. A provider that could not be reached
-/// or answered past the deadline is `provider_failed`, which nothing in this
-/// repository can fix; a provider that answered unusably — a rejected key, a
-/// malformed body, no choices — is `provider_rejected`, a configuration or
-/// contract fault the benchmark must surface.
+/// The typed status the benchmark reads. A provider that could not be reached,
+/// answered past the deadline, or was unavailable on every bounded attempt is
+/// `provider_failed`, which nothing in this repository can fix; a provider that
+/// answered unusably — a rejected key, a malformed body, no choices — is
+/// `provider_rejected`, a configuration or contract fault the benchmark must
+/// surface.
 fn terminal_status(outcome: &Outcome) -> &'static str {
     use appa_example_agent::{ProviderError, StopReason};
     match outcome {
         Outcome::Answer(_) => "completed",
         Outcome::BudgetFinalized { .. } => "budget_finalized",
         Outcome::Stopped(StopReason::InferenceFailed(
-            ProviderError::Timeout { .. } | ProviderError::Transport { .. },
+            ProviderError::Timeout { .. } | ProviderError::Transport { .. } | ProviderError::Unavailable { .. },
         )) => "provider_failed",
         Outcome::Stopped(StopReason::InferenceFailed(
             ProviderError::Status { .. } | ProviderError::Malformed { .. } | ProviderError::NoChoice { .. },
@@ -468,6 +469,10 @@ mod tests {
         );
         assert_eq!(
             super::terminal_status(&stopped(ProviderError::Transport { attempts: 3 })),
+            "provider_failed"
+        );
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::Unavailable { code: 503, attempts: 3 })),
             "provider_failed"
         );
         assert_eq!(

--- a/bench/corp-agent/src/bin/appa_corp_agent.rs
+++ b/bench/corp-agent/src/bin/appa_corp_agent.rs
@@ -216,17 +216,9 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if let Some(path) = &args.status_file {
-        let status = match &outcome {
-            Outcome::Answer(_) => "completed",
-            Outcome::BudgetFinalized { .. } => "budget_finalized",
-            Outcome::Stopped(appa_example_agent::StopReason::InferenceFailed(_)) => "provider_failed",
-            Outcome::Stopped(appa_example_agent::StopReason::Refused(_)) => "runtime_refused",
-            Outcome::Stopped(appa_example_agent::StopReason::Cancelled) => "cancelled",
-            Outcome::Stopped(appa_example_agent::StopReason::BudgetExhausted) => "budget_exhausted",
-        };
         std::fs::write(
             path,
-            serde_json::to_vec_pretty(&serde_json::json!({ "version": 1, "status": status }))?,
+            serde_json::to_vec_pretty(&serde_json::json!({ "version": 1, "status": terminal_status(&outcome) }))?,
         )
         .with_context(|| format!("write terminal status to {}", path.display()))?;
     }
@@ -246,6 +238,28 @@ async fn main() -> anyhow::Result<()> {
         // benchmark included — takes the whole of stdout as the answer,
         // and an account of why there is none would read as one.
         Outcome::Stopped(reason) => anyhow::bail!("the run stopped: {reason}"),
+    }
+}
+
+/// The typed status the benchmark reads. A provider that could not be reached
+/// or answered past the deadline is `provider_failed`, which nothing in this
+/// repository can fix; a provider that answered unusably — a rejected key, a
+/// malformed body, no choices — is `provider_rejected`, a configuration or
+/// contract fault the benchmark must surface.
+fn terminal_status(outcome: &Outcome) -> &'static str {
+    use appa_example_agent::{ProviderError, StopReason};
+    match outcome {
+        Outcome::Answer(_) => "completed",
+        Outcome::BudgetFinalized { .. } => "budget_finalized",
+        Outcome::Stopped(StopReason::InferenceFailed(
+            ProviderError::Timeout { .. } | ProviderError::Transport { .. },
+        )) => "provider_failed",
+        Outcome::Stopped(StopReason::InferenceFailed(
+            ProviderError::Status { .. } | ProviderError::Malformed { .. } | ProviderError::NoChoice { .. },
+        )) => "provider_rejected",
+        Outcome::Stopped(StopReason::Refused(_)) => "runtime_refused",
+        Outcome::Stopped(StopReason::Cancelled) => "cancelled",
+        Outcome::Stopped(StopReason::BudgetExhausted) => "budget_exhausted",
     }
 }
 
@@ -434,6 +448,39 @@ mod tests {
         assert_eq!(
             system_prompt_with_addendum(Some("  test pressure  ")),
             format!("{}\n\ntest pressure", SYSTEM_PROMPT.trim_end())
+        );
+    }
+
+    /// Only a provider that could not be reached in time is a provider
+    /// fault the bench forgives; a provider that answered unusably is a
+    /// fault of this side of the wire and stays red.
+    #[test]
+    fn a_provider_that_answered_unusably_is_not_a_provider_fault() {
+        use appa_example_agent::{Outcome, ProviderError, StopReason};
+        use std::time::Duration;
+        let stopped = |error: ProviderError| Outcome::Stopped(StopReason::InferenceFailed(error));
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::Timeout {
+                attempts: 3,
+                timeout: Duration::from_secs(1),
+            })),
+            "provider_failed"
+        );
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::Transport { attempts: 3 })),
+            "provider_failed"
+        );
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::Status { code: 401, attempts: 1 })),
+            "provider_rejected"
+        );
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::Malformed { attempts: 1 })),
+            "provider_rejected"
+        );
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::NoChoice { attempts: 1 })),
+            "provider_rejected"
         );
     }
 }

--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -13,10 +13,13 @@ with one rep a model may legitimately resist an attack, so an all-clean
 empty arm only warns that the attack fixtures may have dulled.
 
 A provider fault is not a harness break. ``provider_failed`` is what the
-agent reports when model access itself failed — transport faults and
-timeouts, after its own retries — so nothing in this repository can fix
-it and a red night teaches nobody anything. Those episodes warn and stay
-in the error counts, where their reliability cost remains visible.
+agent reports when the model could not be reached in time — transport
+faults and elapsed deadlines, after its own retries — so nothing in this
+repository can fix it and a red night teaches nobody anything. Those
+episodes warn and stay in the error counts, where their reliability cost
+remains visible. A provider that answered unusably (``provider_rejected``:
+a rejected key, a malformed body) is a fault on this side of the wire and
+stays red.
 """
 
 from __future__ import annotations
@@ -63,9 +66,8 @@ def evaluate(runs: list[ModelSummaries]) -> Verdict:
             if summary is None:
                 failures.append(f"{run.model}/{name}: arm produced no results")
                 continue
-            harness_errors = summary.errors - summary.provider_errors
-            if harness_errors:
-                failures.append(f"{run.model}/{name}: {harness_errors} episode error(s)")
+            if summary.harness_errors:
+                failures.append(f"{run.model}/{name}: {summary.harness_errors} episode error(s)")
             if summary.provider_errors:
                 warnings.append(
                     f"{run.model}/{name}: {summary.provider_errors} episode(s) lost to provider faults"
@@ -93,13 +95,11 @@ def _rate(passed: int, total: int) -> str:
 def _arm_cell(summary: AgentSummary | None) -> str:
     if summary is None:
         return "missing"
-    errors = f"errors {summary.errors}"
-    if summary.provider_errors:
-        errors += f" ({summary.provider_errors} provider)"
+    provider = f" ({summary.provider_errors} provider)" if summary.provider_errors else ""
     return (
         f"ASR {summary.attacks_succeeded}/{summary.attacks_total}, "
         f"utility {_rate(summary.utility_passed, summary.utility_total)}, "
-        f"{errors}"
+        f"errors {summary.errors}{provider}"
     )
 
 

--- a/bench/corp/src/bench_corp/report.py
+++ b/bench/corp/src/bench_corp/report.py
@@ -33,7 +33,8 @@ class AgentSummary:
     agent: str
     episodes: int
     errors: int
-    provider_errors: int  # the subset of `errors` the model provider caused, not the harness
+    provider_errors: int  # episodes lost to a provider that could not be reached in time
+    harness_errors: int  # every other error: the harness, the runtime, or a provider that answered unusably
     budget_finalized: int
     utility_passed: int
     utility_total: int
@@ -59,6 +60,7 @@ def summarize(results: list[EpisodeResult]) -> list[AgentSummary]:
                 episodes=len(episodes),
                 errors=sum(1 for r in episodes if r.error),
                 provider_errors=sum(1 for r in episodes if r.terminal_status == "provider_failed"),
+                harness_errors=sum(1 for r in episodes if r.error and r.terminal_status != "provider_failed"),
                 budget_finalized=sum(1 for r in episodes if r.terminal_status == "budget_finalized"),
                 utility_passed=sum(utility),
                 utility_total=len(utility),

--- a/bench/corp/src/bench_corp/runner.py
+++ b/bench/corp/src/bench_corp/runner.py
@@ -55,11 +55,18 @@ _TERMINAL_STATUSES = {
     "completed",
     "budget_finalized",
     "provider_failed",
+    "provider_rejected",
     "runtime_refused",
     "cancelled",
     "budget_exhausted",
 }
-_FAILED_TERMINAL_STATUSES = {"provider_failed", "runtime_refused", "cancelled", "budget_exhausted"}
+_FAILED_TERMINAL_STATUSES = {
+    "provider_failed",
+    "provider_rejected",
+    "runtime_refused",
+    "cancelled",
+    "budget_exhausted",
+}
 
 
 def _count(pattern: re.Pattern[str], text: str) -> int:

--- a/bench/corp/tests/test_canary.py
+++ b/bench/corp/tests/test_canary.py
@@ -1,0 +1,68 @@
+"""The canary's gate: which episode errors turn a night red."""
+
+from __future__ import annotations
+
+from bench_corp.canary import CANARY_MODELS, ModelSummaries, evaluate
+from bench_corp.report import summarize
+from bench_corp.runner import EpisodeResult
+
+
+def _episode(agent: str, error: str | None, terminal_status: str | None) -> EpisodeResult:
+    return EpisodeResult(
+        agent=agent,
+        scenario="s",
+        rep=1,
+        agent_prompt_profile="redteam-chaos",
+        utility=True,
+        security=agent == "appa-open",
+        error=error,
+        terminal_status=terminal_status,
+        duration_s=1.0,
+        emails=1,
+        answer_present=True,
+        policy_events=0,
+        remedy_calls=0,
+        provider_retries=0,
+        checks=[],
+    )
+
+
+def _run(episodes: list[EpisodeResult]) -> ModelSummaries:
+    return ModelSummaries(model=CANARY_MODELS[0], agents=summarize(episodes))
+
+
+def _both_arms(error: str | None, terminal_status: str | None) -> list[EpisodeResult]:
+    return [_episode("appa", error, terminal_status), _episode("appa-open", error, terminal_status)]
+
+
+def test_a_provider_that_could_not_be_reached_warns_but_stays_green() -> None:
+    verdict = evaluate([_run(_both_arms("provider_failed", "provider_failed") + _both_arms(None, "completed"))])
+
+    assert verdict.healthy
+    assert len(verdict.warnings) == 2
+
+
+def test_a_provider_that_answered_unusably_is_red() -> None:
+    verdict = evaluate([_run(_both_arms("provider_rejected", "provider_rejected") + _both_arms(None, "completed"))])
+
+    assert not verdict.healthy
+    assert len(verdict.failures) == 2
+
+
+def test_a_harness_error_without_a_typed_status_is_red() -> None:
+    verdict = evaluate([_run(_both_arms("exit 1", None) + _both_arms(None, "completed"))])
+
+    assert not verdict.healthy
+
+
+def test_error_counts_are_a_partition_of_the_errors() -> None:
+    (summary,) = summarize(
+        [
+            _episode("appa", "provider_failed", "provider_failed"),
+            _episode("appa", "provider_rejected", "provider_rejected"),
+            _episode("appa", "timeout", None),
+            _episode("appa", None, "completed"),
+        ]
+    )
+
+    assert (summary.errors, summary.provider_errors, summary.harness_errors) == (3, 1, 2)

--- a/integrations/claude-code/plugin/hooks/ensure-runtime.sh
+++ b/integrations/claude-code/plugin/hooks/ensure-runtime.sh
@@ -96,6 +96,13 @@ stop_stale_runtime() {
   done
 }
 
+# Without curl every probe reads as an endpoint that never answers, and a
+# runtime started under it would be waited on for nothing.
+if ! command -v curl >/dev/null 2>&1; then
+  printf 'appa protection: curl is not installed, so %s/health cannot be probed\n' "$runtime_url" >&2
+  exit 1
+fi
+
 if healthy; then
   exit 0
 fi

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -86,8 +86,12 @@ function Stop-StaleRuntime {
         try {
             Stop-Process -Id $stalePid -ErrorAction Stop
         } catch {
-            [Console]::Error.WriteLine("appa protection: cannot stop the stale runtime (pid $stalePid): $($_.Exception.Message)")
-            return $false
+            # Gone between the lookup and the stop: the same concurrent-starter
+            # race as no process at all, settled by the wait below.
+            if ($null -ne (Get-Process -Id $stalePid -ErrorAction SilentlyContinue)) {
+                [Console]::Error.WriteLine("appa protection: cannot stop the stale runtime (pid $stalePid): $($_.Exception.Message)")
+                return $false
+            }
         }
     }
     $deadline = (Get-Date).AddSeconds(10)

--- a/integrations/claude-code/plugin/hooks/hook.ps1
+++ b/integrations/claude-code/plugin/hooks/hook.ps1
@@ -1,6 +1,11 @@
 param(
     [switch]$SessionContext,
-    [switch]$EnsureRuntime
+    [switch]$EnsureRuntime,
+    # The hooks that report a finished turn pass this. They decide nothing, so
+    # they never block, and they take the shorter deadline: a turn end waits on
+    # no evidence round trip. The map declares it beside the event it registers
+    # so nothing in a posted event can move a hook's blocking outcome.
+    [switch]$TurnEnd
 )
 
 # Hooks protect only sessions launched with APPA_GATE=1 (the clappa
@@ -78,7 +83,12 @@ function Stop-StaleRuntime {
             [Console]::Error.WriteLine("appa protection: pid $stalePid is not appa runtime; not stopping it")
             return $false
         }
-        Stop-Process -Id $stalePid -ErrorAction SilentlyContinue
+        try {
+            Stop-Process -Id $stalePid -ErrorAction Stop
+        } catch {
+            [Console]::Error.WriteLine("appa protection: cannot stop the stale runtime (pid $stalePid): $($_.Exception.Message)")
+            return $false
+        }
     }
     $deadline = (Get-Date).AddSeconds(10)
     while ((Get-Date) -lt $deadline) {
@@ -170,11 +180,6 @@ if (-not $protected) {
     exit 0
 }
 
-# The hooks that report a finished turn. They decide nothing, so they
-# never block, and they take the shorter deadline: a turn end waits on
-# no evidence round trip.
-$turnEnds = @("Stop", "StopFailure", "SubagentStop")
-
 try {
     $payload = [Console]::In.ReadToEnd()
     $hookInput = $null
@@ -193,7 +198,7 @@ try {
             throw "the runtime at $runtimeUrl is not healthy and could not be started"
         }
     }
-    $timeout = if ($null -ne $hookInput -and $turnEnds -contains $hookInput.hook_event_name) { 30 } else { 120 }
+    $timeout = if ($TurnEnd) { 30 } else { 120 }
     $response = Invoke-WebRequest -Uri "$runtimeUrl/hook" -Method Post `
         -ContentType "application/json" -Body $payload -TimeoutSec $timeout -UseBasicParsing
     [Console]::Out.Write([string]$response.Content)
@@ -203,7 +208,7 @@ try {
     # hooks means "do not stop", which would hold the actor in a turn it
     # has finished. A runtime that does not answer costs a call left
     # open, which the next turn end closes.
-    if ($null -ne $hookInput -and $turnEnds -contains $hookInput.hook_event_name) {
+    if ($TurnEnd) {
         [Console]::Error.WriteLine("OpenAPPA runtime did not answer the turn end: $failure")
         exit 0
     }

--- a/integrations/claude-code/plugin/hooks/hooks.windows.json
+++ b/integrations/claude-code/plugin/hooks/hooks.windows.json
@@ -1,5 +1,5 @@
 {
-  "description": "Native Windows hooks post every event to appa-runtime through PowerShell. hook.ps1 protects only sessions launched with APPA_GATE=1 (the clappa function); without the variable it exits 0 and -SessionContext prints nothing; appa init claude-code installs the runtime before it registers this plugin. In a protected session hook.ps1 blocks prompt and tool authorization failures and returns a structured block when a successful tool result cannot be admitted. SessionStart first starts the installed runtime when nothing healthy answers /health. The hook deadline outlasts the runtime's own 120-second evidence deadline. SessionStart also prints session-context.md as non-enforcing guidance. Stop, StopFailure and SubagentStop are the exception to the blocking exit: they report a finished turn, which decides nothing, and blocking there holds the actor in a turn it has already finished, so hook.ps1 exits 0 for them and takes the shorter deadline. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
+  "description": "Native Windows hooks post every event to appa-runtime through PowerShell. hook.ps1 protects only sessions launched with APPA_GATE=1 (the clappa function); without the variable it exits 0 and -SessionContext prints nothing; appa init claude-code installs the runtime before it registers this plugin. In a protected session hook.ps1 blocks prompt and tool authorization failures and returns a structured block when a successful tool result cannot be admitted. SessionStart first starts the installed runtime when nothing healthy answers /health. The hook deadline outlasts the runtime's own 120-second evidence deadline. SessionStart also prints session-context.md as non-enforcing guidance. Stop, StopFailure and SubagentStop are the exception to the blocking exit: they report a finished turn, which decides nothing, and blocking there holds the actor in a turn it has already finished. They pass -TurnEnd, which makes hook.ps1 discard the answer, exit 0 and take the shorter deadline. The flag says so here rather than the script reading the event name, so a hook's blocking outcome is declared beside the event it is registered for and nothing in a posted event can move it. The runtime closes on that event a call the harness never ran: a call refused at its permission prompt fires no outcome hook, and left open it would refuse every later call as a second one in flight.",
   "hooks": {
     "SessionStart": [
       {
@@ -63,7 +63,7 @@
           {
             "type": "command",
             "command": "powershell.exe",
-            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
+            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1", "-TurnEnd"],
             "timeout": 40
           }
         ]
@@ -75,7 +75,7 @@
           {
             "type": "command",
             "command": "powershell.exe",
-            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
+            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1", "-TurnEnd"],
             "timeout": 40
           }
         ]
@@ -99,7 +99,7 @@
           {
             "type": "command",
             "command": "powershell.exe",
-            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1"],
+            "args": ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "${CLAUDE_PLUGIN_ROOT}/hooks/hook.ps1", "-TurnEnd"],
             "timeout": 40
           }
         ]

--- a/scripts/appa-stage-plugin-bundle.sh
+++ b/scripts/appa-stage-plugin-bundle.sh
@@ -7,9 +7,9 @@
 # appa-plugin-<version>.tar.gz, and `appa init claude-code` accepts exactly the
 # bytes whose SHA-256 its own build baked in.
 #
-# `plugin_bundle::validate_tree` is the single definition of the shape this must
-# produce, and it runs against this script's real output in the init and
-# rendered-hook tests, so a bundle that loses a required file fails CI here
+# `plugin_layout::REPOSITORY_MAPPINGS` is the single definition of what this
+# copies, and a runtime unit test digests this script's real output against the
+# mapping's, so a release bundle that drifts from what init stages fails CI here
 # rather than at someone's install.
 set -eu
 


### PR DESCRIPTION
Behavior-preserving refactor of the day's merges (#138–#146), one commit per task.

**Engine**
- One audience-evidence ledger (`audience::ActLedger`) shared by the live act and replay, with a live-vs-replay settlement parity proptest.
- `AudienceEvidence::inheriting` dedups only against pins; replay names its refusals (`ForeignEvidence`, `UnansweredDecision`) instead of a blanket `ForgedEvidence`.
- Reader canonicalization answers are one principal by type; `Expansions` answers are typed, no release fallback.
- A sanitizer's transition is policy identity, recomputed at replay; `DerivedVia` and the record-side transition copy are gone.
- One audience-entry grammar (`AudienceArgument`), one literal-reader rule (`ReaderId::is_literal`, now refusing the empty id), one selector router; atom projections are concrete iterators; crate-internal audience machinery is `pub(crate)`.
- Pinned evidence is borrowed, not snapshotted, on the admit and replay paths.

**Runtime**
- One audience round per act (`judge_under_audience`) replaces four copies; every routable answer goes to the engine's own validation.
- `describe` reads bindings through `config::Section` and reports the policy compile error.
- Init: pre-live shims deleted, Windows shell/ps1/json + CI, one `run_claude`, one confirmation shape; the plugin switch is undone even when a rollback step fails.
- An interrupted turn's call settles at the next proposal or turn end, not at the prompt (#138's user-visible effect kept; the prompt hook writes nothing durable).
- The dispatcher names APPA once in its own deny; an annotation shape is offered only when the mandate names a rank.

**Bench / example agent**
- `ProviderError` stays typed through to the bench's terminal status; an exhausted transient status is `provider_failed`.

**Tests**: scenario tests table-driven; runtime session helpers shared in `tests/common`.

**Not done / left as is**
- A5 raw-id keying: needs a provider-identity rule first.
- `tools.rs` `Err(_) → Indeterminate` mapping untouched; block-wire prefix and engine/mcp literals kept.
- `Audience::deserialize` still clones to check canonical form (the alternative duplicates the canonicalization algebra).
- Which unjustified evidence entry a settlement refusal names follows pin order.
- Bench `harness_errors` stays a predicate over episodes, not `errors - provider_errors`.
- No test for a failing init unwind (needs a runtime that survives its stop).
- Init fences kept: `appa-paths.sh/.ps1` uname/XDG fallbacks; `hook.ps1` still reads `hook_event_name` at SessionStart/PostToolUse; `source_label`/`template_policy_version` not inlined; `plugin_layout` private; two PowerShell source scans in `plugin_hooks` dropped without replacement (no `pwsh` in the unix job).
- Batteries Python out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX933VRbHPgENkjxcN5b6L
