### PR TITLE
fix(release): derive chart test versions

### DIFF
--- a/charts/appa-runtime/tests/render-test.sh
+++ b/charts/appa-runtime/tests/render-test.sh
@@ -4,6 +4,7 @@
 set -eu
 
 chart=$(cd "$(dirname "$0")/.." && pwd)
+app_version=$(sed -n 's/^appVersion: *"\([^"]*\)".*/\1/p' "$chart/Chart.yaml")
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
@@ -84,7 +85,7 @@ must_render --set appaGuide.enabled=true
 expect 1 '^kind: Agent$'
 must_contain 'name: appa-guide'
 must_contain 'namespace: "kagent"'
-must_contain 'ref: "v0.10.0"'
+must_contain "ref: \"v${app_version}\""
 must_contain 'http://appa-runtime.appa.svc.cluster.local:18787'
 must_contain 'name: "kagent-tool-server"'
 must_contain 'your first tool call must be skills with command appa-guide'

--- a/integrations/kagent/demo/chart/tests/render-test.sh
+++ b/integrations/kagent/demo/chart/tests/render-test.sh
@@ -9,6 +9,7 @@
 set -eu
 
 chart=$(cd "$(dirname "$0")/.." && pwd)
+app_version=$(sed -n 's/^appVersion: *"\([^"]*\)".*/\1/p' "$chart/Chart.yaml")
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
@@ -75,7 +76,7 @@ expect_env() {
 must_render kagent
 expect 2 '/opt/appa/batteries'
 expect 0 '/var/lib/appa/batteries'
-expect 1 'image: ghcr.io/archestra-ai/appa-runtime:0\.10\.0$'
+expect 1 "image: ghcr.io/archestra-ai/appa-runtime:${app_version}$"
 expect 1 '0\.0\.0\.0:18787'
 expect 1 '^            - "appa-runtime\.kagent\.svc\.cluster\.local:18787"$'
 expect 1 'containerPort: 18787'
@@ -89,7 +90,7 @@ expect 0 '18789|appa-runtime-relay|name: relay'
 expect 4 '^kind: Agent$'
 expect_env 1 APPA_CONFIG /etc/appa/demo.appa.toml
 expect 1 '^  name: appa-guide$'
-expect 1 '^        ref: "v0\.10\.0"$'
+expect 1 "^        ref: \"v${app_version}\"$"
 expect 1 '/skills/appa-guide/references/kagent\.md'
 expect 1 'with offset 1 and limit 0. Follow'
 expect 1 'all read-only inspection and present the proposal without asking whether'


### PR DESCRIPTION
## Summary

- derive Helm render assertions from each chart appVersion
- keep chart checks valid when Release Please bumps versions
- verify both chart suites against current 0.10.0 and simulated 0.11.0 metadata