### PR TITLE
fix(release): upload Helm charts separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,13 +547,21 @@ jobs:
           helm push "dist/appa-runtime-${VERSION}.tgz" oci://ghcr.io/archestra-ai/charts
           helm push "dist/appa-kagent-demo-${VERSION}.tgz" oci://ghcr.io/archestra-ai/charts
 
-      - name: Upload the chart artifact
+      - name: Upload the runtime chart artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: appa-charts
-          path: |
-            dist/appa-runtime-${{ needs.release-please.outputs.version }}.tgz
-            dist/appa-kagent-demo-${{ needs.release-please.outputs.version }}.tgz
+          name: appa-runtime-chart
+          path: dist/appa-runtime-${{ needs.release-please.outputs.version }}.tgz
+          archive: false
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload the demo chart artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: appa-kagent-demo-chart
+          path: dist/appa-kagent-demo-${{ needs.release-please.outputs.version }}.tgz
           archive: false
           overwrite: true
           if-no-files-found: error


### PR DESCRIPTION
## Summary

- upload each Helm chart as its own unarchived Actions artifact
- preserve the release job's exact-file download and verification path
- prevent multi-file archive-disabled uploads from skipping GitHub release assets

The v0.10.0 release assets were restored separately after the failed release run.