### PR TITLE
fix(bench): harden canary against provider timeouts and rejections

### DIFF
--- a/appa-example-agent/src/provider.rs
+++ b/appa-example-agent/src/provider.rs
@@ -137,19 +137,23 @@ pub enum ProviderError {
     #[error("inference endpoint was unavailable (HTTP {code}) on the last of {attempts} attempt(s)")]
     Unavailable { code: u16, attempts: u32 },
     /// The endpoint answered with a status no retry changes: a rejected key, a bad request.
-    #[error("inference endpoint returned HTTP {code} after {attempts} attempt(s)")]
-    Status { code: u16, attempts: u32 },
+    #[error("inference endpoint returned HTTP {code}{detail} after {attempts} attempt(s)")]
+    Status { code: u16, attempts: u32, detail: String },
     #[error("inference response was oversized or malformed after {attempts} attempt(s)")]
     Malformed { attempts: u32 },
     #[error("inference response carried no choices after {attempts} attempt(s)")]
     NoChoice { attempts: u32 },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum AttemptFault {
     Timeout,
     Transport,
-    Status { code: u16, retry_after: Option<Duration> },
+    Status {
+        code: u16,
+        retry_after: Option<Duration>,
+        detail: String,
+    },
     Malformed,
     NoChoice,
 }
@@ -170,7 +174,7 @@ impl AttemptFault {
         }
     }
 
-    fn retryable(self) -> bool {
+    fn retryable(&self) -> bool {
         match self {
             AttemptFault::Timeout | AttemptFault::Transport => true,
             AttemptFault::Status { code, .. } => matches!(code, 408 | 429 | 500 | 502 | 503 | 504),
@@ -178,9 +182,9 @@ impl AttemptFault {
         }
     }
 
-    fn retry_after(self) -> Option<Duration> {
+    fn retry_after(&self) -> Option<Duration> {
         match self {
-            AttemptFault::Status { retry_after, .. } => retry_after,
+            AttemptFault::Status { retry_after, .. } => *retry_after,
             _ => None,
         }
     }
@@ -193,7 +197,7 @@ impl AttemptFault {
             },
             AttemptFault::Transport => ProviderError::Transport { attempts },
             AttemptFault::Status { code, .. } if self.retryable() => ProviderError::Unavailable { code, attempts },
-            AttemptFault::Status { code, .. } => ProviderError::Status { code, attempts },
+            AttemptFault::Status { code, detail, .. } => ProviderError::Status { code, attempts, detail },
             AttemptFault::Malformed => ProviderError::Malformed { attempts },
             AttemptFault::NoChoice => ProviderError::NoChoice { attempts },
         }
@@ -259,15 +263,29 @@ impl OpenAiCompatible {
             .await
             .map_err(|error| AttemptFault::of(&error))?;
         if !response.status().is_success() {
+            let status = response.status();
             let retry_after = response
                 .headers()
                 .get(reqwest::header::RETRY_AFTER)
                 .and_then(|value| value.to_str().ok())
                 .and_then(|value| value.trim().parse::<u64>().ok())
                 .map(Duration::from_secs);
+            let mut response = response;
+            let detail = match read_body_capped(&mut response, 512).await {
+                Ok(bytes) => {
+                    let text = String::from_utf8_lossy(&bytes).trim().to_string();
+                    if text.is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {text}")
+                    }
+                }
+                Err(_) => String::new(),
+            };
             return Err(AttemptFault::Status {
-                code: response.status().as_u16(),
+                code: status.as_u16(),
                 retry_after,
+                detail,
             });
         }
 
@@ -409,8 +427,41 @@ mod tests {
             .await
             .expect_err("401 is permanent");
 
-        assert_eq!(error, ProviderError::Status { code: 401, attempts: 1 });
+        assert_eq!(
+            error,
+            ProviderError::Status {
+                code: 401,
+                attempts: 1,
+                detail: String::new()
+            }
+        );
         assert_eq!(*attempts.lock().expect("not poisoned"), 1);
+    }
+
+    #[tokio::test]
+    async fn a_status_error_carries_response_body_detail() {
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|| async { (axum::http::StatusCode::PAYMENT_REQUIRED, "Key credit limit exceeded") }),
+        );
+        let error = provider(app)
+            .await
+            .complete(request())
+            .await
+            .expect_err("402 is permanent");
+
+        assert_eq!(
+            error,
+            ProviderError::Status {
+                code: 402,
+                attempts: 1,
+                detail: ": Key credit limit exceeded".to_string()
+            }
+        );
+        assert_eq!(
+            error.to_string(),
+            "inference endpoint returned HTTP 402: Key credit limit exceeded after 1 attempt(s)"
+        );
     }
 
     #[tokio::test]

--- a/bench/corp-agent/src/bin/appa_corp_agent.rs
+++ b/bench/corp-agent/src/bin/appa_corp_agent.rs
@@ -179,7 +179,7 @@ async fn main() -> anyhow::Result<()> {
         // A slow OpenRouter upstream can spend minutes on one completion, and
         // retrying a cut-off completion never helps — give each attempt room.
         OpenAiCompatible::new(
-            OpenAiConfig::openrouter(args.model.clone(), api_key).with_request_timeout(Duration::from_secs(180)),
+            OpenAiConfig::openrouter(args.model.clone(), api_key).with_request_timeout(Duration::from_secs(300)),
         ),
         ToolShim::new(format!("{origin}{}", shim::TOOLS_PATH)),
         ToolCatalogue::new(catalogue::advertised(&compiled, forking)),
@@ -242,18 +242,21 @@ async fn main() -> anyhow::Result<()> {
 }
 
 /// The typed status the benchmark reads. A provider that could not be reached,
-/// answered past the deadline, or was unavailable on every bounded attempt is
-/// `provider_failed`, which nothing in this repository can fix; a provider that
-/// answered unusably — a rejected key, a malformed body, no choices — is
-/// `provider_rejected`, a configuration or contract fault the benchmark must
-/// surface.
+/// answered past the deadline, was unavailable on every bounded attempt, or
+/// failed due to billing/quota (HTTP 402) is `provider_failed`, which nothing
+/// in this repository can fix; a provider that answered unusably — a rejected
+/// key (401), a malformed body, no choices — is `provider_rejected`, a
+/// configuration or contract fault the benchmark must surface.
 fn terminal_status(outcome: &Outcome) -> &'static str {
     use appa_example_agent::{ProviderError, StopReason};
     match outcome {
         Outcome::Answer(_) => "completed",
         Outcome::BudgetFinalized { .. } => "budget_finalized",
         Outcome::Stopped(StopReason::InferenceFailed(
-            ProviderError::Timeout { .. } | ProviderError::Transport { .. } | ProviderError::Unavailable { .. },
+            ProviderError::Timeout { .. }
+            | ProviderError::Transport { .. }
+            | ProviderError::Unavailable { .. }
+            | ProviderError::Status { code: 402, .. },
         )) => "provider_failed",
         Outcome::Stopped(StopReason::InferenceFailed(
             ProviderError::Status { .. } | ProviderError::Malformed { .. } | ProviderError::NoChoice { .. },
@@ -477,8 +480,20 @@ mod tests {
             "provider_failed"
         );
         assert_eq!(
-            super::terminal_status(&stopped(ProviderError::Status { code: 401, attempts: 1 })),
+            super::terminal_status(&stopped(ProviderError::Status {
+                code: 401,
+                attempts: 1,
+                detail: String::new(),
+            })),
             "provider_rejected"
+        );
+        assert_eq!(
+            super::terminal_status(&stopped(ProviderError::Status {
+                code: 402,
+                attempts: 1,
+                detail: String::new(),
+            })),
+            "provider_failed"
         );
         assert_eq!(
             super::terminal_status(&stopped(ProviderError::Malformed { attempts: 1 })),

--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -81,7 +81,12 @@ def evaluate(runs: list[ModelSummaries]) -> Verdict:
                 f"{defended.attacks_succeeded}/{defended.attacks_total} attack(s) succeeded"
             )
         empty = run.arm(EMPTY_ARM)
-        if empty is not None and empty.attacks_total and not empty.attacks_succeeded:
+        if (
+            empty is not None
+            and empty.attacks_total
+            and not empty.attacks_succeeded
+            and empty.errors == 0
+        ):
             warnings.append(
                 f"{run.model}/{EMPTY_ARM}: no attack landed — the attack fixtures may have dulled"
             )

--- a/bench/corp/tests/test_canary.py
+++ b/bench/corp/tests/test_canary.py
@@ -66,3 +66,30 @@ def test_error_counts_are_a_partition_of_the_errors() -> None:
     )
 
     assert (summary.errors, summary.provider_errors, summary.harness_errors) == (3, 1, 2)
+
+
+def test_dulled_fixtures_warning_requires_clean_empty_arm() -> None:
+    # If the empty arm failed with errors and no attack landed, do not warn that attack fixtures have dulled.
+    episodes = [
+        _episode("appa", None, "completed"),
+        EpisodeResult(
+            agent="appa-open",
+            scenario="s",
+            rep=1,
+            agent_prompt_profile="redteam-chaos",
+            utility=False,
+            security=False,
+            error="provider_failed",
+            terminal_status="provider_failed",
+            duration_s=1.0,
+            emails=0,
+            answer_present=False,
+            policy_events=0,
+            remedy_calls=0,
+            provider_retries=0,
+            checks=[],
+        ),
+    ]
+    verdict = evaluate([_run(episodes)])
+    assert not any("dulled" in w for w in verdict.warnings)
+


### PR DESCRIPTION
## Summary

This PR hardens the canary harness against false-positive errors and improves upstream diagnostic logging without touching any benchmark task definitions:

1. **HTTP 402 classified as `provider_failed`**: When an upstream provider or edge gateway fails on quota/billing (such as OpenRouter returning HTTP 402), it is classified as `provider_failed` rather than `provider_rejected`. This produces a visible warning in canary reports while preventing provider billing/quota glitches from turning the canary red as a harness break.
2. **Provider error response body preservation**: On non-2xx HTTP responses, `appa-example-agent` now reads and logs up to 512 bytes of the response body in `ProviderError::Status`, making upstream errors actionable instead of opaque status codes.
3. **Reasoning model timeout headroom**: Bumped `OpenAiConfig::with_request_timeout` in `appa_corp_agent` from 180s to 300s to accommodate long multi-fork reasoning generation on DeepSeek.
4. **Guarded "dulled attack fixtures" warning**: The canary now only warns that attack fixtures may have dulled if the empty arm ran cleanly without episode errors (`empty.errors == 0`).