### PR TITLE
docs(kagent): add operator guide and integration overview

### DIFF
--- a/integrations/kagent/README.md
+++ b/integrations/kagent/README.md
@@ -1,0 +1,126 @@
+# OpenAPPA for kagent
+
+This directory contains the OpenAPPA integration for [kagent](https://github.com/kagent-dev/kagent), the Kubernetes-native AI agent orchestrator.
+
+OpenAPPA gates every declarative kagent agent on Kubernetes through one install setting: the runtime image. The integration requires no modifications to agent definitions, no forks of kagent, and no forks of the Google Agent Development Kit (ADK).
+
+- **Operator guide**: [website/content/docs/kagent.md](../../website/content/docs/kagent.md)
+- **Implementation specification**: [IMPLEMENTATION.md](IMPLEMENTATION.md)
+- **Demo Helm chart**: [demo/chart/README.md](demo/chart/README.md)
+
+## Components
+
+```text
+integrations/kagent/
+├── appa-kagent-adk/         # Python ADK plugin and entrypoint (appa_kagent_adk)
+├── appa-kagent-adk-go/      # Go ADK plugin and replacement runtime main
+├── appa-kagent-quickstart/  # Unified container image bundling appa-runtime and runtimes
+├── demo/                    # Demo Helm chart, mock services, and demo tools
+│   ├── chart/               # Helm chart (appa-kagent-demo)
+│   ├── mocks/               # Mock external authorities (change-board, annotator)
+│   └── demo_tools.py        # Demo toolset MCP server
+├── e2e/                     # End-to-end integration test suites
+│   ├── a2a/                 # Matrix tests over the A2A protocol
+│   └── ui/                  # Browser matrix tests driving the kagent dashboard
+├── examples/                # Reference policies (e.g. kagent.appa.toml)
+├── fixtures/                # Canonical wire event fixtures shared across languages
+└── IMPLEMENTATION.md        # Technical architecture, callback mappings, and specs
+```
+
+### 1. Python Runtime (`appa-kagent-adk/`)
+Wraps kagent's published Python runtime container image. It ships `AppaPluginKagent`, a Google ADK `BasePlugin` that maps ADK lifecycle callbacks to OpenAPPA `/hook` events, and a replacement entrypoint that preserves the stock arguments while appending the plugin and the `execute_remedy_plan` MCP tool.
+
+### 2. Go Runtime (`appa-kagent-adk-go/`)
+Implements `AppaPluginKagent` for Google Go ADK v2. It provides a replacement runtime main that registers the plugin, manages session lineage headers across agent-to-agent delegation, and coordinates human-in-the-loop approvals.
+
+### 3. Quickstart Image (`appa-kagent-quickstart/`)
+A self-contained container image bundling both Python and Go runtimes together with an embedded `appa-runtime` binary. When deployed without an external `APPA_RUNTIME_URL`, the image starts `appa-runtime` on `127.0.0.1:8787` using a packaged default policy. When `APPA_RUNTIME_URL` is supplied, it connects to the shared runtime service.
+
+### 4. Codec Crate (`appa-adapter-kagent`)
+The Rust codec crate located at `crates/appa-adapter-kagent` (in the workspace root). It is compiled directly into `appa-runtime` and parses wire events sent by `AppaPluginKagent`.
+
+## Quickstart
+
+### Deploy kagent with OpenAPPA
+
+Install kagent CRDs and the kagent controller, setting `controller.agentImage` to the OpenAPPA quickstart image:
+
+```sh
+# 1. Install kagent CRDs
+helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
+  --version 0.9.12 -n kagent --create-namespace
+
+# 2. Install kagent controller with OpenAPPA image
+helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
+  --version 0.9.12 -n kagent \
+  --set controller.agentImage.registry=ghcr.io \
+  --set controller.agentImage.repository=archestra-ai/appa-kagent-quickstart \
+  --set controller.agentImage.tag=0.7.0 --wait
+```
+
+### Deploy the Interactive Demo
+
+Deploy the demo chart with your OpenAI API key:
+
+```sh
+helm upgrade --install appa-kagent-demo ./demo/chart \
+  -n kagent --set openai.apiKey="$OPENAI_API_KEY" --wait
+```
+
+Port-forward the kagent dashboard:
+
+```sh
+kubectl port-forward -n kagent svc/kagent-ui 8901:80
+```
+
+Open [http://localhost:8901](http://localhost:8901) to explore 16 pre-seeded demonstration chats showcasing data exfiltration blocks, untrusted ingress quarantine, human-in-the-loop approvals, and multi-agent delegation.
+
+## Building from Source
+
+To build and test the integration images locally (for example, on a local `kind` cluster):
+
+```sh
+# Build images
+docker build -f appa-kagent-quickstart/Dockerfile -t appa-kagent-quickstart:dev ../../
+docker build -t appa-kagent-adk-go:dev appa-kagent-adk-go
+docker build -t appa-demo-tools:dev demo
+docker build -t appa-demo-mocks:dev demo/mocks
+
+# Load images into kind
+kind load docker-image \
+  appa-kagent-quickstart:dev \
+  appa-kagent-adk-go:dev \
+  appa-demo-tools:dev \
+  appa-demo-mocks:dev \
+  --name <cluster-name>
+```
+
+## Running Tests
+
+### Python Unit Tests
+The Python tests verify callback conversions, config validation, and wire encoding across both supported Google ADK releases (1.31.1 and 2.8.0):
+
+```sh
+cd appa-kagent-adk
+uv run pytest
+uv run --with google-adk==1.31.1 pytest
+```
+
+### Go Unit Tests
+The Go tests verify ADK v2 callbacks and wire format parity:
+
+```sh
+cd appa-kagent-adk-go
+go test ./...
+```
+
+### End-to-End Verification Matrices
+The test matrices run 17 distinct scenarios against the live cluster:
+
+```sh
+# Run A2A protocol test matrix
+pytest integrations/kagent/e2e/a2a
+
+# Run UI dashboard test matrix (requires Playwright / Chromium)
+pytest integrations/kagent/e2e/ui
+```

--- a/integrations/kagent/appa-kagent-adk/README.md
+++ b/integrations/kagent/appa-kagent-adk/README.md
@@ -8,7 +8,7 @@ replays the stock kagent startup and appends the plugin. The package
 ships as the `ghcr.io/archestra-ai/appa-kagent-adk` image on top of
 kagent's published runtime image.
 
-The proposal lives at `website/content/docs/kagent.md`; the
+The operator guide lives at `website/content/docs/kagent.md`; the
 implementation plan, per-version mapping tables, and verification
 matrix live in [`../IMPLEMENTATION.md`](../IMPLEMENTATION.md). The
 adapter wire this package emits is parsed by the `appa-adapter-kagent`

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -3,283 +3,155 @@ title: kAgent
 nav_title: kAgent
 category: Integrations
 order: 6
-description: OpenAPPA on kagent — gate every declarative agent through one runtime-image setting.
+description: Gate every declarative kagent agent on Kubernetes through a single container image setting.
 ---
 
-:::proposal
-name: kAgent
-date: 2026-09-01
-:::
+[kagent](https://github.com/kagent-dev/kagent) runs AI agents natively on Kubernetes. OpenAPPA adds deterministic security: it enforces data boundaries, prevents data exfiltration, and requires human approvals before sensitive tools execute.
 
-[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. This proposal gates every declarative kagent agent with OpenAPPA through one install setting: the runtime image.
+A single container image setting (`controller.agentImage`) protects every declarative agent across your cluster. No agent prompt changes, no kagent forks, and no ADK modifications.
 
-Two stock surfaces carry the whole integration:
+## How it works
 
-- The kagent runtime-image settings name the image that runs every declarative agent. Point them at the OpenAPPA images: `appa-kagent-adk` for the python runtime, `appa-kagent-adk-go` for the Go runtime.
-- Both runtimes take plugins through the official Google ADK plugin API. The OpenAPPA images register one — `AppaPluginKagent` — which maps ADK callbacks to the eight `appa-runtime` hook events and enforces the answered `HookDecision`.
-
-`appa-runtime` owns the decisions: policy, the Engine, remedy plans, and trajectory state. [How it works](/how-it-works) and [Policy contracts](/contracts) define them.
-
-## Highlights
-
-### Gated agents on Kubernetes
+OpenAPPA runs inside the agent pod via the official Google ADK plugin API. Every tool call and multi-agent delegation is evaluated against your policy before execution.
 
 ```text
-kagent controller — stock, unmodified
-  watches the operator's Agent resources
-  runtime image = helm controller.agentImage  ◀── the knob
-        │
-        │  renders per Agent:
-        │  Deployment + Service + config Secret
-        ▼
-┌─ agent pod · one per Agent ───────────────────────────┐
-│                                                       │
-│  image    controller.agentImage = appa-kagent-adk     │
-│  /config  the compiled agent, mounted as data:        │
-│           config.json + agent-card.json               │
-│                                                       │
-│  entrypoint ─▶ KAgentApp(plugins=[ ..stock..,         │
-│                AppaPluginKagent ]) ─▶ serve A2A       │
-└──────────────────────────┬────────────────────────────┘
-                           │  POST /hook · fail closed
-                           │  /mcp · execute_remedy_plan
-                           ▼
-┌─ appa-runtime ────────────────────────────────────────┐
-│  policy · Engine · consults · remedy plans ·          │
-│  trajectory state · appa.db                           │
-│  binds loopback only: a shared runtime sits behind a  │
-│  relay that rewrites Host (the demo chart)            │
-└───────────────────────────────────────────────────────┘
+                  ┌────────────────────────┐
+                  │    kagent Operator     │
+                  │  (watches Agent CRDs)  │
+                  └───────────┬────────────┘
+                              │ deploys agent pod
+                              ▼
+┌─ Agent Pod ──────────────────────────────────────┐
+│                                                  │
+│   Agent (LLM) ──▶ Proposed Tool Call             │
+│                         │                        │
+│                         ▼                        │
+│                 AppaPluginKagent (ADK)           │
+│                         │                        │
+│                         ▼                        │
+│                 OpenAPPA Runtime                 │
+│                 (evaluates policy contracts)     │
+│                         │                        │
+│           ┌─────────────┴─────────────┐          │
+│           ▼                           ▼          │
+│      Allow Call                   Block Call     │
+│     (tool runs)             (offers remedy /     │
+│                              human approval)     │
+└──────────────────────────────────────────────────┘
 ```
 
-The agent exists in the pod only as mounted configuration. One generic image therefore serves every declarative agent, and the rollout is one install-setting change.
+- **Policy enforcement happens before execution**: Tools never run if a policy requirement is unmet.
+- **Fail-closed by default**: If the runtime is unreachable, calls are blocked.
+- **Language support**: Supports both Python (`appa-kagent-adk`) and Go (`appa-kagent-adk-go`) runtimes.
 
-### One image per runtime wraps the stock runtime
+## Quickstart
 
-```text
-┌─ appa-kagent-adk image ───────────────────────────────┐
-│                                                       │
-│  OpenAPPA layer — one package, appa_kagent_adk        │
-│    entrypoint.py  replays the stock entrypoint steps  │
-│                   and accepts the same args the       │
-│                   controller sends                    │
-│    plugin.py      ADK BasePlugin ─▶ POST /hook        │
-│    wire.py        the wire: events, decisions, the    │
-│                   reserved tool's name                │
-│                                                       │
-├─ base: kagent's published runtime image · unmodified ─┤
-│    kagent runtime lib   its CLI present, not PID 1    │
-│    google-adk           BasePlugin is its official    │
-│                         plugin API                    │
-└───────────────────────────────────────────────────────┘
+### 1. Install kagent with OpenAPPA
 
-entrypoint flow — the stock calls, five deltas:
+Install kagent using Helm, setting the agent image to the OpenAPPA quickstart image:
 
-  cfg = AgentConfig.model_validate(config.json)
-                     # refuse unknown fields         ◀ delta
-  cfg.model.reasoning_effort ??=
-      $APPA_KAGENT_OPENAI_REASONING_EFFORT       ◀ delta
-  plugins  = [ ..stock plugins.. ]
-  plugins += [ AppaPluginKagent(APPA_RUNTIME_URL) ]  ◀ delta
-  code_executor, memory persist ─▶ wrapped: each
-      crosses the tool gate as a synthetic call    ◀ delta
-  tools   += [ execute_remedy_plan over
-               $APPA_RUNTIME_URL/mcp · 300 s ]    ◀ delta
-  KAgentApp(root_agent, card, url, name,
-            plugins=plugins).build()   ─▶ serve A2A
+```sh
+# Install kagent CRDs
+helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
+  --version 0.9.12 -n kagent --create-namespace
+
+# Install kagent with OpenAPPA runtime image
+helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
+  --version 0.9.12 -n kagent \
+  --set controller.agentImage.registry=ghcr.io \
+  --set controller.agentImage.repository=archestra-ai/appa-kagent-quickstart \
+  --set controller.agentImage.tag=0.7.0 --wait
 ```
 
-The entrypoint replays the stock startup and appends one plugin to the list ADK already accepts. That one registration covers the root agent, every sub-agent, and every tool. The Go image does the same through the Go ADK plugin API, and its runtime main restores two python-side shapes the Go ADK lacks: it lands the lineage headers in session state, so a delegated child starts as a child, and it keeps a reviewed remedy out of the task history until the person rules, so the dashboard shows the approval card. One model field rides along: `APPA_KAGENT_OPENAI_REASONING_EFFORT` fills the OpenAI model's `reasoning_effort` when the ModelConfig leaves it unset — the v1alpha2 ModelConfig cannot say `none`, and the gpt-5.6 models the demo runs on require it for function tools on chat completions. A value the ModelConfig sets wins.
+### 2. Deploy the interactive demo
 
-### Callback-to-hook mapping
+Deploy the pre-configured demo cluster with sample agents (`cluster-ops`, `log-analyst`) and 16 demonstration scenarios:
 
-The runtime hook vocabulary is the eight `HookEvent` variants of `appa-runtime-api`. The plugin maps each gated ADK callback onto exactly one event. Callbacks with no event either pass through or hold as liveness gates.
-
-```text
-ADK plugin callback                     ─▶ feeds /hook event
-time flows top→bottom within one turn   ◀  decisions answered
-─────────────────────────────────────────────────────────────
-
-session   first invocation of a fresh ADK session,
-│         detected in on_user_message_callback
-│         (no callback exists at session creation)
-│           ─▶ [1] SessionStart   ◀ Ack
-│              root TrajectoryId = the ADK session id
-▼
-prompt    on_user_message_callback — fires BEFORE the
-│         session append, so a Block keeps the exact
-│         bytes out of stored history
-│           ═▶ [2] Prompt         ◀ Ack | Block
-│         before_run_callback · before_agent_cb (root)
-│           ─x no event: Prompt gates the same bytes
-▼
-model     before_model · after_model · on_model_error
-│           ─x no event: held as liveness gates —
-│              /hook channel down ⇒ refuse
-▼
-tool      before_tool_callback — a deny dict SKIPS
-loop      execution and becomes the function response
-│         the model reads
-│           ═▶ [3] ToolCall{spawn:false, ruling?}
-│              ◀ AllowCall | DenyCall{review} | Refuse
-│              ◀ PassControl — execute_remedy_plan only
-│              review: per offer whose plan consults a
-│              hitl authority; ruling: the person's
-│              approve | deny on the resumed reserved call
-│         after_tool_callback — a returned dict
-│         replaces what the model sees
-│           ═▶ [4] ToolResult
-│              ◀ Ack | ReplaceOutput | Block
-│         on_tool_error_callback
-│           ─▶ [4] ToolResult{Failure}
-▼
-child     before_tool_cb on the agent tool
-deleg.    │ ═▶ [3] ToolCall{spawn:true}
-│         │    ◀ AllowCall{binding}
-│         │ child scope opens, in its own pod:
-│         │   the child plugin classifies the
-│         │   delegated entry
-│         │     ─▶ [5] ChildStart        ◀ Ack
-│         │   … the child runs its own [3]/[4] loop …
-│         │   child-side after_run_callback
-│         │     ─▶ [6] TurnEnd (child)   ◀ Ack
-│         └ after_tool_cb on the agent-tool return —
-│           the ONE point where the value the parent
-│           receives can be substituted
-│             ═▶ [7] SpawnResult
-│                ◀ Ack | ChildReturn | ReplaceOutput
-│                  | Block
-▼
-emit      on_event_callback
-│           ─x no event: held as a liveness gate
-▼
-turn      after_run_callback — fires on normal
-end       completion and after a pre-run halt; the
-          pinned google-adk has no error-turn callback
-          (fail-closed rule 4)
-            ─▶ [6] TurnEnd (root)  ◀ Ack
-               closes tool dispatches the turn abandoned
-
-          [8] ChildEnd — unfed BY DESIGN: return
-              substitution is enforceable only on the
-              parent side, so returns cross at
-              [7] SpawnResult.
+```sh
+helm upgrade --install appa-kagent-demo ./integrations/kagent/demo/chart \
+  -n kagent --set openai.apiKey="$OPENAI_API_KEY" --wait
 ```
 
-The load-bearing enforcement points, proven in the pinned ADK sources:
+Forward the kagent dashboard to your machine:
 
-- A deny returned from the before-tool callback skips execution and becomes the function response the model reads.
-- The user-message callback fires before the session append, so a blocked prompt never lands in stored history.
-- An agent called as a tool crosses the same gate as any tool call. The parent side substitutes its return.
-
-### Every gated call runs under one contract
-
-The policy produces the contract for a tool call in one of two ways. It is either a static declaration or a registered annotator that answers per call. The consult happens inside the tool gate, on the runtime side, and kagent never sees it. A wildcard annotator covers the tools the policy never names. That posture fits a kagent fleet, where CRD-declared toolsets produce a long tail of tools.
-
-### Remedy plans stay executable
-
-A block is not a dead end. The blocking feedback quotes an offer id, and the agent executes the offered plan through `execute_remedy_plan` — the reserved tool `appa-runtime` itself serves. The images inject it at agent construction, beside `AppaPluginKagent`, so every declarative agent carries it with zero agent changes. Both images' MCP clients wait 300 s per call: a remedy execution holds `execute_remedy_plan` open for as long as its plan runs — a parked authority consult, a slow sanitizer — and ADK's 5 s default would fail it at the client.
-
-```text
-tool call blocked ─▶ the feedback quotes an offer id
-        │
-        ▼
-execute_remedy_plan(offer_id)
-        │   the reserved appa-runtime tool, injected
-        │   at agent construction beside the plugin
-        ▼
-ToolCall hook  ◀ PassControl — vouched, the call
-        │      passes through to appa-runtime
-        │      (a reviewed offer first asks the person:
-        │       the human-review flow below)
-        ▼
-the offered plan executes:
-   Authorize · Accept · Sanitize · Derive
-a Redispatch plan names a tool instead — the agent
-calls it itself, through the normal gate
+```sh
+kubectl port-forward -n kagent svc/kagent-ui 8901:80
 ```
 
-- Human review rides the stock kagent approval flow, for exactly the remedies whose plan names a human authority. The blocking decision carries the review the person reads, the plugin raises kagent's confirmation for that one `execute_remedy_plan` call, the run suspends, and the person's Approve or Reject returns to `appa-runtime` as the authority's ruling — never through the model; the model learns only that the reviewer has been asked. Approve authorizes that one execution; Reject is the authority's denial and retires the offer; kagent has no cancel, so an abandoned task leaves the offer standing. Over A2A the confirmation carries the full review; the kagent dashboard shows the tool call and its arguments. The Go image carries the same channel: adk-go hands its plugin the tool context, so the reviewed call raises the confirmation and the resumed call returns the ruling the same way.
-- Every other remedy — a narrowing, a sanitizer, a human-less authority, a redispatch — the agent executes itself: no confirmation gate sits on `execute_remedy_plan`, and the agent chooses among the offers under its instruction and the chat. The demo agent's instruction takes the sanitized result when one is offered, otherwise accepts the change, follows a steer from the chat, and reports the remedy it took.
-- People out of band need no kagent surface. A URL authority such as the demo's `change-board` on `rollback_deployment` parks the consult inside the `execute_remedy_plan` call until the ruling arrives on the authority's own channel or its window closes. Approve runs the rollback, Deny retires the offer, and no answer grants nothing — the offer stands.
+Open [http://localhost:8901](http://localhost:8901) in your browser.
 
-```text
-human review on kagent — the person rules before the act;
-the runtime spends the ruling inside it
+## 1. Try a blocked flow (Data leak prevention)
 
-model ─▶ restart_deployment
-  │ ToolCall ─────────▶ appa-runtime: the plan consults
-  │ ◀ DenyCall{feedback,   oncall (hitl); text = the
-  │   review:[{offer_id,   consult artifact
-  │   text}]}
-model ─▶ execute_remedy_plan(offer_id)
-  │ plugin: a reviewed offer, no confirmation on the call
-  │   ─▶ ADK tool confirmation · hint = the review text
-  │      kagent: Approve/Reject card · A2A input-required
-  ·      the run ends · the person rules · a new run
-  │ ToolCall{ruling: approve | deny} ─▶ rides the vouch
-  │ ◀ PassControl
-  │ /mcp execute_remedy_plan ─▶ Authorize(oncall)
-  │      ruling on the vouch: spend it
-  │      none: elicitation (Claude Code)
-  │      neither: no answer, the offer stands
-  │ ◀ Authorized | Declined
-model ─▶ restart_deployment again ─▶ runs · or stays blocked
+In the dashboard, inspect how OpenAPPA stops sensitive data from leaving the cluster.
+
+1. The agent reads an internal Kubernetes secret:
+   ```text
+   read_secret(name: "db-credentials")
+   ```
+   OpenAPPA tags the session data with an audience restriction: `audience = ["ops"]`.
+
+2. The agent attempts to publish that information to a public status channel:
+   ```text
+   post_status_update(message: "Database credentials updated...")
+   ```
+
+3. **OpenAPPA blocks the call before it runs.** The destination requires a `public` audience, but the data in context is restricted to `ops`. The tool never executes, and the model receives a clear explanation of the policy boundary.
+
+## 2. Try human approval (HITL workflows)
+
+OpenAPPA integrates with kagent's native approval cards:
+
+1. The agent proposes a destructive cluster action:
+   ```text
+   restart_deployment(name: "api-gateway")
+   ```
+   The policy requires explicit approval: `attention = ["human-approval"]`.
+
+2. OpenAPPA intercepts the call and suspends the agent's turn. An **Approve / Reject** confirmation card appears directly in the kagent dashboard.
+
+3. **The operator decides**:
+   - **Approve**: OpenAPPA authorizes the execution, records the approval, and allows the deployment to restart.
+   - **Reject**: OpenAPPA cancels the request. The tool does not run.
+
+## 3. Multi-agent delegation
+
+When agents call other agents via the A2A protocol, OpenAPPA isolates their execution contexts:
+
+- **Inherited boundaries**: Child agents inherit the parent's data restrictions automatically.
+- **Quarantine**: Untrusted operations (like inspecting raw pod logs) run inside the child agent. Only validated outputs flow back to the parent.
+- **Explicit authorization**: Agents can only delegate to sub-agents explicitly listed in the policy. Unlisted agent spawns are blocked immediately.
+
+## Policy example
+
+Policies are declarative TOML files checked into version control. Here is the contract governing the demo agent:
+
+```toml
+# In-cluster secret read: restricts audience to ops
+[[policy.tool]]
+name = "read_secret"
+delta = { audience = ["ops"] }
+
+# Outward update: requires public audience
+[[policy.tool]]
+name = "post_status_update"
+[policy.tool.requires]
+audience = { contains = ["public"] }
+
+# Production change: requires human operator sign-off
+[[policy.tool]]
+name = "restart_deployment"
+[policy.tool.requires]
+attention = ["human-approval"]
+
+[[policy.authority]]
+name = "oncall"
+hint = "Ask the on-call lead through kagent approval card."
+[policy.authority.permits]
+attention = ["human-approval"]
 ```
 
-- Every remedy call crosses the same hook gate as any tool call.
+## Where next
 
-### A delegated child starts at its parent's label
-
-kagent delegates by calling another Agent as a tool. On the wire that is a spawn: the runtime prepares a fork seeded with the parent's current label — trust and audience, both inherited — and the child pod opens it through kagent's lineage headers, so its calls land in the child trajectory, in the same log as its parent. Inheritance is why delegation cures nothing on its own: a child would be blocked exactly where the parent is. What the child then does narrows the child, not the parent. Only the value that comes back meets the parent's gate, carrying the child's label. A raw value that narrows nothing crosses unchanged. A raw value that would narrow the parent is withheld there with the parent's own offers: accept the narrowing and it crosses, narrowing the parent as if it had done the read itself; take a sanitizer and only the derivation crosses, leaving the parent as it was. A child that returns nothing, or a return the runtime withholds, changes nothing. That is the productive use of a child — quarantine untrusted work in a disposable trajectory and bring back only a clean derivation.
-
-```text
-delegation — a child starts at its parent's label,
-then diverges
-
-parent trajectory · cluster-ops     label: trusted · public
-  │  tool_call {spawn: true} ─▶ the runtime prepares a fork
-  ▼
-child trajectory · log-analyst      label: trusted · public
-  │  child_start opens the fork     ◀ inherited
-  │  get_pod_logs — suspicious ingress: its own gate,
-  │  its own remedy, in its own trajectory
-  ▼
-child label narrows                 label: suspicious · public
-  │  spawn_result ─▶ the value meets the PARENT's gate
-  ▼
-raw, narrows nothing ─▶ crosses · parent unchanged
-raw, would narrow    ─▶ withheld with the parent's own offers
-   accept it         ─▶ crosses · parent narrows
-   take a sanitizer  ─▶ the derivation crosses · parent as was
-   no remedy         ─▶ parent keeps its label
-no value, or withheld ─▶ parent keeps its label
-```
-
-Four hooks carry it: the spawn on the parent's tool call, `ChildStart` when the child pod enters, `SpawnResult` when the value returns to the parent's gate, and the child's own `TurnEnd`. The demo's `log-analyst` is that child; `confined_child_return` lets the runtime withhold its return or substitute a bound return sanitizer's derivation, and the delegation case in both matrices asserts the injected instruction never reaches the operator through it.
-
-Delegation is off by default. The wildcard entry covers every ordinary call the policy does not write, but on kagent it covers no spawn: a child trajectory is not something a per-call annotation can stand for. An agent the policy never names is denied at the spawn, with the reason as the model's feedback, and the agent never runs. The demo shows both sides: `log-analyst` is named and runs as a child; `release-manager` is listed by the same parent, named by no contract, and every delegation to it is denied.
-
-### Fail-closed rules
-
-1. An unreachable `/hook`, or an answer outside the contract, blocks the gated action.
-2. A config field the python entrypoint does not support refuses to start. The stock parser ignores unknown fields, and that entrypoint does not.
-3. The model and emission callbacks feed no event, but they still hold when the `/hook` channel is down.
-4. When the pinned ADK has no error-turn callback, `appa-runtime` recovery closes the turn at the next admitted event.
-5. A delegation to an agent the policy does not name is denied, wildcard or not. On kagent an agent runs as a child only under a contract that names it, so delegation is off until the policy names the agent. The quickstart's packaged policy names none.
-
-### Scope
-
-Covered: declarative agents on both runtimes. Not covered: BYO agents and the kagent sandbox kinds.
-
-### Try it
-
-The demo is a Helm chart, [integrations/kagent/demo/chart](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/kagent/demo/chart): a gated `cluster-ops` agent with a delegated `log-analyst`, the shared `appa-runtime` with its relay and mock externals in one pod, the demo tools, and every demo case pre-seeded as a real chat in the kagent dashboard — an ordinary read, the exfiltration ask that leaks nothing, the agent taking a sanitized remedy on its own, the chat steering it to accept the change or to decline, a forged offer, the on-call approval, the annotator, the release window in and out of window, the remote change board approving, denying and staying silent, delegation, a delegation the policy never names, and gated ingress. It installs into any cluster running kagent 0.9.12 with `controller.agentImage` set to `appa-kagent-quickstart`; the model key is the one input, in a value or pasted in the dashboard afterwards — the Secret is named after the ModelConfig, so the dashboard's Models → Edit flow supplies it. The default image references name this repository's release tags; the chart README shows how to build the images from source and point the image values at your own registry.
-
-The chart also runs both agents as `cluster-ops-go` and `log-analyst-go` on kagent's Go runtime, with the Go image under the name kagent derives for it. Every case runs the same on either cell.
-
-Two matrices verify the install. [e2e/ui](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/kagent/e2e/ui) drives seventeen conversations — the sixteen seeded cases and the on-call rejection — through the kagent dashboard in headless Chromium with a real model; [e2e/a2a](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/kagent/e2e/a2a) runs the same seventeen over the A2A protocol alone, answers the human-review confirmation with the data part the dashboard sends, and plays the change-board member on the mock's side channel. Both pass 16/16 on the Helm-installed stack, on the python cell and on the Go cell. The matrix spans kagent version, runtime plugin and driver; only kagent v0.9.12 runs today.
-
-## Implementation plan
-
-The [kagent implementation plan](https://github.com/archestra-ai/OpenAPPA/blob/main/integrations/kagent/IMPLEMENTATION.md) carries the rest. It covers source baselines, the target matrix, per-version mapping tables, both delivery lanes, the quickstart option, remedy-plan execution with the human-review channel, the wire obligations a driver keeps, the demo chart, and the verification matrix.
+- [How it works](/how-it-works) — Core concepts, labels, and algebraic flow guarantees.
+- [Policy contracts](/contracts) — Complete policy authoring and syntax guide.
+- [Implementation details](https://github.com/archestra-ai/OpenAPPA/blob/main/integrations/kagent/IMPLEMENTATION.md) — ADK callback lifecycle, Go/Python runtime architecture, and wire specs.


### PR DESCRIPTION
Replaces the initial kagent integration proposal with a streamlined operator guide and adds documentation for the kagent integration package.

**Changes**
- `website/content/docs/kagent.md`: High-signal operator guide with simplified architecture diagram, copy-paste quickstart Helm commands, concrete walk-through scenarios (data leak prevention, HITL approvals, multi-agent delegation), and a concise policy example.
- `integrations/kagent/README.md`: Directory overview covering components, quickstart, building from source, and running test matrices.
- `integrations/kagent/appa-kagent-adk/README.md`: Updated guide reference.

Task: T-1176