### PR TITLE
fix(website): retain common language grammars in markdown highlighter

### DIFF
--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -6,6 +6,7 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import type { LanguageFn } from "highlight.js";
+import { common } from "lowlight";
 
 import { AdvisorySignup } from "@/components/AdvisorySignup";
 import { BatteryCatalog } from "@/components/BatteryCatalog";
@@ -191,7 +192,7 @@ function Markdown({ content, terms = true }: { content: string; terms?: boolean 
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[
         rehypeSlug,
-        [rehypeHighlight, { languages: { appa: appaTraceLanguage } }],
+        [rehypeHighlight, { languages: { ...common, appa: appaTraceLanguage } }],
       ]}
       components={{
         pre: (props) => <CodeBlock {...props} />,

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.11.1",
+    "lowlight": "^3.3.0",
     "lucide-react": "^1.28.0",
     "mcp-handler": "^2.1.0",
     "nanoid": "^6.0.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      lowlight:
+        specifier: ^3.3.0
+        version: 3.3.0
       lucide-react:
         specifier: ^1.28.0
         version: 1.28.0(react@19.2.7)


### PR DESCRIPTION
## What & why

Registering the custom `appa` language in `rehypeHighlight` without spreading `common` grammars from `lowlight` overrode the default language set, breaking syntax highlighting for standard code blocks (`yaml`, `toml`, `sh`, `json`, `ts`) across docs pages including `/kagent`.

Adds `lowlight` to website dependencies and registers `{ ...common, appa: appaTraceLanguage }`.