### PR TITLE
fix(release): make the release gate assert something, and give its checks one definition each

### DIFF
--- a/.github/actions/check-release-versions/action.yml
+++ b/.github/actions/check-release-versions/action.yml
@@ -1,0 +1,31 @@
+name: Check release versions
+description: >-
+  Assert the workspace and the plugin manifest carry the version release-please
+  holds. The tag and the compiled CARGO_PKG_VERSION are concatenated into the
+  plugin artifact URL every shipped binary fetches, so a disagreement between
+  them ships binaries that request a URL which does not exist.
+
+inputs:
+  relock:
+    description: Re-lock the workspace first, for the release PR that must commit it
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Check release versions
+      shell: bash
+      env:
+        RELOCK: ${{ inputs.relock }}
+      run: |
+        version=$(tr -d '\r\n' < .github/release-please/version.txt)
+        if [ "$RELOCK" = "true" ]; then
+          cargo update --workspace
+        fi
+        cargo_version=$(cargo metadata --locked --no-deps --format-version 1 \
+          | jq -r '.packages[] | select(.name == "appa") | .version')
+        plugin_version=$(jq -r '.version' \
+          integrations/claude-code/plugin/.claude-plugin/plugin.json)
+        test "$cargo_version" = "$version"
+        test "$plugin_version" = "$version"

--- a/.github/actions/verify-release-source/action.yml
+++ b/.github/actions/verify-release-source/action.yml
@@ -1,0 +1,43 @@
+name: Verify and checkout release source
+description: >-
+  Prove a release tag resolves to the expected commit, then detach onto that
+  commit. Each release job checks out separately, so each has to do this; the
+  point of doing it here is that they all do it the same way.
+
+inputs:
+  release_ref:
+    description: Immutable release tag the source must be tagged with
+    required: true
+  source_commit:
+    description: Full SHA the tag must resolve to, and the commit to build from
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # A job checks out github.sha, which is trusted, and only then moves to the
+    # release commit. Checking out a mutable ref directly and running code from
+    # it is the thing this avoids.
+    - name: Verify and checkout release source
+      shell: bash
+      env:
+        RELEASE_REF: ${{ inputs.release_ref }}
+        SOURCE_COMMIT: ${{ inputs.source_commit }}
+      run: |
+        if [[ ! "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+          echo "::error::release_ref must be a version tag"
+          exit 1
+        fi
+        if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::source_commit must be a full commit SHA"
+          exit 1
+        fi
+        git fetch --no-tags origin \
+          "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
+        tag_commit=$(git rev-parse "${RELEASE_REF}^{commit}")
+        if [ "$tag_commit" != "$SOURCE_COMMIT" ]; then
+          echo "::error::${RELEASE_REF} targets ${tag_commit}, not source commit ${SOURCE_COMMIT}"
+          exit 1
+        fi
+        git checkout --detach "$SOURCE_COMMIT"
+        test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"

--- a/.github/workflows/build-appa-demo-image.yml
+++ b/.github/workflows/build-appa-demo-image.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write # Required for Workload Identity Federation when pushing images.
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -13,8 +13,7 @@ on:
         type: string
       expected_version:
         description: Version the built binary must report
-        required: false
-        default: ""
+        required: true
         type: string
       plugin_sha256:
         description: SHA-256 of the plugin artifact these binaries must accept
@@ -22,55 +21,42 @@ on:
         type: string
 permissions: {}
 
-concurrency:
-  group: build-appa-runtime-${{ inputs.release_ref }}
-  cancel-in-progress: false
-
 jobs:
   build:
-    name: Build ${{ matrix.os }} ${{ matrix.arch }}
+    name: Build ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
         include:
+          # Both Linux runners are pinned to 22.04 because the packaged binary
+          # must load on glibc 2.34; a newer image links a newer symbol set and
+          # fails the baseline check below.
           - runner: ubuntu-22.04
-            os: Linux
-            arch: amd64
             target: x86_64-unknown-linux-gnu
             executable: appa
             asset: appa-x86_64-unknown-linux-gnu
             archive: appa-x86_64-unknown-linux-gnu.tar.gz
           - runner: ubuntu-22.04-arm
-            os: Linux
-            arch: arm64
             target: aarch64-unknown-linux-gnu
             executable: appa
             asset: appa-aarch64-unknown-linux-gnu
             archive: appa-aarch64-unknown-linux-gnu.tar.gz
           - runner: macos-15-intel
-            os: macOS
-            arch: amd64
             target: x86_64-apple-darwin
             executable: appa
             asset: appa-x86_64-apple-darwin
             archive: appa-x86_64-apple-darwin.tar.gz
           - runner: macos-15
-            os: macOS
-            arch: arm64
             target: aarch64-apple-darwin
             executable: appa
             asset: appa-aarch64-apple-darwin
             archive: appa-aarch64-apple-darwin.tar.gz
           - runner: windows-latest
-            os: Windows
-            arch: amd64
             target: x86_64-pc-windows-msvc
             executable: appa.exe
             asset: appa-x86_64-pc-windows-msvc
             archive: appa-x86_64-pc-windows-msvc.zip
           - runner: windows-11-arm
-            os: Windows
-            arch: arm64
             target: aarch64-pc-windows-msvc
             executable: appa.exe
             asset: appa-aarch64-pc-windows-msvc

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -78,28 +78,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Verify release tag targets the source commit
-        env:
-          RELEASE_REF: ${{ inputs.release_ref }}
-          SOURCE_COMMIT: ${{ inputs.source_commit }}
-        run: |
-          if [[ ! "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::release_ref must be a version tag"
-            exit 1
-          fi
-          if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::source_commit must be a full commit SHA"
-            exit 1
-          fi
-          git fetch --no-tags origin \
-            "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
-          tag_commit=$(git rev-parse "${RELEASE_REF}^{commit}")
-          if [ "$tag_commit" != "$SOURCE_COMMIT" ]; then
-            echo "::error::${RELEASE_REF} targets ${tag_commit}, not source commit ${SOURCE_COMMIT}"
-            exit 1
-          fi
-          git checkout --detach "$SOURCE_COMMIT"
-          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+      - name: Verify and checkout release source
+        uses: ./.github/actions/verify-release-source
+        with:
+          release_ref: ${{ inputs.release_ref }}
+          source_commit: ${{ inputs.source_commit }}
 
       # The binary accepts only the plugin artifact whose digest it is built
       # with. Baking it in at compile time is what makes a shipped binary

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -116,7 +116,6 @@ jobs:
         run: cargo build --release --locked --package appa --target "$TARGET"
 
       - name: Verify release version
-        if: inputs.expected_version != ''
         env:
           EXECUTABLE: ${{ matrix.executable }}
           EXPECTED_VERSION: ${{ inputs.expected_version }}
@@ -182,22 +181,39 @@ jobs:
           mkdir verify
           tar -xzf "dist/${ARCHIVE}" -C verify
           cd verify
-          test -x appa
-          ./appa init claude-code --help >/dev/null
-          # [profile.release] pins debug-assertions = false, so neither
-          # debug-only seam is readable here. A release binary that honoured
-          # them could be pointed at another release's plugin.
-          hostile=$(APPA_PLUGIN_SHA256=$(printf 'a%.0s' {1..64}) \
-            APPA_RELEASE_BASE_URL=http://127.0.0.1:9 \
-            APPA_SOURCE_ARCHIVE_BASE_URL=http://127.0.0.1:9 \
-            APPA_ENDPOINT=http://127.0.0.1:9999 \
-            ./appa init claude-code 2>&1 || true)
+          test -x "./${EXECUTABLE}"
+          "./${EXECUTABLE}" init claude-code --help >/dev/null
+
+          # Every debug-only seam is read through one gate that
+          # [profile.release] pins shut, so a released binary must ignore a
+          # malformed APPA_ENDPOINT and carry on; one that refuses the value
+          # read it, and could be pointed at another release's plugin.
+          #
+          # init exits non-zero on both outcomes, so its output is the
+          # assertion and the exit code is discarded. The progress line is
+          # printed immediately after the endpoint resolves, which makes its
+          # presence the proof that the seam was ignored. Every output is
+          # classified, including the unrecognised one: this probe used to pass
+          # on an empty answer, which is how it stayed inert for four releases.
+          hostile=$(APPA_ENDPOINT=http://127.0.0.1:0 "./${EXECUTABLE}" init claude-code 2>&1 || true)
           case "$hostile" in
-            *"development build"*|*"127.0.0.1:9"*)
-              echo "::error::the released binary honoured a debug-only seam: $hostile"
+            *"is not a usable runtime endpoint"*)
+              echo "::error::the released binary honoured APPA_ENDPOINT: ${hostile}"
+              exit 1
+              ;;
+            "appa init: "*) ;;
+            *)
+              echo "::error::init stopped before the probe could prove anything: ${hostile}"
               exit 1
               ;;
           esac
+
+          if command -v sha256sum >/dev/null 2>&1; then
+            expected_digest=$(sha256sum "./${EXECUTABLE}" | cut -d' ' -f1)
+          else
+            expected_digest=$(shasum -a 256 "./${EXECUTABLE}" | cut -d' ' -f1)
+          fi
+
           "./${EXECUTABLE}" runtime >runtime.stdout.log 2>runtime.stderr.log &
           runtime_pid=$!
           cleanup() {
@@ -209,6 +225,15 @@ jobs:
             if health="$(curl --fail --silent --max-time 1 http://127.0.0.1:8787/health 2>/dev/null)"; then
               test "$health" = "ok"
               test -s appa.toml
+              # Health alone only proves something holds the port. The
+              # fingerprint route answers with the running executable's own
+              # digest, so it proves the responder is the binary just unpacked.
+              served_digest=$(curl --fail --silent --max-time 5 \
+                http://127.0.0.1:8787/binary-fingerprint | head -n 1 | cut -d' ' -f1)
+              if [ "$served_digest" != "$expected_digest" ]; then
+                echo "::error::127.0.0.1:8787 is not this build: answered ${served_digest:-nothing}, expected ${expected_digest}"
+                exit 1
+              fi
               exit 0
             fi
             kill -0 "$runtime_pid" 2>/dev/null || break
@@ -260,33 +285,47 @@ jobs:
             if (-not (Test-Path (Join-Path $package "appa.toml"))) {
               throw "Extracted runtime did not create appa.toml"
             }
-            $cli = Join-Path $package "appa.exe"
+            $cli = Join-Path $package $env:EXECUTABLE
             if (-not (Test-Path $cli)) {
-              throw "Extracted package does not contain appa.exe"
+              throw "Extracted package does not contain $env:EXECUTABLE"
+            }
+            # Health alone only proves something holds the port. The fingerprint
+            # route answers with the running executable's own digest, so it
+            # proves the responder is the binary just unpacked.
+            $expectedDigest = (Get-FileHash -Path $cli -Algorithm SHA256).Hash.ToLower()
+            $answer = Invoke-RestMethod -Uri "http://127.0.0.1:8787/binary-fingerprint" -TimeoutSec 5
+            if ("$answer" -notmatch "^(?<digest>[0-9a-f]{64}) ") {
+              throw "127.0.0.1:8787 did not answer with a build fingerprint: $answer"
+            }
+            if ($Matches.digest -ne $expectedDigest) {
+              throw "127.0.0.1:8787 is not this build: answered $($Matches.digest), expected $expectedDigest"
             }
             & $cli init claude-code --help | Out-Null
             if ($LASTEXITCODE -ne 0) {
-              throw "Extracted appa.exe does not expose init claude-code"
+              throw "Extracted $env:EXECUTABLE does not expose init claude-code"
             }
-            # A released binary must ignore both debug-only seams: the digest
-            # it accepts is compiled in, so a hostile environment cannot point
-            # it at another release's plugin.
-            $env:APPA_PLUGIN_SHA256 = "a" * 64
-            $env:APPA_RELEASE_BASE_URL = "http://127.0.0.1:9"
-            $env:APPA_SOURCE_ARCHIVE_BASE_URL = "http://127.0.0.1:9"
-            $env:APPA_ENDPOINT = "http://127.0.0.1:9999"
+            # Every debug-only seam is read through one gate that
+            # [profile.release] pins shut, so a released binary must ignore a
+            # malformed APPA_ENDPOINT and carry on; one that refuses the value
+            # read it, and could be pointed at another release's plugin.
+            #
+            # The progress line is printed immediately after the endpoint
+            # resolves, which makes its presence the proof that the seam was
+            # ignored. All three outcomes are classified, the unrecognised one
+            # included: this probe used to pass on an empty answer, which is how
+            # it stayed inert for four releases.
+            $env:APPA_ENDPOINT = "http://127.0.0.1:0"
             $hostile = (& $cli init claude-code 2>&1 | Out-String)
-            $env:APPA_PLUGIN_SHA256 = $null
-            $env:APPA_RELEASE_BASE_URL = $null
-            $env:APPA_SOURCE_ARCHIVE_BASE_URL = $null
             $env:APPA_ENDPOINT = $null
-            if ($hostile -match "development build" -or $hostile -match "127\.0\.0\.1:9") {
-              throw "the released binary honoured a debug-only seam: $hostile"
+            if ($hostile -match "is not a usable runtime endpoint") {
+              throw "the released binary honoured APPA_ENDPOINT: $hostile"
             }
-            # The plugin asset is uploaded only after every matrix job passes,
-            # so this probe normally exits non-zero on the first publication
-            # attempt. Its output is the assertion; do not let the expected
-            # native exit code become the PowerShell step's exit code.
+            if ("$hostile" -notmatch "^appa init: ") {
+              throw "init stopped before the probe could prove anything: $hostile"
+            }
+            # init exits non-zero on the path just proven correct, so the
+            # expected native exit code is cleared here and only here, after the
+            # classification above has already thrown on every other outcome.
             $global:LASTEXITCODE = 0
           } finally {
             $process.Refresh()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -113,7 +113,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -139,7 +139,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -164,7 +164,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -190,7 +190,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -254,7 +254,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -276,7 +276,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -295,7 +295,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -322,7 +322,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -359,7 +359,7 @@ jobs:
         working-directory: integrations/kagent/appa-kagent-adk-go
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,7 @@ jobs:
           done
 
       - name: Check release versions
-        run: |
-          version=$(tr -d '\r\n' < .github/release-please/version.txt)
-          cargo_version=$(cargo metadata --locked --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name == "appa") | .version')
-          plugin_version=$(jq -r '.version' \
-            integrations/claude-code/plugin/.claude-plugin/plugin.json)
-          test "$cargo_version" = "$version"
-          test "$plugin_version" = "$version"
+        uses: ./.github/actions/check-release-versions
 
   installer-checks:
     name: Installer Checks (${{ matrix.os }})

--- a/.github/workflows/deploy-to-vercel.yml
+++ b/.github/workflows/deploy-to-vercel.yml
@@ -39,7 +39,7 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -37,7 +37,7 @@ jobs:
       id-token: write # Workload Identity Federation for the optional GCS upload.
     steps:
       - name: Checkout project
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ on:
         description: Existing version without the v prefix (for example, 0.2.0)
         required: false
         type: string
-      tag_name:
-        description: Existing release tag (for example, v0.2.0)
-        required: false
-        type: string
 
 permissions: {}
 
@@ -62,7 +58,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           INPUT_PUBLISH_EXISTING_RELEASE: ${{ inputs.publish_existing_release }}
-          INPUT_TAG_NAME: ${{ inputs.tag_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "$INPUT_PUBLISH_EXISTING_RELEASE" = "true" ]; then
@@ -70,8 +65,7 @@ jobs:
               echo "::error::version is required and must be a release version"
               exit 1
             fi
-            tag_name=${INPUT_TAG_NAME:-v${INPUT_VERSION}}
-            test "$tag_name" = "v${INPUT_VERSION}"
+            tag_name=v${INPUT_VERSION}
             is_draft=$(gh release view "$tag_name" --json isDraft --jq '.isDraft')
             if [ "$is_draft" != "true" ]; then
               echo "::error::${tag_name} is not a draft release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,21 +297,30 @@ jobs:
             echo "::error::the published plugin artifact is not the one the binaries accept"
             exit 1
           fi
-          sha256sum "${expected_archives[@]}" > SHA256SUMS
           sh -n appa-install.sh
+          # The installer is an asset like any other. Leaving it out of
+          # SHA256SUMS meant the one file users are told to pipe into a shell
+          # was the only one they could not verify.
+          sha256sum "${expected_archives[@]}" appa-install.sh > SHA256SUMS
 
-      - name: Read release state
-        id: release-state
+      - name: Refuse an already-published release
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           is_draft=$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')
-          echo "is_draft=${is_draft}" >> "$GITHUB_OUTPUT"
+          # Publishing is the whole point of this job. A release that is already
+          # public cannot be published again, and skipping both remaining steps
+          # would report success for a run that shipped nothing -- the worst
+          # possible answer for a workflow whose recovery story is "dispatch it
+          # again".
+          if [ "$is_draft" != "true" ]; then
+            echo "::error::${TAG_NAME} is already published; nothing was uploaded"
+            exit 1
+          fi
 
       - name: Upload release assets
-        if: ${{ steps.release-state.outputs.is_draft == 'true' }}
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
@@ -319,7 +328,6 @@ jobs:
         run: gh release upload "$TAG_NAME" dist/* --clobber
 
       - name: Publish release
-        if: ${{ steps.release-state.outputs.is_draft == 'true' }}
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,15 +123,9 @@ jobs:
 
       - name: Synchronize release version
         if: ${{ steps.release-pr.outputs.prs_created == 'true' }}
-        run: |
-          version=$(tr -d '\r\n' < .github/release-please/version.txt)
-          cargo update --workspace
-          cargo_version=$(cargo metadata --locked --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name == "appa") | .version')
-          plugin_version=$(jq -r '.version' \
-            integrations/claude-code/plugin/.claude-plugin/plugin.json)
-          test "$cargo_version" = "$version"
-          test "$plugin_version" = "$version"
+        uses: ./.github/actions/check-release-versions
+        with:
+          relock: "true"
 
       - name: Update release PR
         if: ${{ steps.release-pr.outputs.prs_created == 'true' }}
@@ -170,15 +164,10 @@ jobs:
           fetch-depth: 1
 
       - name: Verify and checkout release source
-        env:
-          RELEASE_REF: ${{ needs.release-please.outputs.tag_name }}
-          SOURCE_COMMIT: ${{ needs.release-please.outputs.source_commit }}
-        run: |
-          git fetch --no-tags origin \
-            "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
-          test "$(git rev-parse "${RELEASE_REF}^{commit}")" = "$SOURCE_COMMIT"
-          git checkout --detach "$SOURCE_COMMIT"
-          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+        uses: ./.github/actions/verify-release-source
+        with:
+          release_ref: ${{ needs.release-please.outputs.tag_name }}
+          source_commit: ${{ needs.release-please.outputs.source_commit }}
 
       - name: Package the plugin
         id: package
@@ -236,15 +225,10 @@ jobs:
           fetch-depth: 1
 
       - name: Verify and checkout release source
-        env:
-          RELEASE_REF: ${{ needs.release-please.outputs.tag_name }}
-          SOURCE_COMMIT: ${{ needs.release-please.outputs.source_commit }}
-        run: |
-          git fetch --no-tags origin \
-            "refs/tags/${RELEASE_REF}:refs/tags/${RELEASE_REF}"
-          test "$(git rev-parse "${RELEASE_REF}^{commit}")" = "$SOURCE_COMMIT"
-          git checkout --detach "$SOURCE_COMMIT"
-          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+        uses: ./.github/actions/verify-release-source
+        with:
+          release_ref: ${{ needs.release-please.outputs.tag_name }}
+          source_commit: ${{ needs.release-please.outputs.source_commit }}
 
       - name: Download release archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -85,23 +85,9 @@ fn release_plugin_digest() -> String {
 }
 
 fn plugin_is_dirty(repository: &Path) -> bool {
-    git(
-        repository,
-        &[
-            "status",
-            "--porcelain=v1",
-            "--untracked-files=all",
-            "--",
-            "integrations/claude-code/.claude-plugin",
-            "integrations/claude-code/plugin",
-            "integrations/claude-code/examples",
-            "batteries",
-            "integrations/claude-code/README.md",
-            "integrations/claude-code/live-gate-check.py",
-            "website/content/docs/contracts.md",
-        ],
-    )
-    .is_none_or(|output| !output.trim().is_empty())
+    let mut arguments = vec!["status", "--porcelain=v1", "--untracked-files=all", "--"];
+    arguments.extend(plugin_layout::REPOSITORY_MAPPINGS.iter().map(|(source, _)| *source));
+    git(repository, &arguments).is_none_or(|output| !output.trim().is_empty())
 }
 
 fn export_committed_repository(repository: &Path, destination: &Path) -> std::io::Result<()> {

--- a/appa-runtime/src/plugin_bundle.rs
+++ b/appa-runtime/src/plugin_bundle.rs
@@ -22,6 +22,26 @@ use crate::plugin_layout::{
     EntryKind, MAX_ENTRIES, MAX_UNCOMPRESSED_BYTES, TreeDigestError, absorb_field, canonical_tree_digest, walk,
 };
 
+// ---------------------------------------------------------------------------
+// Debug-only test seams
+// ---------------------------------------------------------------------------
+
+/// The one place a debug-only seam reads the environment.
+///
+/// Three seams exist -- the endpoint, the release download base and the source
+/// archive base -- and each of them is this function. `[profile.release]` pins
+/// `debug-assertions = false`, so a shipped binary reads no environment here at
+/// all. The release workflow proves that on the packaged artifact by feeding it
+/// a malformed `APPA_ENDPOINT` and requiring it to be ignored; that single probe
+/// stands for all three seams only for as long as this is the only gate.
+fn debug_override(name: &str) -> Option<String> {
+    if cfg!(debug_assertions) {
+        env::var(name).ok()
+    } else {
+        None
+    }
+}
+
 /// Files and directories every plugin source must carry, in the marketplace-root
 /// shape `plugin_layout::stage_repository` produces. One validator serves
 /// both source resolution and the reuse check on an existing deployment.
@@ -337,11 +357,7 @@ pub const DEFAULT_ENDPOINT_URL: &str = "http://127.0.0.1:8787";
 
 impl Endpoint {
     pub fn resolve() -> Result<Self, PluginBundleError> {
-        let configured = if cfg!(debug_assertions) {
-            env::var("APPA_ENDPOINT").ok()
-        } else {
-            None
-        };
+        let configured = debug_override("APPA_ENDPOINT");
         Self::parse(configured.as_deref().unwrap_or(DEFAULT_ENDPOINT_URL))
     }
 
@@ -958,23 +974,13 @@ fn cached_archive_path(cache_dir: &Path, version: &str, digest: PluginDigest) ->
 /// builds only, and init reads it once at the boundary rather than leaving the
 /// fetch to consult the environment underneath its caller.
 pub(crate) fn release_base_url() -> String {
-    let configured = if cfg!(debug_assertions) {
-        env::var("APPA_RELEASE_BASE_URL").ok()
-    } else {
-        None
-    };
-    configured.unwrap_or_else(|| RELEASE_BASE_URL.to_owned())
+    debug_override("APPA_RELEASE_BASE_URL").unwrap_or_else(|| RELEASE_BASE_URL.to_owned())
 }
 
 /// The immutable GitHub source-archive base. Like the release test seam, the
 /// override exists only in debug builds and cannot redirect a shipped binary.
 pub(crate) fn source_archive_base_url() -> String {
-    let configured = if cfg!(debug_assertions) {
-        env::var("APPA_SOURCE_ARCHIVE_BASE_URL").ok()
-    } else {
-        None
-    };
-    configured.unwrap_or_else(|| SOURCE_ARCHIVE_BASE_URL.to_owned())
+    debug_override("APPA_SOURCE_ARCHIVE_BASE_URL").unwrap_or_else(|| SOURCE_ARCHIVE_BASE_URL.to_owned())
 }
 
 /// The verified archive for this build's release, from the cache when it is


### PR DESCRIPTION
The release pipeline's hostile-seam probe has never worked. It runs
`appa init claude-code` under a hostile environment and greps the output for
evidence the binary honoured a debug-only seam — but no `claude` CLI exists on a
build runner, so init dies at `run_claude` in step 1, before the code that reads
any of those variables. The output is always the same unavailable-`claude`
error, it matches neither pattern, and the step passes. `|| true` and its
PowerShell twin keep it green. Half the grep was dead on top of that: the
`development build` message it looks for was deleted in f6ebe37, and two later
release fixes edited adjacent lines without noticing.

Reproduced against a real `--release` build before changing it, and the
replacement verified against both profiles: a release binary passes, a debug
binary fails, an empty answer fails.

**Release gate**

- The probe now feeds a malformed `APPA_ENDPOINT`, read at the top of init, and
  classifies all three outcomes. Refusing the value means the seam was read.
  Printing the progress line means init got past the endpoint, which is the
  proof it was ignored. Anything else — an empty answer included — fails, where
  before it passed.
- The three `cfg!(debug_assertions)` env blocks are now one accessor. The probe
  can only afford to test one seam on the packaged artifact, so its claim to
  cover the other two rests on there being one gate rather than on an argument
  about three.
- `/binary-fingerprint` is compared against the digest of the unpacked binary.
  Health alone only proved something held `127.0.0.1:8787` — during testing, a
  runtime already installed on the development machine answered in place of the
  binary under test.
- A dispatch against an already-published release used to skip both the upload
  and the publish step and report success for a run that shipped nothing. It now
  fails.

**One definition per check**

- Verifying that a release tag resolves to the expected commit was written three
  times and had drifted: only one copy validated its inputs, the other two were
  bare `test` calls with no diagnostic. Now one composite, strict version.
- The version assertion was written twice, differing by one
  `cargo update --workspace`. Now one composite with a `relock` input.
- `plugin_is_dirty` spelled the seven staged paths as literals twenty lines above
  the function that iterates `REPOSITORY_MAPPINGS` for the same set. An eighth
  entry would have been staged and exported while dirty detection watched the old
  seven.
- `appa-install.sh` ships as a release asset but was absent from `SHA256SUMS` —
  the one file users are told to pipe into a shell was the only one they could
  not verify.

**Deletions**, each with a callers search behind it: the dead `development build`
pattern (both copies), `matrix.os`/`matrix.arch` (job title only),
`expected_version`'s optionality (the workflow is `workflow_call`-only and its
sole caller always passes it), the `tag_name` dispatch input (rejected unless it
equalled its own default), and the inner concurrency group (subsumed by the
caller's).

`actions/checkout` is unified on v7.0.1; fourteen sites were a patch behind the
five in the release path. Three of the touched files are outside this change's
scope — the pin is one line each and leaving them split preserves the defect.

**Net +53 lines.** Composite boilerplate is ~74 lines replacing ~50 across five
call sites, and the probe carries the rationale above. This buys correctness and
one definition per check, not smaller files.

**Not verified locally:** the PowerShell verify step. `pwsh` is not installable
on the development machine (Homebrew offers only `powershell@preview`), so that
rewrite is reviewed but unexecuted; it uses only constructs already present in
the same file plus `Get-FileHash` and `$Matches`.

**Known gaps**, deliberately left: the two PowerShell health-probe copies remain
duplicated — a composite can only cover start+health, so collapsing them would
split each `try/finally` and lose its cleanup guarantee; it belongs with a
Windows test job. `ci.yml`'s Windows job still never runs `cargo test`, leaving
~200 lines of `init.rs` compile-checked only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MtUpUESGQRbJ3AQBo8evV
