### PR TITLE
docs: streamline battery composition guide

### DIFF
--- a/website/components/BatteryCatalog.tsx
+++ b/website/components/BatteryCatalog.tsx
@@ -9,7 +9,7 @@ const BATTERIES = [
   },
   {
     name: "Claude Code tools",
-    description: "Rules for Claude Code's Bash and Read tools.",
+    description: "Rules for Bash and Read, with a built-in Bash annotator.",
     href: "/battery-claude-code",
     logo: "/images/batteries/claude.svg",
   },

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -45,15 +45,13 @@ OpenAPPA combines these files into one config.
 
 OpenAPPA checks the combined config before using it. If a reload fails, the current config keeps running.
 
-## Rule order
+## Policy order when batteries are used
 
-OpenAPPA checks root rules from top to bottom. It then checks each battery in `include` order, also from top to bottom.
+OpenAPPA checks root rules from top to bottom. It then checks each battery in `include` order, also from top to bottom. The first match wins.
 
 :::battery-rule-order:::
 
-The first match wins. The position of `include` in the root file does not change this order.
-
-The Slack battery asks a person before any message is sent. A root rule placed above it lets one channel through:
+In this example, the Slack battery requires human approval for every message. The root config overrides this rule for one channel, so messages to that channel do not need approval:
 
 ```toml
 # root config: trusted messages go to the engineering channel without a question
@@ -69,11 +67,7 @@ requires = { trust = "trusted", attention = ["hitl"] }
 delta = {}
 ```
 
-Text inside parentheses matches arguments. Write one or more `argument:pattern` clauses and separate them with commas; every clause must match. `*` matches any text.
-
-A bare tool name is the default. It matches when no earlier rule did.
-
-Slack history uses the same first-match rule. The battery labels all history `internal`, the built-in audience of the organization's members. A root rule can mark one channel as untrusted, for example a channel shared with people outside your company:
+In another example, the battery labels all Slack history `internal`. A root rule can mark one channel as untrusted, such as a channel shared with people outside your company:
 
 ```toml
 # root config: a shared channel may contain outsiders' words
@@ -89,114 +83,70 @@ delta = { audience = ["internal"] }
 
 ## Use annotators in batteries
 
-A battery can ship an annotator script beside its config. See [Annotators](/contracts#annotators) for what annotators receive and return.
+A battery can ship an annotator script beside its config. An annotator sets a tool's contract for each call. A root config can use an annotator supplied by an included battery. See [Annotators](/contracts#annotators) for what annotators receive and return.
 
-A tool rule that names an annotator carries no static `delta`, `requires`, or `effects`: the annotator produces the call's complete contract. The battery binds the annotator name to its script. An annotation names literal readers only, never `self` or `internal`, so a battery that labels organization or requester data writes static rules for it; an annotator decides trust and attention. This one asks a person before a hidden file is read:
+This example uses `approve-hidden-file-read`. It calls a local Python script that checks whether the file name starts with a dot. If it does, the script returns an attention requirement before the file is read:
 
 ```toml
 [[policy.annotator]]
-name = "local.read-attention"
+name = "approve-hidden-file-read"
 audiences = []
 marks = ["hitl"]
 
 [[policy.tool]]
 name = "Read"
-annotator = "local.read-attention"
+annotator = "approve-hidden-file-read"
 
-[externals.annotators."local.read-attention"]
-command = ["python3", "./read-attention.py"]
+[externals.annotators.approve-hidden-file-read]
+command = ["python3", "./approve-hidden-file-read.py"]
 ```
 
-### Run a local annotator
+## Use sanitizers in batteries
 
-On Unix systems, OpenAPPA starts the script when a tool call matches its rule. It sends one JSON consult, reads one JSON answer, and waits for the script to exit.
+A battery can ship a sanitizer script beside its config. A sanitizer rewrites data before a tool receives it or before a result returns to the agent. A root config can use a sanitizer supplied by an included battery. See [Sanitizers](/contracts#sanitizers) for what sanitizers receive and return.
 
-Other platforms reject script commands when the config loads.
-
-Consult:
-
-```json
-{"version":1,"kind":"annotation","name":"local.read-attention","declaration":{"inputs":[],"trust_ranks":["suspicious","trusted"],"audiences":[],"attention_marks":["hitl"],"effects":[]},"artifact":{"args":{"name":"Read","arguments":{"file_path":".env"}}}}
-```
-
-Answer:
-
-```json
-{"version":1,"answer":{"delta":{},"requires":{"history":[],"attention":["hitl"]},"emits":[]}}
-```
-
-The annotator can be any program. Here is a Python example:
-
-```python
-import json
-import sys
-from pathlib import PurePath
-
-request = json.load(sys.stdin)
-file_path = request["artifact"]["args"]["arguments"]["file_path"]
-attention = ["hitl"] if PurePath(file_path).name.startswith(".") else []
-
-json.dump(
-    {
-        "version": 1,
-        "answer": {
-            "delta": {},
-            "requires": {"history": [], "attention": attention},
-            "emits": [],
-        },
-    },
-    sys.stdout,
-)
-```
-
-`artifact.args` contains the tool's `name`, `arguments`, and declared `description`. The `Read` rule above has no description, so the consult omits it.
-
-When an annotator maps `inputs`, the consult includes one Value for each input. `declaration` carries the optional `hint`, input names, and mandate vocabulary.
-
-A battery annotator must check the version, `kind`, `name`, tool name, and argument types. It must exit with an error when the input is invalid.
-
-OpenAPPA runs the command without a shell. The script path is relative to the battery config. The battery folder is its working directory.
-
-Script changes apply on the next call. No restart is needed.
-
-## Annotator precedence
-
-Annotators do not have their own order. The first matching tool rule decides which annotator, if any, runs.
-
-A rule written above the rule that names an annotator wins without running it. Here `README.md` is read without a question; every other path asks the annotator:
+This example uses `remove-email-addresses`. It calls a local Python script that removes email addresses before a message is sent:
 
 ```toml
 [[policy.tool]]
-name = "Read(file_path:README.md)"
+name = "SendMessage"
+tags = ["messages"]
+requires = { audience = { contains = ["public"] } }
 delta = {}
 
-[[policy.annotator]]
-name = "local.read-attention"
-audiences = []
-marks = ["hitl"]
+[[policy.sanitizer]]
+name = "remove-email-addresses"
+on = ["tool_input"]
+tags = ["messages"]
 
-[[policy.tool]]
-name = "Read"
-annotator = "local.read-attention"
+[policy.sanitizer.permits]
+audience = { from = ["private"], to = ["public"] }
 
-[externals.annotators."local.read-attention"]
-command = ["python3", "./read-attention.py"]
+[externals.sanitizers.remove-email-addresses]
+command = ["python3", "./remove-email-addresses.py"]
 ```
 
-`README.md` matches the first rule, so `read-attention.py` does not run.
+## Use authorities in batteries
 
-The Claude Code battery labels `Read` with static rules of the same shape:
-hidden paths, credential and private-key names, and system secret locations
-narrow the session to `self`, the requester; other paths keep its label.
+A battery can ship an authority script beside its config. An authority approves or denies one blocked tool call within declared limits. A root config can use an authority supplied by an included battery. See [Authorities](/contracts#authorities) for what authorities receive and return.
 
-The Claude Code battery also sends each Bash call to its built-in model
-annotator. The annotator produces the command's complete contract: the
-output's trust and the call's trust and attention requirements. Its mandate
-names no reader, so the audience of a command's output is the session's.
+This example uses `approve-small-payment`. It calls a local Python script that approves payments of USD 100 or less. Larger payments remain blocked:
 
-This check is not an operating-system sandbox. Bash can read files
-and open network connections. Use a sandbox to protect credentials and network
-access.
+```toml
+[[policy.authority]]
+name = "approve-small-payment"
+
+[policy.authority.permits]
+attention = ["payment-approval"]
+
+[[policy.tool]]
+name = "SendPayment"
+requires = { attention = ["payment-approval"] }
+delta = {}
+
+[externals.authorities.approve-small-payment]
+command = ["python3", "./approve-small-payment.py"]
+```
 
 ## Customise a battery
 
@@ -221,6 +171,7 @@ name = "Bash(command:kubectl *)"
 requires = { attention = ["blocked"] }
 delta = { trust = "suspicious", audience = ["internal"] }
 
+# This declaration replaces the annotator with the same name in the battery.
 [[policy.annotator]]
 name = "local.read-sensitivity"
 audiences = []
@@ -239,21 +190,3 @@ Every other Bash call reaches the battery's model annotator. The root also
 replaces the battery's `Read` rules with a local script.
 
 The battery files stay unchanged.
-
-## Audience sources
-
-OpenAPPA includes audience sources for Google Workspace, Slack, and GitHub. You can use them without including a battery config.
-
-A policy uses these sources to build `self`, `internal`, and named group audiences. OpenAPPA contacts only the sources that the policy uses.
-
-See [Audiences](/contracts#audiences) for the available selectors and the JSON that each source receives.
-
-## Refuse when a script fails
-
-OpenAPPA refuses the tool call when an annotator script is missing, crashes, times out, or returns bad data. This is an execution error, not a policy decision.
-
-The error names the annotator and the problem. It does not show the data the annotator was checking.
-
-Annotator scripts run as trusted local code. Review what they can read, run, and send.
-
-A production file annotator must check full paths, hidden folders, symbolic links, files ignored by Git, and files outside the project.

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -60,7 +60,7 @@ name = "mcp__claude_ai_Slack__slack_send_message(channel_id:C0ABC*)"
 requires = { trust = "trusted" }
 delta = {}
 
-# shipped battery: everything else needs fresh human approval
+# included battery: everything else needs fresh human approval
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_send_message"
 requires = { trust = "trusted", attention = ["hitl"] }
@@ -75,7 +75,7 @@ In another example, the battery labels all Slack history `internal`. A root rule
 name = "mcp__claude_ai_Slack__slack_read_channel(channel_id:C0SHARED*)"
 delta = { trust = "suspicious", audience = ["internal"] }
 
-# shipped battery: every other channel is internal and keeps its trust
+# included battery: every other channel is internal and keeps its trust
 [[policy.tool]]
 name = "mcp__claude_ai_Slack__slack_read_channel"
 delta = { audience = ["internal"] }


### PR DESCRIPTION
## Summary

- clarify policy order when batteries are included
- simplify the annotator example
- add matching sanitizer and authority examples
- remove runtime details that belong in the contracts guide

## Validation

- pnpm typecheck in website
- git diff --check