### PR TITLE
fix(engine): floor-aware fork advice and a return-floor hint that does not spell the current label

### DIFF
--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11865,7 +11865,11 @@ mod tests {
         );
         assert_eq!(
             block.block.fork_advice,
-            Some(crate::plan::ForkAdvice::BelowFloor { sanitized_return: true }),
+            Some(crate::plan::ForkAdvice::Narrowing {
+                standing: crate::plan::FloorStanding::Below,
+                remedies_required: false,
+                sanitized_return: true,
+            }),
             "the child is told a grandchild under the bare floor cannot take the drop either, but one with a \
              return sanitizer can"
         );
@@ -11898,10 +11902,12 @@ mod tests {
         );
         assert_eq!(
             block.block.fork_advice,
-            Some(crate::plan::ForkAdvice::Delegate {
-                remedies_required: false
+            Some(crate::plan::ForkAdvice::Narrowing {
+                standing: crate::plan::FloorStanding::Within,
+                remedies_required: false,
+                sanitized_return: true,
             }),
-            "a drop the floor permits keeps the ordinary delegation advice"
+            "a drop the floor permits is to be accepted here, not delegated again"
         );
         let internal = call("read_internal", json!({ "who": "someone" }));
         let blocked = e
@@ -11941,8 +11947,10 @@ mod tests {
         assert!(block.block.plans.is_empty(), "nothing lifts a drop below the floor");
         assert_eq!(
             block.block.fork_advice,
-            Some(crate::plan::ForkAdvice::BelowFloor {
-                sanitized_return: false
+            Some(crate::plan::ForkAdvice::Narrowing {
+                standing: crate::plan::FloorStanding::Below,
+                remedies_required: false,
+                sanitized_return: false,
             }),
             "with no return sanitizer registered, no grandchild can take the drop either"
         );

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11863,6 +11863,12 @@ mod tests {
                 .all(|plan| plan.executable().is_none_or(|plan| plan.narrowing().is_none())),
             "under a floor at the parent's rank no plan accepts the drop to suspicious"
         );
+        assert_eq!(
+            block.block.fork_advice,
+            Some(crate::plan::ForkAdvice::BelowFloor { sanitized_return: true }),
+            "the child is told a grandchild under the bare floor cannot take the drop either, but one with a \
+             return sanitizer can"
+        );
 
         // Under a sanitizer that raises trust, the trust dimension is unbound: the child may
         // descend there, because the return climbs back through the sanitizer.
@@ -11890,6 +11896,13 @@ mod tests {
                 .any(|plan| plan.narrowing().is_some() && plan.sanitizer().is_none()),
             "the acceptance is offered again"
         );
+        assert_eq!(
+            block.block.fork_advice,
+            Some(crate::plan::ForkAdvice::Delegate {
+                remedies_required: false
+            }),
+            "a drop the floor permits keeps the ordinary delegation advice"
+        );
         let internal = call("read_internal", json!({ "who": "someone" }));
         let blocked = e
             .handle(
@@ -11907,6 +11920,31 @@ mod tests {
                 .iter()
                 .all(|plan| plan.executable().is_none_or(|plan| plan.narrowing().is_none())),
             "the audience dimension stays bound: no plan accepts the drop to internal"
+        );
+    }
+
+    #[test]
+    fn a_child_boxed_by_its_floor_with_no_return_sanitizer_is_told_not_to_delegate() {
+        let e = open_engine(returning_registry(vec![]));
+        let child = TrajectoryId::new("child");
+        let log = spawn_family(&e, &child);
+        let read = call("read_suspicious", json!({ "who": "someone" }));
+        let blocked = e
+            .handle(
+                &viewing(&e, &log),
+                batch_on(&child, "read", Vec::new(), vec![raw(&read)], None),
+            )
+            .expect("a narrowing read blocks");
+        let ([], [block]) = answered(&blocked) else {
+            panic!("the read blocks, got {:?}", answered(&blocked))
+        };
+        assert!(block.block.plans.is_empty(), "nothing lifts a drop below the floor");
+        assert_eq!(
+            block.block.fork_advice,
+            Some(crate::plan::ForkAdvice::BelowFloor {
+                sanitized_return: false
+            }),
+            "with no return sanitizer registered, no grandchild can take the drop either"
         );
     }
 

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11927,6 +11927,15 @@ mod tests {
                 .all(|plan| plan.executable().is_none_or(|plan| plan.narrowing().is_none())),
             "the audience dimension stays bound: no plan accepts the drop to internal"
         );
+        assert_eq!(
+            block.block.fork_advice,
+            Some(crate::plan::ForkAdvice::Narrowing {
+                standing: crate::plan::FloorStanding::Below,
+                remedies_required: false,
+                sanitized_return: false,
+            }),
+            "a trust-raising sanitizer lifts no audience drop, so no sanitized delegation is advised"
+        );
     }
 
     #[test]

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11867,7 +11867,6 @@ mod tests {
             block.block.fork_advice,
             Some(crate::plan::ForkAdvice::Narrowing {
                 standing: crate::plan::FloorStanding::Below,
-                remedies_required: false,
                 sanitized_return: true,
             }),
             "the child is told a grandchild under the bare floor cannot take the drop either, but one with a \
@@ -11904,7 +11903,6 @@ mod tests {
             block.block.fork_advice,
             Some(crate::plan::ForkAdvice::Narrowing {
                 standing: crate::plan::FloorStanding::Within,
-                remedies_required: false,
                 sanitized_return: true,
             }),
             "a drop the floor permits is to be accepted here, not delegated again"
@@ -11931,7 +11929,6 @@ mod tests {
             block.block.fork_advice,
             Some(crate::plan::ForkAdvice::Narrowing {
                 standing: crate::plan::FloorStanding::Below,
-                remedies_required: false,
                 sanitized_return: false,
             }),
             "a trust-raising sanitizer lifts no audience drop, so no sanitized delegation is advised"
@@ -11958,7 +11955,6 @@ mod tests {
             block.block.fork_advice,
             Some(crate::plan::ForkAdvice::Narrowing {
                 standing: crate::plan::FloorStanding::Below,
-                remedies_required: false,
                 sanitized_return: false,
             }),
             "with no return sanitizer registered, no grandchild can take the drop either"

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -11962,6 +11962,57 @@ mod tests {
     }
 
     #[test]
+    fn a_return_sanitizer_that_does_not_admit_the_narrowed_value_is_no_sanitized_route() {
+        let closed_to_suspicious = crate::authority::Sanitizer {
+            transition: crate::authority::DeclaredTransition::Trust {
+                from_floor: TRUSTED,
+                to: TRUSTED,
+            },
+            ..lifting_sanitizer("trusted-only")
+        };
+        let e = open_engine(returning_registry(vec![closed_to_suspicious]));
+        let log = vec![opened(&e)];
+        let read = call("read_suspicious", json!({ "who": "someone" }));
+        let blocked = e
+            .handle(
+                &viewing(&e, &log),
+                batch_on(&traj(), "read", Vec::new(), vec![raw(&read)], None),
+            )
+            .expect("a narrowing read blocks");
+        let ([], [block]) = answered(&blocked) else {
+            panic!("the read blocks, got {:?}", answered(&blocked))
+        };
+        assert_eq!(
+            block.block.fork_advice,
+            Some(crate::plan::ForkAdvice::Narrowing {
+                standing: crate::plan::FloorStanding::Unbound,
+                sanitized_return: false,
+            }),
+            "a sanitizer whose `from` the suspicious value fails would refuse the child's return"
+        );
+
+        let e = open_engine(returning_registry(vec![lifting_sanitizer("redactor")]));
+        let log = vec![opened(&e)];
+        let blocked = e
+            .handle(
+                &viewing(&e, &log),
+                batch_on(&traj(), "read", Vec::new(), vec![raw(&read)], None),
+            )
+            .expect("a narrowing read blocks");
+        let ([], [block]) = answered(&blocked) else {
+            panic!("the read blocks, got {:?}", answered(&blocked))
+        };
+        assert_eq!(
+            block.block.fork_advice,
+            Some(crate::plan::ForkAdvice::Narrowing {
+                standing: crate::plan::FloorStanding::Unbound,
+                sanitized_return: true,
+            }),
+            "a sanitizer admitting the suspicious value and raising it back to trusted is the sanitized route"
+        );
+    }
+
+    #[test]
     fn a_raw_return_crosses_at_the_fold_and_the_child_may_return_again() {
         let e = open_engine(returning_registry(vec![]));
         let child = TrajectoryId::new("child");

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -380,6 +380,13 @@ impl Engine {
         view.views(child)?.return_policy_of(child).cloned()
     }
 
+    /// The lowest trust rank a return declaration made on this branch may set: its own floor's
+    /// trust, or the chain's bottom for a root or under a fork whose sanitizer raises trust.
+    /// A declaration below it is refused as [`plan::ReturnPolicyRefusal::FloorBelowOwn`].
+    pub fn lowest_return_trust(&self, views: &Views) -> crate::label::Trust {
+        plan::floor_of(&self.registry, views).map_or(crate::label::Trust::new(0), |floor| floor.lowest_trust())
+    }
+
     /// The return policy the fork `parent` prepared carries, before a child is bound to it: what
     /// the runtime tells the child at its start, read from the view that binds it.
     pub fn prepared_return_policy(
@@ -12009,6 +12016,37 @@ mod tests {
                 sanitized_return: true,
             }),
             "a sanitizer admitting the suspicious value and raising it back to trusted is the sanitized route"
+        );
+    }
+
+    #[test]
+    fn the_lowest_declarable_return_trust_is_the_own_floors_unless_its_sanitizer_raises_trust() {
+        let e = open_engine(returning_registry(vec![lifting_sanitizer("redactor")]));
+        let root_log = vec![opened(&e)];
+        assert_eq!(
+            e.lowest_return_trust(&viewing(&e, &root_log).views(&traj()).expect("the root is opened")),
+            SUSPICIOUS,
+            "a root is bound by no floor"
+        );
+
+        let bare = TrajectoryId::new("bare");
+        let log = [root_log.clone(), forked_child(&e, &root_log, &bare)].concat();
+        assert_eq!(
+            e.lowest_return_trust(&viewing(&e, &log).views(&bare).expect("the child is opened")),
+            TRUSTED,
+            "under the bare floor the child declares nothing below its parent's trust"
+        );
+
+        let lifted = TrajectoryId::new("lifted");
+        let policy = ReturnPolicy {
+            sanitizer: named("redactor"),
+            ..floor_policy(&e, &root_log)
+        };
+        let log = [root_log.clone(), spawn_family_at(&e, &root_log, &lifted, policy)].concat();
+        assert_eq!(
+            e.lowest_return_trust(&viewing(&e, &log).views(&lifted).expect("the child is opened")),
+            SUSPICIOUS,
+            "a trust-raising return sanitizer leaves the trust dimension unbound"
         );
     }
 

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -217,8 +217,9 @@ pub enum ForkAdvice {
     /// Only requirement gaps: a child starts at the same label, so delegation clears nothing.
     SameLabel,
     /// The block narrows this trajectory. `sanitized_return` when a return sanitizer this
-    /// trajectory may declare raises every dimension the change lowers, so a child's return
-    /// through it leaves this trajectory's label as it is.
+    /// trajectory may declare takes the narrowed value and hands back one this trajectory
+    /// receives unchanged: it admits the narrowed label, and its derivation holds at the
+    /// current label on every dimension.
     Narrowing {
         standing: FloorStanding,
         sanitized_return: bool,
@@ -315,13 +316,7 @@ pub(crate) fn plan(
                 Some(floor) if floor.holds(&narrowing.to) => FloorStanding::Within,
                 Some(_) => FloorStanding::Below,
             },
-            sanitized_return: return_options(registry, floor.as_ref())
-                .into_iter()
-                .flatten()
-                .filter_map(|name| registry.sanitizer(&name))
-                .any(|sanitizer| {
-                    Floor::new(current.clone(), Some(sanitizer.transition.applied())).holds(&narrowing.to)
-                }),
+            sanitized_return: preserving_return_exists(registry, &current, narrowing, floor.as_ref(), context),
         }),
     };
     Ok(PlannedBlock {
@@ -1002,6 +997,36 @@ pub(crate) fn return_options(registry: &Registry, floor: Option<&Floor>) -> Vec<
             .map(|sanitizer| Some(sanitizer.name.clone())),
     );
     options
+}
+
+/// Does a return sanitizer this trajectory may declare take the narrowed value and hand back
+/// one `current` receives unchanged? The sanitizer must admit `narrowing.to` as its declared
+/// `from`, the reserved attestation must fit a fork seeded at `current`, and the derivation
+/// must hold at `current` on both dimensions. A route the child could declare but never
+/// cross, or one whose return still lowers this trajectory, preserves nothing. Advice costs
+/// the block no directory read: a sanitizer whose admission is undecided counts as no route,
+/// and the crossing itself reads the directory when a parent declares it anyway.
+fn preserving_return_exists(
+    registry: &Registry,
+    current: &Label,
+    narrowing: &Narrowing,
+    floor: Option<&Floor>,
+    context: &MembershipContext<'_>,
+) -> bool {
+    let unchanged = Floor::new(current.clone(), None);
+    return_options(registry, floor)
+        .into_iter()
+        .flatten()
+        .filter_map(|name| registry.sanitizer(&name))
+        .filter(|sanitizer| {
+            !sanitizer.name.is_attest_schema()
+                || attest_ceiling(&sanitizer.transition).is_some_and(|ceiling| current.meets_floor(ceiling))
+        })
+        .any(|sanitizer| {
+            sanitizer
+                .derive_output(&narrowing.to, &[], context)
+                .is_ok_and(|derived| derived.is_some_and(|derived| unchanged.holds(&derived)))
+        })
 }
 
 /// Why a parent's declared return policy is not one its spawn's plan can carry.

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -214,15 +214,28 @@ pub struct PlannedBlock {
 /// situation the block is in; the harness spells it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ForkAdvice {
-    /// A child can take this narrowing and finish by returning nothing or a sanitized derivation.
-    /// `remedies_required` when the block also carries requirement gaps the child must clear.
-    Delegate { remedies_required: bool },
     /// Only requirement gaps: a child starts at the same label, so delegation clears nothing.
     SameLabel,
-    /// The narrowing falls below this trajectory's floor: neither it nor a child under the same
-    /// floor can accept it. `sanitized_return` when a return sanitizer this trajectory may
-    /// declare would lift a child's return over the floor.
-    BelowFloor { sanitized_return: bool },
+    /// The block narrows this trajectory. `sanitized_return` when a return sanitizer this
+    /// trajectory may declare would lift a child's return over the change; `remedies_required`
+    /// when the block also carries requirement gaps a child would have to clear.
+    Narrowing {
+        standing: FloorStanding,
+        remedies_required: bool,
+        sanitized_return: bool,
+    },
+}
+
+/// Where a narrowing stands against the floor a fork set on this trajectory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FloorStanding {
+    /// A root: no fork bounds it, and a child can take the change in its place.
+    Unbound,
+    /// The floor permits the change: the parent declared it to be accepted here, and a child
+    /// under the same floor gains nothing.
+    Within,
+    /// The floor refuses the change here and in every child under it.
+    Below,
 }
 
 impl PlannedBlock {
@@ -297,13 +310,14 @@ pub(crate) fn plan(
     let fork_advice = match (role, &raw.narrowing) {
         (CallRole::MarkedSpawn, _) => None,
         (_, None) => Some(ForkAdvice::SameLabel),
-        (_, Some(narrowing)) => Some(match floor.as_ref().filter(|floor| !floor.holds(&narrowing.to)) {
-            Some(_) => ForkAdvice::BelowFloor {
-                sanitized_return: return_options(registry, floor.as_ref()).iter().any(Option::is_some),
+        (_, Some(narrowing)) => Some(ForkAdvice::Narrowing {
+            standing: match &floor {
+                None => FloorStanding::Unbound,
+                Some(floor) if floor.holds(&narrowing.to) => FloorStanding::Within,
+                Some(_) => FloorStanding::Below,
             },
-            None => ForkAdvice::Delegate {
-                remedies_required: !raw.requirement_gaps.is_empty(),
-            },
+            remedies_required: !raw.requirement_gaps.is_empty(),
+            sanitized_return: return_options(registry, floor.as_ref()).iter().any(Option::is_some),
         }),
     };
     Ok(PlannedBlock {
@@ -3373,6 +3387,15 @@ mod tests {
                 from: established(TRUSTED, Audience::public()),
                 to: established(TRUSTED, Audience::restricted([ReaderId::new("insider")])),
             })]
+        );
+        assert_eq!(
+            planned.fork_advice,
+            Some(ForkAdvice::Narrowing {
+                standing: FloorStanding::Unbound,
+                remedies_required: false,
+                sanitized_return: false,
+            }),
+            "a root with no return sanitizer registered is told a child can take the change, unsanitized"
         );
     }
 

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -955,6 +955,16 @@ impl Floor {
         &self.label
     }
 
+    /// The lowest trust a return declaration made under this floor may set: the floor's own
+    /// trust, or the chain's bottom where the fork's sanitizer raises trust and leaves that
+    /// dimension unbound.
+    pub(crate) fn lowest_trust(&self) -> crate::label::Trust {
+        match self.raised {
+            Some(crate::authority::Transition::Trust { .. }) => crate::label::Trust::new(0),
+            _ => self.label.trust,
+        }
+    }
+
     /// Does `label` stay at or above the floor on every dimension the floor binds? A
     /// dimension the fork's sanitizer raises is unbound: the derivation replaces it wholesale.
     pub(crate) fn holds(&self, label: &Label) -> bool {

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -207,7 +207,22 @@ pub struct PlannedBlock {
     pub plans: Vec<RemedyPlan>,
     /// Advice, never a remedy: a child begins at the same label, so a fork cures no requirement.
     /// Kept out of `plans` so the emptiness assertion stays about remedies.
-    pub fork_advice: Option<String>,
+    pub fork_advice: Option<ForkAdvice>,
+}
+
+/// Advice, never a remedy, on delegating a blocked call to a child. The planner decides which
+/// situation the block is in; the harness spells it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForkAdvice {
+    /// A child can take this narrowing and finish by returning nothing or a sanitized derivation.
+    /// `remedies_required` when the block also carries requirement gaps the child must clear.
+    Delegate { remedies_required: bool },
+    /// Only requirement gaps: a child starts at the same label, so delegation clears nothing.
+    SameLabel,
+    /// The narrowing falls below this trajectory's floor: neither it nor a child under the same
+    /// floor can accept it. `sanitized_return` when a return sanitizer this trajectory may
+    /// declare would lift a child's return over the floor.
+    BelowFloor { sanitized_return: bool },
 }
 
 impl PlannedBlock {
@@ -279,22 +294,22 @@ pub(crate) fn plan(
         needs.refuse_if_any()?;
         plans.extend(redispatches.into_iter().map(RemedyPlan::Redispatch));
     }
-    let fork_reason = match (role, &raw.narrowing, raw.requirement_gaps.is_empty()) {
-        (CallRole::MarkedSpawn, _, _) => None,
-        (_, Some(_), true) => Some(
-            "If this trajectory's harness advertises a child-session tool, delegate this call and all work that uses its result there.\nFinish there by returning nothing, or return only a sanitized derivation. Returning the raw value applies the same change to this session.",
-        ),
-        (_, Some(_), false) => Some(
-            "If this trajectory's harness advertises a child-session tool, delegate this call, its required remedies, and all work that uses its result there.\nFinish there by returning nothing, or return only a sanitized derivation. Returning the raw value applies the same change to this session.",
-        ),
-        (_, None, _) => Some(
-            "If this trajectory's harness advertises a child-session tool, handle the work there if isolation is useful.\nA child inherits the same session label, so delegation does not clear these requirements.",
-        ),
+    let fork_advice = match (role, &raw.narrowing) {
+        (CallRole::MarkedSpawn, _) => None,
+        (_, None) => Some(ForkAdvice::SameLabel),
+        (_, Some(narrowing)) => Some(match floor.as_ref().filter(|floor| !floor.holds(&narrowing.to)) {
+            Some(_) => ForkAdvice::BelowFloor {
+                sanitized_return: return_options(registry, floor.as_ref()).iter().any(Option::is_some),
+            },
+            None => ForkAdvice::Delegate {
+                remedies_required: !raw.requirement_gaps.is_empty(),
+            },
+        }),
     };
     Ok(PlannedBlock {
         raw: raw.clone(),
         plans,
-        fork_advice: fork_reason.map(str::to_string),
+        fork_advice,
     })
 }
 
@@ -3324,7 +3339,7 @@ mod tests {
         let planned = plan_of(&registry, &log, &call("wire", json!({})));
         assert!(!planned.is_curable());
         assert!(planned.plans.is_empty());
-        assert!(planned.fork_advice.is_some());
+        assert_eq!(planned.fork_advice, Some(ForkAdvice::SameLabel));
     }
 
     #[test]

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -218,11 +218,9 @@ pub enum ForkAdvice {
     SameLabel,
     /// The block narrows this trajectory. `sanitized_return` when a return sanitizer this
     /// trajectory may declare raises every dimension the change lowers, so a child's return
-    /// through it leaves this trajectory's label as it is; `remedies_required` when the block
-    /// also carries requirement gaps a child would have to clear.
+    /// through it leaves this trajectory's label as it is.
     Narrowing {
         standing: FloorStanding,
-        remedies_required: bool,
         sanitized_return: bool,
     },
 }
@@ -317,7 +315,6 @@ pub(crate) fn plan(
                 Some(floor) if floor.holds(&narrowing.to) => FloorStanding::Within,
                 Some(_) => FloorStanding::Below,
             },
-            remedies_required: !raw.requirement_gaps.is_empty(),
             sanitized_return: return_options(registry, floor.as_ref())
                 .into_iter()
                 .flatten()
@@ -3399,7 +3396,6 @@ mod tests {
             planned.fork_advice,
             Some(ForkAdvice::Narrowing {
                 standing: FloorStanding::Unbound,
-                remedies_required: false,
                 sanitized_return: false,
             }),
             "a root with no return sanitizer registered is told a child can take the change, unsanitized"

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -217,8 +217,9 @@ pub enum ForkAdvice {
     /// Only requirement gaps: a child starts at the same label, so delegation clears nothing.
     SameLabel,
     /// The block narrows this trajectory. `sanitized_return` when a return sanitizer this
-    /// trajectory may declare would lift a child's return over the change; `remedies_required`
-    /// when the block also carries requirement gaps a child would have to clear.
+    /// trajectory may declare raises every dimension the change lowers, so a child's return
+    /// through it leaves this trajectory's label as it is; `remedies_required` when the block
+    /// also carries requirement gaps a child would have to clear.
     Narrowing {
         standing: FloorStanding,
         remedies_required: bool,
@@ -317,7 +318,13 @@ pub(crate) fn plan(
                 Some(_) => FloorStanding::Below,
             },
             remedies_required: !raw.requirement_gaps.is_empty(),
-            sanitized_return: return_options(registry, floor.as_ref()).iter().any(Option::is_some),
+            sanitized_return: return_options(registry, floor.as_ref())
+                .into_iter()
+                .flatten()
+                .filter_map(|name| registry.sanitizer(&name))
+                .any(|sanitizer| {
+                    Floor::new(current.clone(), Some(sanitizer.transition.applied())).holds(&narrowing.to)
+                }),
         }),
     };
     Ok(PlannedBlock {

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -49,7 +49,7 @@ use appa_engine::fact::{
 };
 use appa_engine::label::{Audience, Clause, DeclaredAudience, Label, ReaderId, SymbolicAtom, Trust};
 use appa_engine::names::MarkName;
-use appa_engine::plan::{ExecutableRemedyPlan, PlanId, PlannedBlock, RemedyPlan, RequiredRuling};
+use appa_engine::plan::{ExecutableRemedyPlan, ForkAdvice, PlanId, PlannedBlock, RemedyPlan, RequiredRuling};
 use appa_engine::profile::PolicyFileKey as EnginePolicyFileKey;
 use appa_engine::projection::Views;
 use appa_engine::registry::TrustChain;
@@ -2833,8 +2833,10 @@ fn return_instruction(sanitizer: Option<&appa_engine::names::SanitizerName>, id:
     match sanitizer {
         None => format!(
             "  - Declare the lowest label this session accepts from the subagent's return, then propose the spawn \
-             again. This session's label now is {floor}: an omitted dimension keeps it, a lower one lets the \
-             return narrow this session that far.\n    execute_remedy_plan(offer_id: \"{id}\", label: {floor})"
+             again. The subagent starts at this session's label, now {floor}, and can accept no change below the \
+             floor it is given: a subagent that must read below this session's trust needs the floor at that rank, \
+             and its return may then narrow this session that far. An omitted dimension keeps its current \
+             value.\n    execute_remedy_plan(offer_id: \"{id}\", label: {{trust: \"<rank>\"}})"
         ),
         Some(name) if name.is_attest_schema() => format!(
             "  - Attest the subagent's return: declare the floor and the JSON schema its return must match (a \
@@ -2926,16 +2928,59 @@ fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &
         lines.push("Continue:".to_string());
         lines.extend(remedies);
     }
-    if let Some(advice) = &planned.fork_advice {
+    if let Some(advice) = planned.fork_advice {
         lines.push(String::new());
-        lines.push(if planned.raw.narrowing.is_some() {
-            "Keep this session unchanged:".to_string()
-        } else {
-            "Alternative:".to_string()
-        });
-        lines.push(format!("  {}", advice.replace('\n', "\n  ")));
+        lines.push(fork_heading(advice).to_string());
+        lines.push(format!("  {}", fork_advice_text(advice).replace('\n', "\n  ")));
     }
     lines.join("\n")
+}
+
+fn fork_heading(advice: ForkAdvice) -> &'static str {
+    match advice {
+        ForkAdvice::Delegate { .. } => "Keep this session unchanged:",
+        ForkAdvice::SameLabel => "Alternative:",
+        ForkAdvice::BelowFloor { .. } => "Not acceptable here:",
+    }
+}
+
+fn fork_advice_text(advice: ForkAdvice) -> &'static str {
+    match advice {
+        ForkAdvice::Delegate {
+            remedies_required: false,
+        } => {
+            "If this trajectory's harness advertises a child-session tool, delegate this call and all work that uses \
+             its result there.\nFinish there by returning nothing, or return only a sanitized derivation. Returning \
+             the raw value applies the same change to this session."
+        }
+        ForkAdvice::Delegate {
+            remedies_required: true,
+        } => {
+            "If this trajectory's harness advertises a child-session tool, delegate this call, its required remedies, \
+             and all work that uses its result there.\nFinish there by returning nothing, or return only a sanitized \
+             derivation. Returning the raw value applies the same change to this session."
+        }
+        ForkAdvice::SameLabel => {
+            "If this trajectory's harness advertises a child-session tool, handle the work there if isolation is \
+             useful.\nA child inherits the same session label, so delegation does not clear these requirements."
+        }
+        ForkAdvice::BelowFloor {
+            sanitized_return: true,
+        } => {
+            "This session is a subagent, and this change falls below the floor its parent declared: this session \
+             cannot accept it, and a subagent started here under the bare floor cannot either.\nA subagent started \
+             here with a return sanitizer can: delegate this call and all work that uses its result there, and \
+             declare that sanitizer when the spawn asks for the return declaration."
+        }
+        ForkAdvice::BelowFloor {
+            sanitized_return: false,
+        } => {
+            "This session is a subagent, and this change falls below the floor its parent declared: neither this \
+             session nor any subagent started here can accept it, and no return sanitizer is registered.\nDo not \
+             start a subagent for this. Finish without this call, or return a plain note that the work needs a \
+             subagent declared with a lower floor or a return sanitizer, so the parent can start one."
+        }
+    }
 }
 
 #[cfg(test)]

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -2845,11 +2845,19 @@ struct ReturnSpelling {
 }
 
 impl ReturnSpelling {
+    /// A floor never stands above the declaring trajectory, so only the ranks at or below its
+    /// trust are named; the unnamed top sentinel names the whole chain.
     fn of(chain: &TrustChain, label: &Label) -> ReturnSpelling {
+        let held = if label.trust == Trust::new(u8::MAX) {
+            chain.len()
+        } else {
+            usize::from(label.trust.rank()) + 1
+        };
         ReturnSpelling {
             floor: label_spelling(chain, label),
             ranks: chain
                 .names()
+                .take(held)
                 .map(|name| format!("\"{}\"", terminal_safe(name)))
                 .collect::<Vec<_>>()
                 .join(", "),
@@ -2874,10 +2882,12 @@ fn return_instruction(
              of {ranks} (lowest first)"
         ),
         Some(name) if name.is_attest_schema() => format!(
-            "  - Attest the subagent's return: declare the floor and the JSON schema its return must match (a \
-             closed object schema; a string leaf carries `enum`, `const`, or `format`). The return crosses at the \
-             attestation's label.\n    execute_remedy_plan(offer_id: \"{id}\", label: {floor}, return_schema: \
-             {{type: \"object\", ...}})"
+            "  - Attest the subagent's return: declare the floor and the JSON schema its return must match. The \
+             schema is strict: an object lists its `properties`, every one `required`, and is closed as written \
+             (no `additionalProperties`); an integer carries `minimum` and `maximum`; a string leaf carries \
+             `enum`, `const`, or `format`, never free text. The return crosses at the attestation's \
+             label.\n    execute_remedy_plan(offer_id: \"{id}\", label: {floor}, return_schema: {{type: \
+             \"object\", ...}})"
         ),
         Some(name) => format!(
             "  - Have sanitizer {} rewrite the subagent's return before this session receives it, and declare the \
@@ -2964,9 +2974,13 @@ fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &
         lines.extend(remedies);
     }
     if let Some(advice) = planned.fork_advice {
+        let remedies_required = !planned.raw.requirement_gaps.is_empty();
         lines.push(String::new());
         lines.push(fork_heading(advice).to_string());
-        lines.push(format!("  {}", fork_advice_text(advice).replace('\n', "\n  ")));
+        lines.push(format!(
+            "  {}",
+            fork_advice_text(advice, remedies_required).replace('\n', "\n  ")
+        ));
     }
     lines.join("\n")
 }
@@ -2989,10 +3003,10 @@ fn fork_heading(advice: ForkAdvice) -> &'static str {
     }
 }
 
-fn fork_advice_text(advice: ForkAdvice) -> String {
+/// `remedies_required` when the block also carries requirement gaps a child would clear.
+fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
     let ForkAdvice::Narrowing {
         standing,
-        remedies_required,
         sanitized_return,
     } = advice
     else {

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -49,7 +49,9 @@ use appa_engine::fact::{
 };
 use appa_engine::label::{Audience, Clause, DeclaredAudience, Label, ReaderId, SymbolicAtom, Trust};
 use appa_engine::names::MarkName;
-use appa_engine::plan::{ExecutableRemedyPlan, ForkAdvice, PlanId, PlannedBlock, RemedyPlan, RequiredRuling};
+use appa_engine::plan::{
+    ExecutableRemedyPlan, FloorStanding, ForkAdvice, PlanId, PlannedBlock, RemedyPlan, RequiredRuling,
+};
 use appa_engine::profile::PolicyFileKey as EnginePolicyFileKey;
 use appa_engine::projection::Views;
 use appa_engine::registry::TrustChain;
@@ -1473,7 +1475,6 @@ impl RuntimeEngine {
                 .unwrap_or(current.audience),
         };
         let sanitizer = match step {
-            None => None,
             Some(name) if name.is_attest_schema() => {
                 let Some(schema) = &arguments.return_schema else {
                     return Err(
@@ -1486,6 +1487,14 @@ impl RuntimeEngine {
                     .map_err(|error| format!("`return_schema` does not compile to a return shape: {error}"))?;
                 Some(ReturnSanitizer::Attest(shape))
             }
+            _ if arguments.return_schema.is_some() => {
+                return Err(
+                    "this plan does not attest the subagent's return, so `return_schema` is not taken: declare the \
+                     attest-schema offer to attest, or omit `return_schema`"
+                        .to_string(),
+                );
+            }
+            None => None,
             Some(name) => Some(ReturnSanitizer::Named(name)),
         };
         Ok(Some(ReturnPolicy { floor, sanitizer }))
@@ -2938,47 +2947,71 @@ fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &
 
 fn fork_heading(advice: ForkAdvice) -> &'static str {
     match advice {
-        ForkAdvice::Delegate { .. } => "Keep this session unchanged:",
         ForkAdvice::SameLabel => "Alternative:",
-        ForkAdvice::BelowFloor { .. } => "Not acceptable here:",
+        ForkAdvice::Narrowing {
+            standing: FloorStanding::Unbound,
+            ..
+        } => "Keep this session unchanged:",
+        ForkAdvice::Narrowing {
+            standing: FloorStanding::Within,
+            ..
+        } => "Delegation:",
+        ForkAdvice::Narrowing {
+            standing: FloorStanding::Below,
+            ..
+        } => "Not acceptable here:",
     }
 }
 
-fn fork_advice_text(advice: ForkAdvice) -> &'static str {
-    match advice {
-        ForkAdvice::Delegate {
-            remedies_required: false,
-        } => {
-            "If this trajectory's harness advertises a child-session tool, delegate this call and all work that uses \
-             its result there.\nFinish there by returning nothing, or return only a sanitized derivation. Returning \
-             the raw value applies the same change to this session."
+fn fork_advice_text(advice: ForkAdvice) -> String {
+    let ForkAdvice::Narrowing {
+        standing,
+        remedies_required,
+        sanitized_return,
+    } = advice
+    else {
+        return "If this trajectory's harness advertises a child-session tool, handle the work there if isolation is \
+                useful.\nA child inherits the same session label, so delegation does not clear these requirements."
+            .to_string();
+    };
+    let delegated = if remedies_required {
+        "this call, its required remedies, and all work that uses its result"
+    } else {
+        "this call and all work that uses its result"
+    };
+    match (standing, sanitized_return) {
+        (FloorStanding::Unbound, true) => format!(
+            "If this trajectory's harness advertises a child-session tool, delegate {delegated} there.\nFinish there \
+             by returning nothing, or return only a sanitized derivation. Returning the raw value applies the same \
+             change to this session."
+        ),
+        (FloorStanding::Unbound, false) => format!(
+            "If this trajectory's harness advertises a child-session tool, delegate {delegated} there.\nNo return \
+             sanitizer is registered, so finish there by returning nothing: a returned value applies the same \
+             change to this session."
+        ),
+        (FloorStanding::Within, true) => format!(
+            "This session is a subagent, and the floor its parent declared allows this change: accept it here.\nTo \
+             keep this session unchanged instead, delegate {delegated} to a further subagent declared with a \
+             return sanitizer; one declared with the bare floor would apply the same change here on its return."
+        ),
+        (FloorStanding::Within, false) => {
+            "This session is a subagent, and the floor its parent declared allows this change: accept it here.\nA \
+             further subagent's return would apply the same change to this session, so delegating gains nothing."
+                .to_string()
         }
-        ForkAdvice::Delegate {
-            remedies_required: true,
-        } => {
-            "If this trajectory's harness advertises a child-session tool, delegate this call, its required remedies, \
-             and all work that uses its result there.\nFinish there by returning nothing, or return only a sanitized \
-             derivation. Returning the raw value applies the same change to this session."
-        }
-        ForkAdvice::SameLabel => {
-            "If this trajectory's harness advertises a child-session tool, handle the work there if isolation is \
-             useful.\nA child inherits the same session label, so delegation does not clear these requirements."
-        }
-        ForkAdvice::BelowFloor {
-            sanitized_return: true,
-        } => {
+        (FloorStanding::Below, true) => format!(
             "This session is a subagent, and this change falls below the floor its parent declared: this session \
              cannot accept it, and a subagent started here under the bare floor cannot either.\nA subagent started \
-             here with a return sanitizer can: delegate this call and all work that uses its result there, and \
-             declare that sanitizer when the spawn asks for the return declaration."
-        }
-        ForkAdvice::BelowFloor {
-            sanitized_return: false,
-        } => {
+             here with a return sanitizer can: delegate {delegated} there, and declare that sanitizer when the \
+             spawn asks for the return declaration."
+        ),
+        (FloorStanding::Below, false) => {
             "This session is a subagent, and this change falls below the floor its parent declared: neither this \
              session nor any subagent started here can accept it, and no return sanitizer is registered.\nDo not \
              start a subagent for this. Finish without this call, or return a plain note that the work needs a \
              subagent declared with a lower floor or a return sanitizer, so the parent can start one."
+                .to_string()
         }
     }
 }

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1023,11 +1023,11 @@ impl RuntimeEngine {
             AudienceRound::Failed(error) => return Err(proposal_refusal(error)),
         };
         let append = decision.append.map(ValidatedFactBatch::into_unsealed);
-        let then = self.deliver_proposals(decision.follow_up, &views.current_label())?;
+        let then = self.deliver_proposals(decision.follow_up, &self.return_bounds(&views))?;
         Ok(EngineDecision { append, then })
     }
 
-    fn deliver_proposals(&self, follow_up: FollowUp, label: &Label) -> Result<Next, EngineRefusal> {
+    fn deliver_proposals(&self, follow_up: FollowUp, bounds: &ReturnBounds) -> Result<Next, EngineRefusal> {
         match follow_up {
             FollowUp::Proposals {
                 released: releases,
@@ -1043,7 +1043,7 @@ impl RuntimeEngine {
                     });
                 }
                 if let Some(block) = blocked.into_iter().next() {
-                    let feedback = self.block_delivery(&block, label);
+                    let feedback = self.block_delivery(&block, bounds);
                     return Ok(Next::ModelResponse {
                         invocations: Vec::new(),
                         feedback: vec![feedback],
@@ -1065,8 +1065,8 @@ impl RuntimeEngine {
         }
     }
 
-    fn block_delivery(&self, block: &CoreBlocked, label: &Label) -> Feedback {
-        let (text, offers, review) = self.rendered_block(block, label);
+    fn block_delivery(&self, block: &CoreBlocked, bounds: &ReturnBounds) -> Feedback {
+        let (text, offers, review) = self.rendered_block(block, bounds);
         let offers = offers
             .into_iter()
             .map(|offer| {
@@ -1093,14 +1093,14 @@ impl RuntimeEngine {
         Feedback { text, offers, review }
     }
 
-    fn rendered_block(&self, block: &CoreBlocked, label: &Label) -> (String, Vec<OfferId>, Vec<PendingReview>) {
+    fn rendered_block(&self, block: &CoreBlocked, bounds: &ReturnBounds) -> (String, Vec<OfferId>, Vec<PendingReview>) {
         let offers: Vec<(OfferId, PlanId)> = block
             .offers
             .iter()
             .map(|(offer, plan)| (offer_id(offer), *plan))
             .collect();
         let chain = self.engine.registry().trust_chain();
-        let text = block_feedback(&block.block, &offers, chain, label);
+        let text = block_feedback(&block.block, &offers, chain, bounds);
         let review = self.pending_reviews(block, &offers);
         (text, offers.into_iter().map(|(offer, _)| offer).collect(), review)
     }
@@ -1344,10 +1344,10 @@ impl RuntimeEngine {
                 feedback: "[appa] the state changed and this offer no longer applies; re-propose the call".to_string(),
             }),
             FollowUp::Offer(OfferFollowUp::Denied { block }) => {
-                Next::PresentToModel(self.offer_block_delivery(&block, &views.current_label()))
+                Next::PresentToModel(self.offer_block_delivery(&block, &self.return_bounds(&views)))
             }
             FollowUp::Offer(OfferFollowUp::Substituted { block }) => {
-                Next::PresentToModel(self.offer_block_delivery(&block, &views.current_label()))
+                Next::PresentToModel(self.offer_block_delivery(&block, &self.return_bounds(&views)))
             }
             FollowUp::Offer(OfferFollowUp::Staged(confined)) => Next::PresentToModel(self.stage_delivery(
                 "[appa] the cleaned result still narrows this session.",
@@ -1429,9 +1429,16 @@ impl RuntimeEngine {
         AuthorityOutcome::Outcome(OfferOutcome::Approved(approvals))
     }
 
-    fn offer_block_delivery(&self, block: &CoreBlocked, label: &Label) -> Presentation {
-        let (feedback, offers, _) = self.rendered_block(block, label);
+    fn offer_block_delivery(&self, block: &CoreBlocked, bounds: &ReturnBounds) -> Presentation {
+        let (feedback, offers, _) = self.rendered_block(block, bounds);
         Presentation::Blocked { feedback, offers }
+    }
+
+    fn return_bounds(&self, views: &Views) -> ReturnBounds {
+        ReturnBounds {
+            label: views.current_label(),
+            lowest: self.engine.lowest_return_trust(views),
+        }
     }
 
     /// The return policy an offer's execution declares, where its plan ends in a return step:
@@ -2837,6 +2844,13 @@ fn label_spelling(chain: &TrustChain, label: &Label) -> String {
     }
 }
 
+/// What bounds a return declaration made on a trajectory: its current label, which no floor
+/// stands above, and the lowest trust its own floor lets it declare.
+struct ReturnBounds {
+    label: Label,
+    lowest: Trust,
+}
+
 /// The spelling a return declaration's example needs: this trajectory's label as the
 /// `label` argument takes it, and the trust ranks a placeholder stands for.
 struct ReturnSpelling {
@@ -2845,19 +2859,23 @@ struct ReturnSpelling {
 }
 
 impl ReturnSpelling {
-    /// A floor never stands above the declaring trajectory, so only the ranks at or below its
-    /// trust are named; the unnamed top sentinel names the whole chain.
-    fn of(chain: &TrustChain, label: &Label) -> ReturnSpelling {
+    /// Only the ranks the declaration may take are named: at or below the trajectory's trust,
+    /// and at or above the lowest its own floor permits. The unnamed top sentinel stands for
+    /// the whole chain.
+    fn of(chain: &TrustChain, bounds: &ReturnBounds) -> ReturnSpelling {
+        let ReturnBounds { label, lowest } = bounds;
         let held = if label.trust == Trust::new(u8::MAX) {
             chain.len()
         } else {
             usize::from(label.trust.rank()) + 1
         };
+        let lowest = usize::from(lowest.rank());
         ReturnSpelling {
             floor: label_spelling(chain, label),
             ranks: chain
                 .names()
-                .take(held)
+                .skip(lowest)
+                .take(held.saturating_sub(lowest))
                 .map(|name| format!("\"{}\"", terminal_safe(name)))
                 .collect::<Vec<_>>()
                 .join(", "),
@@ -2941,7 +2959,12 @@ fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], spelling: 
         .collect()
 }
 
-fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &TrustChain, label: &Label) -> String {
+fn block_feedback(
+    planned: &PlannedBlock,
+    offers: &[(OfferId, PlanId)],
+    chain: &TrustChain,
+    bounds: &ReturnBounds,
+) -> String {
     let mut reasons = Vec::new();
     for gap in &planned.raw.requirement_gaps {
         reasons.push(terminal_safe(&gap_text(gap)));
@@ -2967,7 +2990,7 @@ fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &
     ];
     lines.extend(reasons.into_iter().map(|reason| format!("  - {reason}")));
 
-    let remedies = remedy_lines(planned, offers, &ReturnSpelling::of(chain, label));
+    let remedies = remedy_lines(planned, offers, &ReturnSpelling::of(chain, bounds));
     if !remedies.is_empty() {
         lines.push(String::new());
         lines.push("Continue:".to_string());

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -3026,9 +3026,9 @@ fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
              change to this session."
         ),
         (FloorStanding::Unbound, false) => format!(
-            "If this trajectory's harness advertises a child-session tool, delegate {delegated} there.\nNo return \
-             sanitizer is registered, so finish there by returning nothing: a returned value applies the same \
-             change to this session."
+            "If this trajectory's harness advertises a child-session tool, delegate {delegated} there.\nNo \
+             registered return sanitizer carries this change back without applying it here, so finish there by \
+             returning nothing: a returned value applies the same change to this session."
         ),
         (FloorStanding::Within, true) => format!(
             "This session is a subagent, and the floor its parent declared allows this change: accept it here.\nTo \
@@ -3048,9 +3048,10 @@ fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
         ),
         (FloorStanding::Below, false) => {
             "This session is a subagent, and this change falls below the floor its parent declared: neither this \
-             session nor any subagent started here can accept it, and no return sanitizer is registered.\nDo not \
-             start a subagent for this. Finish without this call, or return a plain note that the work needs a \
-             subagent declared with a lower floor or a return sanitizer, so the parent can start one."
+             session nor any subagent started here can accept it, and no registered return sanitizer carries \
+             this change back without applying it.\nDo not start a subagent for this. Finish without this call, \
+             or return a plain note that the work needs a subagent declared with a lower floor or a return \
+             sanitizer, so the parent can start one."
                 .to_string()
         }
     }

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1100,7 +1100,7 @@ impl RuntimeEngine {
             .map(|(offer, plan)| (offer_id(offer), *plan))
             .collect();
         let chain = self.engine.registry().trust_chain();
-        let text = block_feedback(&block.block, &offers, chain, &label_spelling(chain, label));
+        let text = block_feedback(&block.block, &offers, chain, label);
         let review = self.pending_reviews(block, &offers);
         (text, offers.into_iter().map(|(offer, _)| offer).collect(), review)
     }
@@ -2837,15 +2837,41 @@ fn label_spelling(chain: &TrustChain, label: &Label) -> String {
     }
 }
 
-fn return_instruction(sanitizer: Option<&appa_engine::names::SanitizerName>, id: &OfferId, floor: &str) -> String {
+/// The spelling a return declaration's example needs: this trajectory's label as the
+/// `label` argument takes it, and the trust ranks a placeholder stands for.
+struct ReturnSpelling {
+    floor: String,
+    ranks: String,
+}
+
+impl ReturnSpelling {
+    fn of(chain: &TrustChain, label: &Label) -> ReturnSpelling {
+        ReturnSpelling {
+            floor: label_spelling(chain, label),
+            ranks: chain
+                .names()
+                .map(|name| format!("\"{}\"", terminal_safe(name)))
+                .collect::<Vec<_>>()
+                .join(", "),
+        }
+    }
+}
+
+fn return_instruction(
+    sanitizer: Option<&appa_engine::names::SanitizerName>,
+    id: &OfferId,
+    spelling: &ReturnSpelling,
+) -> String {
     let id = terminal_safe(&id.0);
+    let ReturnSpelling { floor, ranks } = spelling;
     match sanitizer {
         None => format!(
             "  - Declare the lowest label this session accepts from the subagent's return, then propose the spawn \
              again. The subagent starts at this session's label, now {floor}, and can accept no change below the \
              floor it is given: a subagent that must read below this session's trust needs the floor at that rank, \
              and its return may then narrow this session that far. An omitted dimension keeps its current \
-             value.\n    execute_remedy_plan(offer_id: \"{id}\", label: {{trust: \"<rank>\"}})"
+             value.\n    execute_remedy_plan(offer_id: \"{id}\", label: {{trust: \"<rank>\"}}), with <rank> one \
+             of {ranks} (lowest first)"
         ),
         Some(name) if name.is_attest_schema() => format!(
             "  - Attest the subagent's return: declare the floor and the JSON schema its return must match (a \
@@ -2861,9 +2887,9 @@ fn return_instruction(sanitizer: Option<&appa_engine::names::SanitizerName>, id:
     }
 }
 
-fn remedy_instruction(plan: &ExecutableRemedyPlan, id: &OfferId, floor: &str) -> String {
+fn remedy_instruction(plan: &ExecutableRemedyPlan, id: &OfferId, spelling: &ReturnSpelling) -> String {
     if let Some(sanitizer) = plan.return_step() {
-        return return_instruction(sanitizer, id, floor);
+        return return_instruction(sanitizer, id, spelling);
     }
     let needs_approval = !plan.required.is_empty();
     let action = match (needs_approval, plan.narrowing().is_some(), plan.sanitizer()) {
@@ -2887,7 +2913,7 @@ fn remedy_instruction(plan: &ExecutableRemedyPlan, id: &OfferId, floor: &str) ->
     )
 }
 
-fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], floor: &str) -> Vec<String> {
+fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], spelling: &ReturnSpelling) -> Vec<String> {
     planned
         .plans
         .iter()
@@ -2895,7 +2921,7 @@ fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], floor: &st
             RemedyPlan::Executable(plan) => offers
                 .iter()
                 .find(|(_, offered)| *offered == plan.id)
-                .map(|(id, _)| remedy_instruction(plan, id, floor)),
+                .map(|(id, _)| remedy_instruction(plan, id, spelling)),
             RemedyPlan::Redispatch(redispatch) => Some(format!(
                 "  - Run {} first; it clears: {}.",
                 terminal_safe(redispatch.tool().as_str()),
@@ -2905,7 +2931,7 @@ fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], floor: &st
         .collect()
 }
 
-fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &TrustChain, floor: &str) -> String {
+fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &TrustChain, label: &Label) -> String {
     let mut reasons = Vec::new();
     for gap in &planned.raw.requirement_gaps {
         reasons.push(terminal_safe(&gap_text(gap)));
@@ -2931,7 +2957,7 @@ fn block_feedback(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], chain: &
     ];
     lines.extend(reasons.into_iter().map(|reason| format!("  - {reason}")));
 
-    let remedies = remedy_lines(planned, offers, floor);
+    let remedies = remedy_lines(planned, offers, &ReturnSpelling::of(chain, label));
     if !remedies.is_empty() {
         lines.push(String::new());
         lines.push("Continue:".to_string());
@@ -3387,11 +3413,15 @@ mod tests {
             (OfferId("offer-for-8".to_string()), PlanId::new(8)),
             (OfferId("offer-for-3".to_string()), PlanId::new(3)),
         ];
+        let spelling = super::ReturnSpelling {
+            floor: "{}".to_string(),
+            ranks: String::new(),
+        };
         assert_eq!(
-            remedy_lines(&planned, &offers, "{}"),
+            remedy_lines(&planned, &offers, &spelling),
             vec![
-                remedy_instruction(&plan(3), &offers[1].0, "{}"),
-                remedy_instruction(&plan(8), &offers[0].0, "{}"),
+                remedy_instruction(&plan(3), &offers[1].0, &spelling),
+                remedy_instruction(&plan(8), &offers[0].0, &spelling),
             ],
             "the plan with no offer is not shown; the rest carry their own offer"
         );


### PR DESCRIPTION
A subagent held under a floor was advised to delegate a narrowing call to a child session; a grandchild inherits the same floor, so each generation spawned the next. The bare-floor return declaration hint spelled the session's current label as its example argument, and the model copied it, boxing the child at the parent's rank.

## Changes

- `plan::ForkAdvice` is a closed enum decided by the planner: `SameLabel` (requirement gaps only) or `Narrowing { standing: FloorStanding::{Unbound, Within, Below}, sanitized_return }`. `sanitized_return` holds only when a declarable return sanitizer raises every dimension the narrowing lowers. The runtime spells it: a root without a sanitizer is told the child must return nothing; a child whose floor permits the change is told to accept it here; a child below its floor is told nothing in its subtree can accept it, with the sanitized route named only where one exists.
- The bare-floor hint explains what the floor bounds and shows `label: {trust: "<rank>"}` with the ranks at or below the session's trust, lowest first. The attest-schema hint describes the return-shape dialect (closed as written, every property required, bounded integers, no free strings).
- A `return_schema` passed on a plan that does not attest the return is refused instead of silently dropped.

## Verification

- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test -p appa-engine -p appa` green. New engine tests: `a_child_boxed_by_its_floor_with_no_return_sanitizer_is_told_not_to_delegate`; standing/sanitizer asserts in `the_floor_removes_acceptances_below_it_from_the_childs_menu` (trust sanitizer lifts no audience drop); plan test `acceptance_plan_for_pure_narrowing` asserts the unbound advice.
- Live `claude -p` runs with the rebuilt plugin: without a sanitizer the parent accepts its own narrowing and answers (8 turns, no spawn); with `attest-schema` registered the parent declares the attestation, the child accepts its narrowing under the floor and returns the attested JSON, the parent stays at its rank (9 turns, one generation). Before the fix the same prompt spawned three generations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnUzfsNHFmg9EiD41deVuA
