### PR TITLE
fix(install): validate the archive before unpacking it

### DIFF
--- a/scripts/appa-install-test.sh
+++ b/scripts/appa-install-test.sh
@@ -159,6 +159,118 @@ while read -r hash name; do
   printf '%s  %s\n' "$(printf '%s' "$hash" | tr '0123456789abcdef' '123456789abcdef0')" "$name"
 done < "$work/SHA256SUMS.good" > "$release/SHA256SUMS"
 expect_refused digest-mismatch APPA_REPOSITORY_URL="$origin/good"
+restore
+
+# The archive this machine will actually ask for, and a way to swap it for a
+# hostile one while keeping SHA256SUMS honest -- so each case below is refused
+# for its own reason and not for a checksum mismatch.
+case $(uname -s) in
+  Linux) host_platform=unknown-linux-gnu ;;
+  Darwin) host_platform=apple-darwin ;;
+  *) echo "unsupported test host: $(uname -s)" >&2; exit 1 ;;
+esac
+case $(uname -m) in
+  x86_64 | amd64) host_arch=x86_64 ;;
+  aarch64 | arm64) host_arch=aarch64 ;;
+  *) echo "unsupported test host: $(uname -m)" >&2; exit 1 ;;
+esac
+host_archive=appa-$host_arch-$host_platform.tar.gz
+cp "$release/$host_archive" "$work/host-archive.good"
+replace_host_archive() {
+  cp "$1" "$release/$host_archive"
+  (cd "$release" && sums appa-*.tar.gz > SHA256SUMS)
+}
+restore_host_archive() {
+  cp "$work/host-archive.good" "$release/$host_archive"
+  restore
+}
+
+# A release whose archive is listed but absent: the download fails, not the
+# checksum.
+mv "$release/$host_archive" "$work/host-archive.hidden"
+expect_refused missing-archive APPA_REPOSITORY_URL="$origin/good"
+mv "$work/host-archive.hidden" "$release/$host_archive"
+
+printf 'not a gzip stream' > "$work/corrupt.tar.gz"
+replace_host_archive "$work/corrupt.tar.gz"
+expect_refused corrupt-archive APPA_REPOSITORY_URL="$origin/good"
+restore_host_archive
+
+mkdir -p "$work/no-appa"
+printf 'nothing to install here\n' > "$work/no-appa/README"
+tar -C "$work/no-appa" -czf "$work/no-appa.tar.gz" .
+replace_host_archive "$work/no-appa.tar.gz"
+expect_refused archive-without-appa APPA_REPOSITORY_URL="$origin/good"
+restore_host_archive
+
+# An archive whose member climbs out of the directory it unpacks into. The
+# digest matches, so only the entry check can refuse it. The member is written
+# through python3 because GNU tar strips a leading `../` from what it is asked
+# to archive, which would leave this case unable to test anything.
+python3 - "$work/stage/appa" "$work/escaping.tar.gz" <<'BUILD'
+import sys, tarfile
+
+source, archive = sys.argv[1], sys.argv[2]
+with tarfile.open(archive, "w:gz") as bundle:
+    bundle.add(source, arcname="appa")
+    bundle.add(source, arcname="../escaped/appa")
+BUILD
+tar -tzf "$work/escaping.tar.gz" | grep -q '^\.\./escaped/appa$' ||
+  { echo "the escaping-archive fixture holds no traversal member" >&2; exit 1; }
+replace_host_archive "$work/escaping.tar.gz"
+expect_refused escaping-archive APPA_REPOSITORY_URL="$origin/good"
+restore_host_archive
+
+# A binary that downloads and unpacks but cannot run here.
+mkdir -p "$work/broken"
+printf '#!/bin/sh\nexit 1\n' > "$work/broken/appa"
+chmod 755 "$work/broken/appa"
+tar -C "$work/broken" -czf "$work/broken.tar.gz" .
+replace_host_archive "$work/broken.tar.gz"
+expect_refused unrunnable-binary APPA_REPOSITORY_URL="$origin/good"
+restore_host_archive
+
+# The reason the installer stages beside the target and renames: a failed
+# install must leave a working appa in place, and must not leave its own
+# half-written one behind.
+upgrade_dir=$(case_dir upgrade-preserves-previous)
+mkdir -p "$upgrade_dir"
+printf '#!/bin/sh\necho "appa 0.0.0-previous"\n' > "$upgrade_dir/appa"
+chmod 755 "$upgrade_dir/appa"
+replace_host_archive "$work/corrupt.tar.gz"
+if env APPA_REPOSITORY_URL="$origin/good" APPA_INSTALL_DIR="$upgrade_dir" \
+  sh "$installer" >"$work/upgrade.out" 2>"$work/upgrade.err"; then
+  report FAIL "upgrade-preserves-previous (installer succeeded)"
+elif [ "$("$upgrade_dir/appa" --version)" != "appa 0.0.0-previous" ]; then
+  report FAIL "upgrade-preserves-previous (the previous binary did not survive)"
+elif [ -n "$(find "$upgrade_dir" -name 'appa.*.new' 2>/dev/null)" ]; then
+  report FAIL "upgrade-preserves-previous (a staged binary was left behind)"
+else
+  report PASS upgrade-preserves-previous
+fi
+restore_host_archive
+
+# ...and a later good release replaces it.
+if env APPA_REPOSITORY_URL="$origin/good" APPA_INSTALL_DIR="$upgrade_dir" \
+  sh "$installer" >"$work/upgrade2.out" 2>"$work/upgrade2.err" &&
+  [ "$("$upgrade_dir/appa" --version)" = "appa 0.0.0-smoke" ]; then
+  report PASS upgrade-replaces-previous
+else
+  cat "$work/upgrade2.out" "$work/upgrade2.err" >&2
+  report FAIL upgrade-replaces-previous
+fi
+
+# On PATH, the installer points at the bare command rather than the full path.
+path_dir=$(case_dir on-path-hint)
+if env APPA_REPOSITORY_URL="$origin/good" APPA_INSTALL_DIR="$path_dir" \
+  PATH="$path_dir:$PATH" sh "$installer" \
+  >"$work/on-path.out" 2>"$work/on-path.err" &&
+  grep -q '^Next: appa init claude-code$' "$work/on-path.out"; then
+  report PASS on-path-hint
+else
+  cat "$work/on-path.out" "$work/on-path.err" >&2
+  report FAIL on-path-hint
+fi
 
 # A PATH holding everything the installer needs except a digest tool.
 mkdir "$work/nodigest"
@@ -166,6 +278,13 @@ for tool in sh curl tar gzip mktemp install uname grep cut mkdir rm cat env; do
   ln -s "$(command -v "$tool")" "$work/nodigest/$tool"
 done
 expect_refused no-digest-tool APPA_REPOSITORY_URL="$origin/good" PATH="$work/nodigest"
+
+# curl is checked before anything else, so a PATH without it refuses early.
+mkdir "$work/nocurl"
+for tool in sh tar gzip mktemp install uname grep cut mkdir rm cat env; do
+  ln -s "$(command -v "$tool")" "$work/nocurl/$tool"
+done
+expect_refused missing-curl APPA_REPOSITORY_URL="$origin/good" PATH="$work/nocurl"
 
 if [ "$failures" -ne 0 ]; then
   echo "$failures installer case(s) failed" >&2

--- a/scripts/appa-install.sh
+++ b/scripts/appa-install.sh
@@ -73,10 +73,24 @@ else
     *) fail "unexpected redirect for the latest release: $latest" ;;
   esac
 fi
+# The character check comes first because `grep -q` succeeds when any single
+# line matches, so a multi-line value would otherwise pass a guard whose whole
+# job is to constrain what reaches a URL.
+case $tag in
+  *[!0-9A-Za-z.-]*) fail "not a release tag: $tag" ;;
+esac
 printf '%s\n' "$tag" | grep -Eq "$tag_pattern" || fail "not a release tag: $tag"
 
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT
+staged=
+cleanup() {
+  rm -rf "$work"
+  if [ -n "$staged" ]; then
+    rm -f "$staged"
+  fi
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT HUP TERM
 
 # The list and the archive come from the same pinned release, never from
 # `latest`, so a release published mid-run cannot pair one with the other.
@@ -94,20 +108,44 @@ expected=${listed%% *}
 actual=$(digest "$work/$archive")
 [ "$actual" = "$expected" ] || fail "checksum mismatch for $archive"
 
-mkdir "$work/extract"
-tar -xzf "$work/$archive" -C "$work/extract"
-[ -f "$work/extract/appa" ] || fail "$archive does not contain appa"
+# The digest is published by the same host that serves the archive, so it
+# proves the download arrived intact, not that the release is honest. The Rust
+# half of this project validates every archive entry before extracting one;
+# match that here rather than rely on tar, whose treatment of `..` and absolute
+# members differs between GNU and BSD.
+entries=$(tar -tzf "$work/$archive") || fail "$archive is not a readable archive"
+[ "$(printf '%s\n' "$entries" | grep -c .)" -le 16 ] ||
+  fail "$archive holds more entries than a release archive carries"
+if ! printf '%s\n' "$entries" | while IFS= read -r entry; do
+  case $entry in
+    /* | .. | ../* | */.. | */../*) exit 1 ;;
+  esac
+done; then
+  fail "$archive holds an entry that escapes the directory it unpacks into"
+fi
+
+mkdir "$work/extract" || fail "could not create a staging directory"
+tar -xzf "$work/$archive" -C "$work/extract" || fail "could not unpack $archive"
+# A symlink would pass -f by resolving elsewhere, and that elsewhere is what
+# would be installed.
+if [ ! -f "$work/extract/appa" ] || [ -L "$work/extract/appa" ]; then
+  fail "$archive does not contain appa"
+fi
 
 # An installed appa is replaced only by one that runs here.
 version=$("$work/extract/appa" --version) ||
   fail "the $tag binary does not run on this system; Linux needs glibc 2.34 or newer"
+[ -n "$version" ] || fail "the $tag binary reported no version"
 
 # The previous appa stays in place until the new one is completely written
 # beside it, so a failed copy never leaves the directory without a working
 # binary.
-mkdir -p "$install_dir"
-install -m 755 "$work/extract/appa" "$install_dir/appa.$$.new"
-mv -f "$install_dir/appa.$$.new" "$install_dir/appa"
+mkdir -p "$install_dir" || fail "could not create $install_dir"
+staged=$install_dir/appa.$$.new
+install -m 755 "$work/extract/appa" "$staged" ||
+  fail "could not write $staged"
+mv -f "$staged" "$install_dir/appa" || fail "could not replace $install_dir/appa"
+staged=
 printf 'Installed %s to %s\n' "$version" "$install_dir/appa"
 case :${PATH:-}: in
   *":$install_dir:"*) printf 'Next: appa init claude-code\n' ;;


### PR DESCRIPTION
`scripts/appa-install.sh` unpacked a downloaded archive with `tar -xzf` after
checking only its SHA-256, and the digest is published by the same host that
serves the archive — it proves the bytes arrived intact, not that they are
honest. The Rust half of this project validates every archive entry before
extracting one; the shell installer did not.

## Installer

- Validate archive entries before extraction: refuse an absolute or `..`
  member, and refuse an archive carrying more entries than a release archive
  holds. `tar` itself is not the check — GNU and BSD differ on what they do
  with such members.
- Refuse a `appa` that is a symlink. `-f` follows one, so the file that gets
  installed would be whatever it resolves to.
- Reject a tag containing anything outside `[0-9A-Za-z.-]` before it reaches
  the version regex.
- Clean up the staged binary and the work directory on `INT`, `HUP` and `TERM`,
  not only on a normal exit.
- Route the remaining bare `mkdir`, `tar`, `install` and `mv` failures through
  `fail`, so every refusal states a reason instead of ending with an exit code.

## Cases

Nine new cases in `scripts/appa-install-test.sh`: `missing-archive`,
`corrupt-archive`, `archive-without-appa`, `escaping-archive`,
`unrunnable-binary`, `upgrade-preserves-previous`, `upgrade-replaces-previous`,
`on-path-hint`, `missing-curl`.

Two of them fail against the previous installer (`corrupt-archive`,
`escaping-archive`); the other seven characterize behavior that already held
and was untested.

The traversal fixture is built with `python3` — already this suite's HTTP
server dependency — because GNU tar strips a leading `../` from a member it is
asked to archive, which would leave that case testing nothing on the Linux
runner. The suite asserts the member survives before using it.

18/18 cases pass on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MtUpUESGQRbJ3AQBo8evV
