### PR TITLE
fix(runtime): disable the classifier CLI's background traffic

### DIFF
--- a/appa-runtime/src/builtins.rs
+++ b/appa-runtime/src/builtins.rs
@@ -469,6 +469,10 @@ fn isolate_claude_environment(command: &mut tokio::process::Command) {
     // tool-less, and non-persistent, so it is safe and necessary to clear the
     // harness marker before launching it.
     command.env_remove("CLAUDECODE");
+    // A consult is one answer, not a session: the CLI's background traffic (telemetry,
+    // bootstrap fetches, the session-title call) is one more connection per consult
+    // on a host that may run many consults at once, and none of it reaches the answer.
+    command.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
     // No APPA variable of any kind reaches the model: the child needs its own credentials
     // and HOME, never this runtime's bearer tokens — and not the provider credential a
     // `command` external inherits either, which this consult never reads.
@@ -509,6 +513,12 @@ mod tests {
                 .get_envs()
                 .any(|(name, value)| name == "CLAUDECODE" && value.is_none()),
             "the nested-session marker is explicitly removed"
+        );
+        assert!(
+            command.as_std().get_envs().any(|(name, value)| {
+                name == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" && value.is_some_and(|value| value == "1")
+            }),
+            "the consult runs without the CLI's background traffic"
         );
     }
 

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -612,7 +612,7 @@ An endpoint or a command answers `{"version": 1, "answer": { … }}`. `version` 
 
 A model answer can do what the kind allows any implementation: an authority's ruling stays within `permits`, an annotation within its annotator's mandate, and a sanitizer's derivation carries exactly the `permits` transition. A model sanitizer deserves a second look: `permits` caps the label the derivation claims, not the bytes the model leaves in it, so keep its transition narrow and its `hint` exact.
 
-`[externals.claude_code]` tunes the subscription transport: `command` sets the executable, `model` pins the model, and `timeout_ms` gives a consult its own budget. Each consult is one `claude -p` process in safe mode with no tools, no project settings, no session persistence, a fresh temporary working directory, and every `APPA_*` variable removed from its environment. At most four run at once per runtime.
+`[externals.claude_code]` tunes the subscription transport: `command` sets the executable, `model` pins the model, and `timeout_ms` gives a consult its own budget. Each consult is one `claude -p` process in safe mode with no tools, no project settings, no session persistence, a fresh temporary working directory, the CLI's optional background traffic disabled, and every `APPA_*` variable removed from its environment. At most four run at once per runtime.
 
 `[externals.llm]` is the API-key transport, one profile per deployment:
 


### PR DESCRIPTION
Each claude-code consult is one `claude -p` process, and the CLI spends a session-title request, a bootstrap fetch, and telemetry on every one of them. On a host that runs many consults at once each of those is one more outbound connection; on a crab-env VM the flag halves the requests a consult makes. `isolate_claude_environment` now sets `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`, the unit test asserts it, and contracts.md names it in the consult description.

Found while tracing crab-env sessions whose Bash classifier ran out its 120 s budget: the process was stuck in TCP connect behind a Cloud NAT port budget the extra connections helped exhaust. The NAT sizing and the proxy routing are fixed on the infra side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuzNioPo1pND86XgvQXLr9
