### PR TITLE
fix(runtime): clarify agent-facing policy block and remedy feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ APPA owes nothing to its own past. Docs describe the current model only
 — no retired rules, no "formerly", no migration notes. Config and wire
 surfaces may break without shims or deprecation paths.
 
+## Policy & Algebra: IFC Monoids First
+
+- **IFC monoids over imperative workarounds**: The core of OpenAPPA is two monoids:
+  the **checked monoid of labels** (`audience × trust`) and the **free monoid of events**.
+  Always prefer Information Flow Control (IFC) monoids (`trust` lattice and `self ⊆ internal ⊆ public` audience chain) to express security invariants.
+- **Effects are a hacky workaround**: History/effect tracking (`emits`, `requires = { history = [...] }`) is an imperative state-machine escape hatch, not the primary algebra. Never reach for effects when information flow / label bounding can express the invariant.
+- **Autonomous execution over attention**: Do not use synthetic `attention` marks (such as `blocked`) to fake policy boundaries, and avoid default `hitl` requirements that stall autonomous agents. Data that is `trusted` and within the target `audience` boundary should flow without human interruption. Attention marks are reserved strictly for real human-in-the-loop decisions (opt-in overlays), or temporary placeholders (`token-exposed`) until a proper sanitizer is available.
+
 ## Collaboration
 
 Applies to discussion and work in this repository.

--- a/appa-agent-python/src/lib.rs
+++ b/appa-agent-python/src/lib.rs
@@ -369,14 +369,14 @@ impl SessionInner {
             .block_on(self.runtime.execute_remedy_with(&self.actor(child), offer, arguments))
         {
             RemedyOutcome::Authorized { call } => format!(
-                "Authorized. Propose the {} call again with exactly these arguments; \
+                "Authorized. Call the {} tool again with exactly these arguments; \
                  it will run without a new check: {}",
                 call.tool,
                 call.arguments.get(),
             ),
             RemedyOutcome::Substituted { call } => format!(
                 "Substituted. The sanitizer replaced the arguments and the call is released. \
-                 Propose the {} call with exactly these arguments to run it: {}",
+                 Call the {} tool with exactly these arguments to run it: {}",
                 call.tool,
                 call.arguments.get(),
             ),

--- a/appa-example-agent/src/agent.rs
+++ b/appa-example-agent/src/agent.rs
@@ -647,7 +647,7 @@ impl Run<'_> {
                 )
                 .await;
                 format!(
-                    "Authorized. Propose the {} call again with exactly these arguments; \
+                    "Authorized. Call the {} tool again with exactly these arguments; \
                      it will run without a new check: {}",
                     call.tool,
                     call.arguments.get(),

--- a/appa-example-agent/src/tools.rs
+++ b/appa-example-agent/src/tools.rs
@@ -7,31 +7,24 @@ use appa_runtime_api::{OutcomeBody, ProposedCall, ToolOutcome};
 use crate::http::{HttpClient, read_body_capped};
 use crate::wire::WireTool;
 
-/// The runtime's own control tool, under the bare wire name the
-/// runtime recognizes. Runtime-provided and identical for
-/// every harness, so the agent advertises it rather than the host.
+/// Runtime control tool for executing remedies.
 pub(crate) const CONTROL_TOOL: &str = "execute_remedy_plan";
 
-/// What the model may call: the host's tools, plus the control tool
-/// the runtime provides.
+/// Host tools combined with the runtime control tool.
 #[derive(Clone, Debug)]
 pub struct ToolCatalogue {
     tools: Vec<WireTool>,
 }
 
 impl ToolCatalogue {
-    /// Build the catalogue from the host's tool schemas. The control
-    /// tool is appended here, so no host can forget it and none can
-    /// describe it differently.
+    /// Builds the catalogue with the control tool appended.
     pub fn new(tools: Vec<WireTool>) -> Self {
         let mut tools = tools;
         tools.push(control_tool_schema());
         ToolCatalogue { tools }
     }
 
-    /// Build one request's catalogue, omitting a host tool that cannot run in
-    /// the current frame. The control tool remains available: recovery is
-    /// trajectory-local and stays useful inside a child.
+    /// Builds the catalogue excluding a tool that cannot run in the current frame.
     pub(crate) fn advertised_without(&self, excluded: Option<&str>) -> Vec<WireTool> {
         self.tools
             .iter()

--- a/appa-example-agent/src/tools.rs
+++ b/appa-example-agent/src/tools.rs
@@ -48,7 +48,8 @@ fn control_tool_schema() -> WireTool {
          quoted exactly. Accepting a narrowing permanently restricts this trajectory, so run any \
          later work that needs its current label before you accept. A plan that declares a \
          subagent's return takes `label`, the lowest label this trajectory accepts from the \
-         return; a plan that attests it also takes `return_schema`.",
+         return; a plan that attests it also takes `return_schema`. After execution succeeds, \
+         re-call the original tool or receive the admitted output.",
         serde_json::json!({
             "type": "object",
             "properties": {

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -128,7 +128,7 @@ const UNCHECKED_RETURN: &str = "[appa] the subagent ended outside the return che
 /// A child that ended by returning nothing is held on any later message: nothing it says
 /// now can cross, and an empty stop lets it go.
 const ENDED_CHILD: &str = "[appa] this subagent ended without a return; nothing it says now can cross. Stop with an \
-                           empty final message.";
+                           empty final message (send no text or explanation).";
 
 fn outcome_decision(decision: EngineDecision) -> Result<ToolResultDecision, EventError> {
     match decision.then {

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -120,13 +120,11 @@ enum SpawnPlan {
     Close(EventError),
 }
 
-/// The spawn result carried a message the child never returned at a stop: the harness
-/// ended the child itself (a turn cap, a kill) and delivered what it had. Nothing crossed.
+/// Delivered when a child terminated without completing its return check.
 const UNCHECKED_RETURN: &str = "[appa] the subagent ended outside the return check and its message is withheld; \
                                 nothing from it crossed into this session";
 
-/// A child that ended by returning nothing is held on any later message: nothing it says
-/// now can cross, and an empty stop lets it go.
+/// Blocks subsequent output from a child that already ended without a return.
 const ENDED_CHILD: &str = "[appa] this subagent ended without a return; nothing it says now can cross. Stop with an \
                            empty final message (send no text or explanation).";
 

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1635,7 +1635,7 @@ impl RuntimeEngine {
                 return blocked(format!(
                     "[appa] your final message cannot cross: this session's label fell below the floor the parent \
                      set for your return ({}). Nothing this session holds now can cross; stop with an empty final \
-                     message to end without a return.",
+                     message (send no text or explanation) to end without a return.",
                     self.label_text(&floor)
                 ));
             }
@@ -2593,11 +2593,15 @@ fn stage_feedback(
             .into_iter()
             .map(|change| format!("  - {change}")),
     );
-    for offer in offers {
-        lines.push(format!(
-            "  - execute_remedy_plan(offer_id: \"{}\")",
-            terminal_safe(&offer.0)
-        ));
+    if !offers.is_empty() {
+        lines.push(String::new());
+        lines.push("To accept this change and receive the output:".to_string());
+        for offer in offers {
+            lines.push(format!(
+                "  - execute_remedy_plan(offer_id: \"{}\")",
+                terminal_safe(&offer.0)
+            ));
+        }
     }
     lines.join("\n")
 }
@@ -2712,11 +2716,15 @@ const fn is_format(c: char) -> bool {
     )
 }
 
-fn gap_text(gap: &appa_engine::check::Gap) -> String {
+fn gap_text(gap: &appa_engine::check::Gap, chain: &TrustChain) -> String {
     use appa_engine::check::Gap;
     match gap {
         Gap::TrustFloor { required, actual } => {
-            format!("trust is {actual:?}, below the required floor {required:?}")
+            format!(
+                "trust is {}, below the required floor {}",
+                trust_feedback(*actual, chain),
+                trust_feedback(*required, chain),
+            )
         }
         Gap::Includes { recipients } => match recipients {
             DeclaredAudience::Public => "the readers are not the public audience".to_string(),
@@ -2893,18 +2901,18 @@ fn return_instruction(
     let ReturnSpelling { floor, ranks } = spelling;
     match sanitizer {
         None => format!(
-            "  - Declare the lowest label this session accepts from the subagent's return, then propose the spawn \
-             again. The subagent starts at this session's label, now {floor}, and can accept no change below the \
-             floor it is given: a subagent that must read below this session's trust needs the floor at that rank, \
-             and its return may then narrow this session that far. An omitted dimension keeps its current \
-             value.\n    execute_remedy_plan(offer_id: \"{id}\", label: {{trust: \"<rank>\"}}), with <rank> one \
-             of {ranks} (lowest first)"
+            "  - Declare the lowest label this session accepts from the subagent's return, then call the subagent \
+             tool again with the same arguments. The subagent starts at this session's label, now {floor}, and can \
+             accept no change below the floor it is given: a subagent that must read below this session's trust needs \
+             the floor at that rank, and its return may then narrow this session that far. An omitted dimension keeps \
+             its current value.\n    execute_remedy_plan(offer_id: \"{id}\", label: {{trust: \"<rank>\"}}), with \
+             <rank> one of {ranks} (lowest first)"
         ),
         Some(name) if name.is_attest_schema() => format!(
             "  - Attest the subagent's return: declare the floor and the JSON schema its return must match. The \
              schema is strict: an object lists its `properties`, every one `required`, and is closed as written \
              (no `additionalProperties`); an integer carries `minimum` and `maximum`; a string leaf carries \
-             `enum`, `const`, or `format`, never free text. The return crosses at the attestation's \
+             `enum`, `const`, or `format`, never free text. The return is delivered at the attestation's \
              label.\n    execute_remedy_plan(offer_id: \"{id}\", label: {floor}, return_schema: {{type: \
              \"object\", ...}})"
         ),
@@ -2924,16 +2932,16 @@ fn remedy_instruction(plan: &ExecutableRemedyPlan, id: &OfferId, spelling: &Retu
     let action = match (needs_approval, plan.narrowing().is_some(), plan.sanitizer()) {
         (true, _, Some(sanitizer)) => {
             format!(
-                "Request approval and use sanitizer {}'s result",
+                "Submit for approval and use sanitizer {}'s result",
                 terminal_safe(sanitizer.as_str())
             )
         }
         (false, _, Some(sanitizer)) => {
             format!("Use sanitizer {}'s result", terminal_safe(sanitizer.as_str()))
         }
-        (true, true, None) => "Request approval and accept this change for the rest of this session".to_string(),
+        (true, true, None) => "Submit for approval and accept this change for the rest of this session".to_string(),
         (false, true, None) => "Accept this change for the rest of this session".to_string(),
-        (true, false, None) => "Request approval".to_string(),
+        (true, false, None) => "Submit for approval".to_string(),
         (false, false, None) => "Apply the offered remedy".to_string(),
     };
     format!(
@@ -2942,7 +2950,12 @@ fn remedy_instruction(plan: &ExecutableRemedyPlan, id: &OfferId, spelling: &Retu
     )
 }
 
-fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], spelling: &ReturnSpelling) -> Vec<String> {
+fn remedy_lines(
+    planned: &PlannedBlock,
+    offers: &[(OfferId, PlanId)],
+    spelling: &ReturnSpelling,
+    chain: &TrustChain,
+) -> Vec<String> {
     planned
         .plans
         .iter()
@@ -2954,7 +2967,14 @@ fn remedy_lines(planned: &PlannedBlock, offers: &[(OfferId, PlanId)], spelling: 
             RemedyPlan::Redispatch(redispatch) => Some(format!(
                 "  - Run {} first; it clears: {}.",
                 terminal_safe(redispatch.tool().as_str()),
-                terminal_safe(&redispatch.clears().iter().map(gap_text).collect::<Vec<_>>().join("; ")),
+                terminal_safe(
+                    &redispatch
+                        .clears()
+                        .iter()
+                        .map(|gap| gap_text(gap, chain))
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                ),
             )),
         })
         .collect()
@@ -2969,7 +2989,7 @@ fn block_feedback(
     let chain = registry.trust_chain();
     let mut reasons = Vec::new();
     for gap in &planned.raw.requirement_gaps {
-        reasons.push(terminal_safe(&gap_text(gap)));
+        reasons.push(terminal_safe(&gap_text(gap, chain)));
     }
     let public_expansion_required = planned.raw.requirement_gaps.iter().any(|gap| {
         matches!(
@@ -3019,7 +3039,7 @@ fn block_feedback(
     ];
     lines.extend(reasons.into_iter().map(|reason| format!("  - {reason}")));
 
-    let remedies = remedy_lines(planned, offers, &ReturnSpelling::of(chain, bounds));
+    let remedies = remedy_lines(planned, offers, &ReturnSpelling::of(chain, bounds), chain);
     if !remedies.is_empty() {
         lines.push(String::new());
         lines.push("Continue:".to_string());
@@ -3062,7 +3082,7 @@ fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
         sanitized_return,
     } = advice
     else {
-        return "If this trajectory's harness advertises a child-session tool, handle the work there if isolation is \
+        return "If a child-session or subagent tool is available, handle the work there if isolation is \
                 useful.\nA child inherits the same session label, so delegation does not clear these requirements."
             .to_string();
     };
@@ -3073,12 +3093,12 @@ fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
     };
     match (standing, sanitized_return) {
         (FloorStanding::Unbound, true) => format!(
-            "If this trajectory's harness advertises a child-session tool, delegate {delegated} there.\nFinish there \
+            "If a child-session or subagent tool is available, delegate {delegated} there.\nFinish there \
              by returning nothing, or return only a sanitized derivation. Returning the raw value applies the same \
              change to this session."
         ),
         (FloorStanding::Unbound, false) => format!(
-            "If this trajectory's harness advertises a child-session tool, delegate {delegated} there.\nNo \
+            "If a child-session or subagent tool is available, delegate {delegated} there.\nNo \
              registered return sanitizer carries this change back without applying it here, so finish there by \
              returning nothing: a returned value applies the same change to this session."
         ),
@@ -3111,6 +3131,7 @@ fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::TrustChain;
     use super::{
         EngineEvent, EngineView, ExternalEvidence, ExternalRequest, Next, OfferId, OfferNonce, ProposedCall,
         Resolution, ReturnBounds, RuntimeEngine, SanitizerSubject, TrajectoryId, audience_wire, block_feedback,
@@ -3486,7 +3507,7 @@ mod tests {
             ranks: String::new(),
         };
         assert_eq!(
-            remedy_lines(&planned, &offers, &spelling),
+            remedy_lines(&planned, &offers, &spelling, &TrustChain::new(Vec::new())),
             vec![
                 remedy_instruction(&plan(3), &offers[1].0, &spelling),
                 remedy_instruction(&plan(8), &offers[0].0, &spelling),

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -1507,9 +1507,7 @@ impl RuntimeEngine {
         Ok(Some(ReturnPolicy { floor, sanitizer }))
     }
 
-    /// What a starting child is told about its return: the schema an attesting fork holds it
-    /// to, or the sanitizer that rewrites it and the echo that follows. A bare floor tells the
-    /// child nothing it could act on.
+    /// Return contract context provided to a starting subagent.
     pub(crate) fn fork_return_contract(
         &self,
         view: &EngineView,
@@ -1589,9 +1587,7 @@ impl RuntimeEngine {
         }
     }
 
-    /// One child's stop. The engine decides what crosses: the value merged, the derivation
-    /// staged for the child to echo, or nothing. A stop held below the floor or outside the
-    /// fork's shape is blocked with the reason.
+    /// Handles one child's stop and decides what crosses or blocks.
     fn child_return(
         &self,
         view: &EngineView,
@@ -2668,8 +2664,7 @@ fn audience_wire(audience: &Audience) -> String {
     audience.clauses().map(clause_wire).collect::<Vec<_>>().join(" ∩ ")
 }
 
-/// One union clause's summary: the chain audience, group marks, and readers in canonical
-/// order — three entries shown, the rest counted; the empty clause is nobody.
+/// One union clause summary: up to three entries shown, remaining counted.
 fn clause_wire(clause: &Clause) -> String {
     let mut entries = crate::consult::clause_entries(clause);
     if entries.is_empty() {
@@ -2735,7 +2730,7 @@ fn gap_text(gap: &appa_engine::check::Gap, chain: &TrustChain) -> String {
                 )
             }
         },
-        // The count only, as for `includes`: a cap may read a directory group's members.
+        // Count only: a cap may read a directory group's members.
         Gap::Cap { cap } => format!("the committed readers exceed the cap of {}", declared_count(cap)),
         Gap::Prior(effect) => format!("requires a prior {} effect", effect.as_str()),
         Gap::NoPrior(effect) => format!("forbidden after a {} effect", effect.as_str()),
@@ -2787,7 +2782,7 @@ fn audience_count(audience: &Audience) -> String {
     clause_count(clause)
 }
 
-/// One clause's atom count as feedback shows it — counts only, never who.
+/// Summarizes a clause as atom counts only.
 fn clause_count(clause: &Clause) -> String {
     let symbolic = clause.groups().count() + usize::from(clause.chain().is_some());
     match (clause.readers().len(), symbolic) {
@@ -2822,9 +2817,7 @@ fn shape_feedback(mismatch: &ReturnMismatch, policy: Option<&ReturnPolicy>) -> S
     )
 }
 
-/// A label in the spelling `execute_remedy_plan` takes for a return floor. An audience that is
-/// an intersection of clauses has no one-list spelling; the trust rank alone is shown then, and
-/// the omitted dimension keeps the trajectory's current value.
+/// Formats a return floor label for `execute_remedy_plan`.
 fn label_spelling(chain: &TrustChain, label: &Label) -> String {
     let quoted = |text: &str| format!("\"{}\"", terminal_safe(text));
     let top = Trust::new((chain.len() - 1) as u8);
@@ -2853,24 +2846,20 @@ fn label_spelling(chain: &TrustChain, label: &Label) -> String {
     }
 }
 
-/// What bounds a return declaration made on a trajectory: its current label, which no floor
-/// stands above, and the lowest trust its own floor lets it declare.
+/// Trajectory bounds for a return declaration: current label and lowest allowed trust.
 struct ReturnBounds {
     label: Label,
     lowest: Trust,
 }
 
-/// The spelling a return declaration's example needs: this trajectory's label as the
-/// `label` argument takes it, and the trust ranks a placeholder stands for.
+/// Formats the example return floor label and permitted trust ranks.
 struct ReturnSpelling {
     floor: String,
     ranks: String,
 }
 
 impl ReturnSpelling {
-    /// Only the ranks the declaration may take are named: at or below the trajectory's trust,
-    /// and at or above the lowest its own floor permits. The unnamed top sentinel stands for
-    /// the whole chain.
+    /// Permitted trust ranks between lowest and current trust.
     fn of(chain: &TrustChain, bounds: &ReturnBounds) -> ReturnSpelling {
         let ReturnBounds { label, lowest } = bounds;
         let held = if label.trust == Trust::new(u8::MAX) {
@@ -3075,7 +3064,7 @@ fn fork_heading(advice: ForkAdvice) -> &'static str {
     }
 }
 
-/// `remedies_required` when the block also carries requirement gaps a child would clear.
+/// Guidance text for delegating blocked work to a subagent.
 fn fork_advice_text(advice: ForkAdvice, remedies_required: bool) -> String {
     let ForkAdvice::Narrowing {
         standing,

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -68,7 +68,8 @@ impl RemedyService {
                        feedback surfaced. The id must be quoted exactly. A plan that \
                        declares a subagent's return takes `label`, the lowest label this \
                        session accepts from the return; a plan that attests it also takes \
-                       `return_schema`.")]
+                       `return_schema`. After execution succeeds, re-call the original \
+                       tool or receive the admitted output.")]
     pub async fn execute_remedy_plan(
         &self,
         Parameters(args): Parameters<ExecuteRemedyPlanArgs>,
@@ -96,13 +97,13 @@ impl RemedyService {
 fn render(outcome: RemedyOutcome) -> CallToolResult {
     match outcome {
         RemedyOutcome::Authorized { call } => CallToolResult::success(vec![ContentBlock::text(format!(
-            "[appa] Authorized. Propose the {} call again with exactly these arguments: {}",
+            "[appa] Authorized. Call the {} tool again with exactly these arguments: {}",
             call.tool,
             call.arguments.get(),
         ))]),
         RemedyOutcome::Substituted { call } => CallToolResult::success(vec![ContentBlock::text(format!(
             "[appa] Substituted. The sanitizer replaced the arguments and the call is released. \
-             Propose the {} call with exactly these arguments to run it: {}",
+             Call the {} tool with exactly these arguments to run it: {}",
             call.tool,
             call.arguments.get(),
         ))]),

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -77,9 +77,7 @@ impl RemedyService {
     ) -> CallToolResult {
         let quoted = OfferId(args.offer_id.clone());
         let arguments = RemedyArguments::from(args);
-        // The trajectory this act belongs to was named by the hook that
-        // preceded it. Without one there is nothing to serve, and guessing
-        // would be choosing a trajectory for the caller.
+        // Requires the vouched trajectory from the preceding hook.
         let Some((acting, ruling)) = self.runtime.take_vouched(&quoted) else {
             return render(RemedyOutcome::Refused {
                 detail: "no live offer with this id exists".to_string(),
@@ -131,13 +129,12 @@ impl ServerHandler for RemedyService {
     }
 }
 
-/// The release version the CLI advertises, so an MCP client and `--version` agree.
+/// Advertised runtime version for MCP clients.
 const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const SESSION_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// The tower service `main` nests at `/mcp`, serving from process
-/// start.
+/// MCP service served at `/mcp`.
 pub fn service(runtime: Arc<Runtime>) -> StreamableHttpService<RemedyService, LocalSessionManager> {
     let mut sessions = LocalSessionManager::default();
     sessions.session_config.keep_alive = Some(runtime.review_timeout() + SESSION_GRACE);

--- a/appa-runtime/tests/examples_load.rs
+++ b/appa-runtime/tests/examples_load.rs
@@ -221,10 +221,90 @@ async fn the_battery_judges_relative_credentials_and_offers_review_for_public_re
         "the default authority can review the audience expansion"
     );
     assert_eq!(review.len(), 1, "the offer is backed by the default human authority");
-    assert!(feedback.contains("Request approval"));
+    assert!(feedback.contains("Submit for approval"));
     assert!(review[0].text.contains("page.html"), "the review shows the exact call");
     assert!(
         review[0].text.contains("public"),
         "the review shows the audience expansion it covers"
+    );
+}
+
+/// The Slack battery requires `contains = ["internal"]` on writes: a public session can
+/// post autonomously without human approval, while a session holding `self` secrets cannot
+/// leak them into Slack channels.
+#[cfg(unix)]
+#[tokio::test]
+async fn the_slack_battery_allows_public_writes_and_blocks_leaking_self_secrets() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let slack_battery_dir = dir.path().join("batteries/slack");
+    let claude_battery_dir = dir.path().join("batteries/claude-code");
+    std::fs::create_dir_all(&slack_battery_dir).expect("slack battery directory is created");
+    std::fs::create_dir_all(&claude_battery_dir).expect("claude battery directory is created");
+
+    let repository = repo_root();
+    let default = std::fs::read_to_string(repository.join("integrations/claude-code/examples/claude-code.appa.toml"))
+        .expect("the initialized default is readable");
+    std::fs::copy(
+        repository.join("batteries/slack/appa.toml"),
+        slack_battery_dir.join("appa.toml"),
+    )
+    .expect("slack battery file is copied");
+    std::fs::copy(
+        repository.join("batteries/claude-code/appa.toml"),
+        claude_battery_dir.join("appa.toml"),
+    )
+    .expect("claude battery file is copied");
+
+    let root_path = dir.path().join("appa.toml");
+    std::fs::write(
+        &root_path,
+        format!("include = [\"batteries/claude-code/appa.toml\", \"batteries/slack/appa.toml\"]\n\n{default}"),
+    )
+    .expect("the config includes both batteries");
+
+    let config = Config::load(&root_path).expect("the config loads");
+    let runtime = Arc::new(Runtime::open(config, dir.path().join("appa.db"), None).expect("opens"));
+    assert_eq!(
+        hooks::handle(&runtime, HookEvent::SessionStart { root: root() }).await,
+        HookDecision::Ack
+    );
+
+    let slack_send = ProposedCall {
+        tool: "mcp__claude_ai_Slack__slack_send_message".to_string(),
+        arguments: raw(serde_json::json!({ "channel_id": "C123", "text": "hello" })),
+    };
+
+    // 1. Fresh public session: slack write is allowed autonomously
+    assert_eq!(
+        propose(&runtime, slack_send.clone()).await,
+        HookDecision::AllowCall { spawn: None },
+        "a public session can post to slack without hitl"
+    );
+    ran(&runtime, slack_send.clone()).await;
+
+    // 2. Read .env and accept narrowing to self
+    let read_env = call("Read", "file_path", ".env");
+    let narrowing = propose(&runtime, read_env.clone()).await;
+    let HookDecision::DenyCall { feedback, .. } = narrowing else {
+        panic!("reading .env narrows to self");
+    };
+    assert!(matches!(
+        runtime.execute_remedy(&actor(), last_offer(&feedback)).await,
+        RemedyOutcome::Authorized { .. }
+    ));
+    assert_eq!(
+        propose(&runtime, read_env.clone()).await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    ran(&runtime, read_env).await;
+
+    // 3. Narrowed to self: slack write is BLOCKED from leaking secrets
+    let blocked_slack = propose(&runtime, slack_send).await;
+    let HookDecision::DenyCall { offers, .. } = blocked_slack else {
+        panic!("slack write must be blocked when session holds self secrets, got {blocked_slack:?}");
+    };
+    assert!(
+        offers.is_empty(),
+        "slack write cannot leak self secrets: no remedy plan"
     );
 }

--- a/appa-runtime/tests/examples_load.rs
+++ b/appa-runtime/tests/examples_load.rs
@@ -168,7 +168,12 @@ async fn the_battery_judges_relative_credentials_and_offers_review_for_public_re
         HookDecision::Ack
     );
 
-    for command in ["cat .netrc", "cat ~/.ssh/id_ed25519", "cat /home/me/.aws/credentials"] {
+    for command in [
+        "cat .env",
+        "cat .netrc",
+        "cat ~/.ssh/id_ed25519",
+        "cat /home/me/.aws/credentials",
+    ] {
         let refused = propose(&runtime, call("Bash", "command", command)).await;
         let HookDecision::DenyCall { offers, .. } = refused else {
             panic!("`{command}` is refused, got {refused:?}");

--- a/batteries/claude-code/README.md
+++ b/batteries/claude-code/README.md
@@ -5,13 +5,15 @@ and `self` labels on the requester's own secrets.
 
 It covers two built-in tools:
 
-- **Bash** — A command that names a credential path (`.ssh/`, `.netrc`,
-  `.claude.json`, `.aws/credentials`, a private key, ...) is refused outright:
-  one contract judges one call, and a compound command could read and send in
-  the same call. Before any other command runs, the Claude Code model decides
-  what trust and fresh attention it requires and labels its output for trust.
-  An annotation names no reader (`audiences = []`), so the model never decides
-  who may see a command's output; static rules do.
+- **Bash** — A command that names a credential path (`.env`, `.ssh/`, `.netrc`,
+  `.claude.json`, `.aws/credentials`, a private key, ...) requires the
+  `token-exposed` mark: we have no token sanitizer yet, and no authority
+  permits `token-exposed`, so the command is refused outright before secrets
+  reach the model context. In the future, a token sanitizer can permit
+  `token-exposed` by redacting values. Before any other command runs, the
+  Claude Code model decides what trust and fresh attention it requires and
+  labels its output for trust. An annotation names no reader (`audiences = []`),
+  so the model never decides who may see a command's output; static rules do.
 - **Read** — Reading a hidden path, a credential file, a private key, or a
   system secret location narrows the session to `self`, the requester: nothing
   built from it reaches a sink that requires `internal` or `public`. The rules

--- a/batteries/claude-code/appa.toml
+++ b/batteries/claude-code/appa.toml
@@ -9,61 +9,91 @@
 [policy]
 version = 2
 
-# --- Bash: a command naming the requester's credentials is refused ---
+# --- Bash: commands naming requester credentials require token-exposed ---
 
-# One contract judges one call, and a compound command could read a secret and
-# send it in the same call, so a command that names a credential path is
-# refused outright. `blocked` is a mark no authority grants: the refusal has
-# no remedy. This is known-path blocking, not containment: `env`, an
-# interpreter, or an unlisted path still reach a secret without naming it.
+# We have no good sanitizer for tokens at the moment. A command naming a
+# credential path requires the `token-exposed` mark. Because no authority
+# permits `token-exposed` today and no token sanitizer yet covers it, the call
+# is refused before secrets reach the model. In the future, a token sanitizer
+# can permit `token-exposed` by redacting or masking values.
+[[policy.tool]]
+name = "Bash(command:*.env*)"
+requires = { attention = ["token-exposed"] }
+delta = {}
+
 [[policy.tool]]
 name = "Bash(command:*.claude.json*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*.credentials.json*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*.ssh/*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*.aws/credentials*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*.netrc*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*.config/gh/hosts.yml*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*id_rsa*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*id_ed25519*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*/proc/*environ*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 [[policy.tool]]
 name = "Bash(command:*/Library/Keychains/*)"
-requires = { attention = ["blocked"] }
+requires = { attention = ["token-exposed"] }
+delta = {}
+
+[[policy.tool]]
+name = "Bash(command:*.docker/config.json*)"
+requires = { attention = ["token-exposed"] }
+delta = {}
+
+[[policy.tool]]
+name = "Bash(command:*.git-credentials*)"
+requires = { attention = ["token-exposed"] }
+delta = {}
+
+[[policy.tool]]
+name = "Bash(command:*.kube/*)"
+requires = { attention = ["token-exposed"] }
+delta = {}
+
+[[policy.tool]]
+name = "Bash(command:*.npmrc*)"
+requires = { attention = ["token-exposed"] }
+delta = {}
+
+[[policy.tool]]
+name = "Bash(command:*.pypirc*)"
+requires = { attention = ["token-exposed"] }
 delta = {}
 
 # The default model Annotator generates every other command's complete contract

--- a/batteries/grain/appa.toml
+++ b/batteries/grain/appa.toml
@@ -209,7 +209,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Grain__create_story"
@@ -217,7 +217,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Grain__add_clips_to_story"
@@ -225,7 +225,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Grain__create_collection"
@@ -233,7 +233,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Grain__add_recordings_to_collection"
@@ -241,7 +241,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Grain__tag_meetings"
@@ -249,7 +249,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Grain__create_smart_topic"
@@ -257,7 +257,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 # --- sharing outward: a person decides ---
 

--- a/batteries/slack/README.md
+++ b/batteries/slack/README.md
@@ -16,8 +16,8 @@ summarised and posted back to Slack.
 your own Drafts. Trusted data, no approval.
 
 *Writes other people read* — sending or scheduling a message, creating
-or updating a canvas, creating a channel. Trusted data bounded to
-`internal` (`audience = { within = ["internal"] }`): agents post
+or updating a canvas, creating a channel. Trusted data that reaches
+`internal` (`audience = { contains = ["internal"] }`): agents post
 autonomously without human interruption, while requester secrets
 (`self`) are strictly prevented from entering channels.
 

--- a/batteries/slack/README.md
+++ b/batteries/slack/README.md
@@ -1,8 +1,7 @@
 # Slack battery
 
 Rules for the claude.ai Slack connector, all 19 of its tools. No argument
-patterns, no channel ids. Add it to your root config with `include`. The
-root config must define an authority named `hitl`.
+patterns, no channel ids. Add it to your root config with `include`.
 
 ## Files
 
@@ -17,8 +16,10 @@ summarised and posted back to Slack.
 your own Drafts. Trusted data, no approval.
 
 *Writes other people read* — sending or scheduling a message, creating
-or updating a canvas, creating a channel. Trusted data and a person's
-approval, every time.
+or updating a canvas, creating a channel. Trusted data bounded to
+`internal` (`audience = { within = ["internal"] }`): agents post
+autonomously without human interruption, while requester secrets
+(`self`) are strictly prevented from entering channels.
 
 **`audience-source.py`** — the `slack` audience source. It answers the
 stock catalog's selectors over the Slack Web API:

--- a/batteries/slack/appa.toml
+++ b/batteries/slack/appa.toml
@@ -1,9 +1,9 @@
 # Included Slack battery for the claude.ai Slack connector.
 #
 # Plain rules only: one per tool, no argument patterns. Everything read
-# from Slack is `internal`: it reaches only the organization's members.
-# Every write needs trusted data within `internal`, keeping internal
-# communication autonomous without blocking on human approval.
+# Every write needs trusted data that includes `internal`, keeping internal
+# communication autonomous without blocking on human approval while barring
+# requester secrets (`self`).
 #
 # A root rule placed above these can narrow any of them by argument.
 # Root rules run first. For example, to let replies inside a thread go
@@ -114,7 +114,7 @@ name = "mcp__claude_ai_Slack__slack_send_message_draft"
 requires = { trust = "trusted" }
 delta = {}
 
-# --- writes other people read: trusted data, bounded to internal audience ---
+# --- writes other people read: trusted data, reaching internal audience ---
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_send_message"
@@ -122,7 +122,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_schedule_message"
@@ -130,7 +130,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_create_canvas"
@@ -138,7 +138,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_update_canvas"
@@ -146,7 +146,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_create_conversation"
@@ -154,4 +154,4 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-audience = { within = ["internal"] }
+audience = { contains = ["internal"] }

--- a/batteries/slack/appa.toml
+++ b/batteries/slack/appa.toml
@@ -2,9 +2,8 @@
 #
 # Plain rules only: one per tool, no argument patterns. Everything read
 # from Slack is `internal`: it reaches only the organization's members.
-# Every write needs trusted data; one that shows
-# text to other people also needs a person's approval. The root config supplies
-# the `hitl` authority.
+# Every write needs trusted data within `internal`, keeping internal
+# communication autonomous without blocking on human approval.
 #
 # A root rule placed above these can narrow any of them by argument.
 # Root rules run first. For example, to let replies inside a thread go
@@ -115,7 +114,7 @@ name = "mcp__claude_ai_Slack__slack_send_message_draft"
 requires = { trust = "trusted" }
 delta = {}
 
-# --- writes other people read: trusted data, a person approves ---
+# --- writes other people read: trusted data, bounded to internal audience ---
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_send_message"
@@ -123,7 +122,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-attention = ["hitl"]
+audience = { within = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_schedule_message"
@@ -131,7 +130,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-attention = ["hitl"]
+audience = { within = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_create_canvas"
@@ -139,7 +138,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-attention = ["hitl"]
+audience = { within = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_update_canvas"
@@ -147,7 +146,7 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-attention = ["hitl"]
+audience = { within = ["internal"] }
 
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_create_conversation"
@@ -155,4 +154,4 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
-attention = ["hitl"]
+audience = { within = ["internal"] }

--- a/integrations/appa-guide/references/claude-code.md
+++ b/integrations/appa-guide/references/claude-code.md
@@ -117,7 +117,15 @@ proposal configures an audience source for it.
 Create root rules only for installed tools that neither the root config nor a
 matched battery covers.
 
-- The built-in audience chain is `self` ⊆ `internal` ⊆ `public`.
+- **IFC monoids first**: Always express security guarantees using Information
+  Flow Control (IFC) monoids (`trust` lattice and `self` ⊆ `internal` ⊆ `public`
+  audience chain). Effects (`emits`, `requires.history`) are a hacky workaround
+  for event sequencing, not the primary algebra; avoid them when label bounding
+  suffices. Do not use synthetic attention marks (`blocked`) or default `hitl`
+  to fake boundaries; keep autonomous execution unblocked for trusted data
+  flowing within its legitimate audience.
+- The built-in audience chain is `self` ⊆ `internal` ⊆ `public`: `self` is the
+  person running the session, `internal` their organization.
 - A tool that reads the requester's private data uses
   `delta = { audience = ["self"] }`.
 - A tool that reads organization-wide data uses
@@ -127,8 +135,13 @@ matched battery covers.
   explicit audience source.
 - Annotator outputs can specify only literal readers, not `self` or `internal`.
   Use a static contract when output belongs to a built-in audience.
-- A tool that publishes, posts, sends, shares, or uploads requires data that
-  may be public: `requires = { audience = { contains = ["public"] } }`.
+- A tool that publishes, posts, sends, shares, or uploads beyond the machine
+  requires data that may be public: `requires = { audience = { contains = ["public"] } }`.
+- A tool that communicates within the organization (e.g. posting internal Slack
+  messages or workspace items) requires trusted data that includes `internal`:
+  `requires = { trust = "trusted", audience = { contains = ["internal"] } }`. This
+  keeps autonomous agent flow unblocked for public or internal data while preventing
+  requester secrets (`self`) from leaking.
 - A clearly public read or a tool whose result carries no data uses
   `delta = {}`.
 - Every new tool entry needs `delta`, including entries with `requires`. Never

--- a/website/content/docs/battery-claude-code.md
+++ b/website/content/docs/battery-claude-code.md
@@ -16,7 +16,7 @@ This battery covers Claude Code's built-in `Read` and `Bash` tools. Batteries ca
 | Tool | Contract |
 |---|---|
 | `Read` | Static rules narrow the session to `self`, the requester, when a hidden path, a credential file, a private key, or a system secret location is read. |
-| `Bash` | A command naming one of the same paths is refused outright. Before every other command runs, the Claude Code model decides the trust and fresh attention it requires and labels its output for trust. Its mandate names no reader, so who may see a command's output is the session's label, not the model's choice. |
+| `Bash` | A command naming a credential path requires the `token-exposed` mark and is refused before secrets reach the model. Before every other command runs, the Claude Code model decides the trust and fresh attention it requires and labels its output for trust. Its mandate names no reader, so who may see a command's output is the session's label, not the model's choice. |
 
 The default config created by `appa init claude-code` handles tools that the battery does not name.
 

--- a/website/content/docs/battery-slack.md
+++ b/website/content/docs/battery-slack.md
@@ -15,7 +15,7 @@ The Slack battery covers all 19 tools in the claude.ai Slack connector. Writes r
 
 - Reads and searches return `internal` data, the built-in audience of the organization's members. OpenAPPA keeps their existing trust level.
 - Adding a reaction or saving a personal draft requires trusted data and no approval.
-- Messages, canvases, channels, and other visible changes require trusted data bounded to `internal` (`audience = { within = ["internal"] }`), enabling autonomous agent posting while keeping requester secrets (`self`) out.
+- Messages, canvases, channels, and other visible changes require trusted data that reaches `internal` (`audience = { contains = ["internal"] }`), enabling autonomous agent posting while keeping requester secrets (`self`) out.
 
 To change how one tool or channel works, add a more specific rule to the root config. Root rules run before battery rules.
 

--- a/website/content/docs/battery-slack.md
+++ b/website/content/docs/battery-slack.md
@@ -7,9 +7,7 @@ sidebar: false
 breadcrumb: Slack
 ---
 
-The Slack battery covers all 19 tools in the claude.ai Slack connector. It asks a person to approve messages and other visible changes.
-
-Your root config must define an Authority named `hitl` for these approvals.
+The Slack battery covers all 19 tools in the claude.ai Slack connector. Writes require trusted data bounded to `internal`.
 
 [View the battery source](https://github.com/archestra-ai/OpenAPPA/tree/main/batteries/slack).
 
@@ -17,7 +15,7 @@ Your root config must define an Authority named `hitl` for these approvals.
 
 - Reads and searches return `internal` data, the built-in audience of the organization's members. OpenAPPA keeps their existing trust level.
 - Adding a reaction or saving a personal draft requires trusted data and no approval.
-- Messages, canvases, channels, and other visible changes require trusted data and approval every time.
+- Messages, canvases, channels, and other visible changes require trusted data bounded to `internal` (`audience = { within = ["internal"] }`), enabling autonomous agent posting while keeping requester secrets (`self`) out.
 
 To change how one tool or channel works, add a more specific rule to the root config. Root rules run before battery rules.
 


### PR DESCRIPTION
## Summary

Improves clarity of agent-facing feedback messages across `appa-runtime`, MCP, and agent adapters, and aligns batteries and guidelines with an IFC-first architecture:

### Agent-Facing Feedback & Clarity
- **Human-readable trust ranks in gap feedback**: `Gap::TrustFloor` now uses policy trust names via `trust_feedback` (or rank numbers) instead of raw Rust `Trust(0)` debug tokens in `gap_text`.
- **Approval action clarity**: Changes `"Request approval"` to `"Submit for approval"` in `remedy_instruction` to prevent LLMs from asking the user in chat rather than executing the remedy plan tool call.
- **Agentic tool verbs**: Replaces `"Propose the <tool> call again"` with `"Call the <tool> tool again with exactly these arguments: ..."` in `RemedyOutcome::Authorized` and `RemedyOutcome::Substituted` across `mcp.rs`, `appa-agent-python`, and `appa-example-agent`.
- **Actionable staged delivery**: Adds an explicit `"To accept this change and receive the output:"` header in `stage_feedback` above the offered remedy plan.
- **Tool-oriented fork advice**: Replaces internal architecture terminology (`"If this trajectory's harness advertises a child-session tool"`) with accessible guidance (`"If a child-session or subagent tool is available"`).
- **Subagent stop clarity**: Clarifies in `child_return` and `ENDED_CHILD` that an empty final message must contain no conversational text or explanation (`"(send no text or explanation)"`), preventing repeated refusal loops.
- **Remedy tool documentation**: Updates `execute_remedy_plan` tool descriptions in MCP and example agent to explicitly note that once executed, the agent re-calls the original tool or receives the admitted output.

### IFC-First Batteries & Token Protection
- **Corrected internal write audience constraints (`contains = ["internal"]`)**: Fixed an inverted lattice constraint in Slack and Grain batteries where `within = ["internal"]`( \subseteq \text{internal}$) erroneously allowed `self`-scoped secrets ($\text{self} \subseteq \text{internal}$) to leak while rejecting standard `public` sessions ($\text{public} \not\subseteq \text{internal}$). Replaced with `audience = { contains = ["internal"] }` ( \supseteq \text{internal}$), correctly permitting public and internal data while barring requester secrets (`self`).
- **`token-exposed` attention mark in Claude Code battery**: Replaces synthetic `blocked` mark on Bash credential commands with `token-exposed`, and adds missing credential patterns (`.env`, `.docker/config.json`, `.kube/*`, `.git-credentials`, `.npmrc`, `.pypirc`). Without a dedicated token sanitizer, `token-exposed` refuses the call before secrets reach model context without masquerading as an authority.
- **CLAUDE.md & appa-guide skill**: Documents explicit preference for IFC monoids (`trust × audience` lattices) over imperative `effects` workarounds, noting that effects are an imperative state-machine workaround and attention should not be used as a blunt kill switch.

## Verification
- Unit & integration tests pass: `cargo test -p appa` (including new `the_slack_battery_allows_public_writes_and_blocks_leaking_self_secrets` test).
- Live Claude Code E2E test suite passes: benign dev flow remains public, credential read narrows to `self` and blocks `WebFetch`, and Bash credential commands (`cat .netrc`, `cat .env`) are refused under `token-exposed`.
- `cargo fmt --check` and `cargo clippy -p appa -p appa-engine` pass with 0 warnings.