### PR TITLE
fix(release): build recovery artifacts from draft tag

### DIFF
--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -7,6 +7,10 @@ on:
         description: Immutable release tag to build and stamp into the binaries
         required: true
         type: string
+      source_commit:
+        description: Exact commit the release tag must resolve to and build from
+        required: true
+        type: string
       expected_version:
         description: Version the built binary must report
         required: false
@@ -82,9 +86,8 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # A workflow input may name the release, but never selects code to
-          # execute in the default-branch cache scope. The caller's commit is
-          # the trusted source; the next step proves the tag names that commit.
+          # Load the workflow from the trusted caller before validating and
+          # switching to the exact release source.
           ref: ${{ github.sha }}
           persist-credentials: false
           fetch-depth: 1
@@ -92,18 +95,25 @@ jobs:
       - name: Verify release tag targets the source commit
         env:
           RELEASE_REF: ${{ inputs.release_ref }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
         run: |
           if [[ ! "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::release_ref must be a version tag"
             exit 1
           fi
+          if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_commit must be a full commit SHA"
+            exit 1
+          fi
           git fetch --no-tags origin \
             "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
           tag_commit=$(git rev-parse "${RELEASE_REF}^{commit}")
-          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
-            echo "::error::${RELEASE_REF} targets ${tag_commit}, not source commit ${GITHUB_SHA}"
+          if [ "$tag_commit" != "$SOURCE_COMMIT" ]; then
+            echo "::error::${RELEASE_REF} targets ${tag_commit}, not source commit ${SOURCE_COMMIT}"
             exit 1
           fi
+          git checkout --detach "$SOURCE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
 
       # The binary accepts only the plugin artifact whose digest it is built
       # with. Baking it in at compile time is what makes a shipped binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       should_publish: ${{ steps.resolve.outputs.should_publish }}
       tag_name: ${{ steps.resolve.outputs.tag_name }}
       version: ${{ steps.resolve.outputs.version }}
+      source_commit: ${{ steps.resolve.outputs.source_commit }}
     steps:
       # Create releases before calculating the next release PR. A draft release
       # needs its forced tag to exist before Release Please can anchor that calculation.
@@ -76,10 +77,16 @@ jobs:
               echo "::error::${tag_name} is not a draft release"
               exit 1
             fi
+            source_commit=$(gh api "repos/${GH_REPO}/commits/${tag_name}" --jq '.sha')
+            if [[ ! "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::${tag_name} did not resolve to a commit"
+              exit 1
+            fi
             {
               echo "should_publish=true"
               echo "version=${INPUT_VERSION}"
               echo "tag_name=${tag_name}"
+              echo "source_commit=${source_commit}"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -88,6 +95,7 @@ jobs:
             echo "should_publish=${ACTION_RELEASE_CREATED:-false}"
             echo "version=${ACTION_VERSION}"
             echo "tag_name=${ACTION_TAG_NAME}"
+            echo "source_commit=${GITHUB_SHA}"
           } >> "$GITHUB_OUTPUT"
 
   release-pr:
@@ -163,12 +171,20 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The same ref the binaries are built from. `github.sha` would be the
-          # commit that triggered this run, which is not the release tag when
-          # publishing an existing release.
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ github.sha }}
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Verify and checkout release source
+        env:
+          RELEASE_REF: ${{ needs.release-please.outputs.tag_name }}
+          SOURCE_COMMIT: ${{ needs.release-please.outputs.source_commit }}
+        run: |
+          git fetch --no-tags origin \
+            "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
+          test "$(git rev-parse "${RELEASE_REF}^{commit}")" = "$SOURCE_COMMIT"
+          git checkout --detach "$SOURCE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
 
       - name: Package the plugin
         id: package
@@ -197,10 +213,11 @@ jobs:
       - release-please
       - plugin-artifact
     permissions:
-      contents: read # Required to check out the source commit and verify its release tag.
+      contents: read # Required to verify and check out the release tag.
     uses: ./.github/workflows/build-appa-runtime-binaries.yml
     with:
       release_ref: ${{ needs.release-please.outputs.tag_name }}
+      source_commit: ${{ needs.release-please.outputs.source_commit }}
       expected_version: ${{ needs.release-please.outputs.version }}
       plugin_sha256: ${{ needs.plugin-artifact.outputs.sha256 }}
 
@@ -220,9 +237,20 @@ jobs:
       - name: Checkout release source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ github.sha }}
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Verify and checkout release source
+        env:
+          RELEASE_REF: ${{ needs.release-please.outputs.tag_name }}
+          SOURCE_COMMIT: ${{ needs.release-please.outputs.source_commit }}
+        run: |
+          git fetch --no-tags origin \
+            "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
+          test "$(git rev-parse "${RELEASE_REF}^{commit}")" = "$SOURCE_COMMIT"
+          git checkout --detach "$SOURCE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
 
       - name: Download release archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
The explicit draft-recovery path resolves and validates an existing release tag, but the reusable binary build still assumed that tag must equal the current workflow-dispatch SHA. That makes recovery impossible as soon as main advances to fix the failed release pipeline.

Make the release resolver output the exact source commit instead. Ordinary releases use the triggering main commit; draft recovery resolves the validated version tag to its commit through GitHub. Plugin, binary, and publish jobs all check out that immutable SHA. The reusable build accepts no bypass: it fetches the release tag and requires the tag commit to equal `source_commit` before compiling.

This lets the current fixed workflow rebuild v0.7.1 from its original source without moving the tag or weakening the tag/source invariant.