### PR TITLE
fix(release): tolerate expected Windows init failure

### DIFF
--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -287,6 +287,11 @@ jobs:
             if ($hostile -match "development build" -or $hostile -match "127\.0\.0\.1:9") {
               throw "the released binary honoured a debug-only seam: $hostile"
             }
+            # The plugin asset is uploaded only after every matrix job passes,
+            # so this probe normally exits non-zero on the first publication
+            # attempt. Its output is the assertion; do not let the expected
+            # native exit code become the PowerShell step's exit code.
+            $global:LASTEXITCODE = 0
           } finally {
             $process.Refresh()
             if (-not $process.HasExited) { Stop-Process -Id $process.Id -Force }


### PR DESCRIPTION
The Windows package smoke test intentionally runs `appa init claude-code` before the draft release's plugin asset has been uploaded. The command is therefore expected to fail, and its captured output—not its status—is the debug-seam assertion. PowerShell propagated the lingering native exit code and failed both Windows release matrix jobs after every substantive check had passed. Clear `LASTEXITCODE` after validating the captured output, matching the existing Unix `|| true` behavior.\n\nAfter merge, rerun the existing v0.7.1 draft via `workflow_dispatch` with `publish_existing_release=true`.