### PR TITLE
docs(replay): shorten the validation guide

### DIFF
--- a/website/content/docs/validation.md
+++ b/website/content/docs/validation.md
@@ -2,22 +2,38 @@
 title: Validation
 category: Operations
 order: 8
-description: Check that policy changes keep your security rules.
+description: Test policy decisions across multi-step agent trajectories without running tools.
 ---
 
-To help you make sure your configuration behaves as intended, OpenAPPA ships the
-`appa replay` CLI tool. It tests a [policy file](/contracts) against a trace file. The
-trace contains a sequence of tool calls and the expected decision for each call. Replay
-checks these decisions but does not run the tools.
+OpenAPPA includes `appa replay` to test your policies offline. It checks policy rules against scripted tool traces without calling an LLM or running tools.
 
-## Start with an example
+Each trace defines a sequence of proposed tool calls and the expected decision for each call. Replay verifies that security rules—such as audience limits, taint tracking, required approvals, and sanitization—hold across multi-step agent trajectories.
 
-This trace reads an HR file. It then checks that the data cannot go to an external email
-address. The data can still go to the HR email address.
+## Minimal example
 
-Create `secret-stays-inside.appa`:
+Consider an agent that reads internal records and sends emails. The policy blocks sending HR files outside the company while allowing internal emails.
+
+The policy tags files read from `/hr/*` with an audience limit, and requires emails to stay within that audience:
+
+```toml
+# appa.toml
+[policy]
+version = 2
+
+[[policy.tool]]
+name = "Read(path:/hr/*)"
+delta = { audience = ["hr@archestra.ai"] }
+
+[[policy.tool]]
+name = "Email"
+requires = { audience = { contains = ["$to"] } }
+delta = {}
+```
+
+A trace file tests this interaction over three steps:
 
 ```text
+# secret-stays-inside.appa
 Read {
   path: "/hr/salaries.csv"
 }
@@ -34,69 +50,44 @@ Email {
 expect allow
 ```
 
-Create `appa.toml` in the same directory:
+Here is what happens during replay:
 
-```toml
-[policy]
-version = 2
+1. **Read file (`expect allow`):**  
+   The agent calls `Read` on `/hr/salaries.csv`. The engine matches `Read(path:/hr/*)` and allows the call. Replay records an empty output, and the contract's `delta` restricts the trajectory's audience to `hr@archestra.ai`.
 
-[[policy.tool]]
-name = "Read(path:/hr/*)"
-delta = { audience = ["hr@archestra.ai"] }
+2. **Block external recipient (`expect deny`):**  
+   The agent tries to email `x@other.com`. The `Email` rule requires the recipient to be inside the current audience (`hr@archestra.ai`). Because `x@other.com` is outside the audience, the engine blocks the call without offering a remedy.
 
-[[policy.tool]]
-name = "Email"
-parameters = { type = "object", properties = { to = { type = "string" } }, required = ["to"] }
-requires = { audience = { contains = ["$to"] } }
-delta = {}
+3. **Allow internal recipient (`expect allow`):**  
+   The agent emails `hr@archestra.ai`. The recipient matches the allowed audience, so the engine lets the call through.
 
-[externals]
-timeout_ms = 2000
-max_body_bytes = 65536
-```
+This test confirms that the policy prevents data leaks across tools without needing real CSV files or live email accounts.
 
-The `Read` rule limits the data to `hr@archestra.ai`. The `Email` rule uses the `to`
-value from each call. It allows the email only if the recipient can receive the data.
+## Running replay
 
-These rules use an [audience](/contracts#audiences). An audience states who can receive
-data. See [Tools](/contracts#tools) for all tool rule options.
-
-Run the test:
-
-```sh
-appa replay --config appa.toml secret-stays-inside.appa
-```
-
-The command exits with code `0` when all three decisions match the trace.
-
-## Configuration
-
-Use `--config` to select the policy file. Then add one or more trace files or directories:
+Pass your policy configuration with `--config`, followed by trace files or directories:
 
 ```sh
 appa replay --config appa.toml first.appa second.appa
 ```
 
-A directory adds the `.appa` files directly inside that directory:
+Passing a directory runs all `.appa` files directly inside it:
 
 ```sh
 appa replay --config appa.toml traces/
 ```
 
-Each trace file is one test case. Calls in one file run in order and share the same data
-limits. A new file starts a new test case.
+Each trace file runs as an isolated trajectory starting with a clean state. Steps in a file run in order, so label restrictions and recorded effects carry forward from one step to the next.
 
-Add `-v` to show every call:
+Add `-v` to print each call as it runs:
 
 ```sh
 appa replay -v --config appa.toml traces/
 ```
 
-## Trace syntax
+## Syntax
 
-A call starts with the tool name. Put its arguments between `{` and `}`. Put one argument
-on each line. Each value must be valid JSON. This means that a text value needs double
-quotes.
+Trace files (`.appa`) are plain text and line-oriented. Each step pairs a proposed tool call with its expected decision:
 
 ```text
 Email {
@@ -106,114 +97,39 @@ Email {
 expect allow
 ```
 
-Use `{}` when a call has no arguments:
+### Tool calls
 
-```text
-Backup {}
-expect allow
-```
+- **Tool name:** Start with the tool name and `{`. If a tool takes no arguments, write `{}`.
+- **Arguments:** Put one `key: <JSON value>` per line. Values must be valid JSON (quotes around strings, raw numbers or booleans, JSON objects or arrays).
+- **Comments:** Empty lines and lines starting with `#` are ignored.
+- **Errors:** Replay reports the file and line number if an argument repeats, a JSON value is invalid, or a call lacks an `expect` line.
 
-Write the expected result immediately after each call. A line that starts with `#` is a
-comment.
+### Expectations
 
-Replay reports a syntax error when:
+The line right after `}` declares the expected outcome:
 
-- an argument occurs more than one time;
-- a value is not valid JSON;
-- a call has no `expect` line.
-
-The error includes the file name and line number.
-
-## Expected results
-
-### `allow`
-
-Use `allow` when the policy must allow the call.
-
-```text
-Backup {}
-expect allow
-```
-
-A read can reduce the trust level or the audience for later calls. APPA normally asks the
-model to accept this change. Replay accepts the change for an `allow` step. See
-[Labels only move one way](/how-it-works#labels-only-move-one-way) for an explanation of
-these data limits.
-
-### `deny`
-
-Use `deny` when the policy must block the call and must not offer another way to run it.
-
-```text
-Deploy {}
-expect deny
-```
-
-### `authority`
-
-Use `authority` when the policy must require approval from an
-[authority](/contracts#authorities).
-
-```text
-Publish {}
-expect authority
-```
-
-You can require one named authority:
-
-```text
-Publish {}
-expect authority security-team
-```
-
-Replay does not contact the configured authority. It gives approval and continues the
-test case.
-
-### `sanitizer`
-
-Use `sanitizer` when the policy must require a [sanitizer](/contracts#sanitizers).
-
-```text
-Email {
-  to: "person@example.com"
-}
-expect sanitizer
-```
-
-You can require one named sanitizer:
-
-```text
-Email {
-  to: "person@example.com"
-}
-expect sanitizer remove-secrets
-```
-
-Replay does not call the configured sanitizer. It continues with the same value. This
-checks that the policy requires the sanitizer. It does not test how the sanitizer changes
-the value.
+| Expectation | When to use | What replay does |
+|---|---|---|
+| **`expect allow`** | The policy must allow the call. | Accepts label narrowing automatically. Returns an empty output so the contract's `delta` and `effects` apply to later steps. |
+| **`expect deny`** | The policy must block the call with no remedy offered. | Checks that the call is refused outright. No label changes or effects are recorded. |
+| **`expect authority [name]`** | The call must be blocked with an offer requiring approval from an [authority](/contracts#authorities). | Approves the request via a stand-in backend and continues the test. If a name is given, verifies that the offer named that exact authority. |
+| **`expect sanitizer [name]`** | The call must be blocked with an offer requiring transformation through a [sanitizer](/contracts#sanitizers). | Returns the value unchanged via a stand-in backend and applies the declassification delta. If a name is given, verifies that the offer named that exact sanitizer. |
 
 ## Calls during replay
 
-Replay never runs a tool from the trace. When the policy allows a call, replay records an
-empty successful result. It also records the effects from the
-[tool rule](/contracts#tools). The next call can then check those effects.
+Replay checks policy rules without running your tools. When a call is allowed, replay returns an empty output and applies the contract's `delta` and `effects` to the trajectory.
 
-Replay does not call [authorities](/contracts#authorities) or
-[sanitizers](/contracts#sanitizers). It uses the test behavior described above.
+External services behave differently depending on their type:
 
-Replay does call configured [annotators](/contracts#annotators). An annotator provides a
-rule for a proposed tool call, so replay needs its answer to make the real policy decision.
-Replay also calls configured [audience services](/contracts#audience-sources) and
-[identity services](/contracts#identity) when a decision needs them.
+- **Authorities and sanitizers:** Handled by built-in test stand-ins. Replay grants approval and accepts sanitization without sending HTTP requests or asking users.
+- **Annotators:** Called live. [Annotators](/contracts#annotators) generate dynamic contracts for proposed tool calls, so replay needs their responses to make policy decisions.
+- **Audience and identity services:** Called live. Replay queries configured providers to check dynamic group membership ([audience sources](/contracts#audience-sources)) and canonicalize user identities ([identity services](/contracts#identity)).
 
-If one of these services fails, replay reports that the call could not run. It does not
-report a policy denial.
+If a live external service fails or times out, replay reports that the step could not run instead of a policy failure.
 
 ## Results and exit codes
 
-Replay prints `ok` for a test case when all decisions match. If a decision does not match,
-replay prints the file name, line number, actual result, and expected result.
+When all steps match, replay prints `ok` for each file. If a step fails, replay prints the location and the mismatch:
 
 ```text
 secret-stays-inside.appa:6: Email: got allow, want deny
@@ -221,15 +137,14 @@ FAIL  secret-stays-inside.appa
 1 file: 0 ok, 1 failed, 0 could not run
 ```
 
-A wrong result stops the current test case. Other test cases continue.
+A failed step stops that file immediately. Other trace files continue running.
 
 | Exit code | Meaning |
 |---|---|
-| `0` | All expected results matched. |
-| `1` | One or more results did not match. |
-| `2` | Replay could not complete one or more calls. |
+| `0` | All decisions matched the trace files. |
+| `1` | One or more steps did not match their expected decisions. |
+| `2` | Replay could not run (trace syntax error, bad config, or external service failure). |
 
 ## More examples
 
-See the [replay examples on GitHub](https://github.com/archestra-ai/OpenAPPA/tree/main/examples/tests)
-for policies that test audiences, trust levels, approval, sanitizers, and recorded effects.
+The [shipped test cases](https://github.com/archestra-ai/OpenAPPA/tree/main/examples/tests) contain complete examples testing audience restrictions, trust levels, approvals, sanitizers, and action ordering.


### PR DESCRIPTION
## Summary

- open with a minimal example and a numbered walk-through of each expectation
- fold the configuration and expected-results sections into shorter Running replay and Syntax sections
- the expectation table now states when to use each expectation and what replay does for it

Restores the rewrite that was drafted on `docs/replay-validation` after #164 merged but never committed.

## Validation

- docs-only change, no code touched