### PR TITLE
docs(kagent): add operator guide, existing cluster setup, and interactive figure

### DIFF
--- a/integrations/kagent/README.md
+++ b/integrations/kagent/README.md
@@ -1,0 +1,126 @@
+# OpenAPPA for kagent
+
+This directory contains the OpenAPPA integration for [kagent](https://github.com/kagent-dev/kagent), the Kubernetes-native AI agent orchestrator.
+
+OpenAPPA gates every declarative kagent agent on Kubernetes through one install setting: the runtime image. The integration requires no modifications to agent definitions, no forks of kagent, and no forks of the Google Agent Development Kit (ADK).
+
+- **Operator guide**: [website/content/docs/kagent.md](../../website/content/docs/kagent.md)
+- **Implementation specification**: [IMPLEMENTATION.md](IMPLEMENTATION.md)
+- **Demo Helm chart**: [demo/chart/README.md](demo/chart/README.md)
+
+## Components
+
+```text
+integrations/kagent/
+├── appa-kagent-adk/         # Python ADK plugin and entrypoint (appa_kagent_adk)
+├── appa-kagent-adk-go/      # Go ADK plugin and replacement runtime main
+├── appa-kagent-quickstart/  # Unified container image bundling appa-runtime and runtimes
+├── demo/                    # Demo Helm chart, mock services, and demo tools
+│   ├── chart/               # Helm chart (appa-kagent-demo)
+│   ├── mocks/               # Mock external authorities (change-board, annotator)
+│   └── demo_tools.py        # Demo toolset MCP server
+├── e2e/                     # End-to-end integration test suites
+│   ├── a2a/                 # Matrix tests over the A2A protocol
+│   └── ui/                  # Browser matrix tests driving the kagent dashboard
+├── examples/                # Reference policies (e.g. kagent.appa.toml)
+├── fixtures/                # Canonical wire event fixtures shared across languages
+└── IMPLEMENTATION.md        # Technical architecture, callback mappings, and specs
+```
+
+### 1. Python Runtime (`appa-kagent-adk/`)
+Wraps kagent's published Python runtime container image. It ships `AppaPluginKagent`, a Google ADK `BasePlugin` that maps ADK lifecycle callbacks to OpenAPPA `/hook` events, and a replacement entrypoint that preserves the stock arguments while appending the plugin and the `execute_remedy_plan` MCP tool.
+
+### 2. Go Runtime (`appa-kagent-adk-go/`)
+Implements `AppaPluginKagent` for Google Go ADK v2. It provides a replacement runtime main that registers the plugin, manages session lineage headers across agent-to-agent delegation, and coordinates human-in-the-loop approvals.
+
+### 3. Quickstart Image (`appa-kagent-quickstart/`)
+A self-contained container image bundling both Python and Go runtimes together with an embedded `appa-runtime` binary. When deployed without an external `APPA_RUNTIME_URL`, the image starts `appa-runtime` on `127.0.0.1:8787` using a packaged default policy. When `APPA_RUNTIME_URL` is supplied, it connects to the shared runtime service.
+
+### 4. Codec Crate (`appa-adapter-kagent`)
+The Rust codec crate located at `crates/appa-adapter-kagent` (in the workspace root). It is compiled directly into `appa-runtime` and parses wire events sent by `AppaPluginKagent`.
+
+## Quickstart
+
+### Deploy kagent with OpenAPPA
+
+Install kagent CRDs and the kagent controller, setting `controller.agentImage` to the OpenAPPA quickstart image:
+
+```sh
+# 1. Install kagent CRDs
+helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
+  --version 0.9.12 -n kagent --create-namespace
+
+# 2. Install kagent controller with OpenAPPA image
+helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
+  --version 0.9.12 -n kagent \
+  --set controller.agentImage.registry=ghcr.io \
+  --set controller.agentImage.repository=archestra-ai/appa-kagent-quickstart \
+  --set controller.agentImage.tag=0.7.0 --wait
+```
+
+### Deploy the Interactive Demo
+
+Deploy the demo chart with your OpenAI API key:
+
+```sh
+helm upgrade --install appa-kagent-demo ./demo/chart \
+  -n kagent --set openai.apiKey="$OPENAI_API_KEY" --wait
+```
+
+Port-forward the kagent dashboard:
+
+```sh
+kubectl port-forward -n kagent svc/kagent-ui 8901:80
+```
+
+Open [http://localhost:8901](http://localhost:8901) to explore 16 pre-seeded demonstration chats showcasing data exfiltration blocks, untrusted ingress quarantine, human-in-the-loop approvals, and multi-agent delegation.
+
+## Building from Source
+
+To build and test the integration images locally (for example, on a local `kind` cluster):
+
+```sh
+# Build images
+docker build -f appa-kagent-quickstart/Dockerfile -t appa-kagent-quickstart:dev ../../
+docker build -t appa-kagent-adk-go:dev appa-kagent-adk-go
+docker build -t appa-demo-tools:dev demo
+docker build -t appa-demo-mocks:dev demo/mocks
+
+# Load images into kind
+kind load docker-image \
+  appa-kagent-quickstart:dev \
+  appa-kagent-adk-go:dev \
+  appa-demo-tools:dev \
+  appa-demo-mocks:dev \
+  --name <cluster-name>
+```
+
+## Running Tests
+
+### Python Unit Tests
+The Python tests verify callback conversions, config validation, and wire encoding across both supported Google ADK releases (1.31.1 and 2.8.0):
+
+```sh
+cd appa-kagent-adk
+uv run pytest
+uv run --with google-adk==1.31.1 pytest
+```
+
+### Go Unit Tests
+The Go tests verify ADK v2 callbacks and wire format parity:
+
+```sh
+cd appa-kagent-adk-go
+go test ./...
+```
+
+### End-to-End Verification Matrices
+The test matrices run 17 distinct scenarios against the live cluster:
+
+```sh
+# Run A2A protocol test matrix
+pytest integrations/kagent/e2e/a2a
+
+# Run UI dashboard test matrix (requires Playwright / Chromium)
+pytest integrations/kagent/e2e/ui
+```

--- a/integrations/kagent/appa-kagent-adk/README.md
+++ b/integrations/kagent/appa-kagent-adk/README.md
@@ -8,7 +8,7 @@ replays the stock kagent startup and appends the plugin. The package
 ships as the `ghcr.io/archestra-ai/appa-kagent-adk` image on top of
 kagent's published runtime image.
 
-The proposal lives at `website/content/docs/kagent.md`; the
+The operator guide lives at `website/content/docs/kagent.md`; the
 implementation plan, per-version mapping tables, and verification
 matrix live in [`../IMPLEMENTATION.md`](../IMPLEMENTATION.md). The
 adapter wire this package emits is parsed by the `appa-adapter-kagent`

--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -20,6 +20,7 @@ import { ClaudeCodeHooksFigure } from "@/components/figures/ClaudeCodeHooksFigur
 import { ConnectedAgentFigure } from "@/components/figures/ConnectedAgentFigure";
 import { ExfiltrationFigure } from "@/components/figures/ExfiltrationFigure";
 import { GuardrailFigure } from "@/components/figures/GuardrailFigure";
+import { KagentFigure } from "@/components/figures/KagentFigure";
 import { LabelFoldFigure } from "@/components/figures/LabelFoldFigure";
 import { NegotiationFigure } from "@/components/figures/NegotiationFigure";
 import { PolicyStackFigure } from "@/components/figures/PolicyStackFigure";
@@ -64,6 +65,7 @@ const DIRECTIVES: Record<string, () => ReactNode> = {
   "fig-connected-agent": () => <ConnectedAgentFigure />,
   "fig-exfiltration": () => <ExfiltrationFigure />,
   "fig-guardrail": () => <GuardrailFigure />,
+  "fig-kagent": () => <KagentFigure />,
   "fig-label-fold": () => <LabelFoldFigure />,
   "fig-negotiation": () => <NegotiationFigure />,
   "fig-policy-stack": () => <PolicyStackFigure />,

--- a/website/components/figures/Figure.tsx
+++ b/website/components/figures/Figure.tsx
@@ -38,17 +38,25 @@ export function Figure({ draw, designW, designH, durationMs = 16000 }: FigurePro
     if (!ctx) return;
 
     let scale = 1;
+    let lastDpr = window.devicePixelRatio || 1;
+    let lastCssW = 0;
+
     const resize = () => {
       const cssW = wrap.clientWidth;
       const dpr = window.devicePixelRatio || 1;
+      if (cssW === 0) return;
+      lastCssW = cssW;
+      lastDpr = dpr;
       scale = cssW / designW;
       canvas.width = Math.round(cssW * dpr);
       canvas.height = Math.round(designH * scale * dpr);
       canvas.style.height = `${designH * scale}px`;
     };
     resize();
+
     const ro = new ResizeObserver(resize);
     ro.observe(wrap);
+    window.addEventListener("resize", resize);
 
     const io = new IntersectionObserver((entries) => {
       visibleRef.current = entries[0]?.isIntersecting ?? true;
@@ -74,8 +82,14 @@ export function Figure({ draw, designW, designH, durationMs = 16000 }: FigurePro
         }
       }
       lastTickRef.current = now;
+
       const dpr = window.devicePixelRatio || 1;
-      ctx.setTransform(scale * dpr, 0, 0, scale * dpr, 0, 0);
+      const cssW = wrap.clientWidth;
+      if (dpr !== lastDpr || cssW !== lastCssW) {
+        resize();
+      }
+
+      ctx.setTransform(scale * lastDpr, 0, 0, scale * lastDpr, 0, 0);
       ctx.clearRect(0, 0, designW, designH);
       draw(ctx, tRef.current, readTheme(canvas));
     };
@@ -85,6 +99,7 @@ export function Figure({ draw, designW, designH, durationMs = 16000 }: FigurePro
       cancelAnimationFrame(raf);
       ro.disconnect();
       io.disconnect();
+      window.removeEventListener("resize", resize);
     };
   }, [draw, designW, designH, durationMs]);
 

--- a/website/components/figures/KagentFigure.tsx
+++ b/website/components/figures/KagentFigure.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { Figure } from "@/components/figures/Figure";
+import { chip, drawCard, ease, lerp, roundRect, seg, type Theme } from "@/components/figures/lib";
+import { logoPixelData } from "@/components/Logo";
+
+/* Integration figure: a protected kagent declarative agent on Kubernetes.
+   Every tool call passes through the Google ADK plugin gate (AppaPluginKagent)
+   to OpenAPPA before execution.
+   Call 1: Allowed secret read narrows trajectory audience to [ops].
+   Call 2: Blocked leak — sending ops data to public sink is blocked.
+   Call 3: Full Human-in-the-Loop flow to completion — destructive action suspends,
+           operator clicks Approve in kagent UI, and deployment restarts. */
+
+const W = 900;
+const H = 400;
+
+const LOGO = logoPixelData();
+
+const POD = { x: 24, y: 40, w: 230, h: 250 };
+const GATE = { x: 334, y: 40, w: 232, h: 250 };
+const RUNTIME = { x: 646, y: 40, w: 230, h: 250 };
+
+const HOOK_ROWS = [
+  "SessionStart",
+  "UserPrompt",
+  "BeforeTool (PreTool)",
+  "AfterTool (PostTool)",
+  "A2ASpawn (Child)",
+  "TurnEnd",
+];
+const rowY = (i: number) => GATE.y + 50 + i * 28;
+const PRE = 2; // BeforeTool row
+const RAIL_Y = rowY(PRE);
+
+const CARD = { w: 198, h: 32 };
+const CARD_X = POD.x + 16;
+const CARD_Y = RAIL_Y - CARD.h / 2;
+
+/* Beat boundaries for the three cycles */
+const CALL_1 = {
+  prep: [0.02, 0.07],
+  call: [0.07, 0.14],
+  post: [0.15, 0.22],
+  back: [0.23, 0.29],
+  done: 0.30,
+};
+const CALL_2 = {
+  prep: [0.33, 0.38],
+  call: [0.38, 0.45],
+  post: [0.46, 0.53],
+  back: [0.54, 0.60],
+  done: 0.61,
+};
+const CALL_3 = {
+  prep: [0.64, 0.69],
+  call: [0.69, 0.75],
+  post: [0.76, 0.81],
+  back: [0.82, 0.86],
+  review: [0.86, 0.93],
+  vouch: [0.93, 0.96],
+  auth: [0.96, 0.98],
+  done: 0.98,
+};
+
+function drawLogo(ctx: CanvasRenderingContext2D, th: Theme, x: number, y: number, capPx: number) {
+  const s = capPx / LOGO.capHeight;
+  const size = LOGO.cell * s + 0.4;
+  for (const p of LOGO.pixels) {
+    ctx.fillStyle = p.dim ? th.textWeak : th.textStrong;
+    ctx.fillRect(x + p.x * LOGO.cell * s, y + p.y * LOGO.cell * s, size, size);
+  }
+}
+
+function renderCallCycle(
+  ctx: CanvasRenderingContext2D,
+  th: Theme,
+  t: number,
+  beat: typeof CALL_1,
+  toolLabel: string,
+  toolColor: string,
+  answerText: string,
+  answerColor: string,
+  answerBg: string,
+) {
+  // 1. Tool card inside POD
+  const appear = ease(seg(t, beat.prep[0], beat.prep[1]));
+  const fade = seg(t, beat.done + 0.02, beat.done + 0.05);
+  if (t >= beat.prep[0] && fade < 1) {
+    drawCard(ctx, th, CARD_X, CARD_Y, CARD.w, CARD.h, toolLabel, toolColor, Math.min(appear, 1 - fade));
+  }
+
+  // 2. Dispatch chip from POD to GATE
+  const callF = seg(t, beat.call[0], beat.call[1]);
+  if (callF > 0 && callF < 1) {
+    const chipX = lerp(POD.x + POD.w, GATE.x, ease(callF));
+    chip(ctx, chipX, RAIL_Y, "tool_call", th.textStrong, th.bgWeak, th.mono);
+  }
+
+  // 3. POST /hook from GATE to RUNTIME
+  const postF = seg(t, beat.post[0], beat.post[1]);
+  if (postF > 0 && postF < 1) {
+    const chipX = lerp(GATE.x + GATE.w, RUNTIME.x, ease(postF));
+    chip(ctx, chipX, RAIL_Y, "POST /hook", th.textStrong, th.bgWeak, th.mono);
+  }
+
+  // 4. Answer chip from RUNTIME back to GATE
+  const backF = seg(t, beat.back[0], beat.back[1]);
+  if (backF > 0 && backF < 1) {
+    const chipX = lerp(RUNTIME.x, GATE.x + GATE.w, ease(backF));
+    chip(ctx, chipX, RAIL_Y, answerText, answerColor, answerBg, th.mono);
+  }
+}
+
+function draw(ctx: CanvasRenderingContext2D, t: number, th: Theme) {
+  const font = (size: number, weight = 400) => `${weight} ${size}px ${th.mono}`;
+
+  const runtimeBusy =
+    (t > CALL_1.post[0] && t < CALL_1.back[1]) ||
+    (t > CALL_2.post[0] && t < CALL_2.back[1]) ||
+    (t > CALL_3.post[0] && t < CALL_3.back[1]) ||
+    (t > CALL_3.vouch[0] && t < CALL_3.auth[1]);
+
+  const isBlocked = t >= CALL_2.done && t < CALL_3.prep[0];
+  const isUnderReview = t >= CALL_3.back[1] && t < CALL_3.auth[1];
+  const isApproved = t >= CALL_3.done;
+
+  /* The connecting rails: Pod -> Gate -> Runtime */
+  ctx.strokeStyle = th.borderWeak;
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  // Rail 1: POD to GATE
+  ctx.moveTo(POD.x + POD.w, RAIL_Y);
+  ctx.lineTo(GATE.x, RAIL_Y);
+  // Rail 2: GATE to RUNTIME
+  ctx.moveTo(GATE.x + GATE.w, RAIL_Y);
+  ctx.lineTo(RUNTIME.x, RAIL_Y);
+  ctx.stroke();
+
+  /* 1. kagent Agent Pod */
+  ctx.fillStyle = th.bg;
+  ctx.strokeStyle = th.border;
+  roundRect(ctx, POD.x, POD.y, POD.w, POD.h, 6);
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle = th.textStrong;
+  ctx.font = font(13, 600);
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+  ctx.fillText("kagent Agent Pod", POD.x + 14, POD.y + 20);
+  ctx.fillStyle = th.textWeak;
+  ctx.font = font(11.5);
+  ctx.fillText("cluster-ops · declarative Agent", POD.x + 14, POD.y + 40);
+  ctx.fillText("Google ADK runtime in k8s", POD.x + 14, POD.y + POD.h - 18);
+
+  /* 2. ADK Plugin Gate (AppaPluginKagent) */
+  ctx.save();
+  ctx.strokeStyle = isBlocked ? th.danger : isUnderReview ? th.warn : isApproved ? th.accent : th.border;
+  ctx.setLineDash([3, 5]);
+  if (isBlocked) {
+    ctx.shadowColor = th.danger;
+    ctx.shadowBlur = 8;
+  } else if (isUnderReview) {
+    ctx.shadowColor = th.warn;
+    ctx.shadowBlur = 8;
+  } else if (isApproved) {
+    ctx.shadowColor = th.accent;
+    ctx.shadowBlur = 8;
+  }
+  roundRect(ctx, GATE.x, GATE.y, GATE.w, GATE.h, 6);
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.fillStyle = th.textStrong;
+  ctx.font = font(13, 600);
+  ctx.fillText("AppaPluginKagent", GATE.x + 14, GATE.y + 20);
+  HOOK_ROWS.forEach((name, i) => {
+    const active = i === PRE && (t > CALL_1.call[0] || t > CALL_2.call[0] || t > CALL_3.call[0]);
+    ctx.fillStyle = active ? th.accent : th.textWeak;
+    ctx.font = font(11.5, active ? 600 : 400);
+    ctx.fillText(name, GATE.x + 14, rowY(i));
+  });
+
+  /* 3. OpenAPPA Runtime */
+  ctx.save();
+  if (runtimeBusy) {
+    ctx.shadowColor = th.accent;
+    ctx.shadowBlur = 10;
+    ctx.strokeStyle = th.accent;
+  } else {
+    ctx.strokeStyle = th.border;
+  }
+  ctx.fillStyle = th.bg;
+  roundRect(ctx, RUNTIME.x, RUNTIME.y, RUNTIME.w, RUNTIME.h, 6);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+
+  drawLogo(ctx, th, RUNTIME.x + 14, RUNTIME.y + 13, 10);
+  ctx.fillStyle = th.textStrong;
+  ctx.font = font(13, 600);
+  ctx.fillText("OpenAPPA Runtime", RUNTIME.x + 14, RUNTIME.y + 46);
+  ["Policy Contract (appa.toml)", "Deterministic Engine", "Trajectory Labels & Log"].forEach((line, i) => {
+    drawCard(ctx, th, RUNTIME.x + 14, RUNTIME.y + 66 + i * 44, RUNTIME.w - 28, 36, line, th.border);
+  });
+
+  /* Calls 1 and 2 */
+  renderCallCycle(ctx, th, t, CALL_1, "read_secret(db)", th.accent, "allow", th.accent, th.accentBg);
+  renderCallCycle(ctx, th, t, CALL_2, "post_status(leak)", th.danger, "block", th.danger, th.dangerBg);
+
+  /* Call 3: Full Human-in-the-Loop lifecycle */
+  // 3a. Initial tool proposal
+  const c3Appear = ease(seg(t, CALL_3.prep[0], CALL_3.prep[1]));
+  const c3Fade = seg(t, 0.99, 1.0);
+  if (t >= CALL_3.prep[0] && c3Fade < 1) {
+    drawCard(
+      ctx,
+      th,
+      CARD_X,
+      CARD_Y,
+      CARD.w,
+      CARD.h,
+      isApproved ? "restart_deployment ✓" : "restart_deployment",
+      isApproved ? th.accent : th.warn,
+      Math.min(c3Appear, 1 - c3Fade),
+    );
+  }
+  // 3b. Dispatch chip
+  const c3CallF = seg(t, CALL_3.call[0], CALL_3.call[1]);
+  if (c3CallF > 0 && c3CallF < 1) {
+    const chipX = lerp(POD.x + POD.w, GATE.x, ease(c3CallF));
+    chip(ctx, chipX, RAIL_Y, "tool_call", th.textStrong, th.bgWeak, th.mono);
+  }
+  // 3c. Initial policy check POST /hook
+  const c3PostF = seg(t, CALL_3.post[0], CALL_3.post[1]);
+  if (c3PostF > 0 && c3PostF < 1) {
+    const chipX = lerp(GATE.x + GATE.w, RUNTIME.x, ease(c3PostF));
+    chip(ctx, chipX, RAIL_Y, "POST /hook", th.textStrong, th.bgWeak, th.mono);
+  }
+  // 3d. Engine returns remedy offer citing oncall authority
+  const c3BackF = seg(t, CALL_3.back[0], CALL_3.back[1]);
+  if (c3BackF > 0 && c3BackF < 1) {
+    const chipX = lerp(RUNTIME.x, GATE.x + GATE.w, ease(c3BackF));
+    chip(ctx, chipX, RAIL_Y, "remedy: oncall", th.warn, th.warnBg, th.mono);
+  }
+
+  // 3e. kagent UI Approval Card popup at Gate
+  const reviewProgress = seg(t, CALL_3.review[0], CALL_3.review[1]);
+  if (reviewProgress > 0 && t < CALL_3.auth[1]) {
+    const cardAlpha = reviewProgress < 0.2 ? ease(reviewProgress * 5) : t > CALL_3.vouch[1] ? 1 - ease(seg(t, CALL_3.vouch[1], CALL_3.auth[1])) : 1;
+    const isClicked = t >= 0.90;
+
+    ctx.save();
+    ctx.globalAlpha = cardAlpha;
+    const POP_X = GATE.x + 12;
+    const POP_Y = GATE.y + 140;
+    const POP_W = GATE.w - 24;
+    const POP_H = 80;
+
+    ctx.fillStyle = th.bgWeak;
+    ctx.strokeStyle = isClicked ? th.accent : th.warn;
+    ctx.lineWidth = 1.5;
+    roundRect(ctx, POP_X, POP_Y, POP_W, POP_H, 5);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = th.textStrong;
+    ctx.font = font(11.5, 600);
+    ctx.fillText("kagent Confirmation", POP_X + 12, POP_Y + 16);
+
+    ctx.fillStyle = th.textWeak;
+    ctx.font = font(10.5);
+    ctx.fillText("restart_deployment(api)", POP_X + 12, POP_Y + 34);
+
+    // Approve button
+    const BTN_Y = POP_Y + 48;
+    const BTN_W = 86;
+    const BTN_H = 22;
+    ctx.fillStyle = isClicked ? th.accent : th.bg;
+    ctx.strokeStyle = th.accent;
+    roundRect(ctx, POP_X + 12, BTN_Y, BTN_W, BTN_H, 3);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = isClicked ? th.bg : th.accent;
+    ctx.font = font(10.5, 700);
+    ctx.fillText("Approve", POP_X + 28, BTN_Y + 11);
+
+    // Reject button
+    ctx.fillStyle = th.bg;
+    ctx.strokeStyle = th.border;
+    roundRect(ctx, POP_X + 106, BTN_Y, BTN_W - 10, BTN_H, 3);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = th.textWeak;
+    ctx.font = font(10.5);
+    ctx.fillText("Reject", POP_X + 122, BTN_Y + 11);
+
+    ctx.restore();
+  }
+
+  // 3f. Vouch approval sent to Runtime
+  const vouchF = seg(t, CALL_3.vouch[0], CALL_3.vouch[1]);
+  if (vouchF > 0 && vouchF < 1) {
+    const chipX = lerp(GATE.x + GATE.w, RUNTIME.x, ease(vouchF));
+    chip(ctx, chipX, RAIL_Y, "ruling: approve", th.accent, th.accentBg, th.mono);
+  }
+
+  // 3g. Authorized response back to Gate
+  const authF = seg(t, CALL_3.auth[0], CALL_3.auth[1]);
+  if (authF > 0 && authF < 1) {
+    const chipX = lerp(RUNTIME.x, GATE.x + GATE.w, ease(authF));
+    chip(ctx, chipX, RAIL_Y, "authorized", th.accent, th.accentBg, th.mono);
+  }
+
+  /* Verdict markers at the gate */
+  // Call 1: Allowed checkmark
+  if (t >= CALL_1.done && t < CALL_2.prep[0]) {
+    ctx.fillStyle = th.accent;
+    ctx.font = font(16, 700);
+    ctx.textAlign = "center";
+    ctx.fillText("✓", GATE.x + GATE.w + 14, RAIL_Y - 14);
+    ctx.textAlign = "left";
+  }
+  // Call 2: Blocked cross
+  if (isBlocked) {
+    const pulse = 1 + 0.15 * Math.sin(t * 70);
+    ctx.save();
+    ctx.fillStyle = th.dangerBg;
+    ctx.strokeStyle = th.danger;
+    ctx.beginPath();
+    ctx.arc(GATE.x + GATE.w + 14, RAIL_Y, 10 * pulse, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = th.danger;
+    ctx.font = font(12, 700);
+    ctx.textAlign = "center";
+    ctx.fillText("✕", GATE.x + GATE.w + 14, RAIL_Y + 0.5);
+    ctx.restore();
+    ctx.textAlign = "left";
+  }
+  // Call 3: Review pause -> Approved checkmark
+  if (isUnderReview) {
+    ctx.save();
+    ctx.fillStyle = th.warnBg;
+    ctx.strokeStyle = th.warn;
+    ctx.beginPath();
+    ctx.arc(GATE.x + GATE.w + 14, RAIL_Y, 10, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = th.warn;
+    ctx.font = font(11, 700);
+    ctx.textAlign = "center";
+    ctx.fillText("⏸", GATE.x + GATE.w + 14, RAIL_Y + 0.5);
+    ctx.restore();
+    ctx.textAlign = "left";
+  }
+  if (isApproved) {
+    ctx.save();
+    ctx.fillStyle = th.accentBg;
+    ctx.strokeStyle = th.accent;
+    ctx.beginPath();
+    ctx.arc(GATE.x + GATE.w + 14, RAIL_Y, 10, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = th.accent;
+    ctx.font = font(12, 700);
+    ctx.textAlign = "center";
+    ctx.fillText("✓", GATE.x + GATE.w + 14, RAIL_Y + 0.5);
+    ctx.restore();
+    ctx.textAlign = "left";
+  }
+
+  /* Bottom status notes */
+  ctx.font = font(12.5);
+  ctx.textAlign = "left";
+  ctx.textBaseline = "middle";
+
+  const notesList = [
+    { at: CALL_1.done, text: "✓ allowed — secret read narrows session audience to [ops]", color: "accent" as const },
+    { at: CALL_2.done, text: "✕ blocked — ops data cannot leak into public sink post_status_update", color: "danger" as const },
+    {
+      at: CALL_3.back[1],
+      text: isApproved
+        ? "✓ approved & executed — operator confirmed in kagent UI; deployment restarted"
+        : "⏸ review — restart_deployment suspends until operator approval in kagent UI",
+      color: isApproved ? ("accent" as const) : ("warn" as const),
+    },
+  ];
+
+  notesList.forEach((note, i) => {
+    const lineF = seg(t, note.at, note.at + 0.03);
+    if (lineF <= 0) return;
+    ctx.save();
+    ctx.globalAlpha = ease(lineF);
+    ctx.fillStyle = th[note.color];
+    ctx.fillText(note.text, POD.x, 315 + i * 24);
+    ctx.restore();
+  });
+}
+
+export function KagentFigure() {
+  return <Figure draw={draw} designW={W} designH={H} durationMs={16000} />;
+}

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -3,283 +3,187 @@ title: kAgent
 nav_title: kAgent
 category: Integrations
 order: 6
-description: OpenAPPA on kagent — gate every declarative agent through one runtime-image setting.
+description: Gate every declarative kagent agent on Kubernetes through a single container image setting.
 ---
 
-:::proposal
-name: kAgent
-date: 2026-09-01
-:::
+[kagent](https://kagent.dev/docs/kagent/introduction/what-is-kagent/) runs AI agents natively on Kubernetes. OpenAPPA adds deterministic security to kagent. It enforces data boundaries, stops data leaks, and requires human approvals before sensitive tools run.
 
-[kagent](https://github.com/kagent-dev/kagent) runs LLM agents on Kubernetes. This proposal gates every declarative kagent agent with OpenAPPA through one install setting: the runtime image.
+You protect every [declarative agent](https://kagent.dev/docs/kagent/concepts/agents/) in your cluster with one Helm configuration value:
 
-Two stock surfaces carry the whole integration:
-
-- The kagent runtime-image settings name the image that runs every declarative agent. Point them at the OpenAPPA images: `appa-kagent-adk` for the python runtime, `appa-kagent-adk-go` for the Go runtime.
-- Both runtimes take plugins through the official Google ADK plugin API. The OpenAPPA images register one — `AppaPluginKagent` — which maps ADK callbacks to the eight `appa-runtime` hook events and enforces the answered `HookDecision`.
-
-`appa-runtime` owns the decisions: policy, the Engine, remedy plans, and trajectory state. [How it works](/how-it-works) and [Policy contracts](/contracts) define them.
-
-## Highlights
-
-### Gated agents on Kubernetes
-
-```text
-kagent controller — stock, unmodified
-  watches the operator's Agent resources
-  runtime image = helm controller.agentImage  ◀── the knob
-        │
-        │  renders per Agent:
-        │  Deployment + Service + config Secret
-        ▼
-┌─ agent pod · one per Agent ───────────────────────────┐
-│                                                       │
-│  image    controller.agentImage = appa-kagent-adk     │
-│  /config  the compiled agent, mounted as data:        │
-│           config.json + agent-card.json               │
-│                                                       │
-│  entrypoint ─▶ KAgentApp(plugins=[ ..stock..,         │
-│                AppaPluginKagent ]) ─▶ serve A2A       │
-└──────────────────────────┬────────────────────────────┘
-                           │  POST /hook · fail closed
-                           │  /mcp · execute_remedy_plan
-                           ▼
-┌─ appa-runtime ────────────────────────────────────────┐
-│  policy · Engine · consults · remedy plans ·          │
-│  trajectory state · appa.db                           │
-│  binds loopback only: a shared runtime sits behind a  │
-│  relay that rewrites Host (the demo chart)            │
-└───────────────────────────────────────────────────────┘
+```yaml
+# Helm values for the kagent controller
+controller:
+  agentImage:
+    registry: ghcr.io
+    repository: archestra-ai/appa-kagent-quickstart
+    tag: 0.7.0
 ```
 
-The agent exists in the pod only as mounted configuration. One generic image therefore serves every declarative agent, and the rollout is one install-setting change.
+This setting requires no changes to agent manifests, no fork of kagent, and no fork of the Google Agent Development Kit (ADK).
 
-### One image per runtime wraps the stock runtime
+## How it works
 
-```text
-┌─ appa-kagent-adk image ───────────────────────────────┐
-│                                                       │
-│  OpenAPPA layer — one package, appa_kagent_adk        │
-│    entrypoint.py  replays the stock entrypoint steps  │
-│                   and accepts the same args the       │
-│                   controller sends                    │
-│    plugin.py      ADK BasePlugin ─▶ POST /hook        │
-│    wire.py        the wire: events, decisions, the    │
-│                   reserved tool's name                │
-│                                                       │
-├─ base: kagent's published runtime image · unmodified ─┤
-│    kagent runtime lib   its CLI present, not PID 1    │
-│    google-adk           BasePlugin is its official    │
-│                         plugin API                    │
-└───────────────────────────────────────────────────────┘
+OpenAPPA runs inside the agent pod through the official Google ADK plugin API. Every [tool call](https://kagent.dev/docs/kagent/concepts/tools/) and [agent-to-agent delegation](https://kagent.dev/docs/kagent/examples/a2a-agents/) passes through the policy engine before execution.
 
-entrypoint flow — the stock calls, five deltas:
+:::fig-kagent:::
 
-  cfg = AgentConfig.model_validate(config.json)
-                     # refuse unknown fields         ◀ delta
-  cfg.model.reasoning_effort ??=
-      $APPA_KAGENT_OPENAI_REASONING_EFFORT       ◀ delta
-  plugins  = [ ..stock plugins.. ]
-  plugins += [ AppaPluginKagent(APPA_RUNTIME_URL) ]  ◀ delta
-  code_executor, memory persist ─▶ wrapped: each
-      crosses the tool gate as a synthetic call    ◀ delta
-  tools   += [ execute_remedy_plan over
-               $APPA_RUNTIME_URL/mcp · 300 s ]    ◀ delta
-  KAgentApp(root_agent, card, url, name,
-            plugins=plugins).build()   ─▶ serve A2A
+- **Enforcement occurs before execution**: A tool does not run if a policy requirement fails.
+- **Fail-closed default**: If the policy runtime is unreachable, calls stop.
+- **Runtime support**: Works with both Python (`appa-kagent-adk`) and Go (`appa-kagent-adk-go`) runtimes.
+
+## Policy scope
+
+The current integration enforces one cluster-wide union policy across all agents.
+
+A single `appa.toml` policy file governs all [Agent](https://kagent.dev/docs/kagent/concepts/agents/) resources in the cluster. Individual per-agent policy overrides are not supported in this version.
+
+## Quickstart
+
+Follow this guide to deploy kagent with OpenAPPA and run your first protected agent in a test cluster.
+
+### Prerequisites
+
+Make sure you have installed:
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or an existing Kubernetes cluster
+- [Helm](https://helm.sh/docs/intro/install/) (v3.8+)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- An [OpenAI API key](https://platform.openai.com/account/api-keys)
+
+### 1. Install kagent with OpenAPPA
+
+Install the kagent [CRDs and Helm chart](https://kagent.dev/docs/kagent/resources/helm/) with the OpenAPPA runtime image:
+
+```sh
+# Install kagent CRDs
+helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
+  --version 0.9.12 -n kagent --create-namespace
+
+# Install kagent controller with OpenAPPA runtime
+helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
+  --version 0.9.12 -n kagent \
+  --set controller.agentImage.registry=ghcr.io \
+  --set controller.agentImage.repository=archestra-ai/appa-kagent-quickstart \
+  --set controller.agentImage.tag=0.7.0 --wait
 ```
 
-The entrypoint replays the stock startup and appends one plugin to the list ADK already accepts. That one registration covers the root agent, every sub-agent, and every tool. The Go image does the same through the Go ADK plugin API, and its runtime main restores two python-side shapes the Go ADK lacks: it lands the lineage headers in session state, so a delegated child starts as a child, and it keeps a reviewed remedy out of the task history until the person rules, so the dashboard shows the approval card. One model field rides along: `APPA_KAGENT_OPENAI_REASONING_EFFORT` fills the OpenAI model's `reasoning_effort` when the ModelConfig leaves it unset — the v1alpha2 ModelConfig cannot say `none`, and the gpt-5.6 models the demo runs on require it for function tools on chat completions. A value the ModelConfig sets wins.
+### 2. Deploy the demo stack
 
-### Callback-to-hook mapping
+Install the demo chart to create sample agents (`cluster-ops`, `log-analyst`) and 16 demonstration scenarios:
 
-The runtime hook vocabulary is the eight `HookEvent` variants of `appa-runtime-api`. The plugin maps each gated ADK callback onto exactly one event. Callbacks with no event either pass through or hold as liveness gates.
-
-```text
-ADK plugin callback                     ─▶ feeds /hook event
-time flows top→bottom within one turn   ◀  decisions answered
-─────────────────────────────────────────────────────────────
-
-session   first invocation of a fresh ADK session,
-│         detected in on_user_message_callback
-│         (no callback exists at session creation)
-│           ─▶ [1] SessionStart   ◀ Ack
-│              root TrajectoryId = the ADK session id
-▼
-prompt    on_user_message_callback — fires BEFORE the
-│         session append, so a Block keeps the exact
-│         bytes out of stored history
-│           ═▶ [2] Prompt         ◀ Ack | Block
-│         before_run_callback · before_agent_cb (root)
-│           ─x no event: Prompt gates the same bytes
-▼
-model     before_model · after_model · on_model_error
-│           ─x no event: held as liveness gates —
-│              /hook channel down ⇒ refuse
-▼
-tool      before_tool_callback — a deny dict SKIPS
-loop      execution and becomes the function response
-│         the model reads
-│           ═▶ [3] ToolCall{spawn:false, ruling?}
-│              ◀ AllowCall | DenyCall{review} | Refuse
-│              ◀ PassControl — execute_remedy_plan only
-│              review: per offer whose plan consults a
-│              hitl authority; ruling: the person's
-│              approve | deny on the resumed reserved call
-│         after_tool_callback — a returned dict
-│         replaces what the model sees
-│           ═▶ [4] ToolResult
-│              ◀ Ack | ReplaceOutput | Block
-│         on_tool_error_callback
-│           ─▶ [4] ToolResult{Failure}
-▼
-child     before_tool_cb on the agent tool
-deleg.    │ ═▶ [3] ToolCall{spawn:true}
-│         │    ◀ AllowCall{binding}
-│         │ child scope opens, in its own pod:
-│         │   the child plugin classifies the
-│         │   delegated entry
-│         │     ─▶ [5] ChildStart        ◀ Ack
-│         │   … the child runs its own [3]/[4] loop …
-│         │   child-side after_run_callback
-│         │     ─▶ [6] TurnEnd (child)   ◀ Ack
-│         └ after_tool_cb on the agent-tool return —
-│           the ONE point where the value the parent
-│           receives can be substituted
-│             ═▶ [7] SpawnResult
-│                ◀ Ack | ChildReturn | ReplaceOutput
-│                  | Block
-▼
-emit      on_event_callback
-│           ─x no event: held as a liveness gate
-▼
-turn      after_run_callback — fires on normal
-end       completion and after a pre-run halt; the
-          pinned google-adk has no error-turn callback
-          (fail-closed rule 4)
-            ─▶ [6] TurnEnd (root)  ◀ Ack
-               closes tool dispatches the turn abandoned
-
-          [8] ChildEnd — unfed BY DESIGN: return
-              substitution is enforceable only on the
-              parent side, so returns cross at
-              [7] SpawnResult.
+```sh
+helm upgrade --install appa-kagent-demo ./integrations/kagent/demo/chart \
+  -n kagent --set openai.apiKey="$OPENAI_API_KEY" --wait
 ```
 
-The load-bearing enforcement points, proven in the pinned ADK sources:
+### 3. Open the kagent dashboard
 
-- A deny returned from the before-tool callback skips execution and becomes the function response the model reads.
-- The user-message callback fires before the session append, so a blocked prompt never lands in stored history.
-- An agent called as a tool crosses the same gate as any tool call. The parent side substitutes its return.
+Forward the [kagent dashboard](https://kagent.dev/docs/kagent/observability/launch-ui/) to your machine:
 
-### Every gated call runs under one contract
-
-The policy produces the contract for a tool call in one of two ways. It is either a static declaration or a registered annotator that answers per call. The consult happens inside the tool gate, on the runtime side, and kagent never sees it. A wildcard annotator covers the tools the policy never names. That posture fits a kagent fleet, where CRD-declared toolsets produce a long tail of tools.
-
-### Remedy plans stay executable
-
-A block is not a dead end. The blocking feedback quotes an offer id, and the agent executes the offered plan through `execute_remedy_plan` — the reserved tool `appa-runtime` itself serves. The images inject it at agent construction, beside `AppaPluginKagent`, so every declarative agent carries it with zero agent changes. Both images' MCP clients wait 300 s per call: a remedy execution holds `execute_remedy_plan` open for as long as its plan runs — a parked authority consult, a slow sanitizer — and ADK's 5 s default would fail it at the client.
-
-```text
-tool call blocked ─▶ the feedback quotes an offer id
-        │
-        ▼
-execute_remedy_plan(offer_id)
-        │   the reserved appa-runtime tool, injected
-        │   at agent construction beside the plugin
-        ▼
-ToolCall hook  ◀ PassControl — vouched, the call
-        │      passes through to appa-runtime
-        │      (a reviewed offer first asks the person:
-        │       the human-review flow below)
-        ▼
-the offered plan executes:
-   Authorize · Accept · Sanitize · Derive
-a Redispatch plan names a tool instead — the agent
-calls it itself, through the normal gate
+```sh
+kubectl port-forward -n kagent svc/kagent-ui 8901:80
 ```
 
-- Human review rides the stock kagent approval flow, for exactly the remedies whose plan names a human authority. The blocking decision carries the review the person reads, the plugin raises kagent's confirmation for that one `execute_remedy_plan` call, the run suspends, and the person's Approve or Reject returns to `appa-runtime` as the authority's ruling — never through the model; the model learns only that the reviewer has been asked. Approve authorizes that one execution; Reject is the authority's denial and retires the offer; kagent has no cancel, so an abandoned task leaves the offer standing. Over A2A the confirmation carries the full review; the kagent dashboard shows the tool call and its arguments. The Go image carries the same channel: adk-go hands its plugin the tool context, so the reviewed call raises the confirmation and the resumed call returns the ruling the same way.
-- Every other remedy — a narrowing, a sanitizer, a human-less authority, a redispatch — the agent executes itself: no confirmation gate sits on `execute_remedy_plan`, and the agent chooses among the offers under its instruction and the chat. The demo agent's instruction takes the sanitized result when one is offered, otherwise accepts the change, follows a steer from the chat, and reports the remedy it took.
-- People out of band need no kagent surface. A URL authority such as the demo's `change-board` on `rollback_deployment` parks the consult inside the `execute_remedy_plan` call until the ruling arrives on the authority's own channel or its window closes. Approve runs the rollback, Deny retires the offer, and no answer grants nothing — the offer stands.
+Open [http://localhost:8901](http://localhost:8901) in your browser.
 
-```text
-human review on kagent — the person rules before the act;
-the runtime spends the ruling inside it
+## Protect an existing cluster
 
-model ─▶ restart_deployment
-  │ ToolCall ─────────▶ appa-runtime: the plan consults
-  │ ◀ DenyCall{feedback,   oncall (hitl); text = the
-  │   review:[{offer_id,   consult artifact
-  │   text}]}
-model ─▶ execute_remedy_plan(offer_id)
-  │ plugin: a reviewed offer, no confirmation on the call
-  │   ─▶ ADK tool confirmation · hint = the review text
-  │      kagent: Approve/Reject card · A2A input-required
-  ·      the run ends · the person rules · a new run
-  │ ToolCall{ruling: approve | deny} ─▶ rides the vouch
-  │ ◀ PassControl
-  │ /mcp execute_remedy_plan ─▶ Authorize(oncall)
-  │      ruling on the vouch: spend it
-  │      none: elicitation (Claude Code)
-  │      neither: no answer, the offer stands
-  │ ◀ Authorized | Declined
-model ─▶ restart_deployment again ─▶ runs · or stays blocked
+If you already run kagent in your cluster, you do not need to recreate your agents.
+
+### 1. Update the kagent controller image
+
+Update your existing Helm release to use the OpenAPPA quickstart image:
+
+```sh
+helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
+  -n kagent --reuse-values \
+  --set controller.agentImage.registry=ghcr.io \
+  --set controller.agentImage.repository=archestra-ai/appa-kagent-quickstart \
+  --set controller.agentImage.tag=0.7.0
 ```
 
-- Every remedy call crosses the same hook gate as any tool call.
+### 2. Restart agent deployments
 
-### A delegated child starts at its parent's label
+Restart the agent deployments to load the OpenAPPA runtime container:
 
-kagent delegates by calling another Agent as a tool. On the wire that is a spawn: the runtime prepares a fork seeded with the parent's current label — trust and audience, both inherited — and the child pod opens it through kagent's lineage headers, so its calls land in the child trajectory, in the same log as its parent. Inheritance is why delegation cures nothing on its own: a child would be blocked exactly where the parent is. What the child then does narrows the child, not the parent. Only the value that comes back meets the parent's gate, carrying the child's label. A raw value that narrows nothing crosses unchanged. A raw value that would narrow the parent is withheld there with the parent's own offers: accept the narrowing and it crosses, narrowing the parent as if it had done the read itself; take a sanitizer and only the derivation crosses, leaving the parent as it was. A child that returns nothing, or a return the runtime withholds, changes nothing. That is the productive use of a child — quarantine untrusted work in a disposable trajectory and bring back only a clean derivation.
-
-```text
-delegation — a child starts at its parent's label,
-then diverges
-
-parent trajectory · cluster-ops     label: trusted · public
-  │  tool_call {spawn: true} ─▶ the runtime prepares a fork
-  ▼
-child trajectory · log-analyst      label: trusted · public
-  │  child_start opens the fork     ◀ inherited
-  │  get_pod_logs — suspicious ingress: its own gate,
-  │  its own remedy, in its own trajectory
-  ▼
-child label narrows                 label: suspicious · public
-  │  spawn_result ─▶ the value meets the PARENT's gate
-  ▼
-raw, narrows nothing ─▶ crosses · parent unchanged
-raw, would narrow    ─▶ withheld with the parent's own offers
-   accept it         ─▶ crosses · parent narrows
-   take a sanitizer  ─▶ the derivation crosses · parent as was
-   no remedy         ─▶ parent keeps its label
-no value, or withheld ─▶ parent keeps its label
+```sh
+kubectl rollout restart deployment -n kagent -l app.kubernetes.io/managed-by=kagent
 ```
 
-Four hooks carry it: the spawn on the parent's tool call, `ChildStart` when the child pod enters, `SpawnResult` when the value returns to the parent's gate, and the child's own `TurnEnd`. The demo's `log-analyst` is that child; `confined_child_return` lets the runtime withhold its return or substitute a bound return sanitizer's derivation, and the delegation case in both matrices asserts the injected instruction never reaches the operator through it.
+Your existing agents now route every tool call through OpenAPPA policy enforcement.
 
-Delegation is off by default. The wildcard entry covers every ordinary call the policy does not write, but on kagent it covers no spawn: a child trajectory is not something a per-call annotation can stand for. An agent the policy never names is denied at the spawn, with the reason as the model's feedback, and the agent never runs. The demo shows both sides: `log-analyst` is named and runs as a child; `release-manager` is listed by the same parent, named by no contract, and every delegation to it is denied.
+## 1. Try a blocked flow (Data leak prevention)
 
-### Fail-closed rules
+In the [kagent dashboard](https://kagent.dev/docs/kagent/observability/launch-ui/), inspect how OpenAPPA stops sensitive data from leaving the cluster.
 
-1. An unreachable `/hook`, or an answer outside the contract, blocks the gated action.
-2. A config field the python entrypoint does not support refuses to start. The stock parser ignores unknown fields, and that entrypoint does not.
-3. The model and emission callbacks feed no event, but they still hold when the `/hook` channel is down.
-4. When the pinned ADK has no error-turn callback, `appa-runtime` recovery closes the turn at the next admitted event.
-5. A delegation to an agent the policy does not name is denied, wildcard or not. On kagent an agent runs as a child only under a contract that names it, so delegation is off until the policy names the agent. The quickstart's packaged policy names none.
+1. The agent reads an internal Kubernetes secret:
+   ```text
+   read_secret(name: "db-credentials")
+   ```
+   OpenAPPA tags the session data with an audience restriction: `audience = ["ops"]`.
 
-### Scope
+2. The agent attempts to publish that information to a public status channel:
+   ```text
+   post_status_update(message: "Database credentials updated...")
+   ```
 
-Covered: declarative agents on both runtimes. Not covered: BYO agents and the kagent sandbox kinds.
+3. **OpenAPPA blocks the call before it runs.** The destination requires a `public` audience, but the data in context is restricted to `ops`. The tool never executes, and the model receives a clear explanation of the policy boundary.
 
-### Try it
+## 2. Try human approval (HITL workflows)
 
-The demo is a Helm chart, [integrations/kagent/demo/chart](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/kagent/demo/chart): a gated `cluster-ops` agent with a delegated `log-analyst`, the shared `appa-runtime` with its relay and mock externals in one pod, the demo tools, and every demo case pre-seeded as a real chat in the kagent dashboard — an ordinary read, the exfiltration ask that leaks nothing, the agent taking a sanitized remedy on its own, the chat steering it to accept the change or to decline, a forged offer, the on-call approval, the annotator, the release window in and out of window, the remote change board approving, denying and staying silent, delegation, a delegation the policy never names, and gated ingress. It installs into any cluster running kagent 0.9.12 with `controller.agentImage` set to `appa-kagent-quickstart`; the model key is the one input, in a value or pasted in the dashboard afterwards — the Secret is named after the ModelConfig, so the dashboard's Models → Edit flow supplies it. The default image references name this repository's release tags; the chart README shows how to build the images from source and point the image values at your own registry.
+OpenAPPA integrates with kagent's native [Human-in-the-Loop](https://kagent.dev/docs/kagent/examples/human-in-the-loop/) approval cards:
 
-The chart also runs both agents as `cluster-ops-go` and `log-analyst-go` on kagent's Go runtime, with the Go image under the name kagent derives for it. Every case runs the same on either cell.
+1. The agent proposes a destructive cluster action:
+   ```text
+   restart_deployment(name: "api-gateway")
+   ```
+   The policy requires explicit approval: `attention = ["human-approval"]`.
 
-Two matrices verify the install. [e2e/ui](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/kagent/e2e/ui) drives seventeen conversations — the sixteen seeded cases and the on-call rejection — through the kagent dashboard in headless Chromium with a real model; [e2e/a2a](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/kagent/e2e/a2a) runs the same seventeen over the A2A protocol alone, answers the human-review confirmation with the data part the dashboard sends, and plays the change-board member on the mock's side channel. Both pass 16/16 on the Helm-installed stack, on the python cell and on the Go cell. The matrix spans kagent version, runtime plugin and driver; only kagent v0.9.12 runs today.
+2. OpenAPPA intercepts the call and suspends the agent turn. An **Approve / Reject** confirmation card appears directly in the kagent dashboard.
 
-## Implementation plan
+3. **The operator decides**:
+   - **Approve**: OpenAPPA authorizes the execution, records the approval, and allows the deployment to restart.
+   - **Reject**: OpenAPPA cancels the request. The tool does not run.
 
-The [kagent implementation plan](https://github.com/archestra-ai/OpenAPPA/blob/main/integrations/kagent/IMPLEMENTATION.md) carries the rest. It covers source baselines, the target matrix, per-version mapping tables, both delivery lanes, the quickstart option, remedy-plan execution with the human-review channel, the wire obligations a driver keeps, the demo chart, and the verification matrix.
+## 3. Multi-agent delegation
+
+When agents call other agents through [A2A (Agent-to-Agent)](https://kagent.dev/docs/kagent/examples/a2a-agents/) delegation, OpenAPPA isolates their execution contexts:
+
+- **Inherited boundaries**: Child agents inherit the parent's data restrictions automatically.
+- **Quarantine**: Untrusted operations (like inspecting raw pod logs) run inside the child agent. Only validated outputs flow back to the parent.
+- **Explicit authorization**: Agents can only delegate to sub-agents explicitly listed in the policy. Unlisted agent spawns are blocked immediately.
+
+## Policy example
+
+Policies are declarative TOML files checked into version control. Here is the contract governing the demo agent:
+
+```toml
+# In-cluster secret read: restricts audience to ops
+[[policy.tool]]
+name = "read_secret"
+delta = { audience = ["ops"] }
+
+# Outward update: requires public audience
+[[policy.tool]]
+name = "post_status_update"
+[policy.tool.requires]
+audience = { contains = ["public"] }
+
+# Production change: requires human operator sign-off
+[[policy.tool]]
+name = "restart_deployment"
+[policy.tool.requires]
+attention = ["human-approval"]
+
+[[policy.authority]]
+name = "oncall"
+hint = "Ask the on-call lead through kagent approval card."
+[policy.authority.permits]
+attention = ["human-approval"]
+```
+
+## Where next
+
+- [How it works](/how-it-works) — Core concepts, labels, and algebraic flow guarantees.
+- [Policy contracts](/contracts) — Complete policy authoring and syntax guide.
+- [kagent documentation](https://kagent.dev/docs/kagent/) — Official kagent guides and references.
+- [Implementation details](https://github.com/archestra-ai/OpenAPPA/blob/main/integrations/kagent/IMPLEMENTATION.md) — ADK callback lifecycle, Go/Python runtime architecture, and wire specs.

--- a/website/lib/mcp-content.ts
+++ b/website/lib/mcp-content.ts
@@ -23,6 +23,8 @@ const DIRECTIVE_DESCRIPTIONS: Record<string, string> = {
     "[Animated figure: the same agent, on another run, pulls another client's call notes into the update — data exfiltration without any attacker.]",
   "fig-guardrail":
     "[Animated figure: the agent runs inside a policy boundary; labeled data crosses in, and outbound flows are checked against contracts before dispatch.]",
+  "fig-kagent":
+    "[Animated figure: a protected kagent agent on Kubernetes sends tool calls through the ADK plugin gate to OpenAPPA; one call is allowed, one exfiltration is blocked, and one destructive call requests operator approval.]",
   "fig-label-fold":
     "[Animated figure: labels fold as the agent reads — audience intersects, trust takes the minimum.]",
   "fig-negotiation":


### PR DESCRIPTION
Adds the complete kagent operator guide on the website, documentation for the kagent integration package, and an interactive canvas figure.

**Changes**
- `website/content/docs/kagent.md`: High-signal operator guide adhering to ASD-STE100 with quickstart demo deployment, guide for existing clusters, policy scope notice, concrete scenarios (data leak prevention, HITL approval, multi-agent delegation), and links to kagent documentation.
- `website/components/figures/KagentFigure.tsx`: Animated canvas figure illustrating kagent agent pod, Google ADK plugin gate, OpenAPPA runtime, and the full HITL approval lifecycle to completion.
- `website/components/figures/Figure.tsx`: Dynamic `devicePixelRatio` / zoom resizing fix for high-DPI viewports.
- `integrations/kagent/README.md`: Directory overview covering components, quickstart, building from source, and running test matrices.

Task: T-1175