### PR TITLE
fix(kagent): allow appa-guide skills and stabilize upgrades

### DIFF
--- a/appa-runtime/tests/guide_skill.rs
+++ b/appa-runtime/tests/guide_skill.rs
@@ -32,7 +32,7 @@ fn the_router_routes_by_host_and_carries_the_shared_rules() {
         router.contains("Do not call `Read`"),
         "Claude bootstraps without a gated tool call"
     );
-    assert!(router.contains("`quickstart`") && router.contains("`init`") && router.contains("`adjust`"));
+    assert!(router.contains("`init`") && router.contains("`adjust`"));
     for shared in [
         "Never edit a battery",
         "OpenAPPA pieces",
@@ -86,8 +86,6 @@ fn the_kagent_reference_carries_the_full_flow() {
         "kubelet syncs",
         "Read-only fallback",
         "Approve, or tell me what to change.",
-        "## Quickstart",
-        "one concrete next action",
         "## Cluster operations",
         "helm_upgrade",
         "Protect all Agents",
@@ -127,7 +125,7 @@ fn the_kagent_chart_consumes_this_skill_package() {
     let policy = fs::read_to_string(chart.join("files/demo.appa.toml")).expect("the demo policy exists");
     assert!(policy.contains("name = \"k8s_apply_manifest\""));
     assert!(policy.contains("attention = [\"human-approval\"]"));
-    assert!(policy.contains("name = \"appa-guide\""));
+    assert!(policy.contains("name = \"skills\""));
     assert!(
         !policy.contains("name = \"bash\""),
         "the unused skill helpers stay undeclared"

--- a/charts/appa-runtime/files/appa.toml
+++ b/charts/appa-runtime/files/appa.toml
@@ -77,7 +77,7 @@ trust = "trusted"
 attention = ["human-approval"]
 
 [[policy.tool]]
-name = "appa-guide"
+name = "skills"
 delta = {}
 
 [[policy.tool]]

--- a/integrations/appa-guide/SKILL.md
+++ b/integrations/appa-guide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: appa-guide
-description: Guide an operator through configuring OpenAPPA on the host you run in — Claude Code or a kagent cluster. Use for a guided quickstart, an initial sync of installed tools, after MCP servers change, or when the operator wants to adjust how OpenAPPA treats a tool, data source, destination, battery, or approval.
-argument-hint: "quickstart|init|adjust"
+description: Guide an operator through configuring OpenAPPA on the host you run in — Claude Code or a kagent cluster. Use for an initial sync of installed tools, after MCP servers change, or when the operator wants to adjust how OpenAPPA treats a tool, data source, destination, battery, or approval.
+argument-hint: "init|adjust"
 ---
 
 OpenAPPA configuration helper. Request: $ARGUMENTS
@@ -29,17 +29,17 @@ guess its content.
 
 Use one mode:
 
-- **`quickstart`** — on kagent, guide the operator through initial policy,
-  batteries, health verification, and one useful protected action.
 - **`init`** — inspect the installed tools and build a useful starting
   config.
 - **`adjust`** — help the operator make changes to an existing config.
 
 If the request already makes the mode clear, start there. Otherwise show
-these three choices in one short message and wait. Do not run modes
-together. `quickstart` is available only on kagent; on Claude Code,
-recommend `init` instead. If the operator chooses `adjust` without
-describing the change, ask what they want OpenAPPA to do differently.
+these two choices in one short message and wait. Do not run both modes
+together. Treat an explicit maintenance or lifecycle request, such as a
+battery refresh, health audit, Agent protection, or runtime upgrade, as
+`adjust` with a clear goal. Do not ask the operator to select a mode in
+that case. If the operator chooses `adjust` without describing the change,
+ask what they want OpenAPPA to do differently.
 
 ## Rules that apply on every host
 

--- a/integrations/appa-guide/references/kagent.md
+++ b/integrations/appa-guide/references/kagent.md
@@ -263,33 +263,6 @@ After approval:
    the approved source. Explain the error. Ask again before a fix that
    changes approved behavior.
 
-## Quickstart
-
-Treat `quickstart` as one guided setup, not as several modes the operator
-must invoke separately.
-
-1. Run the live-config and tool inventory. Report runtime reachability,
-   gated and ungated Agents, uninspected servers, policy health, and
-   whether persistent battery storage is available.
-2. Find useful batteries and cover remaining tools exactly as in `init`.
-   Present one complete plain-English policy proposal. End with
-   **Approve, or tell me what to change.** Wait for the response.
-3. After approval, apply and reload exactly as in **Propose, then apply**.
-4. If persistent battery storage is available, run
-   `appa-refresh-batteries --check`. If a newer stable release exists,
-   explain the version change and request approval before installing it.
-   Commit a successful refresh or roll it back on refusal. If storage is
-   not persistent, report that refresh is unavailable and continue.
-5. Re-run the inventory and `appa describe`. Report runtime, policy,
-   battery, Agent, and RemoteMCPServer health. Do not call setup complete
-   while a gated Agent is not ready or a referenced server is unaccepted.
-6. Finish with one concrete next action. When `cluster-ops` exists, direct
-   the operator to its seeded confidential-read chat and state what block
-   or remedy to observe. Otherwise name one ready gated Agent and one of
-   its installed tools whose behavior the active policy demonstrates.
-   Tell the operator where to observe the result in the agent chat and
-   runtime log.
-
 ## Cluster operations
 
 Handle OpenAPPA lifecycle requests through the declared Kubernetes and

--- a/integrations/kagent/README.md
+++ b/integrations/kagent/README.md
@@ -46,6 +46,8 @@ The host-neutral `appa-guide` skill routes to a Claude Code or kagent reference.
 
 ## Quickstart
 
+These commands require Helm 4 because upgrades reclaim chart-owned fields with server-side apply.
+
 ### Deploy kagent with OpenAPPA
 
 Install kagent CRDs and the kagent controller, setting `controller.agentImage` to the OpenAPPA quickstart image:
@@ -53,7 +55,7 @@ Install kagent CRDs and the kagent controller, setting `controller.agentImage` t
 ```sh
 # 1. Install kagent CRDs
 helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
-  --version 0.9.12 -n kagent --create-namespace
+  --version 0.9.12 -n kagent --create-namespace --force-conflicts
 
 # 2. Install kagent controller with OpenAPPA image
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
@@ -70,6 +72,7 @@ helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --set cilium-policy-agent.enabled=false \
   --set cilium-manager-agent.enabled=false \
   --set cilium-debug-agent.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m \
   --set controller.agentImage.tag=0.9.0 # x-release-please-version
 ```
@@ -120,6 +123,8 @@ helm upgrade --install appa-kagent-demo \
   "https://github.com/archestra-ai/OpenAPPA/releases/download/v${APPA_VERSION}/appa-kagent-demo-${APPA_VERSION}.tgz" \
   -n kagent \
   --set-string openai.apiKey="$OPENAI_API_KEY" \
+  --set agents.go.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m
 ```
 

--- a/integrations/kagent/demo/README.md
+++ b/integrations/kagent/demo/README.md
@@ -3,11 +3,13 @@
 The demo is a Helm chart, [chart/](chart/). It installs a gated
 `cluster-ops` fleet with a delegated `log-analyst` and a
 `release-manager` the policy never names, so every delegation to it is
-denied. It also installs the go twins of all three (`cluster-ops-go`,
-`log-analyst-go`, `release-manager-go`). The shared `appa-runtime` runs
+denied. Optional Go twins (`cluster-ops-go`, `log-analyst-go`, and
+`release-manager-go`) are disabled by default. The shared `appa-runtime` runs
 in one pod with its relay and mock externals. The chart adds the demo
 tools and pre-seeds every demo case as a real chat in the kagent
 dashboard.
+
+The commands below require Helm 4 because upgrades reclaim chart-owned fields with server-side apply.
 
 Install it into any cluster that runs kagent 0.9.12 on the OpenAPPA
 runtime image. Two inputs are yours: the images ([chart/README.md](chart/README.md)) and the model key. Install
@@ -35,6 +37,7 @@ helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --set cilium-policy-agent.enabled=false \
   --set cilium-manager-agent.enabled=false \
   --set cilium-debug-agent.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m \
   --set controller.agentImage.tag=0.9.0 # x-release-please-version
 
@@ -44,6 +47,8 @@ helm upgrade --install appa-kagent-demo \
   "https://github.com/archestra-ai/OpenAPPA/releases/download/v${APPA_VERSION}/appa-kagent-demo-${APPA_VERSION}.tgz" \
   -n kagent \
   --set-string openai.apiKey="$OPENAI_API_KEY" \
+  --set agents.go.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m
 kubectl -n kagent port-forward svc/kagent-ui 8901:8080
 ```

--- a/integrations/kagent/demo/chart/README.md
+++ b/integrations/kagent/demo/chart/README.md
@@ -1,9 +1,9 @@
 # appa-kagent-demo
 
 OpenAPPA on kagent, as a demo you can install in any cluster.
-The chart deploys a gated `cluster-ops` fleet of six agents:
-`cluster-ops`, its delegated `log-analyst`, a `release-manager` the
-policy never names, and their go twins. It deploys the shared
+The chart deploys a gated `cluster-ops` fleet of three agents:
+`cluster-ops`, its delegated `log-analyst`, and a `release-manager` the
+policy never names. Optional Go twins are disabled by default. It deploys the shared
 `appa-runtime` in one pod with its relay and mock externals, and the
 demo tools. It pre-seeds every demo case as a real chat in the
 dashboard (sixteen captured transcripts).
@@ -13,12 +13,12 @@ after install.
 
 ## Prerequisites
 
-kagent 0.9.12 with its agent image set to the OpenAPPA runtime image.
+Helm 4 and kagent 0.9.12 with its agent image set to the OpenAPPA runtime image.
 That one value puts every declarative python agent in the cluster on
 the OpenAPPA image. Go agents run the Go image under the name kagent
 derives. Both images ship with the gate off, so every gated agent sets
 `APPA_ENABLED=true` beside `APPA_RUNTIME_URL` — the chart sets both on
-every agent it renders, the fleet's six and `appa-guide`. Agents kagent
+every agent it renders, the default fleet's three and `appa-guide`. Agents kagent
 routes to `<tag>-full` stay uncovered. The release workflow publishes
 both runtime images at the release version ([Images](#images)). Set this
 tag to the same version as the chart's `appVersion`:
@@ -40,6 +40,7 @@ helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --set cilium-policy-agent.enabled=false \
   --set cilium-manager-agent.enabled=false \
   --set cilium-debug-agent.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m \
   --set controller.agentImage.tag=0.9.0 # x-release-please-version
 ```
@@ -54,6 +55,8 @@ helm upgrade --install appa-kagent-demo \
   "https://github.com/archestra-ai/OpenAPPA/releases/download/v${APPA_VERSION}/appa-kagent-demo-${APPA_VERSION}.tgz" \
   -n kagent \
   --set-string openai.apiKey="$OPENAI_API_KEY" \
+  --set agents.go.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m
 ```
 
@@ -124,7 +127,7 @@ the controller compile it again.
 ## What is inside
 
 ```
-six agents (cluster-ops, log-analyst, release-manager, and their go twins)
+three agents (cluster-ops, log-analyst, and release-manager; optional Go twins)
                                   ──APPA_RUNTIME_URL──▶ Service appa-runtime:18789
                                                         │ pod appa-runtime
                                                         ├─ relay (nginx)     :18789 → 127.0.0.1:18787, Host rewritten

--- a/integrations/kagent/demo/chart/files/demo.appa.toml
+++ b/integrations/kagent/demo/chart/files/demo.appa.toml
@@ -227,7 +227,7 @@ trust = "trusted"
 attention = ["human-approval"]
 
 [[policy.tool]]
-name = "appa-guide"
+name = "skills"
 delta = {}
 
 [[policy.tool]]

--- a/integrations/kagent/demo/chart/templates/guide.yaml
+++ b/integrations/kagent/demo/chart/templates/guide.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "appa-demo.labels" . | nindent 4 }}
 spec:
   type: Declarative
-  description: Configure and operate OpenAPPA for this cluster. Say quickstart, init, or adjust.
+  description: Configure and operate OpenAPPA for this cluster. Say init or adjust.
   skills:
     gitRefs:
       - url: {{ .Values.guide.skill.git.url | quote }}
@@ -24,7 +24,7 @@ spec:
   declarative:
     systemMessage: |
       You configure OpenAPPA for this kagent cluster. When the operator
-      says quickstart, init, or adjust, or asks to manage runtimes, demo agents,
+      says init or adjust, or asks to manage runtimes, demo agents,
       protected agents, tools, batteries, or policy, invoke
       the appa-guide skill and follow it exactly; it directs you to
       references/kagent.md — read that file with read_file before you

--- a/integrations/kagent/demo/chart/tests/render-test.sh
+++ b/integrations/kagent/demo/chart/tests/render-test.sh
@@ -70,14 +70,15 @@ expect_env() {
   fi
 }
 
-# The defaults render both cells and the guide agent, and the policy
+# The defaults render the Python cell and the guide agent, and the policy
 # declares both children by their wire spelling.
 must_render kagent
 expect 2 '/opt/appa/batteries'
 expect 0 '/var/lib/appa/batteries'
-expect 7 '^kind: Agent$'
+expect 4 '^kind: Agent$'
 expect_env 1 APPA_CONFIG /etc/appa/demo.appa.toml
 expect 1 '^  name: appa-guide$'
+expect 1 '^    name = "skills"$'
 expect 1 '^    name = "kagent__NS__log_analyst"$'
 expect 1 '^    name = "kagent__NS__log_analyst_go"$'
 
@@ -94,27 +95,25 @@ expect 0 '^kind: PersistentVolumeClaim$'
 # The runtime image is a drop-in replacement for the stock kagent image
 # and runs ungated until APPA_ENABLED reads true, and this is a gated
 # demo, so every agent sets it.
-expect_env 7 APPA_ENABLED true
-expect 7 '^        - name: APPA_RUNTIME_URL$'
+expect_env 4 APPA_ENABLED true
+expect 4 '^        - name: APPA_RUNTIME_URL$'
 
 # A name that repeats another agent name fails the render, the fixed
 # cluster-ops and release-manager included.
 must_refuse 'agent names collide' kagent --set agents.childName=release-manager
-must_refuse 'agent names collide' kagent --set agents.childName=cluster-ops-go
+must_refuse 'agent names collide' kagent --set agents.go.enabled=true --set agents.childName=cluster-ops-go
 must_refuse 'agent names collide' kagent --set agents.go.childName=log-analyst
-must_refuse 'agent names collide' kagent --set agents.go.name=cluster-ops
-must_refuse 'agent names collide' kagent --set agents.go.undeclaredName=release-manager
+must_refuse 'agent names collide' kagent --set agents.go.enabled=true --set agents.go.name=cluster-ops
+must_refuse 'agent names collide' kagent --set agents.go.enabled=true --set agents.go.undeclaredName=release-manager
 
-# Without the go cell, agents.go.name and agents.go.undeclaredName leave
-# the set. agents.go.childName stays: the policy declares both children
-# in any case, and the runtime refuses a duplicate tool contract.
-must_render kagent --set agents.go.enabled=false --set agents.childName=cluster-ops-go
-expect 4 '^kind: Agent$'
+# Enabling the Go cell adds its three optional agents.
+must_render kagent --set agents.go.enabled=true
+expect 7 '^kind: Agent$'
 
 # The guide agent is its own switch, and it leaves the collision set: it
 # takes no value-derived name.
 must_render kagent --set guide.enabled=false
-expect 6 '^kind: Agent$'
+expect 3 '^kind: Agent$'
 expect 0 '^  name: appa-guide$'
 must_render kagent --set agents.go.enabled=false --set agents.childName=release-manager-go
 must_refuse 'agent names collide' kagent --set agents.go.enabled=false --set agents.childName=log-analyst-go
@@ -132,7 +131,7 @@ must_refuse 'schema' kagent --set agents.childName=123
 # a numeric release namespace, a numeric ModelConfig name (an integer
 # after --set), and children named 123 and null.
 must_render 123 --set-string agents.childName=123 --set-string agents.go.childName=null \
-  --set modelConfig.name=123 --set openai.apiKey=k
+  --set agents.go.enabled=true --set modelConfig.name=123 --set openai.apiKey=k
 expect 0 ': 123$'
 expect 0 ': null$'
 expect "$(count '^kind: ')" '^  namespace: "123"$'

--- a/integrations/kagent/demo/chart/values.yaml
+++ b/integrations/kagent/demo/chart/values.yaml
@@ -108,7 +108,7 @@ agents:
   # last path segment becomes `golang-adk` — so it needs that image
   # beside appa-kagent-quickstart (the chart README shows the build).
   go:
-    enabled: true
+    enabled: false
     name: cluster-ops-go
     # Its delegated child on the go runtime too, so the fork's child side
     # is exercised on the go plugin as well.

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -66,7 +66,7 @@ Follow this guide to deploy kagent with OpenAPPA and run your first protected ag
 
 Make sure you have installed:
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or an existing Kubernetes cluster
-- [Helm](https://helm.sh/docs/intro/install/) (v3.8+)
+- [Helm](https://helm.sh/docs/intro/install/) v4
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - An [OpenAI API key](https://platform.openai.com/api-keys) (or credentials for another [supported kagent provider](https://kagent.dev/docs/kagent/supported-providers/))
 
@@ -83,7 +83,7 @@ Then install the kagent [CRDs and Helm chart](https://kagent.dev/docs/kagent/res
 ```sh
 # Install kagent CRDs
 helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds \
-  --version 0.9.12 -n kagent --create-namespace
+  --version 0.9.12 -n kagent --create-namespace --force-conflicts
 
 # Install kagent controller with OpenAPPA runtime
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
@@ -102,6 +102,7 @@ helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --set cilium-debug-agent.enabled=false \
   --set providers.default=openAI \
   --set-string providers.openAI.apiKey="$OPENAI_API_KEY" \
+  --force-conflicts \
   --wait --timeout 10m \
   --set controller.agentImage.tag=0.9.0 # x-release-please-version
 ```
@@ -121,10 +122,14 @@ helm upgrade --install appa-kagent-demo \
   -n kagent \
   --set-string openai.apiKey="$OPENAI_API_KEY" \
   --set runtime.persistence.enabled=true \
+  --set agents.go.enabled=false \
+  --force-conflicts \
   --wait --timeout 10m
 ```
 
 The chart installs a gated cluster-operations fleet, `appa-guide`, the demo tools, the OpenAPPA runtime, and 16 seeded showcase chats. It uses OpenAI's `gpt-4.1-mini` by default. You can select any compatible provider and model through the chart's `openai.*` and `llm.*` values.
+
+Helm 4 uses server-side apply. `--force-conflicts` makes these chart values authoritative if the dashboard, `kubectl`, or `appa-guide` previously changed a chart-owned field such as `ModelConfig.spec.apiKeySecret`.
 
 After `appa-guide` is installed, you can install or upgrade the demo without returning to Helm. Send it: `install or upgrade the OpenAPPA demo agents using the existing kagent model credentials`.
 
@@ -145,15 +150,15 @@ kubectl port-forward -n kagent svc/kagent-ui 8080:8080
 
 Keep that command running while you use the dashboard. Open [http://localhost:8080](http://localhost:8080) in your browser. Open **Agents → cluster-ops → Chat** to run the seeded demo cases, or **Agents → appa-guide → Chat** to manage policies.
 
-### 4. Finish setup with appa-guide
+### 4. Initialize policy with appa-guide
 
-Open **Agents → appa-guide → Chat** and send one message:
+Open **Agents → appa-guide → Chat** and send:
 
 ```text
-quickstart
+init
 ```
 
-The guide inventories the live cluster, proposes an initial policy and matching batteries, waits for your approval, refreshes batteries when needed, reloads the runtime, and audits the result. Review its proposal, reply with your approval, and approve the kagent confirmation card for the policy write.
+As in Claude Code, `init` inventories the live tools, proposes an initial policy and matching batteries, and waits for your approval. Review its proposal, reply with your approval, and approve the kagent confirmation card. The guide applies the policy, reloads the runtime, and verifies the result.
 
 ### 5. Run and observe a protected flow
 
@@ -180,6 +185,7 @@ Update your existing kagent Helm release to use the OpenAPPA runtime image:
 ```sh
 helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent --reuse-values \
+  --force-conflicts \
   --set controller.agentImage.registry=ghcr.io \
   --set controller.agentImage.repository=archestra-ai/appa-kagent-quickstart \
   --set controller.agentImage.tag=0.9.0 \
@@ -202,6 +208,7 @@ helm upgrade --install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runti
   --namespace appa --create-namespace \
   --set persistence.enabled=true \
   --set persistence.size=8Gi \
+  --force-conflicts \
   --wait --timeout 10m
 ```
 
@@ -311,7 +318,7 @@ EOF
 
 ### 6. Finish setup and exercise the policy
 
-Open **Agents → appa-guide → Chat** and send `quickstart`. Review and approve the proposed behavior and the kagent confirmation card. The guide installs applicable batteries, reloads the runtime, audits the integration, and identifies a useful protected action to run next.
+Open **Agents → appa-guide → Chat** and send `init`. Review and approve the proposed behavior and the kagent confirmation card. The guide installs applicable batteries, reloads the runtime, and verifies the integration.
 
 Run that action in a new chat with the protected agent. Observe the resulting allow, block, or remedy in the chat and in the shared runtime log:
 
@@ -321,23 +328,17 @@ kubectl logs -n appa deployment/appa-runtime -c runtime --tail=50
 
 ## Manage integration with appa-guide
 
-The demo chart installs `appa-guide`. For an existing-agent integration, install it in step 5 above. Open [http://localhost:8080](http://localhost:8080), navigate to **Agents → appa-guide → Chat**, and send:
+The demo chart installs `appa-guide`. For an existing-agent integration, install it in step 5 above. Its two modes match the Claude Code experience: `init` creates the initial configuration, and `adjust` changes an existing configuration.
 
-```text
-quickstart
-```
+Run these interactions in order:
 
-That one command guides the complete setup. `appa-guide`:
+1. Send `init`. The guide inventories runtimes, Agents, RemoteMCPServers, tools, and current policy. It finds applicable batteries and proposes contracts for uncovered tools.
+2. Review the complete behavior in plain English. Reply with your approval, then approve the kagent **Approve / Reject** card. The guide writes the policy and reloads the runtime.
+3. Send `refresh batteries` when you want to check for a newer battery release. The guide verifies persistent storage, presents the version change, and waits for approval before installing it.
+4. Send an `adjust` request for subsequent policy changes, such as `adjust require human approval before calling delete_namespace`.
+5. Send `diagnose the OpenAPPA integration` to audit runtime, policy, battery, Agent, and tool-server health.
 
-- inventories runtimes, Agents, RemoteMCPServers, tools, and current policy;
-- finds applicable batteries and proposes contracts for uncovered tools;
-- presents the complete behavior in plain English and waits for approval;
-- applies the policy through kagent's **Approve / Reject** card and reloads the runtime;
-- checks for battery updates when persistent storage is available;
-- audits runtime, policy, battery, Agent, and tool-server health; and
-- identifies one concrete protected action to run and tells you where to observe its decision.
-
-No policy write occurs without explicit approval. After setup, tell `appa-guide` what should change in ordinary language, for example: `adjust require human approval before calling delete_namespace`.
+No policy write occurs without explicit approval.
 
 The same chat is the ongoing control surface for OpenAPPA operations. Examples include `protect payments-agent`, `enable OpenAPPA for all agents`, `install the demo agents`, `upgrade the shared runtime`, `diagnose the cluster integration`, and `remove the demo deployment`. The guide inspects current state and presents the exact affected resources before requesting approval.
 


### PR DESCRIPTION
### Summary

- declare kagent's actual `skills` wire tool in both demo and shared-runtime bootstrap policies, fixing the fail-closed 409 on appa-guide invocation
- remove the kagent-only `quickstart` mode and restore Claude Code parity: `init`, explicit maintenance requests, and `adjust <goal>`
- document the ordered `init` → approval → battery refresh → adjust → diagnose workflow
- add Helm 4 `--force-conflicts` handling so dashboard, kubectl, or appa-guide field ownership cannot strand chart upgrades
- make optional Go parity agents opt-in and explicitly disable them in quickstart upgrades, leaving four intended dashboard Agents

### Verification

- exact public chart command succeeds against the live kind cluster
- demo and shared policies load; rendered policy declares `skills`
- appa-guide request passes the OpenAPPA gate (provider inference is externally blocked by exhausted account credits)
- all four default Agents are Ready/Accepted; 16 seeded demo sessions remain
- Helm lint/render suites, guide/runtime tests, and website production build pass