### PR TITLE
fix(ci): stabilize release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,7 +572,6 @@ jobs:
       needs.changes.outputs.e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    continue-on-error: true
     env:
       KIND_CLUSTER: appa-e2e
       KAGENT_VERSION: "0.9.12"
@@ -658,12 +657,14 @@ jobs:
           enable-cache: true
 
       - name: Run the five A2A cases
+        id: live-e2e
+        continue-on-error: true
         run: bash integrations/kagent/e2e/ci/run-subset.sh
 
-      # The job already failed here, so a failing diagnostic command must not
-      # replace the real failure.
+      # The informational live step may fail, so a diagnostic command must not
+      # replace its outcome.
       - name: Collect cluster diagnostics
-        if: failure()
+        if: steps.live-e2e.outcome == 'failure'
         env:
           DIAGNOSTICS_DIR: ${{ runner.temp }}/kagent-e2e-diagnostics
         run: |
@@ -677,7 +678,7 @@ jobs:
           df -h /
 
       - name: Upload the cluster diagnostics
-        if: failure()
+        if: steps.live-e2e.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kagent-e2e-subset-diagnostics

--- a/appa-runtime/src/init/endpoint.rs
+++ b/appa-runtime/src/init/endpoint.rs
@@ -611,12 +611,23 @@ mod tests {
         // never ran.
         let ready = at.with_extension("ready");
         let script = "open(my $f, '>', $ARGV[0]) or die; close $f; sleep 30";
-        let mut child = Command::new(at)
-            .args(["-e", script])
-            .arg(&ready)
-            .args(arguments)
-            .spawn()
-            .expect("the stand-in process starts");
+        let spawn_deadline = std::time::Instant::now() + STOP_DEADLINE;
+        let mut child = loop {
+            match Command::new(at)
+                .args(["-e", script])
+                .arg(&ready)
+                .args(arguments)
+                .spawn()
+            {
+                Ok(child) => break child,
+                Err(source)
+                    if source.raw_os_error() == Some(libc::ETXTBSY) && std::time::Instant::now() < spawn_deadline =>
+                {
+                    std::thread::sleep(STOP_POLL);
+                }
+                Err(source) => panic!("the stand-in process starts: {source}"),
+            }
+        };
         let pid = child.id() as i32;
         std::thread::spawn(move || child.wait());
 

--- a/integrations/kagent/tests/test_remedies.py
+++ b/integrations/kagent/tests/test_remedies.py
@@ -34,7 +34,7 @@ ROLLBACK_SILENT = "roll back the checkout-api deployment for a silent board"
 # The offer actions the runtime renders (`appa-runtime/src/engine.rs`,
 # `remedy_instruction`). A `{"remedy": ...}` turn names one of them.
 ACCEPT = "Accept this change"
-APPROVAL = "Request approval"
+APPROVAL = "Submit for approval"
 
 # The reserved call's answer when a plan releases the call
 # (`appa-runtime/src/mcp.rs`, `render`).


### PR DESCRIPTION
Fixes the current CI failures exposed by release PR #158 without modifying its release-please branch.\n\n- align the kagent remedy fixture with the current runtime wording\n- keep live model E2E informational while preserving failure diagnostics\n- retry the Linux ETXTBSY race in the copied-executable test fixture\n\nValidated with actionlint, Ruff, the locked Rust check/clippy suite, the targeted Rust regression, and all 22 deterministic kagent integration cases.