### PR TITLE
docs(website): add agent integration guide and architecture diagram

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -894,6 +894,15 @@ samp {
   border: 1px solid var(--border-weak);
   padding: 6px 12px;
   text-align: left;
+  vertical-align: top;
+}
+
+/* Keep identifiers intact in tables. The table wrapper provides horizontal
+   scrolling when an identifier is wider than the available viewport. */
+.prose td code {
+  overflow-wrap: normal;
+  word-break: normal;
+  white-space: nowrap;
 }
 
 .prose th {
@@ -2166,6 +2175,101 @@ samp {
   display: block;
   width: 100%;
   height: auto;
+}
+
+/* Runtime overview — host, fail-closed bridge, and policy runtime. */
+.runtime-overview-figure {
+  width: 100%;
+  margin: 1.5rem 0 2rem;
+}
+
+.runtime-overview-figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  font-family: var(--font-mono);
+}
+
+.rof-panel {
+  fill: var(--bg);
+  stroke: var(--border);
+  stroke-width: 1.2;
+}
+
+.rof-panel-bridge {
+  fill: var(--bg-weak);
+  stroke: var(--accent-border);
+}
+
+.rof-title {
+  fill: var(--text-strong);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.rof-agent-title {
+  fill: var(--text-strong);
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.rof-subtitle,
+.rof-card-detail,
+.rof-rail-label {
+  fill: var(--text-weak);
+  font-size: 12px;
+}
+
+.rof-card {
+  fill: var(--bg-weak);
+  stroke: var(--border-weak);
+  stroke-width: 1;
+}
+
+.rof-panel-bridge .rof-card {
+  fill: var(--bg);
+}
+
+.rof-card-title {
+  fill: var(--text-strong);
+  font-size: 13.5px;
+  font-weight: 500;
+}
+
+.rof-fail-closed circle {
+  fill: var(--accent);
+}
+
+.rof-fail-closed text {
+  fill: var(--accent);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.rof-rail,
+.rof-remedy-rail {
+  fill: none;
+  stroke: var(--icon);
+  stroke-width: 1.25;
+}
+
+.rof-rail-accent {
+  stroke: var(--accent);
+}
+
+.rof-remedy-rail {
+  stroke: var(--border);
+}
+
+.rof-remedy-chip {
+  fill: var(--bg);
+  stroke: var(--border-weak);
+}
+
+.rof-remedy-label {
+  fill: var(--text);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .psf-mascot {

--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -23,6 +23,7 @@ import { LabelFoldFigure } from "@/components/figures/LabelFoldFigure";
 import { NegotiationFigure } from "@/components/figures/NegotiationFigure";
 import { PolicyStackFigure } from "@/components/figures/PolicyStackFigure";
 import { RemedyPlanFigure } from "@/components/figures/RemedyPlanFigure";
+import { RuntimeOverviewFigure } from "@/components/figures/RuntimeOverviewFigure";
 import { TwoEndingsFigure } from "@/components/figures/TwoEndingsFigure";
 import { MascotBoard } from "@/components/MascotBoard";
 import { ProposalBlock } from "@/components/ProposalBlock";
@@ -47,6 +48,7 @@ const DIRECTIVES: Record<string, () => ReactNode> = {
   "fig-negotiation": () => <NegotiationFigure />,
   "fig-policy-stack": () => <PolicyStackFigure />,
   "fig-remedy-plan": () => <RemedyPlanFigure />,
+  "fig-runtime-overview": () => <RuntimeOverviewFigure />,
   "fig-two-endings": () => <TwoEndingsFigure />,
   "mascot-board": () => <MascotBoard />,
   "details-7pc-leak": () => (

--- a/website/components/figures/RuntimeOverviewFigure.tsx
+++ b/website/components/figures/RuntimeOverviewFigure.tsx
@@ -19,15 +19,31 @@ function PanelTitle({ x, title, subtitle }: { x: number; title: string; subtitle
   );
 }
 
-function Card({ x, y, width, title, detail }: { x: number; y: number; width: number; title: string; detail: string }) {
+function Card({
+  x,
+  y,
+  width,
+  title,
+  detail,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  title: string;
+  detail: string[];
+}) {
   return (
     <g>
-      <rect x={x} y={y} width={width} height="58" rx="6" className="rof-card" />
+      <rect x={x} y={y} width={width} height="92" rx="6" className="rof-card" />
       <text x={x + 14} y={y + 23} className="rof-card-title">
         {title}
       </text>
-      <text x={x + 14} y={y + 42} className="rof-card-detail">
-        {detail}
+      <text x={x + 14} y={y + 47} className="rof-card-detail">
+        {detail.map((line, index) => (
+          <tspan key={line} x={x + 14} dy={index === 0 ? 0 : 18}>
+            {line}
+          </tspan>
+        ))}
       </text>
     </g>
   );
@@ -58,36 +74,36 @@ export function RuntimeOverviewFigure() {
         <rect x="30" y="42" width="390" height="292" rx="9" className="rof-panel rof-panel-bridge" />
         <rect x="480" y="42" width="390" height="292" rx="9" className="rof-panel" />
 
-        {/* Left: Agent Harness (can be in-process middleware, callbacks, or external plugin) */}
-        <PanelTitle x={54} title="Agent harness" subtitle="agent loop · in-process middleware, callbacks, or plugin" />
-        <Card x={54} y={122} width={342} title="Agent execution loop" detail="prompts model & plans proposed tool calls" />
-        <path d="M 225 180 L 225 195" className="rof-rail" markerEnd="url(#rof-arrow)" />
-        <Card x={54} y={198} width={342} title="Lifecycle hooks & enforcement" detail="intercepts calls & results · enforces allow, block, replace" />
+        {/* The hooks sit on the harness boundary: agent loop -> hooks -> Appa. */}
+        <PanelTitle x={54} title="Agent harness" subtitle="agent loop · callbacks · plugins" />
+        <Card x={54} y={132} width={153} title="Agent loop" detail={["prompts the model", "proposes calls"]} />
+        <path d="M 207 178 L 235 178" className="rof-rail" markerEnd="url(#rof-arrow)" />
+        <Card x={238} y={132} width={182} title="Agent hooks" detail={["sends hook payloads", "applies decisions"]} />
         <g className="rof-fail-closed">
           <circle cx="65" cy="286" r="4" />
           <text x="77" y="290">fail closed on any error</text>
         </g>
 
-        {/* Right: OpenAPPA Runtime */}
+        {/* The adapter sits on the Appa boundary: hooks -> adapter -> core. */}
         <g transform="translate(504 61)" aria-hidden="true">
           <PixelMark size={24} />
         </g>
         <text x="538" y="76" className="rof-title">OpenAPPA runtime</text>
-        <text x="504" y="99" className="rof-subtitle">daemon (appa-runtime) · policy engine & adapters</text>
-        <Card x={504} y={122} width={342} title="Adapter (hook receiver)" detail="receives POST /hook · decodes payload into HookEvent" />
-        <path d="M 675 180 L 675 195" className="rof-rail" markerEnd="url(#rof-arrow)" />
-        <Card x={504} y={198} width={342} title="Policy engine (APPA core)" detail="evaluates security labels, tool contracts & remedies" />
+        <text x="504" y="99" className="rof-subtitle">daemon · policy engine · adapters</text>
+        <Card x={480} y={132} width={184} title="Appa adapter" detail={["maps hook payloads", "to OpenAPPA events"]} />
+        <path d="M 664 178 L 692 178" className="rof-rail" markerEnd="url(#rof-arrow)" />
+        <Card x={695} y={132} width={151} title="Appa core" detail={["checks policy", "returns decisions"]} />
         <g className="rof-fail-closed">
           <circle cx="515" cy="286" r="4" />
           <text x="527" y="290">deterministic policy rules</text>
         </g>
 
         {/* Request and response rails between harness and runtime. */}
-        <path d="M 420 150 L 477 150" className="rof-rail rof-rail-accent" markerEnd="url(#rof-arrow-accent)" />
-        <text x="450" y="137" className="rof-rail-label" textAnchor="middle">POST /hook</text>
+        <path d="M 420 157 L 477 157" className="rof-rail rof-rail-accent" markerEnd="url(#rof-arrow-accent)" />
+        <text x="450" y="148" className="rof-rail-label" textAnchor="middle">POST /hook</text>
 
-        <path d="M 480 231 L 423 231" className="rof-rail" markerEnd="url(#rof-arrow)" />
-        <text x="450" y="219" className="rof-rail-label" textAnchor="middle">decision</text>
+        <path d="M 480 202 L 423 202" className="rof-rail" markerEnd="url(#rof-arrow)" />
+        <text x="450" y="193" className="rof-rail-label" textAnchor="middle">decision</text>
 
         {/* Remedies use the runtime's MCP surface rather than the hook codec. */}
         <path d="M 225 334 C 225 385, 675 385, 675 334" className="rof-remedy-rail" markerEnd="url(#rof-arrow)" />

--- a/website/components/figures/RuntimeOverviewFigure.tsx
+++ b/website/components/figures/RuntimeOverviewFigure.tsx
@@ -1,0 +1,99 @@
+import { PixelMark } from "@/components/Logo";
+
+/* Static architecture figure for the integration guide. It follows the
+   site's native figure language: quiet panels, mono labels, restrained
+   accent color, and explicit rails for the two enforcement directions. */
+
+function PanelTitle({ x, title, subtitle }: { x: number; title: string; subtitle?: string }) {
+  return (
+    <>
+      <text x={x} y="76" className="rof-title">
+        {title}
+      </text>
+      {subtitle && (
+        <text x={x} y="99" className="rof-subtitle">
+          {subtitle}
+        </text>
+      )}
+    </>
+  );
+}
+
+function Card({ x, y, width, title, detail }: { x: number; y: number; width: number; title: string; detail: string }) {
+  return (
+    <g>
+      <rect x={x} y={y} width={width} height="58" rx="6" className="rof-card" />
+      <text x={x + 14} y={y + 23} className="rof-card-title">
+        {title}
+      </text>
+      <text x={x + 14} y={y + 42} className="rof-card-detail">
+        {detail}
+      </text>
+    </g>
+  );
+}
+
+export function RuntimeOverviewFigure() {
+  return (
+    <div className="runtime-overview-figure">
+      <svg
+        viewBox="0 0 900 390"
+        role="img"
+        aria-labelledby="runtime-overview-title runtime-overview-description"
+      >
+        <title id="runtime-overview-title">OpenAPPA integration architecture</title>
+        <desc id="runtime-overview-description">
+          The agent harness intercepts lifecycle events via middleware, callbacks, or plugins and sends them to the OpenAPPA runtime at POST /hook. Inside the runtime, an adapter decodes the event and the policy engine evaluates security rules to return a decision. Remediation runs through the runtime MCP service.
+        </desc>
+        <defs>
+          <marker id="rof-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="var(--icon)" />
+          </marker>
+          <marker id="rof-arrow-accent" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+            <path d="M 0 0 L 8 4 L 0 8 z" fill="var(--accent)" />
+          </marker>
+        </defs>
+
+        {/* Two ownership boundaries: the agent harness and the OpenAPPA runtime. */}
+        <rect x="30" y="42" width="390" height="292" rx="9" className="rof-panel rof-panel-bridge" />
+        <rect x="480" y="42" width="390" height="292" rx="9" className="rof-panel" />
+
+        {/* Left: Agent Harness (can be in-process middleware, callbacks, or external plugin) */}
+        <PanelTitle x={54} title="Agent harness" subtitle="agent loop · in-process middleware, callbacks, or plugin" />
+        <Card x={54} y={122} width={342} title="Agent execution loop" detail="prompts model & plans proposed tool calls" />
+        <path d="M 225 180 L 225 195" className="rof-rail" markerEnd="url(#rof-arrow)" />
+        <Card x={54} y={198} width={342} title="Lifecycle hooks & enforcement" detail="intercepts calls & results · enforces allow, block, replace" />
+        <g className="rof-fail-closed">
+          <circle cx="65" cy="286" r="4" />
+          <text x="77" y="290">fail closed on any error</text>
+        </g>
+
+        {/* Right: OpenAPPA Runtime */}
+        <g transform="translate(504 61)" aria-hidden="true">
+          <PixelMark size={24} />
+        </g>
+        <text x="538" y="76" className="rof-title">OpenAPPA runtime</text>
+        <text x="504" y="99" className="rof-subtitle">daemon (appa-runtime) · policy engine & adapters</text>
+        <Card x={504} y={122} width={342} title="Adapter (hook receiver)" detail="receives POST /hook · decodes payload into HookEvent" />
+        <path d="M 675 180 L 675 195" className="rof-rail" markerEnd="url(#rof-arrow)" />
+        <Card x={504} y={198} width={342} title="Policy engine (APPA core)" detail="evaluates security labels, tool contracts & remedies" />
+        <g className="rof-fail-closed">
+          <circle cx="515" cy="286" r="4" />
+          <text x="527" y="290">deterministic policy rules</text>
+        </g>
+
+        {/* Request and response rails between harness and runtime. */}
+        <path d="M 420 150 L 477 150" className="rof-rail rof-rail-accent" markerEnd="url(#rof-arrow-accent)" />
+        <text x="450" y="137" className="rof-rail-label" textAnchor="middle">POST /hook</text>
+
+        <path d="M 480 231 L 423 231" className="rof-rail" markerEnd="url(#rof-arrow)" />
+        <text x="450" y="219" className="rof-rail-label" textAnchor="middle">decision</text>
+
+        {/* Remedies use the runtime's MCP surface rather than the hook codec. */}
+        <path d="M 225 334 C 225 385, 675 385, 675 334" className="rof-remedy-rail" markerEnd="url(#rof-arrow)" />
+        <rect x="338" y="343" width="224" height="27" rx="13.5" className="rof-remedy-chip" />
+        <text x="450" y="361" className="rof-remedy-label" textAnchor="middle">/mcp · execute_remedy_plan</text>
+      </svg>
+    </div>
+  );
+}

--- a/website/content/docs/writing-an-integration.md
+++ b/website/content/docs/writing-an-integration.md
@@ -1,0 +1,127 @@
+---
+title: Add to your agent
+category: Integrations
+order: 7
+description: Connect an agent harness to OpenAPPA, map its lifecycle to the runtime API, and add optional capabilities such as subagents.
+---
+
+**OpenAPPA is a deterministic security and policy engine for AI agents.**
+
+When an LLM agent runs, it ingests data (user prompts, files, web pages, APIs) and takes actions (executes commands, calls external services, writes to databases). OpenAPPA sits between your agent framework (the **harness**) and those tools. Before any action runs or new data enters model context, OpenAPPA evaluates one question: *Can this data, given where it originated, legally flow into this destination?*
+
+An **integration** connects an agent harness (such as Claude Code, Hermes, or a custom agent loop) to OpenAPPA. It intercepts the agent at key lifecycle points, submits proposed actions to OpenAPPA, and enforces the engine's gating decision before execution proceeds.
+
+Follow [Add an Integration](#add-an-integration) to wire your harness hooks, or see [Appa Overview](#appa-overview) for runtime architecture details.
+
+---
+
+## Add an Integration
+
+OpenAPPA's integration surface centers on the [`POST /hook`](#endpoints-openappa-exposes) endpoint. The runtime handles five core lifecycle events for single-agent workflows, plus three optional events for child agents (subagents).
+
+Connecting an agent harness requires two steps:
+1. Configure your [agent harness](#connect-the-agent-hooks) to intercept execution at these lifecycle events.
+2. Implement or select an [Appa adapter](#implement-the-appa-adapter) that converts your harness's wire payloads into OpenAPPA events.
+
+### Lifecycle Events
+
+Every integration maps harness lifecycle hooks to OpenAPPA's typed events. The agent harness does not need to send OpenAPPA's schema directly: the [Appa adapter](#implement-the-appa-adapter) accepts the harness's native payload, translates it into an OpenAPPA `HookEvent`, and renders the returned `HookDecision` into the format your harness expects.
+
+Every payload must supply a stable session identifier to represent the root trajectory. If an event originates from a child agent, it must identify the child trajectory as well.
+
+| # | OpenAPPA Event | When to Call OpenAPPA | Adapter Must Create | Agent Must Apply |
+|---|---|---|---|---|
+| 1 | **`SessionStart`** | When a root conversation or agent task initializes. | `SessionStart { root }` with a stable root trajectory ID from the harness session ID. | `Ack`: Continue session startup.<br>`Refuse`: Abort session startup and display the returned `detail` message. |
+| 2 | **`Prompt`** | When user or system input initiates an agent turn. | `Prompt { actor, text }` with the actor reference and exact input text. | `Ack`: Forward the prompt to the model.<br>`Block`: Withhold the prompt and abort the turn. |
+| 3 | **`ToolCall`** | When the model proposes a tool call, before the tool executes. | `ToolCall { actor, call, ... }` with the `Actor` and a `ProposedCall` parsed from the tool name and raw arguments. | `AllowCall`: Execute the tool call.<br>`DenyCall`: Refuse tool execution. Feed the policy `feedback` and remedy offers back to the model. |
+| 4 | **`ToolResult`** | After tool execution finishes, before output enters model context or trajectory history. | `ToolResult { actor, call, outcome }` with the matching `ProposedCall` and `ToolOutcome` (`Success`, `Failure`, or `Indeterminate`). | `Ack`: Supply output to the model.<br>`ReplaceOutput`: Supply the substituted output instead.<br>`Block`: Withhold output completely from model context and trajectory history. |
+| 5 | **`TurnEnd`** | When an agent turn completes. | `TurnEnd { actor }` for the completed turn. | `Ack`: Finalize the turn. Settles any unexecuted tool dispatches. |
+
+If the agent framework supports child agents (subagents), send these three events:
+
+| # | OpenAPPA Event | When to Call OpenAPPA | Adapter Must Create | Agent Must Apply |
+|---|---|---|---|---|
+| 6 | **`ChildStart`** | When a child agent initializes. | `ChildStart { root, child, spawn }` linking the child trajectory to the parent root. | `Ack`: Start child with inherited parent boundaries.<br>`Context`: Pass the returned contract text to the child agent.<br>`Refuse`: Abort child launch. |
+| 7 | **`ChildEnd`** | When a child agent finishes its task, before returning data to the parent. | `ChildEnd { root, child, value }` with the child's proposed return value. | `Ack`: Return original value to parent.<br>`ChildReturn`: Forward the canonical or sanitized replacement `value` to parent.<br>`Block`: Withhold child output. |
+| 8 | **`SpawnResult`** | When the parent agent receives the result from a child agent. | `SpawnResult { actor, call, outcome, child, value }` in parent trajectory context. | `Ack`: Deliver child result into parent model context.<br>`Block`: Withhold child result from parent context. |
+
+If your agent framework does not support child agents, skip these three events.
+
+### Connect the Agent Hooks
+
+Integration hooks can live directly inside your agent or run as an external extension:
+
+- **In-process inside the agent**: For custom agent loops (Python, TypeScript, Go), hook calls run directly inside the agent—as middleware, SDK wrappers, or tool dispatch callbacks around model turns and tool execution.
+- **External plugin**: For closed agent runtimes (such as Claude Code), hooks run as client-side interceptors or shell scripts configured in the harness.
+
+At each hook point, the harness must:
+
+1. **Pause** the pending action.
+2. **Send** the event payload to the OpenAPPA [`POST /hook`](#endpoints-openappa-exposes) endpoint.
+3. **Enforce** the returned `HookDecision` before resuming the agent.
+
+**Fail closed on errors:** If `appa-runtime` is unreachable, times out, or returns an HTTP error, the harness must treat the response as `Block` and refuse the action. Never fail open.
+
+### Implement the Appa Adapter
+
+The adapter is the component inside `appa-runtime` that receives incoming requests at [`POST /hook`](#endpoints-openappa-exposes), translates the payload into an OpenAPPA `HookEvent`, and hands it to the core policy engine.
+
+An adapter implements a two-function codec:
+
+- **`parse(bytes)`**: Extracts session and call context from the incoming JSON payload and maps it to a typed `HookEvent` (or returns a `ParseRefusal` on unreadable or malformed input).
+- **`render(decision)`**: Serializes the engine's `HookDecision` into the response format expected by the harness (such as process exit codes, JSON hook outputs, or substituted tool arguments).
+
+If your agent harness sends OpenAPPA's typed `HookEvent` JSON natively, no custom translation is needed. When integrating an agent with its own wire schema, compile or register an adapter codec with `appa-runtime` (like the shipped Claude Code and kAgent adapters). For a complete reference, see [`appa-adapter-claude-code`](https://github.com/archestra-ai/OpenAPPA/tree/main/appa-adapter-claude-code).
+
+### Reference Implementation
+
+Inspect the Claude Code integration on GitHub for a complete reference:
+
+- **Appa Adapter**: [`appa-adapter-claude-code`](https://github.com/archestra-ai/OpenAPPA/tree/main/appa-adapter-claude-code) — maps Claude Code's native JSON hooks (`PreToolUse`, `PostToolUse`, `SubagentStart`, `SubagentStop`) to typed `HookEvent` variants, and renders `HookDecision` values into Claude Code responses.
+- **Claude Code Hooks Plugin**: [`integrations/claude-code`](https://github.com/archestra-ai/OpenAPPA/tree/main/integrations/claude-code) — client-side harness configuration (`hooks.json`, shell interceptors, and MCP registration).
+
+### Smoke-Test Checklist
+
+Verify your integration against these core behaviors:
+
+- [ ] **Allowed tool calls execute**: When OpenAPPA returns `AllowCall`, the tool runs once with unmodified arguments.
+- [ ] **Denied tool calls never execute**: When OpenAPPA returns `DenyCall`, the harness prevents execution and feeds policy `feedback` and remedy offers back to the model.
+- [ ] **Replaced outputs take effect**: When OpenAPPA returns `ReplaceOutput`, model context and trajectory history receive substituted content, never the raw tool output.
+- [ ] **Blocked outputs are withheld**: A blocked result is completely dropped from model attention and trajectory history.
+- [ ] **Fails closed on connection failure**: Stopping [`appa-runtime`](#appa-overview) causes subsequent prompts and tool calls to fail safely instead of running unprotected.
+- [ ] **Subagents are bounded (if supported)**: Child trajectories inherit parent security labels, and unverified child returns are blocked at `ChildEnd`.
+
+---
+
+## Appa Overview
+
+OpenAPPA runs as a standalone daemon written in Rust (`appa-runtime`). In production or local development, it runs alongside your agent as a local background process or sidecar container.
+
+:::fig-runtime-overview:::
+
+### Endpoints OpenAPPA Exposes
+
+By default, `appa-runtime` listens on `http://127.0.0.1:8787` (`--listen`) and exposes HTTP and MCP endpoints:
+
+- **`POST /hook`**: Primary lifecycle interception endpoint. Receives serialized harness events (e.g., `ToolCall`, `ToolResult`) and returns synchronous gating decisions (`HookDecision`).
+- **`/mcp`**: Built-in Model Context Protocol endpoint. Exposes runtime tools like `execute_remedy_plan` and handles human-in-the-loop (HITL) review elicitation when a blocked action requires approval or sanitization.
+- **`GET /health` & `GET /status`**: Liveness probes and operational status for active trajectories.
+- **`POST /reload`**: Hot-reloads policy configurations from disk without restarting the runtime process.
+- **`GET /binary-fingerprint`**: Deployment check. Returns the process ID, binary build digest, and config file path so CLI tools (such as `appa init`) can verify process ownership.
+- **`GET /policy-key`**: Policy synchronization check. Returns the hash of the active in-memory policy to detect disk-policy changes.
+
+### Persistence: SQLite by Default, Pluggable for Any Storage
+
+OpenAPPA records an append-only log of every trajectory, tool dispatch, authority approval, and policy decision.
+
+- **SQLite by default**: Out of the box, `appa-runtime` persists state to a local SQLite database (`--db ./appa.db`).
+- **Pluggable storage mechanism**: The storage layer (`appa-eventlog`) abstracts durability behind an append-only event log interface. SQLite is the only shipped backend today, but the storage architecture is pluggable so alternative backends can be implemented as needed.
+
+---
+
+## Existing Integrations
+
+Explore working integrations in this repository:
+
+- **[Claude Code](/claude-code)**: Anthropic's terminal agent gated via client-side shell hooks and an Appa adapter.
+- **[kAgent](/kagent)**: Kubernetes agents gated using the Kubernetes Agent Development Kit (ADK) in Go and Python.


### PR DESCRIPTION
## Summary
Adds the new 'Add to your agent' integration documentation guide (`writing-an-integration.md`) along with its architecture diagram (`RuntimeOverviewFigure.tsx`).

### Changes
- **Integration Guide (`website/content/docs/writing-an-integration.md`)**:
  - Explains how to integrate an agent harness with OpenAPPA via the `POST /hook` endpoint.
  - Details the 5 core lifecycle events and 3 child agent events with 5-column mapping tables (`OpenAPPA Event`, `When to Call OpenAPPA`, `Adapter Must Create`, `Agent Must Apply`).
  - Covers both integration placement models: in-process (middleware, callbacks) and external plugins.
  - Explains the two-function adapter codec (`parse` and `render`) bridging native wire JSON and OpenAPPA's typed API.
  - Details fail-closed requirements, smoke-test verification checklist, runtime endpoints, and pluggable persistence (SQLite by default).
- **Architecture Figure (`website/components/figures/RuntimeOverviewFigure.tsx`)**:
  - Two-panel layout showing the Agent Harness boundary (execution loop + hooks/enforcement) and OpenAPPA Runtime boundary (adapter codec + policy engine).
  - Explicit rails for `POST /hook` events, decisions, and `/mcp` remedy calls.
- **Styles & Component Wiring (`website/app/globals.css`, `website/components/DocContent.tsx`)**:
  - Registers `:::fig-runtime-overview:::` directive and adds SVG styling.