### PR TITLE
feat(yell): the agent's own report, vouched by the hook that saw the call

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ Setup, upgrade and uninstall: [Claude Code
 integration](https://openappa.com/claude-code) ·
 [`integrations/claude-code`](integrations/claude-code/README.md).
 
+## When APPA is in the way
+
+```sh
+appa yell "the hook blocked a Bash call I needed and the remedy went nowhere"
+```
+
+The report carries your message and what APPA decided — rulings, remedies, label
+changes, and the policy they were made under. It never carries a prompt, a tool
+argument, a tool output, or a path. You are asked twice: whether to replace the
+names your policy chose with tokens such as `tool-1`, and whether to send the
+finished file, which is named before you answer and kept either way.
+
+The agent can report on its own through the `yell` tool, on a deployment that
+turns it on. `appa init` asks; `[reporting] agent_yell` in the config is the
+answer. That call is checked by your policy like any other, so a session
+narrowed to `self` or `internal` reaches a human review instead of sending.
+
 ## Status
 
 OpenAPPA is a **preview and an RFC**. The model is settled enough to build

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -57,6 +57,40 @@ struct Vouch {
     ruling: Option<appa_runtime_api::Ruling>,
 }
 
+/// What a vouch is *about*, and the reason a runtime-provided tool can trust the trajectory
+/// it is told it belongs to.
+///
+/// An MCP request carries no session, so a tool this runtime serves cannot know which
+/// trajectory called it. The hook that preceded the call does know — it is the one place the
+/// harness names the actor — so it records the standing here and the tool spends it. The two
+/// variants are the two things a hook can key that record by, and they are separate variants
+/// because they can never mean each other: an offer id is a name the engine minted and the
+/// model quotes back, and a ticket is the call itself.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PermitKey {
+    /// The offer id `execute_remedy_plan` quotes.
+    Offer(String),
+    /// One `yell` call, by its arguments: the tool takes no id, and the arguments are the
+    /// only thing both the hook and the tool see. A digest, so nothing a person wrote is a
+    /// map key.
+    Yell(String),
+}
+
+impl PermitKey {
+    pub(crate) fn offer(quoted: &OfferId) -> Self {
+        Self::Offer(quoted.0.clone())
+    }
+}
+
+/// Why a runtime-provided tool has no trajectory to act for. The two are different things to
+/// tell a caller: one says no hook saw this call, the other says the call does not identify
+/// which of two sessions made it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Unvouched {
+    Nobody,
+    Ambiguous,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ToolCallDecision {
     Allow {
@@ -444,7 +478,7 @@ struct Inner {
     store: LogStore,
     modules: crate::builtins::ModuleRegistry,
     executing: std::sync::Mutex<std::collections::BTreeSet<String>>,
-    permits: std::sync::Mutex<std::collections::BTreeMap<String, Vec<Vouch>>>,
+    permits: std::sync::Mutex<std::collections::BTreeMap<PermitKey, Vec<Vouch>>>,
     management_permits: std::sync::Mutex<std::collections::BTreeMap<Vec<u8>, Vec<Actor>>>,
     /// Trajectories a prompt reached since their turn last settled. Claude Code sends no
     /// `Stop` hook for a turn the user interrupted, so the prompt is the only sign the
@@ -874,6 +908,22 @@ impl Runtime {
         }
     }
 
+    /// [`Runtime::report`], off the async workers.
+    ///
+    /// Stripping, serializing and gzipping a long trajectory is seconds of CPU over as much
+    /// as [`crate::yell::report::MAX_PLAIN_BYTES`], and the same runtime serves the hooks that gate
+    /// an agent's every tool call. A report is never worth stalling the sessions it is about,
+    /// so every async caller goes through here and the synchronous builder stays synchronous.
+    pub(crate) async fn report_off_thread(
+        self: &Arc<Self>,
+        request: yell::ReportRequest,
+    ) -> Result<yell::Finished, yell::Oversize> {
+        let runtime = Arc::clone(self);
+        tokio::task::spawn_blocking(move || runtime.report(request))
+            .await
+            .expect("building a report does not panic")
+    }
+
     /// One finished `openappa.yell.v1` document, ready to write and to send.
     ///
     /// Assembling here rather than in the CLI is what keeps the size loop honest: only a
@@ -928,8 +978,11 @@ impl Runtime {
         // a policy, and "the runtime would not give me my session" is a thing worth yelling.
         let serving = || policy_section(deployment.config.policy_file().bytes());
         let root = match selection {
-            Some(root) => root,
-            None => match yell::resolve(self.inner.recent_root(yell::RECENT_WINDOW)) {
+            yell::Selection::RulesOnly => {
+                return yell::Projection::rules_only(serving(), mode, yell::OmittedReason::NotRequested);
+            }
+            yell::Selection::Vouched(root) => root,
+            yell::Selection::Recent => match yell::resolve(self.inner.recent_root(yell::RECENT_WINDOW)) {
                 Ok(root) => root,
                 Err(omitted_reason) => return yell::Projection::rules_only(serving(), mode, omitted_reason),
             },
@@ -1029,7 +1082,7 @@ impl Runtime {
         if pursuer != trajectory {
             return unknown();
         }
-        self.spend_vouch(&quoted, acting);
+        self.spend_vouch(&PermitKey::offer(&quoted), acting);
         let Some(_claim) = self.claim_offer(&offer) else {
             return RemedyOutcome::Refused {
                 detail: "this offer is already being executed".to_string(),
@@ -1079,13 +1132,13 @@ impl Runtime {
         Some((offer, pursuer))
     }
 
-    /// Record that this trajectory quoted this offer id, for the request
+    /// Record that this trajectory stands behind this key, for the request
     /// that runs it. `ruling` is a person's answer the harness obtained
     /// through its own review channel; it rides the vouch and is spent
     /// with it, so it can answer exactly the execution it was given for.
-    pub(crate) fn vouch(&self, quoted: &OfferId, acting: &Actor, ruling: Option<appa_runtime_api::Ruling>) {
+    pub(crate) fn vouch(&self, key: &PermitKey, acting: &Actor, ruling: Option<appa_runtime_api::Ruling>) {
         let mut permits = self.inner.permits.lock().expect("the permit mutex is never poisoned");
-        let holders = permits.entry(quoted.0.clone()).or_default();
+        let holders = permits.entry(key.clone()).or_default();
         match holders.iter_mut().find(|holder| holder.actor == *acting) {
             Some(holder) => holder.ruling = ruling,
             None => holders.push(Vouch {
@@ -1095,15 +1148,23 @@ impl Runtime {
         }
     }
 
-    /// The trajectory vouched for this quoted id, taken once, with the
-    /// ruling its harness attached.
-    pub(crate) fn take_vouched(&self, quoted: &OfferId) -> Option<(Actor, Option<appa_runtime_api::Ruling>)> {
+    /// The trajectory vouched for this key, taken once, with the ruling its harness
+    /// attached.
+    ///
+    /// Two trajectories standing behind one key is not a tie to break: it means the key does
+    /// not identify a caller, and answering either one would put one session's standing
+    /// behind another session's call. That case keeps the record rather than consuming it —
+    /// destroying it would make the *next* identical call look like one nothing vouched for,
+    /// and the two need different answers. The turn's end releases it either way.
+    pub(crate) fn take_vouched(&self, key: &PermitKey) -> Result<(Actor, Option<appa_runtime_api::Ruling>), Unvouched> {
         let mut permits = self.inner.permits.lock().expect("the permit mutex is never poisoned");
-        let mut holders = permits.remove(&quoted.0)?;
-        (holders.len() == 1).then(|| {
-            let vouch = holders.remove(0);
-            (vouch.actor, vouch.ruling)
-        })
+        let holders = permits.get_mut(key).ok_or(Unvouched::Nobody)?;
+        if holders.len() != 1 {
+            return Err(Unvouched::Ambiguous);
+        }
+        let vouch = holders.remove(0);
+        permits.remove(key);
+        Ok((vouch.actor, vouch.ruling))
     }
 
     /// Drop every vouch this actor still holds. A vouch is recorded when the actor
@@ -1186,14 +1247,14 @@ impl Runtime {
         prompted.remove(acting_trajectory(acting).0.as_str())
     }
 
-    fn spend_vouch(&self, quoted: &OfferId, acting: &Actor) {
+    fn spend_vouch(&self, key: &PermitKey, acting: &Actor) {
         let mut permits = self.inner.permits.lock().expect("the permit mutex is never poisoned");
-        let Some(holders) = permits.get_mut(&quoted.0) else {
+        let Some(holders) = permits.get_mut(key) else {
             return;
         };
         holders.retain(|holder| holder.actor != *acting);
         if holders.is_empty() {
-            permits.remove(&quoted.0);
+            permits.remove(key);
         }
     }
 
@@ -1327,6 +1388,13 @@ impl Runtime {
     /// person reads the arguments and thinks.
     pub(crate) fn review_timeout(&self) -> std::time::Duration {
         self.inner.deployment().config.externals.review_timeout
+    }
+
+    /// Whether this deployment lets an agent report on its own. Read from the deployment
+    /// this runtime serves *now*, so a `/reload` that flips the knob decides the next MCP
+    /// session rather than the next restart.
+    pub(crate) fn agent_yell(&self) -> bool {
+        self.inner.deployment().config.reporting.agent_yell
     }
 }
 
@@ -1950,12 +2018,12 @@ delta = { audience = { resolver = "directory", argument = "customer" } }
             root: root.clone(),
             child: None,
         };
-        let quoted = OfferId("offer-1".to_string());
+        let quoted = PermitKey::offer(&OfferId("offer-1".to_string()));
 
         runtime.vouch(&quoted, &actor, None);
         assert_eq!(
             runtime.take_vouched(&quoted),
-            Some((actor.clone(), None)),
+            Ok((actor.clone(), None)),
             "a standing vouch is what the tool takes"
         );
 
@@ -1963,9 +2031,41 @@ delta = { audience = { resolver = "directory", argument = "customer" } }
         crate::hooks::handle(&runtime, appa_runtime_api::HookEvent::TurnEnd { actor: actor.clone() }).await;
         assert_eq!(
             runtime.take_vouched(&quoted),
-            None,
+            Err(Unvouched::Nobody),
             "the turn ended without spending it, so nothing later can"
         );
+    }
+
+    /// Two trajectories behind one key is a key that does not identify a caller. Both are
+    /// refused, and both are told *why* — a caller told "nothing vouched for this" would
+    /// make the identical call again and be told the same thing forever.
+    #[tokio::test]
+    async fn an_ambiguous_vouch_refuses_every_holder_and_says_so() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime =
+            Runtime::open(versioned_policy("first"), dir.path().join("appa.db"), None).expect("the deployment opens");
+        let key = PermitKey::Yell("same-call".to_string());
+        let one = Actor {
+            root: TrajectoryId("cc:one".to_string()),
+            child: None,
+        };
+        let other = Actor {
+            root: TrajectoryId("cc:other".to_string()),
+            child: None,
+        };
+        runtime.vouch(&key, &one, None);
+        runtime.vouch(&key, &other, None);
+
+        assert_eq!(runtime.take_vouched(&key), Err(Unvouched::Ambiguous));
+        assert_eq!(
+            runtime.take_vouched(&key),
+            Err(Unvouched::Ambiguous),
+            "the second caller is told the same thing, not that nobody vouched"
+        );
+
+        // Once one of them is gone the key identifies a caller again.
+        runtime.release_vouches(&other);
+        assert_eq!(runtime.take_vouched(&key), Ok((one, None)));
     }
 
     #[tokio::test]

--- a/appa-runtime/src/bin/appa.rs
+++ b/appa-runtime/src/bin/appa.rs
@@ -58,7 +58,17 @@ enum Command {
     },
 
     /// Tell the OpenAPPA team that this deployment is broken, confusing, or in the way.
+    #[command(long_about = "Tell the OpenAPPA team that this deployment is broken, confusing, or \
+                            in the way.\n\n\
+                            The report carries your message and what APPA decided — its rulings, \
+                            remedies, label changes and the policy they were made under. It never \
+                            carries a prompt, a tool argument, a tool output, or a path.\n\n\
+                            Two questions, in this order: whether to replace the names your policy \
+                            chose with report-local tokens such as `tool-1`, and whether to send \
+                            the finished file, which is named before you answer. The file is kept \
+                            either way.")]
     Yell {
+        /// The runtime that builds the report. Loopback only.
         #[arg(long, env = "APPA_RUNTIME_URL", default_value = "http://127.0.0.1:8787")]
         url: String,
 

--- a/appa-runtime/src/events.rs
+++ b/appa-runtime/src/events.rs
@@ -212,8 +212,10 @@ impl From<crate::consult::ConsultKind> for ExternalRole {
     }
 }
 
-/// A remedy carries the offer it executes; a report carries the dispatch it was released
-/// under. One shape with a single optional string could model neither honestly.
+/// Which control tool ran, with what identifies its act: a remedy carries the offer it
+/// executes and the dispatch it opened, where it opened one. Tagged by tool rather than
+/// flattened, so a second control tool's own identifiers are a variant and not another
+/// optional string on this one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "tool", rename_all = "snake_case")]
 pub(crate) enum ControlCall {

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -256,6 +256,7 @@ async fn dispatch_event(runtime: &Runtime, event: HookEvent, dispatch: &mut Opti
                     dispatch: opened,
                 }) => {
                     *dispatch = Some(opened);
+                    vouch_yell(runtime, &actor, &call);
                     runtime.vouch_management(&call, &actor);
                     HookDecision::AllowCall { spawn }
                 }
@@ -379,7 +380,7 @@ fn control_call(runtime: &Runtime, actor: &Actor, call: &ProposedCall, ruling: O
     let acting = actor.child.clone().unwrap_or_else(|| actor.root.clone());
     match runtime.resolve_in(&actor.root, &quoted) {
         Some((_, pursuer)) if pursuer == acting => {
-            runtime.vouch(&quoted, actor, ruling);
+            runtime.vouch(&crate::api::PermitKey::offer(&quoted), actor, ruling);
             tracing::debug!(trajectory = %acting.0, "control tool names an offer this trajectory pursues");
             HookDecision::PassControl
         }
@@ -388,6 +389,31 @@ fn control_call(runtime: &Runtime, actor: &Actor, call: &ProposedCall, ruling: O
             deny("this offer no longer stands; re-propose the call".to_string())
         }
     }
+}
+
+/// Record who is making a released `yell` call, so the tool can report on that session
+/// rather than on whichever one this machine ran most recently.
+///
+/// Only a released call: the vouch is what lets a report be built, so a `yell` the policy
+/// blocked must leave nothing behind for the tool to spend. Unlike the control tool, this is
+/// an ordinary checked call — it is a flow like any other, and the policy decides it first.
+fn vouch_yell(runtime: &Runtime, actor: &Actor, call: &ProposedCall) {
+    if !is_yell_tool(&call.tool) {
+        return;
+    }
+    let Some(args) = crate::yell::YellArgs::parse(&call.arguments) else {
+        tracing::debug!(trajectory = %actor.root.0, "yell proposed with arguments this build cannot read");
+        return;
+    };
+    runtime.vouch(&args.ticket(), actor, None);
+    tracing::debug!(trajectory = %actor.root.0, "yell vouched for this trajectory");
+}
+
+/// The runtime's own reporting tool, by the wire names its distribution channels produce.
+/// A lookalike on another server is an ordinary tool this never vouches for, so it reaches
+/// no session's decisions.
+fn is_yell_tool(tool: &str) -> bool {
+    tool == "yell" || tool == "mcp__appa__yell" || tool == "mcp__plugin_appa-runtime_appa__yell"
 }
 
 fn quoted_offer(call: &ProposedCall) -> Option<OfferId> {
@@ -785,7 +811,7 @@ mod tests {
             root: appa_runtime_api::TrajectoryId("cc:s1".to_string()),
             child: None,
         };
-        let quoted = OfferId("offer-1".to_string());
+        let quoted = crate::api::PermitKey::offer(&OfferId("offer-1".to_string()));
         runtime.vouch(&quoted, &actor, None);
 
         // Interrupted: neither PostToolUse nor Stop arrives.
@@ -797,7 +823,7 @@ mod tests {
         assert!(closed_as_unknown(&runtime), "the interrupted call closed as unreported");
         assert_eq!(
             runtime.take_vouched(&quoted),
-            None,
+            Err(crate::api::Unvouched::Nobody),
             "the interrupted turn's vouch is released"
         );
 
@@ -1324,5 +1350,116 @@ mod tests {
         let (status, answer) = call_hook(&runtime, &serde_json::to_vec(&event).expect("serializes")).await;
         assert_eq!(status, 409);
         assert_eq!(answer, serde_json::json!({"error": "PreToolUse without a tool call"}));
+    }
+
+    /// A deployment that declares the reporting tool, so a proposal of it is released rather
+    /// than refused as undeclared.
+    fn yelling_runtime(dir: &tempfile::TempDir) -> Runtime {
+        let text = r#"
+            [policy]
+            version = 2
+
+            [[policy.tool]]
+            name = "mcp__appa__yell"
+
+            [externals]
+            timeout_ms = 1000
+            max_body_bytes = 4096
+        "#;
+        let path = dir.path().join("appa.toml");
+        std::fs::write(&path, text).expect("the fixture writes");
+        Runtime::open(
+            Config::load(&path).expect("the fixture validates"),
+            dir.path().join("appa.db"),
+            None,
+        )
+        .expect("the fixture deployment opens")
+    }
+
+    fn yell_call(message: &str, with_trajectory: bool) -> serde_json::Value {
+        serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "s1",
+            "tool_name": "mcp__appa__yell",
+            "tool_input": {"message": message, "with_trajectory": with_trajectory},
+        })
+    }
+
+    fn ticket(message: &str, with_trajectory: bool) -> crate::api::PermitKey {
+        crate::yell::YellArgs {
+            message: message.to_string(),
+            with_trajectory,
+        }
+        .ticket()
+    }
+
+    /// An MCP request names no session, so the report a `yell` builds is about whatever the
+    /// hook before it attested. Two sessions on one machine are what makes this matter.
+    #[tokio::test]
+    async fn a_released_yell_vouches_for_the_trajectory_that_made_it() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = yelling_runtime(&dir);
+        let released = hook(&runtime, &yell_call("the hook blocked", true)).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+
+        assert_eq!(
+            runtime.take_vouched(&ticket("the hook blocked", true)),
+            Ok((
+                Actor {
+                    root: TrajectoryId("cc:s1".to_string()),
+                    child: None,
+                },
+                None
+            ))
+        );
+    }
+
+    /// The vouch is what lets a report be built at all, so a call the policy refused must
+    /// leave nothing behind for the tool to spend.
+    #[tokio::test]
+    async fn a_blocked_yell_vouches_for_nobody() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        // The default fixture declares no `yell` and has no wildcard: undeclared is refused.
+        let runtime = open_runtime(&dir);
+        let refused = hook(&runtime, &yell_call("the hook blocked", true)).await;
+        assert_ne!(refused.1["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            runtime.take_vouched(&ticket("the hook blocked", true)),
+            Err(crate::api::Unvouched::Nobody)
+        );
+    }
+
+    /// The standing is for the call the hook saw. A tool that then reports something else is
+    /// spending a vouch that was never given for it.
+    #[tokio::test]
+    async fn a_yell_vouch_answers_only_the_call_it_was_given_for() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = yelling_runtime(&dir);
+        let released = hook(&runtime, &yell_call("the hook blocked", true)).await;
+        assert_eq!(released.1["hookSpecificOutput"]["permissionDecision"], "allow");
+
+        let nobody = Err(crate::api::Unvouched::Nobody);
+        assert_eq!(runtime.take_vouched(&ticket("the hook blocked", false)), nobody);
+        assert_eq!(runtime.take_vouched(&ticket("something else", true)), nobody);
+        assert!(runtime.take_vouched(&ticket("the hook blocked", true)).is_ok());
+    }
+
+    /// One turn's standing, like the control tool's: the harness may decline the call after
+    /// the hook released it, and nothing later may spend what that turn left behind.
+    #[tokio::test]
+    async fn an_unspent_yell_vouch_does_not_outlive_its_turn() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = yelling_runtime(&dir);
+        hook(&runtime, &yell_call("the hook blocked", true)).await;
+
+        let actor = Actor {
+            root: TrajectoryId("cc:s1".to_string()),
+            child: None,
+        };
+        crate::hooks::handle(&runtime, HookEvent::TurnEnd { actor }).await;
+        assert_eq!(
+            runtime.take_vouched(&ticket("the hook blocked", true)),
+            Err(crate::api::Unvouched::Nobody)
+        );
     }
 }

--- a/appa-runtime/src/init/config.rs
+++ b/appa-runtime/src/init/config.rs
@@ -123,6 +123,52 @@ pub(super) fn offer_config_rewrite(path: &Path) -> Result<ConfigOutcome, InitErr
     offer_config_rewrite_with(path, &mut stdin.lock(), &mut stderr.lock())
 }
 
+/// The line the template carries, and the line an accepted offer replaces it with. Anchored
+/// to the start of a line, so prose that quotes the setting is not mistaken for it.
+const AGENT_YELL_OFF: &str = "\nagent_yell = false";
+const AGENT_YELL_ON: &str = "\nagent_yell = true";
+
+/// Ask whether the agent may report on its own, and write the answer into the config init
+/// has just authored.
+///
+/// Asked only about a file init wrote. A config the user has been keeping is theirs, and the
+/// rest of init already refuses to edit one; an upgrade that turned agent reporting on
+/// behind their back would be exactly the kind of thing worth yelling about.
+pub(super) fn offer_agent_yell(path: &Path) -> Result<(), InitError> {
+    let stdin = std::io::stdin();
+    if !stdin.is_terminal() {
+        return Ok(());
+    }
+    let stderr = std::io::stderr();
+    offer_agent_yell_with(path, &mut stdin.lock(), &mut stderr.lock())
+}
+
+fn offer_agent_yell_with(path: &Path, input: &mut impl BufRead, output: &mut impl Write) -> Result<(), InitError> {
+    let write = |source| InitError::WriteFile {
+        path: path.to_path_buf(),
+        source,
+    };
+    let text = fs::read_to_string(path).map_err(write)?;
+    if !text.contains(AGENT_YELL_OFF) {
+        return Ok(());
+    }
+    let offer = Confirmation {
+        question: "appa: may the agent report to the OpenAPPA team when APPA is in its way?\n\
+                   A report carries APPA's own decisions — its rulings, remedies and label\n\
+                   changes — and never a prompt, a tool argument or a tool output. The agent's\n\
+                   call is checked by your policy like any other, so a session narrowed to\n\
+                   `self` or `internal` reaches a human review instead of sending. You can\n\
+                   report yourself with `appa yell` either way, and change this later under\n\
+                   `[reporting]`."
+            .to_string(),
+        default: Answer::Yes,
+    };
+    if offer.ask(input, output).map_err(write)? == Answer::No {
+        return Ok(());
+    }
+    fs::write(path, text.replace(AGENT_YELL_OFF, AGENT_YELL_ON)).map_err(write)
+}
+
 fn offer_config_rewrite_with(
     path: &Path,
     input: &mut impl BufRead,
@@ -334,5 +380,79 @@ mod tests {
             Some(default_config::text().into_owned())
         );
         assert!(!directory.path().join("appa.toml.bak").exists());
+    }
+
+    /// The offer works by replacing the one line the template writes, so the template has to
+    /// carry exactly one of it. Two, or none, and the answer silently does nothing.
+    #[test]
+    fn the_default_config_states_the_reporting_posture_exactly_once() {
+        let text = default_config::text();
+        assert_eq!(text.matches(AGENT_YELL_OFF).count(), 1);
+        assert_eq!(text.matches(AGENT_YELL_ON).count(), 0);
+    }
+
+    fn answer_agent_yell(config: &Path, answer: &str) -> (String, String) {
+        let mut prompt = Vec::new();
+        offer_agent_yell_with(config, &mut answer.as_bytes(), &mut prompt).expect("the offer completes");
+        (
+            fs::read_to_string(config).expect("the config is readable"),
+            String::from_utf8(prompt).expect("the prompt is text"),
+        )
+    }
+
+    /// A default config, as `create_default_config` writes it, and a config that has already
+    /// answered — the second must not be asked again.
+    fn seeded_config(directory: &Path) -> PathBuf {
+        let config = directory.join("appa.toml");
+        assert_eq!(
+            create_default_config(&config).expect("the default config is written"),
+            ConfigOutcome::Created
+        );
+        config
+    }
+
+    #[test]
+    fn agent_reporting_is_turned_on_by_the_answer_and_by_nothing_else() {
+        // An empty line is the default, which this question defaults to yes.
+        for accepted in ["\n", "y\n", "yes\n", "Y\n"] {
+            let directory = tempfile::tempdir().expect("temporary directory");
+            let config = seeded_config(directory.path());
+            let (text, prompt) = answer_agent_yell(&config, accepted);
+            assert!(!prompt.is_empty(), "the offer is shown for {accepted:?}");
+            assert!(text.contains(AGENT_YELL_ON), "{accepted:?} turns it on");
+            crate::config::Config::load(&config).expect("the answered config still loads");
+        }
+
+        // Including end of input: nobody is there to say yes to an agent reporting.
+        for declined in ["", "n\n", "no\n", "what?\n"] {
+            let directory = tempfile::tempdir().expect("temporary directory");
+            let config = seeded_config(directory.path());
+            let (text, _) = answer_agent_yell(&config, declined);
+            assert!(text.contains(AGENT_YELL_OFF), "{declined:?} leaves it off");
+        }
+    }
+
+    /// Nothing else in the file moves. The answer is one line, not a rewrite.
+    #[test]
+    fn answering_changes_only_that_one_line() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let config = seeded_config(directory.path());
+        let before = fs::read_to_string(&config).expect("the config is readable");
+        let (after, _) = answer_agent_yell(&config, "y\n");
+        assert_eq!(after.replace(AGENT_YELL_ON, AGENT_YELL_OFF), before);
+    }
+
+    /// A config that already says what it wants — because a person edited it, or because
+    /// this ran once already — is not asked again and is not rewritten.
+    #[test]
+    fn a_config_that_has_already_answered_is_left_alone() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let config = seeded_config(directory.path());
+        answer_agent_yell(&config, "y\n");
+        let answered = fs::read_to_string(&config).expect("the config is readable");
+
+        let (after, prompt) = answer_agent_yell(&config, "n\n");
+        assert!(prompt.is_empty(), "no second offer is made");
+        assert_eq!(after, answered);
     }
 }

--- a/appa-runtime/src/init/mod.rs
+++ b/appa-runtime/src/init/mod.rs
@@ -24,7 +24,8 @@ use self::claude::{
     prepare_plugin_recovery, replace_plugin, run_claude, start_runtime, undo_plugin_switch,
 };
 use self::config::{
-    ComposedPolicy, ConfigOutcome, create_default_config, discard_file, offer_config_rewrite, verify_config,
+    ComposedPolicy, ConfigOutcome, create_default_config, discard_file, offer_agent_yell, offer_config_rewrite,
+    verify_config,
 };
 use self::endpoint::{
     RuntimeOutcome, clear_foreign_endpoint, clear_stale_endpoint, endpoint_health, reconcile_policy,
@@ -132,6 +133,9 @@ pub fn claude_code(explicit_source: Option<&str>) -> Result<String, InitError> {
         ConfigOutcome::Kept => offer_config_rewrite(&config)?,
         created => created,
     };
+    if config_outcome != ConfigOutcome::Kept {
+        offer_agent_yell(&config)?;
+    }
     let composed_policy = verify_config(&config)?;
 
     // 3. Materialize the deployment, or validate and reuse an existing one.

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -92,8 +92,11 @@ struct Args {
 
 /// The adapter surface this binary can serve. The one place harness
 /// names appear in this crate: each variant maps to one codec crate.
+///
+/// Public because the MCP service is: the tools it serves name the harness in what they
+/// build, so a caller that mounts the service chooses one.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
-pub(crate) enum Adapter {
+pub enum Adapter {
     ClaudeCode,
     Kagent,
 }
@@ -341,12 +344,13 @@ async fn report(
         // nothing. That narrows the endpoint — no session can be asked for by name — without
         // making it a per-caller boundary. The recently active trajectory may well belong to
         // someone else's session on this machine, and loopback is the only thing between them.
-        selection: None,
+        selection: crate::yell::Selection::Recent,
         harness: state.adapter,
     };
     state
         .runtime
-        .report(request)
+        .report_off_thread(request)
+        .await
         .map(|finished| finished.plain)
         .map_err(|oversize| refuse(axum::http::StatusCode::PAYLOAD_TOO_LARGE, oversize.to_string()))
 }
@@ -436,7 +440,7 @@ async fn serve(args: Args) -> ExitCode {
         .route("/hook", post(hook))
         .nest_service(
             "/mcp",
-            mcp::service_with_allowed_hosts(Arc::clone(&runtime), &args.mcp_allowed_hosts),
+            mcp::service_with_allowed_hosts(Arc::clone(&runtime), &args.mcp_allowed_hosts, args.adapter),
         )
         .merge(management)
         .with_state(state);

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -1,13 +1,22 @@
-//! Runtime-owned MCP tools, provided identically to every harness.
+//! Runtime-owned MCP tools, provided identically to every harness: `execute_remedy_plan`,
+//! the engine's reserved tool; the `appa_*` management tools; and `yell`, which reports
+//! that APPA is in the way.
 //!
-//! `execute_remedy_plan` carries only the quoted id and no trajectory, so
-//! the trajectory comes from the hook that preceded the call. A request no
-//! hook vouched for is refused. `appa_match_batteries` is read-only: it
-//! intersects host-observed names with the runtime's current catalog.
+//! Served over streamable HTTP from process start. `execute_remedy_plan` and `yell` carry
+//! no trajectory, so both take it from the hook that preceded the call — the one place the
+//! harness names it. A request no hook vouched for is refused. For a remedy the engine then
+//! judges from the log whether the offer still stands: an unknown, unpursued, cross-turn,
+//! or terminal id is refused. `appa_match_batteries` is read-only: it intersects
+//! host-observed names with the runtime's current catalog.
+//!
+//! `yell` is advertised only where the deployment turned agent reporting on. A build that
+//! does not advertise it does not route it either, so a client holding a stale tool list
+//! gets the same answer as a client that invented the name.
 
 use std::collections::BTreeSet;
 use std::sync::{Arc, RwLock};
 
+use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo};
 use rmcp::service::{RequestContext, RoleServer};
@@ -15,10 +24,15 @@ use rmcp::transport::streamable_http_server::session::local::LocalSessionManager
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 
-use crate::api::{LabelSpelling, OfferId, RemedyArguments, RemedyOutcome, Runtime};
+use crate::api::{LabelSpelling, OfferId, PermitKey, RemedyArguments, RemedyOutcome, Runtime};
 use crate::batteries::{BatteriesResponse, BundledBattery};
 use crate::elicit::Elicitation;
+use crate::runtime_cli::Adapter;
+use crate::yell::YellArgs;
 
+/// The tools this runtime serves, and the router that decides which of them exist for this
+/// session. Built per session, so a `/reload` that turns agent reporting on or off settles
+/// the next client rather than the next restart.
 #[derive(Clone)]
 pub struct RuntimeToolService {
     runtime: Arc<Runtime>,
@@ -26,8 +40,10 @@ pub struct RuntimeToolService {
 }
 
 #[derive(Clone)]
-pub struct RemedyService {
+pub struct RuntimeTools {
     runtime: Arc<Runtime>,
+    harness: Adapter,
+    tool_router: ToolRouter<Self>,
 }
 
 #[derive(Debug, Clone)]
@@ -175,7 +191,7 @@ async fn execute_remedy(
     let quoted = OfferId(args.offer_id.clone());
     let arguments = RemedyArguments::from(args);
     // Requires the vouched trajectory from the preceding hook.
-    let Some((acting, ruling)) = runtime.take_vouched(&quoted) else {
+    let Ok((acting, ruling)) = runtime.take_vouched(&PermitKey::offer(&quoted)) else {
         return render(RemedyOutcome::Refused {
             detail: "no live offer with this id exists".to_string(),
         });
@@ -204,9 +220,20 @@ async fn execute_remedy(
 }
 
 #[tool_router]
-impl RemedyService {
-    pub fn new(runtime: Arc<Runtime>) -> RemedyService {
-        RemedyService { runtime }
+impl RuntimeTools {
+    /// The tools this deployment serves right now. `yell` is dropped from the router where
+    /// the deployment has not turned agent reporting on, which is both how it stops being
+    /// advertised and how a call to it stops being routed.
+    pub fn new(runtime: Arc<Runtime>, harness: Adapter) -> RuntimeTools {
+        let mut tool_router = Self::tool_router();
+        if !runtime.agent_yell() {
+            tool_router.remove_route(YELL);
+        }
+        RuntimeTools {
+            runtime,
+            harness,
+            tool_router,
+        }
     }
 
     #[tool(description = "Execute one remedy plan by the offer id that blocking \
@@ -222,7 +249,55 @@ impl RemedyService {
     ) -> CallToolResult {
         execute_remedy(&self.runtime, args, request).await
     }
+
+    #[tool(description = "Report to the OpenAPPA team that APPA is broken, confusing, or in \
+                       the way. Say in `message` what you were trying to do and what APPA \
+                       did. Set `with_trajectory` to include this session's APPA decisions \
+                       — its rulings, remedies and label changes, never your prompts, tool \
+                       arguments or tool outputs — or leave it false to report on the \
+                       policy alone.")]
+    pub(crate) async fn yell(&self, Parameters(args): Parameters<YellArgs>) -> CallToolResult {
+        match crate::yell::agent::yell(&self.runtime, self.harness, &args).await {
+            crate::yell::agent::Outcome::Sent(receipt) => {
+                let already = match receipt.duplicate {
+                    true => " (already had this one)",
+                    false => "",
+                };
+                CallToolResult::success(vec![ContentBlock::text(format!(
+                    "[appa] Reported{already}. Receipt {}.",
+                    receipt.receipt_id
+                ))])
+            }
+            crate::yell::agent::Outcome::Refused(refusal) => {
+                CallToolResult::error(vec![ContentBlock::text(format!("[appa] {refusal}"))])
+            }
+            crate::yell::agent::Outcome::Unvouched(crate::api::Unvouched::Nobody) => {
+                CallToolResult::error(vec![ContentBlock::text(
+                    "[appa] This call was not seen by a hook, so there is no session to report on. \
+                     Propose it as an ordinary tool call.",
+                )])
+            }
+            // Retrying the identical call cannot work, so the answer says what to change.
+            crate::yell::agent::Outcome::Unvouched(crate::api::Unvouched::Ambiguous) => {
+                CallToolResult::error(vec![ContentBlock::text(
+                    "[appa] Another session on this machine is reporting the same thing word for \
+                     word, so this call does not say which session it is about. Call again with a \
+                     message that describes your own session.",
+                )])
+            }
+            crate::yell::agent::Outcome::Oversize => CallToolResult::error(vec![ContentBlock::text(
+                "[appa] The report is too large to send even with the session left out.",
+            )]),
+            crate::yell::agent::Outcome::Undeliverable(failure) => {
+                CallToolResult::error(vec![ContentBlock::text(format!("[appa] Not reported: {failure}"))])
+            }
+        }
+    }
 }
+
+/// The advertised name of the reporting tool, and the route removed where the deployment
+/// leaves agent reporting off.
+const YELL: &str = "yell";
 
 #[tool_router]
 impl RuntimeToolService {
@@ -478,8 +553,8 @@ impl ServerHandler for RuntimeToolService {
     }
 }
 
-#[tool_handler]
-impl ServerHandler for RemedyService {
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for RuntimeTools {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
         info.server_info.name = "appa-runtime".to_string();
@@ -497,19 +572,20 @@ const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
 const SESSION_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// MCP service served at `/mcp`.
-pub fn service(runtime: Arc<Runtime>) -> StreamableHttpService<RemedyService, LocalSessionManager> {
-    service_with_allowed_hosts(runtime, &[])
+pub fn service(runtime: Arc<Runtime>, harness: Adapter) -> StreamableHttpService<RuntimeTools, LocalSessionManager> {
+    service_with_allowed_hosts(runtime, &[], harness)
 }
 
 pub fn service_with_allowed_hosts(
     runtime: Arc<Runtime>,
     allowed_hosts: &[String],
-) -> StreamableHttpService<RemedyService, LocalSessionManager> {
+    harness: Adapter,
+) -> StreamableHttpService<RuntimeTools, LocalSessionManager> {
     let mut sessions = LocalSessionManager::default();
     sessions.session_config.keep_alive = Some(runtime.review_timeout() + SESSION_GRACE);
     let config = server_config(allowed_hosts);
     StreamableHttpService::new(
-        move || Ok(RemedyService::new(Arc::clone(&runtime))),
+        move || Ok(RuntimeTools::new(Arc::clone(&runtime), harness)),
         Arc::new(sessions),
         config,
     )
@@ -564,9 +640,12 @@ mod tests {
             )
             .expect("the deployment opens"),
         );
-        let service = RemedyService::new(Arc::clone(&runtime));
+        let service = RuntimeTools::new(Arc::clone(&runtime), Adapter::ClaudeCode);
         assert_eq!(service.get_info().server_info.version, env!("CARGO_PKG_VERSION"));
-        let remedy_tools: Vec<String> = RemedyService::tool_router()
+        // The instance's router, not the static one: `RuntimeTools` decides per session
+        // whether `yell` exists, and this fixture leaves agent reporting off.
+        let remedy_tools: Vec<String> = service
+            .tool_router
             .list_all()
             .into_iter()
             .map(|tool| tool.name.to_string())
@@ -609,6 +688,7 @@ mod tests {
                 Runtime::open(config(), directory.path().join("appa.db"), None).expect("the deployment opens"),
             ),
             &["appa-runtime.appa.svc.cluster.local:18787".to_string()],
+            Adapter::ClaudeCode,
         );
 
         let response = service
@@ -650,6 +730,43 @@ mod tests {
         let path = dir.path().join("appa.toml");
         std::fs::write(&path, text).expect("the fixture writes");
         Config::load(&path).expect("the minimal fixture validates")
+    }
+
+    /// The tools a deployment with this reporting posture serves.
+    fn tools_with(agent_yell: bool) -> RuntimeTools {
+        let text = format!(
+            r#"
+            [policy]
+            version = 2
+            [externals]
+            timeout_ms = 1000
+            max_body_bytes = 4096
+            [reporting]
+            agent_yell = {agent_yell}
+        "#
+        );
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let path = dir.path().join("appa.toml");
+        std::fs::write(&path, text).expect("the fixture writes");
+        let config = Config::load(&path).expect("the fixture validates");
+        let runtime = Runtime::open(config, dir.path().join("appa.db"), None).expect("the deployment opens");
+        RuntimeTools::new(std::sync::Arc::new(runtime), Adapter::ClaudeCode)
+    }
+
+    /// A deployment that has not turned agent reporting on does not advertise the tool, and
+    /// a client that calls it anyway — from a stale list, or by guessing — finds no route.
+    /// The remedy tool is unaffected either way: it is the engine's, not the deployment's.
+    #[test]
+    fn agent_reporting_off_serves_no_yell_at_all() {
+        let off = tools_with(false);
+        assert!(!off.tool_router.has_route(YELL));
+        assert!(!off.tool_router.list_all().iter().any(|tool| tool.name == YELL));
+        assert!(off.tool_router.has_route("execute_remedy_plan"));
+
+        let on = tools_with(true);
+        assert!(on.tool_router.has_route(YELL));
+        assert!(on.tool_router.list_all().iter().any(|tool| tool.name == YELL));
+        assert!(on.tool_router.has_route("execute_remedy_plan"));
     }
 
     #[test]
@@ -908,7 +1025,7 @@ mod tests {
             "another trajectory's quote is refused where the harness names it: {stranger:?}",
         );
         assert!(
-            runtime.take_vouched(&quoted).is_none(),
+            runtime.take_vouched(&PermitKey::offer(&quoted)).is_err(),
             "a refused control act vouches for nobody"
         );
 
@@ -917,17 +1034,17 @@ mod tests {
             assert!(matches!(admitted, HookDecision::PassControl), "got {admitted:?}");
         }
         assert_eq!(
-            runtime.take_vouched(&quoted),
-            Some((acting(root.0.as_str()), None)),
+            runtime.take_vouched(&PermitKey::offer(&quoted)),
+            Ok((acting(root.0.as_str()), None)),
             "a repeated hook is one caller"
         );
-        assert!(runtime.take_vouched(&quoted).is_none());
+        assert!(runtime.take_vouched(&PermitKey::offer(&quoted)).is_err());
 
         let admitted = crate::hooks::handle(&runtime, control_act(&acting(root.0.as_str()), &quoted)).await;
         assert!(matches!(admitted, HookDecision::PassControl));
         let _ = runtime.execute_remedy(&acting(root.0.as_str()), quoted.clone()).await;
         assert!(
-            runtime.take_vouched(&quoted).is_none(),
+            runtime.take_vouched(&PermitKey::offer(&quoted)).is_err(),
             "executing the act spends its vouch on every transport"
         );
     }

--- a/appa-runtime/src/yell/agent.rs
+++ b/appa-runtime/src/yell/agent.rs
@@ -1,0 +1,203 @@
+//! The agent's own yell: the tool's arguments, the ticket that ties one call to the
+//! trajectory that made it, and the act itself.
+//!
+//! An MCP request carries no session. The hook that precedes the call is the one place the
+//! harness names the trajectory, so it records the caller's standing under a ticket derived
+//! from the call, and the tool spends that ticket to learn whose session it is reporting on.
+//! A call no hook vouched for is refused rather than attributed to a guess.
+//!
+//! Nothing is written to disk here. `appa yell` keeps a file because a person is asked to
+//! read it before it leaves; nobody reads an agent's, so a report that does not send is gone.
+
+use sha2::Digest;
+
+use crate::api::{Actor, PermitKey, Runtime};
+use crate::runtime_cli::Adapter;
+
+use super::client::{self, Receipt, SendFailure};
+use super::report::{Author, ReportRequest, YellMessage};
+use super::{Mode, Selection};
+
+/// The arguments the `yell` tool takes.
+///
+/// One type for both readers: the hook parses the harness's tool input with it and the tool
+/// parses the MCP request with it, so the ticket the hook records and the ticket the tool
+/// spends are computed from the same reading of the same call. Unknown fields are refused,
+/// which is what keeps those two readings identical.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct YellArgs {
+    /// What APPA did that is in the way, in the agent's own words.
+    pub(crate) message: String,
+    /// Whether the report carries this session's decisions as well as the policy.
+    pub(crate) with_trajectory: bool,
+}
+
+impl YellArgs {
+    /// The key this call is vouched under: a digest of the call itself, because the tool
+    /// takes no id and the arguments are the only thing the hook and the tool both see.
+    ///
+    /// RFC 8785 over the parsed arguments, not over the bytes either side received: the
+    /// harness and the MCP client serialize the same call differently, and the digest has to
+    /// survive that. A digest rather than the text, so nothing a person wrote is a map key.
+    pub(crate) fn ticket(&self) -> PermitKey {
+        let value = serde_json::to_value(self).expect("two owned scalars always serialize");
+        let digest = sha2::Sha256::digest(appa_engine::params::canonical_bytes(&value));
+        PermitKey::Yell(format!("{digest:x}"))
+    }
+
+    /// The tool input a harness reported, read as this call. `None` when it is not one:
+    /// something else was proposed under a name that matched, and nothing is vouched.
+    pub(crate) fn parse(arguments: &serde_json::value::RawValue) -> Option<Self> {
+        serde_json::from_str(arguments.get()).ok()
+    }
+}
+
+/// What one agent yell did, in the words the model is given back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    Sent(Receipt),
+    /// The message is not one: empty, or past what a report carries.
+    Refused(String),
+    /// There is no session to report on: no hook saw this call, or two sessions made a call
+    /// this one cannot be told apart from.
+    Unvouched(crate::api::Unvouched),
+    /// The report is over what a receiver accepts even with nothing left to drop.
+    Oversize,
+    Undeliverable(SendFailure),
+}
+
+/// Build and send one agent's report.
+///
+/// Always in the deployment's own names: nobody is here to be asked the pseudonymization
+/// question, and a deployment that turned agent reporting on has already answered it. What
+/// may leave is the same either way — the mode chooses only how the names are spelled.
+pub(crate) async fn yell(runtime: &std::sync::Arc<Runtime>, harness: Adapter, args: &YellArgs) -> Outcome {
+    let acting = match runtime.take_vouched(&args.ticket()) {
+        Ok((acting, _)) => acting,
+        Err(refusal) => return Outcome::Unvouched(refusal),
+    };
+    let message = match YellMessage::new(&args.message) {
+        Ok(message) => message,
+        Err(refusal) => return Outcome::Refused(refusal.to_string()),
+    };
+    let request = ReportRequest {
+        message,
+        author: Author::Agent,
+        mode: Mode::Baseline,
+        selection: selection(&acting, args.with_trajectory),
+        harness,
+    };
+    let Ok(finished) = runtime.report_off_thread(request).await else {
+        return Outcome::Oversize;
+    };
+    let Some(receiver) = client::Receiver::resolve() else {
+        return Outcome::Undeliverable(SendFailure::NoReceiver);
+    };
+    match client::send(&finished, &receiver).await {
+        Ok(receipt) => Outcome::Sent(receipt),
+        Err(failure) => Outcome::Undeliverable(failure),
+    }
+}
+
+/// The family, never the acting trajectory: a subagent's complaint is about the session it
+/// runs in, and the export is of the whole family either way.
+fn selection(acting: &Actor, with_trajectory: bool) -> Selection {
+    match with_trajectory {
+        true => Selection::Vouched(acting.root.clone()),
+        false => Selection::RulesOnly,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(message: &str, with_trajectory: bool) -> YellArgs {
+        YellArgs {
+            message: message.to_string(),
+            with_trajectory,
+        }
+    }
+
+    /// The hook and the tool never see the same bytes — one reads a harness's hook JSON and
+    /// the other an MCP request — so the ticket has to come from the call, not its rendering.
+    #[test]
+    fn a_ticket_is_the_call_and_not_its_spelling() {
+        let spelled = YellArgs::parse(
+            &serde_json::value::RawValue::from_string(
+                r#"{ "with_trajectory": true,
+                     "message":  "the hook blocked" }"#
+                    .to_string(),
+            )
+            .expect("the fixture is one JSON value"),
+        )
+        .expect("the fixture is this call");
+        assert_eq!(spelled.ticket(), args("the hook blocked", true).ticket());
+    }
+
+    /// Every field is part of what was vouched: a call the hook let through must not spend
+    /// its standing on a different report.
+    #[test]
+    fn a_different_call_is_a_different_ticket() {
+        let ticket = args("the hook blocked", true).ticket();
+        assert_ne!(ticket, args("the hook blocked", false).ticket());
+        assert_ne!(ticket, args("the hook blocked ", true).ticket());
+        assert_ne!(ticket, args("something else", true).ticket());
+    }
+
+    /// A ticket and an offer id are different things, and a map holding both must not
+    /// confuse them however they are spelled.
+    #[test]
+    fn a_ticket_is_not_an_offer_id() {
+        let ticket = args("x", true).ticket();
+        let PermitKey::Yell(digest) = ticket.clone() else {
+            panic!("a yell ticket");
+        };
+        assert_ne!(ticket, PermitKey::Offer(digest));
+    }
+
+    /// The proposal a hook reads is not always the call: the tool's name can be matched by
+    /// something carrying other arguments, and that is not a call to vouch for.
+    #[test]
+    fn only_this_shape_is_a_yell_call() {
+        for refused in [
+            r#"{"message":"x"}"#,
+            r#"{"with_trajectory":true}"#,
+            r#"{"message":"x","with_trajectory":true,"endpoint":"https://evil.example"}"#,
+            r#"{"message":"x","with_trajectory":"yes"}"#,
+            r#"{"message":"x","with_trajectory":true,"trajectory":"someone-else"}"#,
+            r#"[]"#,
+        ] {
+            let raw = serde_json::value::RawValue::from_string(refused.to_string()).expect("one JSON value");
+            assert_eq!(YellArgs::parse(&raw), None, "{refused}");
+        }
+    }
+
+    #[test]
+    fn the_rules_alone_name_no_trajectory() {
+        let acting = Actor {
+            root: appa_runtime_api::TrajectoryId("root".to_string()),
+            child: None,
+        };
+        assert_eq!(
+            selection(&acting, true),
+            Selection::Vouched(appa_runtime_api::TrajectoryId("root".to_string()))
+        );
+        assert_eq!(selection(&acting, false), Selection::RulesOnly);
+    }
+
+    /// A subagent reports on the family it runs in, not on itself: the export is of the
+    /// whole family, and the child alone would name a log that holds part of the story.
+    #[test]
+    fn a_subagent_reports_on_its_family() {
+        let acting = Actor {
+            root: appa_runtime_api::TrajectoryId("root".to_string()),
+            child: Some(appa_runtime_api::TrajectoryId("child".to_string())),
+        };
+        assert_eq!(
+            selection(&acting, true),
+            Selection::Vouched(appa_runtime_api::TrajectoryId("root".to_string()))
+        );
+    }
+}

--- a/appa-runtime/src/yell/cli.rs
+++ b/appa-runtime/src/yell/cli.rs
@@ -131,10 +131,17 @@ async fn build(url: &str, message: &YellMessage, mode: Mode) -> Result<Finished,
             status: status.as_u16(),
         });
     }
-    let plain = answer.bytes().await.map_err(|_| UnreachableClass::Timeout)?;
+    // Bounded by what a report may weigh, because whatever is on that port has not earned
+    // the right to decide how much memory this process commits.
+    let plain = client::bounded_body(answer, super::report::MAX_PLAIN_BYTES)
+        .await
+        .map_err(|refusal| match refusal {
+            client::BodyRefusal::Transport => UnreachableClass::Timeout,
+            client::BodyRefusal::TooLarge => UnreachableClass::NotARuntime,
+        })?;
     // Something answered on the runtime's port. Whether it *is* the runtime is a different
     // question, and these bytes are about to be written to disk and offered for sending.
-    Finished::of(plain.to_vec())
+    Finished::of(plain)
         .ok()
         .filter(|finished| is_a_report(&finished.plain))
         .ok_or(UnreachableClass::NotARuntime)
@@ -143,9 +150,15 @@ async fn build(url: &str, message: &YellMessage, mode: Mode) -> Result<Finished,
 /// Whether the answer claims to be the document this build knows how to send.
 ///
 /// A discriminator, not an identity check: it separates the runtime from whatever else may be
-/// listening on that port, and nothing here proves the answer came from a runtime.
+/// listening on that port, and nothing here proves the answer came from a runtime. Read
+/// through a probe rather than a `Value`, so a large document is not also materialized as a
+/// tree of nodes to look at one string.
 fn is_a_report(plain: &[u8]) -> bool {
-    serde_json::from_slice::<serde_json::Value>(plain).is_ok_and(|document| document["schema"] == super::report::SCHEMA)
+    #[derive(serde::Deserialize)]
+    struct Probe {
+        schema: String,
+    }
+    serde_json::from_slice::<Probe>(plain).is_ok_and(|probe| probe.schema == super::report::SCHEMA)
 }
 
 /// `<url>/report`, when `url` is `http://<loopback literal>[:port]` and nothing else.

--- a/appa-runtime/src/yell/client.rs
+++ b/appa-runtime/src/yell/client.rs
@@ -174,6 +174,10 @@ enum Attempt {
     Give(SendFailure),
 }
 
+/// What a receipt may weigh. It is two short strings; anything larger is a receiver that is
+/// broken or is not one, and either way this process will not hold it in memory to find out.
+const MAX_RECEIPT_BYTES: usize = 64 * 1024;
+
 async fn read(response: reqwest::Response) -> Result<Receipt, Attempt> {
     let status = response.status();
     if status.is_success() {
@@ -181,8 +185,9 @@ async fn read(response: reqwest::Response) -> Result<Receipt, Attempt> {
         // in transit is exactly the case the idempotency id exists for: the same bytes go up
         // again and come back marked as the duplicate they are. A body that arrives whole and
         // does not parse is a different thing, and retrying it changes nothing.
-        return match response.bytes().await {
-            Err(_) => Err(Attempt::Retry(SendFailure::UnreadableReceipt)),
+        return match bounded_body(response, MAX_RECEIPT_BYTES).await {
+            Err(BodyRefusal::Transport) => Err(Attempt::Retry(SendFailure::UnreadableReceipt)),
+            Err(BodyRefusal::TooLarge) => Err(Attempt::Give(SendFailure::UnreadableReceipt)),
             Ok(body) => {
                 serde_json::from_slice::<Receipt>(&body).map_err(|_| Attempt::Give(SendFailure::UnreadableReceipt))
             }
@@ -197,6 +202,35 @@ async fn read(response: reqwest::Response) -> Result<Receipt, Attempt> {
     match matches!(status.as_u16(), 408 | 429) || status.is_server_error() {
         true => Err(Attempt::Retry(failure)),
         false => Err(Attempt::Give(failure)),
+    }
+}
+
+/// Why a body did not arrive whole.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BodyRefusal {
+    Transport,
+    TooLarge,
+}
+
+/// One response body, read a chunk at a time and refused the moment it passes `cap`.
+///
+/// Neither side of this exchange has earned the right to decide how much memory this process
+/// commits: the receiver is somebody else's service, and the runtime a `yell` asks may not be
+/// a runtime at all. A declared content length is a claim, not a bound, so the count is of
+/// bytes actually taken.
+pub(crate) async fn bounded_body(mut response: reqwest::Response, cap: usize) -> Result<Vec<u8>, BodyRefusal> {
+    let mut body = Vec::new();
+    loop {
+        match response.chunk().await {
+            Err(_) => return Err(BodyRefusal::Transport),
+            Ok(None) => return Ok(body),
+            Ok(Some(chunk)) => {
+                if body.len() + chunk.len() > cap {
+                    return Err(BodyRefusal::TooLarge);
+                }
+                body.extend_from_slice(&chunk);
+            }
+        }
     }
 }
 
@@ -245,6 +279,55 @@ mod tests {
         assert_eq!(
             send(&finished, &receiver).await,
             Err(SendFailure::Unreachable { attempts: 3 })
+        );
+    }
+
+    /// A receiver that answers on loopback, so the send path is exercised against a real
+    /// socket rather than a stand-in for one. Returns the address it is listening on.
+    async fn receiver_answering(body: &'static str) -> Receiver {
+        let app = axum::Router::new().route(
+            "/",
+            axum::routing::post(
+                move || async move { ([(axum::http::header::CONTENT_TYPE, "application/json")], body) },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("loopback binds");
+        let address = listener.local_addr().expect("the listener has an address");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Receiver::parse(&format!("http://{address}/")).expect("loopback is a receiver")
+    }
+
+    fn one_report() -> Finished {
+        Finished::of(br#"{"schema":"openappa.yell.v1"}"#.to_vec()).expect("the fixture fits")
+    }
+
+    #[tokio::test]
+    async fn a_receipt_is_read_back_from_a_real_receiver() {
+        let receiver = receiver_answering(r#"{"receipt_id":"r-1","duplicate":true}"#).await;
+        assert_eq!(
+            send(&one_report(), &receiver).await,
+            Ok(Receipt {
+                receipt_id: "r-1".to_string(),
+                duplicate: true,
+            })
+        );
+    }
+
+    /// A receipt is two short strings. A receiver that answers with megabytes is broken or is
+    /// not a receiver, and either way this process does not hold the answer to find out — nor
+    /// does it retry, because the same bytes would come back.
+    #[tokio::test]
+    async fn a_receipt_larger_than_the_contract_is_refused_without_being_held() {
+        let flood: &'static str =
+            Box::leak(format!(r#"{{"receipt_id":"{}"}}"#, "x".repeat(MAX_RECEIPT_BYTES + 1)).into_boxed_str());
+        let receiver = receiver_answering(flood).await;
+        assert_eq!(
+            send(&one_report(), &receiver).await,
+            Err(SendFailure::UnreadableReceipt)
         );
     }
 

--- a/appa-runtime/src/yell/diagnostic.rs
+++ b/appa-runtime/src/yell/diagnostic.rs
@@ -43,10 +43,20 @@ const MAX_FACT_BYTES: usize = 24 * 1024 * 1024;
 /// against something close to the emitted document rather than the facts alone.
 const ENTRY_OVERHEAD: usize = 32;
 
-/// Which trajectory an export is about: the root a vouched caller names, or — for a caller
-/// with no session of its own — whichever one was recently active. The runtime refuses to
-/// guess between several.
-pub(crate) type Selection = Option<TrajectoryId>;
+/// Which trajectory an export is about.
+///
+/// A caller never names one: `Vouched` carries the root the hook before the call attested,
+/// and `Recent` is for a caller with no session of its own, where the runtime takes whichever
+/// trajectory was recently active and refuses to guess between several.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Selection {
+    /// Whichever trajectory was recently active on this machine. What `appa yell` gets.
+    Recent,
+    /// The trajectory a hook vouched for, which is the one that made the call.
+    Vouched(TrajectoryId),
+    /// No trajectory at all: the agent asked for the rules alone.
+    RulesOnly,
+}
 
 /// How much of a trajectory an export may carry, when the caller has to fit it inside
 /// something this process cannot measure.
@@ -99,6 +109,9 @@ pub(crate) enum OmittedReason {
     LogUnavailable,
     /// The author could not reach a runtime at all, so there was nothing to ask.
     RuntimeUnavailable,
+    /// The author asked for the rules alone. An agent says whether its complaint is about a
+    /// session or about the policy, and this is the second answer.
+    NotRequested,
 }
 
 /// The rules, and the decisions made under them.
@@ -183,6 +196,12 @@ pub(crate) struct Export {
     pub(crate) events_dropped_through_seq: Option<u64>,
     pub(crate) deployment_events_dropped: u64,
     pub(crate) deployment_events_dropped_through_seq: Option<u64>,
+    /// What *this report's* event budget left out, and the sequence it runs through. Separate
+    /// from the four counters above, which are the log's own evictions: those happened to the
+    /// deployment, this happened to the document. Without it a report trimmed down to one
+    /// event reads exactly like a session that only ever had one.
+    pub(crate) events_trimmed: usize,
+    pub(crate) events_trimmed_through_seq: Option<u64>,
 }
 
 /// The deployment's rules, as far as a report may carry them.
@@ -341,10 +360,17 @@ pub(crate) fn build(source: Source<'_>, mode: Mode, budget: Budget) -> Projectio
         });
     }
     runtime_events.sort_by_key(|entry| entry.seq);
-    if let Some(cap) = budget.events {
-        let drop = runtime_events.len().saturating_sub(cap);
-        runtime_events.drain(..drop);
-    }
+    // The oldest go, and the document says so. The last dropped sequence rather than the first
+    // surviving one: a budget of zero drops everything and still has to leave a mark.
+    let events_trimmed = match budget.events {
+        Some(cap) => runtime_events.len().saturating_sub(cap),
+        None => 0,
+    };
+    let events_trimmed_through_seq = match events_trimmed {
+        0 => None,
+        trimmed => runtime_events.get(trimmed - 1).map(|entry| entry.seq),
+    };
+    runtime_events.drain(..events_trimmed);
 
     let export = Export {
         branches,
@@ -357,6 +383,8 @@ pub(crate) fn build(source: Source<'_>, mode: Mode, budget: Budget) -> Projectio
         events_dropped_through_seq: source.events.dropped_through_seq,
         deployment_events_dropped: source.events.deployment_dropped,
         deployment_events_dropped_through_seq: source.events.deployment_dropped_through_seq,
+        events_trimmed,
+        events_trimmed_through_seq,
     };
     Projection {
         policy,
@@ -520,7 +548,7 @@ mod tests {
     }
 
     fn project(runtime: &Runtime, root: &TrajectoryId, mode: Mode, budget: Budget) -> Projection {
-        runtime.projection(Some(root.clone()), mode, budget)
+        runtime.projection(Selection::Vouched(root.clone()), mode, budget)
     }
 
     fn export(runtime: &Runtime, root: &TrajectoryId, mode: Mode) -> Export {
@@ -679,6 +707,16 @@ mod tests {
             whole.runtime_events.last().map(|entry| entry.seq),
             "so does the newest event"
         );
+        // A one-event report and a session that only ever had one event are different things,
+        // and the document has to say which one it is.
+        assert_eq!(budgeted.events_trimmed, whole.runtime_events.len() - 1);
+        assert_eq!(
+            budgeted.events_trimmed_through_seq,
+            whole.runtime_events.get(whole.runtime_events.len() - 2).map(|e| e.seq),
+            "the hole runs through the last event left out"
+        );
+        assert_eq!(whole.events_trimmed, 0, "an untrimmed export says it was not trimmed");
+        assert_eq!(whole.events_trimmed_through_seq, None);
         // The budget only shortens: what the export says about the deployment is unchanged.
         assert_eq!(
             serde_json::to_value(&budgeted.branches).ok(),
@@ -701,7 +739,7 @@ mod tests {
                     .expect("the message is valid"),
                 author: crate::yell::Author::Cli,
                 mode: Mode::Pseudonymized,
-                selection: Some(root),
+                selection: Selection::Vouched(root),
                 harness: crate::runtime_cli::Adapter::ClaudeCode,
             })
             .expect("a recorded session fits a report");
@@ -854,6 +892,38 @@ mod tests {
         assert_eq!(
             resolve(crate::events::Recent::None),
             Err(OmittedReason::NoRecentTrajectory)
+        );
+    }
+
+    /// An agent that reports on the policy alone gets the policy alone — not the session it
+    /// happens to be running in, and not whichever session this machine ran most recently.
+    #[tokio::test]
+    async fn the_rules_alone_carry_the_policy_and_no_session() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let (runtime, root) = recorded_session(&dir).await;
+        assert!(
+            matches!(
+                project(&runtime, &root, Mode::Baseline, Budget::default()).trajectory,
+                Diagnostic::Present(_)
+            ),
+            "the session this one declines to export does export when asked for"
+        );
+
+        let projection = runtime.projection(Selection::RulesOnly, Mode::Baseline, Budget::default());
+        assert_eq!(
+            projection.counts(),
+            (0, 0),
+            "no fact and no event of a session nobody asked about"
+        );
+        assert!(matches!(
+            projection.trajectory,
+            Diagnostic::Omitted {
+                omitted_reason: OmittedReason::NotRequested
+            }
+        ));
+        assert!(
+            projection.policy.is_some(),
+            "the rules are the whole of what was asked for"
         );
     }
 }

--- a/appa-runtime/src/yell/mod.rs
+++ b/appa-runtime/src/yell/mod.rs
@@ -8,6 +8,7 @@
 //! trajectory's export from them, and [`report`] puts that export in the envelope a receiver
 //! accepts.
 
+pub(crate) mod agent;
 pub mod cli;
 pub(crate) mod client;
 pub(crate) mod diagnostic;
@@ -17,6 +18,7 @@ pub(crate) mod strip;
 pub(crate) mod tables;
 pub(crate) mod tokens;
 
+pub(crate) use agent::YellArgs;
 pub(crate) use diagnostic::{
     Budget, Diagnostic, OmittedReason, Projection, RECENT_WINDOW, Selection, Source, branches, build, resolve,
 };

--- a/appa-runtime/src/yell/report.rs
+++ b/appa-runtime/src/yell/report.rs
@@ -76,6 +76,7 @@ impl ReportId {
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Author {
     Cli,
+    Agent,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/appa-runtime/src/yell/tables.rs
+++ b/appa-runtime/src/yell/tables.rs
@@ -679,9 +679,11 @@ static OFFER_OPENED: Table = Table {
     ],
 };
 
-/// `OfferAccepted` and `OfferInvalidated` carry the same two fields.
+/// `OfferAccepted` and `OfferInvalidated` carry the same two fields. The name is the shared
+/// one, not either variant's: it is what a drift report prints, and naming one of the two
+/// would file the other's drift under a fact it did not come from.
 static OFFER_LIFECYCLE: Table = Table {
-    name: "OfferAccepted",
+    name: "OfferLifecycle",
     entries: &[("trajectory", TRAJECTORY), ("offer", DIGEST)],
 };
 

--- a/appa-runtime/tests/hitl_elicitation.rs
+++ b/appa-runtime/tests/hitl_elicitation.rs
@@ -163,7 +163,10 @@ async fn deployment_with(review_timeout_ms: u64) -> Deployment {
         "http://{}/mcp",
         listener.local_addr().expect("the socket has an address")
     );
-    let app = axum::Router::new().nest_service("/mcp", mcp::service(Arc::clone(&runtime)));
+    let app = axum::Router::new().nest_service(
+        "/mcp",
+        mcp::service(Arc::clone(&runtime), appa_runtime::runtime_cli::Adapter::ClaudeCode),
+    );
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
@@ -281,7 +284,10 @@ builtin = "hitl"
         "http://{}/mcp",
         listener.local_addr().expect("the socket has an address")
     );
-    let app = axum::Router::new().nest_service("/mcp", mcp::service(Arc::clone(&runtime)));
+    let app = axum::Router::new().nest_service(
+        "/mcp",
+        mcp::service(Arc::clone(&runtime), appa_runtime::runtime_cli::Adapter::ClaudeCode),
+    );
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });

--- a/integrations/claude-code/examples/claude-code.appa.toml
+++ b/integrations/claude-code/examples/claude-code.appa.toml
@@ -221,6 +221,27 @@ name = "WebSearch"
 requires = { audience = { contains = ["public"] } }
 delta = { trust = "suspicious" }
 
+# Reporting to the OpenAPPA team that APPA is in the way. Served by the runtime
+# itself, and gated by the same algebra as any other sink that leaves this
+# machine: the report carries this session's APPA decisions, so a session
+# narrowed by a battery's reads reaches a human review instead of sending. The
+# report never carries a prompt, a tool argument or a tool output — what it may
+# carry is decided by the runtime, not by this rule. Turn the tool off entirely
+# with `[reporting] agent_yell = false` at the end of this file; a deployment
+# that leaves it on and wants a person in the loop can add
+# `requires = { attention = ["hitl"] }` here instead.
+[[policy.tool]]
+name = "mcp__plugin_appa-runtime_appa__yell"
+requires = { audience = { contains = ["public"] } }
+delta = {}
+
+# The same tool where the runtime's MCP server is registered directly rather
+# than through the plugin. One deployment reaches only one of these names.
+[[policy.tool]]
+name = "mcp__appa__yell"
+requires = { audience = { contains = ["public"] } }
+delta = {}
+
 # Compatibility net for tools installed after this policy was generated. Exact
 # declarations always win over the wildcard, including declarations supplied by
 # connector batteries. The mandate is deliberately closed to this deployment's
@@ -305,3 +326,9 @@ builtin = "hitl"
 #   [externals.audience.github]
 #   command = ["python3", "batteries/github/audience-source.py"]
 #   token_env = "APPA_PROVIDER_GITHUB_TOKEN"
+
+# Whether the agent may report on its own through the `yell` tool. Off leaves it
+# unadvertised and unroutable; a person can always report with `appa yell`.
+# `appa init` asks, and writes the answer here.
+[reporting]
+agent_yell = false


### PR DESCRIPTION
Stacked on #214. Design: `/tmp/tokenmaxxer-OpenAPPA-public-build-yell-design-20260903-1200.md`

The agent's own `yell(message, with_trajectory)`, served by the runtime's MCP
endpoint beside `execute_remedy_plan`.

## The trajectory an MCP call cannot name

`yell` is an **ordinary policy-covered tool**, not a control tool: the PreToolUse
hook checks it like any other flow. But an MCP request carries no session, so the
tool cannot know whose trajectory it is reporting on. Taking whichever trajectory
was recently active — what `appa yell` does, because a person at a terminal has
no session of their own — would quietly describe another Claude Code session
running on the same machine.

So the hook records the caller's standing under a **ticket**: SHA-256 over the
RFC 8785 canonicalization of the parsed arguments. Both sides parse the same
`YellArgs`, so the harness's hook JSON and the MCP client's request produce the
same ticket for the same call, however each spells it. The tool spends it.

- A call no hook vouched for is refused, symmetric with the remedy tool. That is
  also the answer to a client calling from a stale tool list.
- A call the policy *blocked* leaves nothing behind: the vouch is recorded only
  on release.
- Two trajectories behind one ticket means the ticket does not identify a
  caller. Both are refused, and told so — a caller told "nothing vouched for
  this" would make the identical call again forever.

`permits` is keyed by `PermitKey::{Offer, Yell}` rather than a bare string, so an
offer id and a ticket cannot be confused, and one turn-end release covers both.

## The policy declares it like any other sink

```toml
[[policy.tool]]
name = "mcp__plugin_appa-runtime_appa__yell"
requires = { audience = { contains = ["public"] } }
delta = {}
```

APPA gating its own feedback tool by its own algebra. A session narrowed by a
battery's reads — the Claude Code battery labels the requester's credentials
`self`, the Slack battery labels channel history `internal` — reaches a human
review instead of sending. That is the right answer for "put this session's
decisions on someone else's disk", and it needed no special case in the runtime.

A deployment that wants a person in the loop unconditionally adds
`requires = { attention = ["hitl"] }` to that rule.

## The knob

`[reporting] agent_yell` finally has its consumer. Off drops the route from the
router, so the tool is neither advertised nor callable, and the remedy tool is
unaffected either way — it is the engine's, not the deployment's. The router is
built per MCP session, so a `/reload` that flips the knob settles the next client
rather than the next restart.

`appa init` proposes turning it on, default yes, and only for a config init
itself wrote. A config a person has been keeping is theirs: an upgrade that
turned agent reporting on behind their back would be exactly the kind of thing
worth yelling about.

An agent's report is always in the deployment's own names. Nobody is there to
answer the pseudonymization question, and a deployment that turned the knob on
has already answered it.

## Review

Two rounds, both of which found defects a live smoke test had already passed
over.

**Round 1.** A budget that halved the event list drained the oldest entries
silently: the four `dropped` counters describe the *event log's* own evictions,
so a report trimmed to one event read exactly like a session that only ever had
one. `events_trimmed` and `events_trimmed_through_seq` now say what the document
left out, separately from what the deployment lost. Also: `Runtime::report` is
seconds of CPU over as much as 224 MiB, and both async callers ran it inline on a
worker that also serves the hooks gating every tool call.

**Round 2.** `take_vouched` removed the record even when it refused, so the first
of two colliding callers destroyed the permit and the second was told nothing had
vouched for it — a model reading that retries the identical call forever. Also:
both body reads were unbounded, and the schema check built a whole `Value` to
look at one string.

## Verified

| Check | Result |
| --- | --- |
| `cargo test -p appa --locked` | 540 passed, 0 failed |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | clean |

## Known gaps, recorded not closed

- No `RuntimeEvent` for an agent yell. `ControlOutcome` is
  `Executed/Declined/NoAnswer/Refused`, which does not describe "the receiver was
  unreachable"; forcing it would abuse the vocabulary or grow a second outcome
  enum for one call site.
- No client-side rate limit. Each yell needs its own released tool call, so the
  policy is the control; the receiver's own limits are the next slice.
- The yell feature is undocumented on the website, this branch and #214 both. No
  golden file states anything either branch makes false, so nothing had to land
  with them — but a reader has no way to learn the feature exists.
