### PR TITLE
fix(release): make packaged runtime verification portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,70 @@ jobs:
           cargo test --locked --package appa --test plugin_hooks
           cargo test --locked --package appa --test rendered_hooks
 
+  windows-deployment-checks:
+    name: Windows Deployment Checks
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Setup Rust
+        run: rustup show
+
+      - name: Build runtime
+        run: cargo build --locked --package appa
+
+      # Start from an empty directory, as the release package check does. The
+      # generated policy must both open and omit the subprocess fallback this
+      # platform cannot serve.
+      - name: Verify fresh deployment
+        shell: pwsh
+        run: |
+          $work = Join-Path $env:RUNNER_TEMP "appa-windows-deployment"
+          New-Item -ItemType Directory -Path $work | Out-Null
+          $stdout = Join-Path $work "runtime.stdout.log"
+          $stderr = Join-Path $work "runtime.stderr.log"
+          $start = @{
+            FilePath = Join-Path $PWD "target/debug/appa.exe"
+            ArgumentList = @("runtime")
+            WorkingDirectory = $work
+            PassThru = $true
+            RedirectStandardOutput = $stdout
+            RedirectStandardError = $stderr
+          }
+          $process = Start-Process @start
+          try {
+            $healthy = $false
+            for ($attempt = 0; $attempt -lt 30; $attempt++) {
+              try {
+                $health = Invoke-RestMethod -Uri "http://127.0.0.1:8787/health" -TimeoutSec 1
+                if ("$health".Trim() -eq "ok") {
+                  $healthy = $true
+                  break
+                }
+              } catch {
+                $process.Refresh()
+                if ($process.HasExited) { break }
+              }
+              Start-Sleep -Seconds 1
+            }
+            if (-not $healthy) {
+              if (Test-Path $stderr) { Get-Content $stderr }
+              throw "Fresh Windows runtime did not become healthy"
+            }
+            $policy = Get-Content (Join-Path $work "appa.toml") -Raw
+            if ($policy -match 'builtin = "claude-code"' -or $policy -match '(?m)^name = "\*"\r?$') {
+              throw "Fresh Windows policy contains the unsupported Claude subprocess fallback"
+            }
+          } finally {
+            $process.Refresh()
+            if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force }
+          }
+
   python-binding-checks:
     name: Python Binding Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,10 @@ jobs:
       - name: Update release PR
         if: ${{ steps.release-pr.outputs.prs_created == 'true' }}
         env:
-          RELEASE_BRANCH: ${{ fromJSON(steps.release-pr.outputs.pr).headBranchName }}
+          RELEASE_PR: ${{ steps.release-pr.outputs.pr }}
           RELEASE_PUSH_TOKEN: ${{ github.token }}
         run: |
+          release_branch=$(jq -er '.headBranchName' <<<"$RELEASE_PR")
           if git diff --quiet; then
             exit 0
           fi
@@ -146,7 +147,7 @@ jobs:
           git commit -m "chore: synchronize release version"
           git -c credential.helper= \
             -c 'credential.helper=!f() { test "$1" = get && printf "%s\n" "username=x-access-token" "password=$RELEASE_PUSH_TOKEN"; }; f' \
-            push origin "HEAD:${RELEASE_BRANCH}"
+            push origin "HEAD:${release_branch}"
 
   plugin-artifact:
     name: Build the plugin artifact

--- a/appa-runtime/src/default_config.rs
+++ b/appa-runtime/src/default_config.rs
@@ -1,0 +1,65 @@
+//! The fresh deployment policy, adapted only where a platform cannot serve one
+//! of its builtins.
+
+use std::borrow::Cow;
+
+const TEMPLATE: &str = include_str!("../../integrations/claude-code/examples/claude-code.appa.toml");
+const UNIX_FALLBACK_BEGIN: &str = "# APPA-UNIX-FALLBACK-BEGIN";
+const UNIX_FALLBACK_END: &str = "# APPA-UNIX-FALLBACK-END";
+
+/// The policy written for a fresh deployment on this platform.
+pub(crate) fn text() -> Cow<'static, str> {
+    for_platform(cfg!(unix))
+}
+
+fn for_platform(supports_claude_subprocess: bool) -> Cow<'static, str> {
+    for_template(TEMPLATE, supports_claude_subprocess)
+}
+
+fn for_template(template: &str, supports_claude_subprocess: bool) -> Cow<'_, str> {
+    if supports_claude_subprocess {
+        return Cow::Borrowed(template);
+    }
+
+    let (before, marked) = template
+        .split_once(UNIX_FALLBACK_BEGIN)
+        .expect("the default policy marks its Unix-only fallback");
+    let (_, after) = marked
+        .split_once(UNIX_FALLBACK_END)
+        .expect("the default policy closes its Unix-only fallback");
+    Cow::Owned(format!(
+        "{before}# This platform cannot run the Claude subprocess fallback. Tools not declared above remain fail-closed.{after}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_keeps_the_undeclared_tool_fallback() {
+        let config = for_platform(true);
+        assert!(config.contains("name = \"claude-code.undeclared-tool\""));
+        assert!(config.contains("name = \"*\""));
+    }
+
+    #[test]
+    fn platforms_without_the_claude_subprocess_fail_closed_on_undeclared_tools() {
+        let config = for_platform(false);
+        assert!(!config.contains("name = \"claude-code.undeclared-tool\""));
+        assert!(!config.contains("name = \"*\""));
+
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let path = directory.path().join("appa.toml");
+        std::fs::write(&path, config.as_bytes()).expect("the portable default is written");
+        crate::config::Config::load(&path).expect("the portable default config loads");
+    }
+
+    #[test]
+    fn windows_line_endings_do_not_change_the_platform_markers() {
+        let windows = TEMPLATE.replace('\n', "\r\n");
+        let portable = for_template(&windows, false);
+        assert!(!portable.contains("name = \"claude-code.undeclared-tool\""));
+        assert!(!portable.contains("name = \"*\""));
+    }
+}

--- a/appa-runtime/src/init.rs
+++ b/appa-runtime/src/init.rs
@@ -12,14 +12,13 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::config::{Config, ConfigError};
+use crate::default_config;
 use crate::plugin_bundle::{self, Deployment, Endpoint, PluginBundleError, PluginSource, Population};
 use crate::runtime_cli::{Adapter, refuse_unobservable_returns};
 
 const MARKETPLACE: &str = "appa";
 const PLUGIN: &str = "appa-runtime@appa";
 const RECOVERY_PREFIX: &str = ".appa-init-recovery-";
-const DEFAULT_CONFIG: &str = include_str!("../../integrations/claude-code/examples/claude-code.appa.toml");
-
 #[derive(Debug, Error)]
 pub enum InitError {
     #[error("cannot find the current executable: {0}")]
@@ -816,7 +815,10 @@ fn create_default_config(path: &Path) -> Result<ConfigOutcome, InitError> {
             });
         }
     };
-    if let Err(source) = file.write_all(DEFAULT_CONFIG.as_bytes()).and_then(|()| file.sync_all()) {
+    if let Err(source) = file
+        .write_all(default_config::text().as_bytes())
+        .and_then(|()| file.sync_all())
+    {
         drop(file);
         discard_file(path);
         return Err(InitError::WriteFile {
@@ -829,7 +831,7 @@ fn create_default_config(path: &Path) -> Result<ConfigOutcome, InitError> {
 
 /// The policy version this build's default config declares.
 fn template_policy_version() -> i64 {
-    policy_version(DEFAULT_CONFIG).expect("the bundled default config declares an integer policy version")
+    policy_version(&default_config::text()).expect("the bundled default config declares an integer policy version")
 }
 
 /// The `[policy] version` of one config's own text, before any include composes.
@@ -2367,7 +2369,10 @@ mod tests {
         }
 
         assert_eq!(answer_rewrite(&config, "y\n").0, ConfigOutcome::Rewritten);
-        assert_eq!(fs::read_to_string(&config).ok(), Some(DEFAULT_CONFIG.to_string()));
+        assert_eq!(
+            fs::read_to_string(&config).ok(),
+            Some(default_config::text().into_owned())
+        );
         assert_eq!(fs::read_to_string(&backup).ok(), Some(authored));
         verify_config(&config).expect("the rewritten config composes");
     }
@@ -2384,7 +2389,10 @@ mod tests {
         let (outcome, prompt) = answer_rewrite(&config, "y\n");
         assert!(prompt.is_empty(), "no offer is made");
         assert_eq!(outcome, ConfigOutcome::Kept);
-        assert_eq!(fs::read_to_string(&config).ok(), Some(DEFAULT_CONFIG.to_string()));
+        assert_eq!(
+            fs::read_to_string(&config).ok(),
+            Some(default_config::text().into_owned())
+        );
         assert!(!directory.path().join("appa.toml.bak").exists());
     }
 

--- a/appa-runtime/src/lib.rs
+++ b/appa-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod api;
 pub mod config;
+mod default_config;
 pub mod describe;
 pub mod hook_client;
 pub mod hooks;

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -18,10 +18,9 @@ use sha2::{Digest, Sha256};
 
 use crate::api::{Reloaded, Runtime};
 use crate::config::Config;
+use crate::default_config;
 use crate::{hooks, mcp};
 use appa_runtime_api::Codec;
-
-const DEFAULT_CONFIG: &str = include_str!("../../integrations/claude-code/examples/claude-code.appa.toml");
 
 fn ensure_default_config(path: &Path) -> io::Result<bool> {
     let mut file = match OpenOptions::new().write(true).create_new(true).open(path) {
@@ -29,7 +28,10 @@ fn ensure_default_config(path: &Path) -> io::Result<bool> {
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => return Ok(false),
         Err(error) => return Err(error),
     };
-    if let Err(error) = file.write_all(DEFAULT_CONFIG.as_bytes()).and_then(|()| file.sync_all()) {
+    if let Err(error) = file
+        .write_all(default_config::text().as_bytes())
+        .and_then(|()| file.sync_all())
+    {
         drop(file);
         let _ = fs::remove_file(path);
         return Err(error);
@@ -382,7 +384,7 @@ mod tests {
         assert!(ensure_default_config(&path).expect("default config is created"));
         assert_eq!(
             fs::read_to_string(&path).expect("default config is readable"),
-            DEFAULT_CONFIG
+            default_config::text()
         );
         Config::load(&path).expect("the embedded default config validates");
 

--- a/integrations/claude-code/examples/claude-code.appa.toml
+++ b/integrations/claude-code/examples/claude-code.appa.toml
@@ -206,6 +206,7 @@ delta = { trust = "suspicious" }
 # declarations always win over the wildcard, including declarations supplied by
 # connector batteries. The mandate is deliberately closed to this deployment's
 # two trust ranks, its one private audience, HITL, and no effects.
+# APPA-UNIX-FALLBACK-BEGIN
 [[policy.annotator]]
 name = "claude-code.undeclared-tool"
 builtin = "claude-code"
@@ -217,6 +218,7 @@ effects = []
 [[policy.tool]]
 name = "*"
 annotator = "claude-code.undeclared-tool"
+# APPA-UNIX-FALLBACK-END
 
 # The deployment controls what a subagent starts from: the harness gives
 # every subagent exactly the prompt the parent's spawn call carried, and


### PR DESCRIPTION
## What changed

- write a platform-safe fresh policy that keeps the Claude subprocess fallback on Unix and leaves undeclared tools fail-closed elsewhere
- share that default between `appa init` and `appa runtime`
- avoid evaluating an empty Release Please PR JSON output after a release

## Why

The v0.7.0 release run built both Windows binaries but their package smoke tests failed because the generated default policy selected the Unix-only `claude-code` annotator. The same run also failed its follow-up PR maintenance job by calling `fromJSON()` on an empty output when there were no post-release commits.

## Validation

- `cargo clippy --locked --package appa --all-targets -- -D warnings`
- `cargo test --locked --package appa --lib` (274 passed)
- targeted default-config, init, and runtime tests
- `sh -n scripts/appa-stage-plugin-bundle.sh scripts/appa-install.sh scripts/appa-install-test.sh`
- `git diff --check`

The GitHub Windows matrix is the authoritative MSVC build and package-startup check.