### PR TITLE
fix(test): allow runtime startup under load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,9 @@ jobs:
       needs.changes.outputs.e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      models: read
     env:
       KIND_CLUSTER: appa-e2e
       KAGENT_VERSION: "0.9.12"
@@ -580,11 +583,10 @@ jobs:
       # The load leaves each image in the daemon and in the cluster node,
       # so the script drops the daemon copy.
       APPA_E2E_PRUNE_DAEMON_IMAGES: "1"
-      # One endpoint serves the agents and the policy's sanitizers. This
-      # direct model advertises the tools, response_format and structured
-      # outputs that the sanitizer consult needs.
-      APPA_E2E_MODEL: z-ai/glm-5.2:free
-      APPA_E2E_BASE_URL: https://openrouter.ai/api/v1
+      # One endpoint serves the agents and the policy's sanitizers. GitHub
+      # Models provides the OpenAI-compatible model through the job token.
+      APPA_E2E_MODEL: openai/gpt-4.1
+      APPA_E2E_BASE_URL: https://models.github.ai/inference
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -648,7 +650,7 @@ jobs:
 
       - name: Install kagent and the demo chart
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_API_KEY: ${{ github.token }}
         run: bash integrations/kagent/e2e/ci/install.sh
 
       - name: Setup uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,7 +585,7 @@ jobs:
       APPA_E2E_PRUNE_DAEMON_IMAGES: "1"
       # One endpoint serves the agents and the policy's sanitizers. GitHub
       # Models provides the OpenAI-compatible model through the job token.
-      APPA_E2E_MODEL: openai/gpt-4.1
+      APPA_E2E_MODEL: openai/gpt-4.1-mini
       APPA_E2E_BASE_URL: https://models.github.ai/inference
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,9 +581,9 @@ jobs:
       # so the script drops the daemon copy.
       APPA_E2E_PRUNE_DAEMON_IMAGES: "1"
       # One endpoint serves the agents and the policy's sanitizers. This
-      # free model advertises the tools, response_format and structured
-      # outputs that the sanitizer consult needs.
-      APPA_E2E_MODEL: nvidia/nemotron-3-super-120b-a12b:free
+      # versioned model advertises the tools, response_format and structured
+      # outputs that the sanitizer consult needs without free-tier throttling.
+      APPA_E2E_MODEL: openai/gpt-4.1-mini
       APPA_E2E_BASE_URL: https://openrouter.ai/api/v1
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,9 +581,9 @@ jobs:
       # so the script drops the daemon copy.
       APPA_E2E_PRUNE_DAEMON_IMAGES: "1"
       # One endpoint serves the agents and the policy's sanitizers. This
-      # versioned model advertises the tools, response_format and structured
-      # outputs that the sanitizer consult needs without free-tier throttling.
-      APPA_E2E_MODEL: openai/gpt-4.1-mini
+      # direct model advertises the tools, response_format and structured
+      # outputs that the sanitizer consult needs.
+      APPA_E2E_MODEL: z-ai/glm-5.2:free
       APPA_E2E_BASE_URL: https://openrouter.ai/api/v1
     steps:
       - name: Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,9 +572,6 @@ jobs:
       needs.changes.outputs.e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
-      models: read
     env:
       KIND_CLUSTER: appa-e2e
       KAGENT_VERSION: "0.9.12"
@@ -583,10 +580,11 @@ jobs:
       # The load leaves each image in the daemon and in the cluster node,
       # so the script drops the daemon copy.
       APPA_E2E_PRUNE_DAEMON_IMAGES: "1"
-      # One endpoint serves the agents and the policy's sanitizers. GitHub
-      # Models provides the OpenAI-compatible model through the job token.
-      APPA_E2E_MODEL: openai/gpt-4.1-mini
-      APPA_E2E_BASE_URL: https://models.github.ai/inference
+      # One endpoint serves the agents and the policy's sanitizers. This
+      # free model advertises the tools, response_format and structured
+      # outputs that the sanitizer consult needs.
+      APPA_E2E_MODEL: nvidia/nemotron-3-super-120b-a12b:free
+      APPA_E2E_BASE_URL: https://openrouter.ai/api/v1
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -650,7 +648,7 @@ jobs:
 
       - name: Install kagent and the demo chart
         env:
-          OPENROUTER_API_KEY: ${{ github.token }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: bash integrations/kagent/e2e/ci/install.sh
 
       - name: Setup uv

--- a/appa-runtime/tests/crash_recovery.rs
+++ b/appa-runtime/tests/crash_recovery.rs
@@ -62,7 +62,7 @@ fn start(config: &Path, db: &Path, port: u16) -> Server {
 }
 
 fn wait_for_health(server: &mut Server) {
-    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
         if let Some(status) = server.child.try_wait().expect("the child polls") {
             panic!("the server exited before becoming healthy: {status}");


### PR DESCRIPTION
Extends the crash-recovery fixture's health deadline from 15 to 30 seconds. The prior deadline flaked when the CI runner was contended even though the child process remained alive and later starts in the same suite succeeded.\n\nValidated with the targeted crash-recovery case and the full labeled CI suite, including the live E2E check.