### PR TITLE
fix(kagent): resolve appa-guide reference path

### DIFF
--- a/appa-runtime/tests/guide_skill.rs
+++ b/appa-runtime/tests/guide_skill.rs
@@ -23,7 +23,7 @@ fn the_router_routes_by_host_and_carries_the_shared_rules() {
     assert!(router.starts_with("---\n"), "the router keeps its frontmatter");
     assert!(router.contains("name: appa-guide"));
     assert!(router.contains("references/claude-code.md"));
-    assert!(router.contains("references/kagent.md"));
+    assert!(router.contains("/skills/appa-guide/references/kagent.md"));
     assert!(
         router.contains("k8s_get_resources"),
         "the router detects the kagent host"
@@ -118,6 +118,7 @@ fn the_kagent_chart_consumes_this_skill_package() {
         assert!(guide.contains(tool), "the guide agent carries {tool}");
     }
     assert!(guide.contains("APPA_RUNTIME_URL"));
+    assert!(guide.contains("/skills/appa-guide/references/kagent.md"));
 
     let values = fs::read_to_string(chart.join("values.yaml")).expect("the chart values exist");
     assert!(values.contains("integrations/appa-guide"));

--- a/integrations/appa-guide/SKILL.md
+++ b/integrations/appa-guide/SKILL.md
@@ -21,7 +21,7 @@ guess its content.
   reference.
 - **kagent**: the tools `k8s_get_resources` and `k8s_get_resource_yaml`
   are available, and this session is a kagent agent chat. Read
-  `references/kagent.md` and follow it.
+  `/skills/appa-guide/references/kagent.md` and follow it.
 - Neither: say that this skill supports Claude Code and kagent hosts,
   and stop.
 

--- a/integrations/kagent/demo/chart/templates/guide.yaml
+++ b/integrations/kagent/demo/chart/templates/guide.yaml
@@ -27,8 +27,8 @@ spec:
       says init or adjust, or asks to manage runtimes, demo agents,
       protected agents, tools, batteries, or policy, invoke
       the appa-guide skill and follow it exactly; it directs you to
-      references/kagent.md — read that file with read_file before you
-      act. Work only through your k8s tools and read_file. Do not
+      /skills/appa-guide/references/kagent.md — read that file with
+      read_file before you act. Work only through your k8s tools and read_file. Do not
       change the policy until the operator approves the proposal in
       chat; applying then raises the kagent Approve card. After a
       successful reload, tell the operator to start a new chat with a

--- a/integrations/kagent/demo/chart/tests/render-test.sh
+++ b/integrations/kagent/demo/chart/tests/render-test.sh
@@ -78,6 +78,7 @@ expect 0 '/var/lib/appa/batteries'
 expect 4 '^kind: Agent$'
 expect_env 1 APPA_CONFIG /etc/appa/demo.appa.toml
 expect 1 '^  name: appa-guide$'
+expect 1 '/skills/appa-guide/references/kagent\.md'
 expect 1 '^    name = "skills"$'
 expect 1 '^    name = "kagent__NS__log_analyst"$'
 expect 1 '^    name = "kagent__NS__log_analyst_go"$'

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -287,7 +287,8 @@ spec:
   declarative:
     systemMessage: |
       Configure OpenAPPA for this kagent cluster. For quickstart, init, or adjust,
-      invoke the appa-guide skill and follow references/kagent.md exactly.
+      invoke the appa-guide skill and follow
+      /skills/appa-guide/references/kagent.md exactly.
     modelConfig: "default-model-config"
     tools:
       - type: McpServer


### PR DESCRIPTION
## Summary

- resolve the kagent guide reference from its mounted skill directory
- keep the chart and standalone manifest aligned with the skill router
- regress the absolute path in Rust and Helm render tests

The relative path was resolved from each chat workspace, so appa-guide init could not read its required kagent instructions.