### PR TITLE
fix(engine): encode policy digests explicitly

### DIFF
--- a/appa-engine/src/profile.rs
+++ b/appa-engine/src/profile.rs
@@ -254,7 +254,8 @@ pub struct PolicyFileKey(String);
 impl PolicyFileKey {
     pub fn of(bytes: &[u8]) -> PolicyFileKey {
         use sha2::Digest as _;
-        PolicyFileKey(format!("{:x}", sha2::Sha256::digest(bytes)))
+        let digest = sha2::Sha256::digest(bytes).into();
+        PolicyFileKey(crate::hex32::encode(&digest))
     }
 
     pub fn as_str(&self) -> &str {


### PR DESCRIPTION
Replace digest LowerHex formatting with the engine's fixed-width lowercase hex encoder. sha2 0.11 removed LowerHex from its digest array, which currently breaks dependency PR #75.\n\nValidated with all 424 appa-engine tests on main's sha2 0.10 and all 437 appa-engine tests in a temporary checkout of PR #75 using sha2 0.11.