### PR TITLE
fix(website): set prose back to 15px

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -681,7 +681,7 @@ samp {
    Prose (rendered markdown)
    ———————————————————————————————————————————————— */
 .prose {
-  font-size: 16px;
+  font-size: 15px;
 }
 
 /* Anchor targets stop below the sticky header instead of underneath it. */


### PR DESCRIPTION
The contrast fix (#165) moved prose to 16px alongside darker text tokens and the font-smoothing removal. Those two changes carry the readability gain on their own; 16px reads oversized, so this returns prose to 15px. Tokens and smoothing are untouched.