### PR TITLE
feat(kagent): manage OpenAPPA through appa-guide

### DIFF
--- a/appa-runtime/tests/guide_skill.rs
+++ b/appa-runtime/tests/guide_skill.rs
@@ -88,6 +88,9 @@ fn the_kagent_reference_carries_the_full_flow() {
         "Approve, or tell me what to change.",
         "## Quickstart",
         "one concrete next action",
+        "## Cluster operations",
+        "helm_upgrade",
+        "Protect all Agents",
     ] {
         assert!(reference.contains(marker), "the kagent flow names {marker:?}");
     }
@@ -107,7 +110,13 @@ fn the_kagent_chart_consumes_this_skill_package() {
         guide.contains("gitRefs"),
         "the agent attaches the skill through git refs"
     );
-    for tool in ["k8s_get_resources", "k8s_apply_manifest", "k8s_execute_command"] {
+    for tool in [
+        "k8s_get_resources",
+        "k8s_apply_manifest",
+        "k8s_patch_resource",
+        "k8s_execute_command",
+        "helm_upgrade",
+    ] {
         assert!(guide.contains(tool), "the guide agent carries {tool}");
     }
     assert!(guide.contains("APPA_RUNTIME_URL"));

--- a/charts/appa-runtime/files/appa.toml
+++ b/charts/appa-runtime/files/appa.toml
@@ -14,7 +14,31 @@ name = "k8s_get_resource_yaml"
 delta = {}
 
 [[policy.tool]]
+name = "k8s_get_events"
+delta = {}
+
+[[policy.tool]]
+name = "k8s_get_pod_logs"
+delta = {}
+
+[[policy.tool]]
 name = "k8s_apply_manifest"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
+
+[[policy.tool]]
+name = "k8s_patch_resource"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
+
+[[policy.tool]]
+name = "k8s_delete_resource"
 delta = {}
 
 [policy.tool.requires]
@@ -27,6 +51,30 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
+
+[[policy.tool]]
+name = "helm_list_releases"
+delta = {}
+
+[[policy.tool]]
+name = "helm_get_release"
+delta = {}
+
+[[policy.tool]]
+name = "helm_upgrade"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
+
+[[policy.tool]]
+name = "helm_uninstall"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
 
 [[policy.tool]]
 name = "appa-guide"

--- a/integrations/appa-guide/README.md
+++ b/integrations/appa-guide/README.md
@@ -15,7 +15,7 @@ to the staged `SKILL.md`. Claude therefore needs no gated `Read` call to
 bootstrap the guide. There is no second source copy.
 
 The demo chart installs a pre-configured kagent Agent around the skill.
-The Agent supplies the kagent tool server's `k8s_*` tools and sets
+The Agent supplies the kagent tool server's Kubernetes and Helm tools and sets
 `APPA_ENABLED=true` beside `APPA_RUNTIME_URL`. That pair puts it behind
 the shared runtime. The skill itself remains usable from any kagent
 Agent that has those tools and permissions and sets the same pair. An

--- a/integrations/appa-guide/references/kagent.md
+++ b/integrations/appa-guide/references/kagent.md
@@ -9,7 +9,11 @@ error. Do not retry the call or route around it.
 ## Tools
 
 - Read: `k8s_get_resources`, `k8s_get_resource_yaml`.
-- Write and exec: `k8s_apply_manifest`, `k8s_execute_command`.
+- Diagnose: `k8s_get_events`, `k8s_get_pod_logs`.
+- Write and exec: `k8s_apply_manifest`, `k8s_patch_resource`,
+  `k8s_delete_resource`, `k8s_execute_command`.
+- Helm: `helm_list_releases`, `helm_get_release`, `helm_upgrade`,
+  `helm_uninstall`.
 - Files: the skill tool `appa-guide` and `read_file`.
 
 Use only these. Never kubectl, never bash, never a file write to change
@@ -226,10 +230,10 @@ Show:
 - one short **OpenAPPA pieces** line;
 - **Needed for this to work** at the end, when support is missing —
   group every missing requirement there with the concrete fix. An
-  ungated agent belongs there: the fix adds `APPA_ENABLED=true` in that
-  agent's `spec.declarative.deployment.env`. Shared mode also needs the
-  correct `APPA_RUNTIME_URL`. Bundled mode leaves that URL unset. Give
-  the operator that change. Do not apply it yourself.
+   ungated agent belongs there: the fix adds `APPA_ENABLED=true` in that
+   agent's `spec.declarative.deployment.env`. Shared mode also needs the
+   correct `APPA_RUNTIME_URL`. Bundled mode leaves that URL unset. Propose
+   the change and apply it only after approval.
 
 In read-only fallback, put the complete TOML in chat instead. Otherwise
 end with: **Approve, or tell me what to change.** Wait for the reply.
@@ -285,6 +289,35 @@ must invoke separately.
    its installed tools whose behavior the active policy demonstrates.
    Tell the operator where to observe the result in the agent chat and
    runtime log.
+
+## Cluster operations
+
+Handle OpenAPPA lifecycle requests through the declared Kubernetes and
+Helm tools. Always inspect current state, present the exact intended
+change and its affected Agents, and wait for approval before invoking a
+state-changing tool. The runtime policy independently enforces the same
+approval on apply, patch, delete, Helm upgrade, and Helm uninstall.
+
+- **Protect one Agent**: read its complete environment list. Preserve every
+  existing entry. Add or replace `APPA_ENABLED=true` and, for shared mode,
+  the selected `APPA_RUNTIME_URL`. Apply with `k8s_patch_resource`. Wait for
+  the new pod and verify its startup log and Agent conditions.
+- **Protect all Agents**: inventory every declarative Agent first. Skip
+  `appa-guide`. Group Agents by intended runtime and list them in the
+  proposal. Preserve every Agent's complete environment list. Patch one at
+  a time after approval, then verify every rollout. Stop on the first
+  failure; do not leave the remaining result unreported.
+- **Install the demo fleet**: discover the active OpenAPPA release version
+  with `helm_get_release`. Install the matching public
+  `appa-kagent-demo-<version>.tgz` release asset with `helm_upgrade`. Reuse
+  the existing kagent provider Secret, enable runtime persistence, and set
+  `guide.enabled=false` when `appa-guide` already exists. Wait for all demo
+  Agents and the seed Job. Report the seeded session count.
+- **Upgrade or remove OpenAPPA resources**: inspect the Helm release first.
+  State what changes or data retention applies. Never uninstall unless the
+  operator explicitly asks. Use only published release charts and images.
+- **Diagnose**: inspect Agent conditions, pods, events, and relevant logs.
+  Make the smallest repair and ask before any state change.
 
 ## Adjust
 

--- a/integrations/kagent/demo/chart/files/demo.appa.toml
+++ b/integrations/kagent/demo/chart/files/demo.appa.toml
@@ -151,8 +151,8 @@ delta = {}
 
 # --- the configuring actor: the appa-guide agent ---
 # The guide agent runs the routing skill against these tools. Reads are
-# unrestricted; the policy write sits behind a person (kagent's Approve
-# card is the oncall authority's channel), and exec needs trusted data.
+# unrestricted; cluster and Helm writes sit behind a person (kagent's
+# Approve card is the oncall authority's channel), and exec needs trusted data.
 # The skill's file helpers that it never uses (bash, write_file,
 # edit_file) stay undeclared, so they are refused.
 [[policy.tool]]
@@ -164,7 +164,31 @@ name = "k8s_get_resource_yaml"
 delta = {}
 
 [[policy.tool]]
+name = "k8s_get_events"
+delta = {}
+
+[[policy.tool]]
+name = "k8s_get_pod_logs"
+delta = {}
+
+[[policy.tool]]
 name = "k8s_apply_manifest"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
+
+[[policy.tool]]
+name = "k8s_patch_resource"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
+
+[[policy.tool]]
+name = "k8s_delete_resource"
 delta = {}
 
 [policy.tool.requires]
@@ -177,6 +201,30 @@ delta = {}
 
 [policy.tool.requires]
 trust = "trusted"
+
+[[policy.tool]]
+name = "helm_list_releases"
+delta = {}
+
+[[policy.tool]]
+name = "helm_get_release"
+delta = {}
+
+[[policy.tool]]
+name = "helm_upgrade"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
+
+[[policy.tool]]
+name = "helm_uninstall"
+delta = {}
+
+[policy.tool.requires]
+trust = "trusted"
+attention = ["human-approval"]
 
 [[policy.tool]]
 name = "appa-guide"

--- a/integrations/kagent/demo/chart/templates/guide.yaml
+++ b/integrations/kagent/demo/chart/templates/guide.yaml
@@ -3,8 +3,8 @@
 # integrations/appa-guide (SKILL.md router plus host reference files).
 # This agent guarantees the kagent side's prerequisites: the kagent tool
 # server's k8s tools, the shared runtime as its own gate, and the model.
-# The fleet policy puts k8s_apply_manifest behind human-approval, so the
-# apply raises kagent's Approve/Reject card.
+# The fleet policy puts cluster and Helm writes behind human-approval, so
+# each mutation raises kagent's Approve/Reject card.
 apiVersion: kagent.dev/v1alpha2
 kind: Agent
 metadata:
@@ -14,7 +14,7 @@ metadata:
     {{- include "appa-demo.labels" . | nindent 4 }}
 spec:
   type: Declarative
-  description: Configure OpenAPPA for this cluster. Say init or adjust.
+  description: Configure and operate OpenAPPA for this cluster. Say quickstart, init, or adjust.
   skills:
     gitRefs:
       - url: {{ .Values.guide.skill.git.url | quote }}
@@ -24,7 +24,8 @@ spec:
   declarative:
     systemMessage: |
       You configure OpenAPPA for this kagent cluster. When the operator
-      says quickstart, init, or adjust, or asks to configure tools or policy, invoke
+      says quickstart, init, or adjust, or asks to manage runtimes, demo agents,
+      protected agents, tools, batteries, or policy, invoke
       the appa-guide skill and follow it exactly; it directs you to
       references/kagent.md — read that file with read_file before you
       act. Work only through your k8s tools and read_file. Do not
@@ -41,8 +42,16 @@ spec:
           toolNames:
             - k8s_get_resources
             - k8s_get_resource_yaml
+            - k8s_get_events
+            - k8s_get_pod_logs
             - k8s_apply_manifest
+            - k8s_patch_resource
+            - k8s_delete_resource
             - k8s_execute_command
+            - helm_list_releases
+            - helm_get_release
+            - helm_upgrade
+            - helm_uninstall
     deployment:
       env:
         # The image is a drop-in replacement for the stock kagent one and

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -126,6 +126,8 @@ helm upgrade --install appa-kagent-demo \
 
 The chart installs a gated cluster-operations fleet, `appa-guide`, the demo tools, the OpenAPPA runtime, and 16 seeded showcase chats. It uses OpenAI's `gpt-4.1-mini` by default. You can select any compatible provider and model through the chart's `openai.*` and `llm.*` values.
 
+After `appa-guide` is installed, you can install or upgrade the demo without returning to Helm. Send it: `install or upgrade the OpenAPPA demo agents using the existing kagent model credentials`.
+
 If the install times out, inspect the resource that did not become ready:
 
 ```sh
@@ -188,6 +190,8 @@ helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
 
 This image replaces the base container image for declarative agent pods. It stays inert until an agent enables `APPA_ENABLED: "true"`. Existing agents remain unaffected.
 
+With `appa-guide` already available, send: `update the kagent controller to the current OpenAPPA agent images`.
+
 ### 2. Deploy the shared OpenAPPA runtime
 
 Deploy one policy runtime for the agents you want to protect:
@@ -202,6 +206,8 @@ helm upgrade --install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runti
 ```
 
 Agents reach this runtime at `http://appa-runtime.appa.svc.cluster.local:18789`. The runtime stores its trajectory log on the persistent volume and reads policy from the `appa-policy` ConfigMap.
+
+With `appa-guide` already available, send: `install or upgrade the shared OpenAPPA runtime with persistent battery storage`.
 
 ### 3. Wire existing agents to the runtime
 
@@ -221,6 +227,10 @@ kubectl patch agent sre-agent -n kagent --type=merge -p '{
   }
 }'
 ```
+
+Alternatively, send `appa-guide`: `protect sre-agent with the shared OpenAPPA runtime and verify its rollout`.
+
+To protect every eligible declarative Agent, send: `enable OpenAPPA for all agents using the shared runtime; show me the affected agents before applying`.
 
 | Mode | `APPA_ENABLED` | `APPA_RUNTIME_URL` | Gating Behavior |
 |---|---|---|---|
@@ -280,8 +290,16 @@ spec:
           toolNames:
             - k8s_get_resources
             - k8s_get_resource_yaml
+            - k8s_get_events
+            - k8s_get_pod_logs
             - k8s_apply_manifest
+            - k8s_patch_resource
+            - k8s_delete_resource
             - k8s_execute_command
+            - helm_list_releases
+            - helm_get_release
+            - helm_upgrade
+            - helm_uninstall
     deployment:
       env:
         - name: APPA_ENABLED
@@ -320,6 +338,8 @@ That one command guides the complete setup. `appa-guide`:
 - identifies one concrete protected action to run and tells you where to observe its decision.
 
 No policy write occurs without explicit approval. After setup, tell `appa-guide` what should change in ordinary language, for example: `adjust require human approval before calling delete_namespace`.
+
+The same chat is the ongoing control surface for OpenAPPA operations. Examples include `protect payments-agent`, `enable OpenAPPA for all agents`, `install the demo agents`, `upgrade the shared runtime`, `diagnose the cluster integration`, and `remove the demo deployment`. The guide inspects current state and presents the exact affected resources before requesting approval.
 
 ## Demonstration scenarios
 


### PR DESCRIPTION
### Summary

- give `appa-guide` read-only diagnostic tools plus policy-approved Kubernetes and Helm lifecycle tools
- require trusted context and kagent human approval for apply, patch, delete, Helm upgrade, and Helm uninstall
- teach the skill to protect one Agent, protect all eligible Agents, install the public demo fleet, upgrade resources, remove explicitly requested resources, and diagnose integration health
- preserve existing Agent environment values and skip `appa-guide` during bulk protection
- keep educational Helm/kubectl snippets while adding adjacent one-message `appa-guide` alternatives throughout the website guide

### Validation

- both Helm chart lint/render suites pass
- demo and shared bootstrap policies load in runtime tests
- appa-guide package tests pass
- website production build passes
- public demo chart upgraded successfully in the live kind cluster; `appa-guide` is Ready/Accepted with the expanded tool set