### PR TITLE
feat(release): publish v* and rolling CI tags to appa-public

### DIFF
--- a/.github/actions/auth-to-gar/action.yml
+++ b/.github/actions/auth-to-gar/action.yml
@@ -1,0 +1,24 @@
+name: Authenticate to Artifact Registry
+description: Authenticate to Google Cloud and configure Docker for europe-west1 Artifact Registry.
+inputs:
+  service_account:
+    description: The GCP service account email
+    required: true
+  workload_identity_provider:
+    description: The GCP Workload Identity Provider identifier
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        service_account: ${{ inputs.service_account }}
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+
+    - name: Set up Google Cloud
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+    - name: Configure Docker for Artifact Registry
+      shell: bash
+      run: gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet

--- a/.github/actions/check-release-versions/action.yml
+++ b/.github/actions/check-release-versions/action.yml
@@ -4,7 +4,7 @@ description: >-
   carry the version release-please holds. The tag and the compiled CARGO_PKG_VERSION
   are concatenated into the plugin artifact URL every shipped binary fetches, so a
   disagreement between them ships binaries that request a URL which does not exist.
-  The charts resolve image tags to appVersion, and the operator guides spell an
+  The charts resolve image tags to v<appVersion>, and the operator guides spell an
   image tag a reader pastes, so a disagreement names images no release published.
 
 inputs:

--- a/.github/workflows/build-appa-demo-image.yml
+++ b/.github/workflows/build-appa-demo-image.yml
@@ -36,26 +36,21 @@ jobs:
           fetch-depth: 1
 
       - name: Build image
-        run: docker build --tag "$IMAGE:${GITHUB_SHA::12}" --tag "$IMAGE:latest" .
+        run: docker build --tag "$IMAGE:sha-${GITHUB_SHA::12}" --tag "$IMAGE:latest" .
 
-      - name: Authenticate to Google Cloud
+      - name: Authenticate to Artifact Registry
         # Publishing only ever comes from a dispatch on main — a
         # workflow_dispatch on any other ref builds without publishing.
         if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        uses: ./.github/actions/auth-to-gar
         with:
           service_account: ${{ secrets.APPA_GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Set up Google Cloud
-        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-
       - name: Push image
         if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
         run: |
-          gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
-          docker push "$IMAGE:${GITHUB_SHA::12}"
+          docker push "$IMAGE:sha-${GITHUB_SHA::12}"
           docker push "$IMAGE:latest"
 
       - name: Deploy to Cloud Run
@@ -63,4 +58,4 @@ jobs:
         run: |
           gcloud run services update appa-demo \
             --region europe-west1 \
-            --image "$IMAGE:${GITHUB_SHA::12}"
+            --image "$IMAGE:sha-${GITHUB_SHA::12}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,16 @@ jobs:
               - 'scripts/test_appa_refresh_batteries.py'
               - 'scripts/appa-guide-runtime.py'
               - 'scripts/test_appa_guide_runtime.py'
+              - 'scripts/appa-oci-tags.py'
+              - 'scripts/test_appa_oci_tags.py'
+              - 'scripts/appa-gar-cleanup-policies.json'
+              - '.github/actions/auth-to-gar/**'
               - '.github/actions/check-release-versions/**'
               - '.github/release-please/**'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/publish-oci-images.yml'
+              - '.github/workflows/publish-ci-images.yml'
               - 'Cargo.toml'
               - 'charts/appa-runtime/Chart.yaml'
               - 'charts/appa-runtime/README.md'
@@ -238,7 +245,7 @@ jobs:
           done
 
       - name: Test release battery refresh
-        run: python3 -m unittest scripts/test_appa_refresh_batteries.py scripts/test_appa_guide_runtime.py
+        run: python3 -m unittest scripts/test_appa_refresh_batteries.py scripts/test_appa_guide_runtime.py scripts/test_appa_oci_tags.py
 
       - name: Check release versions
         uses: ./.github/actions/check-release-versions

--- a/.github/workflows/publish-ci-images.yml
+++ b/.github/workflows/publish-ci-images.yml
@@ -1,0 +1,130 @@
+name: Publish CI images
+
+# Rolling tags for appa-public. These are not releases. A new digest is
+# attached to sha-/main/latest on each image-changing push; GAR
+# deletes those prefixes after 30 days and keeps the last ten versions.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: publish-ci-images-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Changed Paths
+    # Release commits attach rolling tags in the release build itself.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore(main): release ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      images: ${{ steps.filter.outputs.images }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            images:
+              - 'appa-runtime/**'
+              - 'appa-runtime-api/**'
+              - 'appa-engine/**'
+              - 'appa-eventlog/**'
+              - 'appa-policy/**'
+              - 'appa-builtin/**'
+              - 'appa-adapter-kagent/**'
+              - 'appa-adapter-claude-code/**'
+              - 'appa-example-agent/**'
+              - 'appa-agent-python/**'
+              - 'integrations/kagent/**'
+              - 'integrations/claude-code/**'
+              - 'integrations/appa-guide/**'
+              - 'batteries/**'
+              - 'scripts/appa-oci-tags.py'
+              - 'scripts/appa-gar-cleanup-policies.json'
+              - 'scripts/appa-refresh-batteries.py'
+              - 'scripts/appa-guide-runtime.py'
+              - '.github/actions/auth-to-gar/**'
+              - '.github/workflows/publish-oci-images.yml'
+              - '.github/workflows/publish-ci-images.yml'
+              - '.github/workflows/release.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.dockerignore'
+              - 'Dockerfile'
+
+  tags:
+    name: Resolve rolling tags
+    needs: changes
+    if: needs.changes.outputs.images == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      tags: ${{ steps.resolve.outputs.tags }}
+      source_commit: ${{ steps.resolve.outputs.source_commit }}
+      version_label: ${{ steps.resolve.outputs.version_label }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Resolve rolling tags
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+        run: |
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source commit must be a full SHA"
+            exit 1
+          fi
+          args=(rolling --event "$EVENT" --sha "$SHA" --ref "$REF")
+          mapfile -t tags < <(python3 scripts/appa-oci-tags.py "${args[@]}")
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "::error::no rolling tags to publish"
+            exit 1
+          fi
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "source_commit=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "version_label=${tags[0]}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish rolling images
+    needs: tags
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-oci-images.yml
+    with:
+      tags: ${{ needs.tags.outputs.tags }}
+      source_commit: ${{ needs.tags.outputs.source_commit }}
+      version_label: ${{ needs.tags.outputs.version_label }}
+      checkout_ref: ${{ needs.tags.outputs.source_commit }}
+      immutable: false
+    secrets:
+      APPA_GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/publish-ci-images.yml
+++ b/.github/workflows/publish-ci-images.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: read # Required to diff changed paths on a push.
     outputs:
       images: ${{ steps.filter.outputs.images }}
     steps:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: read # Required to check out the tag-contract script.
     outputs:
       tags: ${{ steps.resolve.outputs.tags }}
       source_commit: ${{ steps.resolve.outputs.source_commit }}
@@ -116,9 +116,9 @@ jobs:
     name: Publish rolling images
     needs: tags
     permissions:
-      actions: read
-      contents: read
-      id-token: write
+      actions: read # Required to download image digest artifacts.
+      contents: read # Required to check out the source that is published.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     uses: ./.github/workflows/publish-oci-images.yml
     with:
       tags: ${{ needs.tags.outputs.tags }}

--- a/.github/workflows/publish-oci-images.yml
+++ b/.github/workflows/publish-oci-images.yml
@@ -1,0 +1,381 @@
+name: Publish OCI images
+
+# Builds the five OpenAPPA images, merges the two multi-arch indexes, and
+# attaches the caller's tags. Release callers pass one immutable v* tag.
+# CI callers pass rolling sha-/pr-/main/latest tags. Charts stay in
+# release.yml: their versions are SemVer without v and must not be GC'd.
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: Newline-separated image tags to attach
+        required: true
+        type: string
+      source_commit:
+        description: Commit stamped into the image revision label
+        required: true
+        type: string
+      version_label:
+        description: Value for org.opencontainers.image.version
+        required: true
+        type: string
+      checkout_ref:
+        description: Git ref the trusted workflow YAML was loaded from
+        required: true
+        type: string
+      verify_release:
+        description: Verify and detach onto the release tag before building
+        required: false
+        type: boolean
+        default: false
+      release_ref:
+        description: Immutable release tag; required when verify_release is true
+        required: false
+        type: string
+        default: ""
+      immutable:
+        description: Refuse to attach an existing v* release tag
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      APPA_GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+
+permissions: {}
+
+env:
+  REGISTRY: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public
+
+jobs:
+  publish-shared-image-legs:
+    name: Build ${{ matrix.image }} (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: appa-runtime
+            arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - image: appa-runtime
+            arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - image: appa-kagent-adk
+            arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - image: appa-kagent-adk
+            arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Verify and checkout release source
+        if: ${{ inputs.verify_release }}
+        uses: ./.github/actions/verify-release-source
+        with:
+          release_ref: ${{ inputs.release_ref }}
+          source_commit: ${{ inputs.source_commit }}
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h /
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Authenticate to Artifact Registry
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: appa-release-publish@friendly-path-465518-r6.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Build and push appa-runtime leg
+        if: ${{ matrix.image == 'appa-runtime' }}
+        id: build-runtime
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: appa-runtime/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
+      - name: Build and push appa-kagent-adk leg
+        if: ${{ matrix.image == 'appa-kagent-adk' }}
+        id: build-adk
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/appa-kagent-adk
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
+      - name: Record image digest
+        env:
+          RUNTIME_DIGEST: ${{ steps.build-runtime.outputs.digest }}
+          ADK_DIGEST: ${{ steps.build-adk.outputs.digest }}
+        run: |
+          DIGEST=${RUNTIME_DIGEST:-$ADK_DIGEST}
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::image build did not report a digest"
+            exit 1
+          fi
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.image }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-shared-images:
+    name: Publish shared multi-platform images
+    needs: publish-shared-image-legs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Download appa-runtime digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-appa-runtime-*
+          path: /tmp/digests/appa-runtime
+          merge-multiple: true
+
+      - name: Download appa-kagent-adk digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-appa-kagent-adk-*
+          path: /tmp/digests/appa-kagent-adk
+          merge-multiple: true
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Authenticate to Artifact Registry
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: appa-release-publish@friendly-path-465518-r6.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Merge and tag image manifests
+        env:
+          IMMUTABLE: ${{ inputs.immutable }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          test "$(python3 scripts/appa-oci-tags.py registry)" = "$REGISTRY"
+          mapfile -t tags < <(printf '%s\n' "$TAGS" | awk 'NF')
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "::error::no image tags to publish"
+            exit 1
+          fi
+          for image in appa-runtime appa-kagent-adk; do
+            sources=()
+            for digest in "/tmp/digests/${image}"/*; do
+              sources+=("${REGISTRY}/${image}@sha256:${digest##*/}")
+            done
+            if [ "${#sources[@]}" -ne 2 ]; then
+              echo "::error::${image} has ${#sources[@]} platform digests, expected 2"
+              exit 1
+            fi
+            tag_args=()
+            for tag in "${tags[@]}"; do
+              ref="${REGISTRY}/${image}:${tag}"
+              if [ "$IMMUTABLE" = "true" ] && [[ "$tag" == v* ]] && docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+                echo "::error::${ref} already exists"
+                exit 1
+              fi
+              tag_args+=(--tag "$ref")
+            done
+            docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+            docker buildx imagetools inspect "${REGISTRY}/${image}:${tags[0]}"
+            docker buildx imagetools inspect --raw \
+              "${REGISTRY}/${image}:${tags[0]}" \
+              | jq -e '[.manifests[].platform | select(.os == "linux") | .architecture] | sort == ["amd64", "arm64"]'
+          done
+
+  publish-images:
+    name: Publish container images
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Verify and checkout release source
+        if: ${{ inputs.verify_release }}
+        uses: ./.github/actions/verify-release-source
+        with:
+          release_ref: ${{ inputs.release_ref }}
+          source_commit: ${{ inputs.source_commit }}
+
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h /
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Authenticate to Artifact Registry
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: appa-release-publish@friendly-path-465518-r6.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Resolve image tags
+        id: tags
+        env:
+          IMMUTABLE: ${{ inputs.immutable }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          test "$(python3 scripts/appa-oci-tags.py registry)" = "$REGISTRY"
+          mapfile -t tags < <(printf '%s\n' "$TAGS" | awk 'NF')
+          if [ "${#tags[@]}" -eq 0 ]; then
+            echo "::error::no image tags to publish"
+            exit 1
+          fi
+          if [ "$IMMUTABLE" = "true" ]; then
+            for image in appa-kagent-adk-go appa-demo-tools appa-demo-mocks golang-adk; do
+              for tag in "${tags[@]}"; do
+                [[ "$tag" == v* ]] || continue
+                ref="${REGISTRY}/${image}:${tag}"
+                if docker buildx imagetools inspect "$ref" >/dev/null 2>&1; then
+                  echo "::error::${ref} already exists"
+                  exit 1
+                fi
+              done
+            done
+          fi
+          {
+            echo "adk_go<<EOF"
+            for tag in "${tags[@]}"; do printf '%s\n' "${REGISTRY}/appa-kagent-adk-go:${tag}"; done
+            echo "EOF"
+            echo "tools<<EOF"
+            for tag in "${tags[@]}"; do printf '%s\n' "${REGISTRY}/appa-demo-tools:${tag}"; done
+            echo "EOF"
+            echo "mocks<<EOF"
+            for tag in "${tags[@]}"; do printf '%s\n' "${REGISTRY}/appa-demo-mocks:${tag}"; done
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push appa-kagent-adk-go
+        id: adk-go
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/appa-kagent-adk-go
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          sbom: true
+          tags: ${{ steps.tags.outputs.adk_go }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
+      - name: Build and push appa-demo-tools
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/demo
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          sbom: true
+          tags: ${{ steps.tags.outputs.tools }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
+      - name: Build and push appa-demo-mocks
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/demo/mocks
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          sbom: true
+          tags: ${{ steps.tags.outputs.mocks }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
+      - name: Alias the Go image to the name kagent derives
+        env:
+          GO_DIGEST: ${{ steps.adk-go.outputs.digest }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          if [[ ! "$GO_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::the Go image build did not report a digest"
+            exit 1
+          fi
+          mapfile -t tags < <(printf '%s\n' "$TAGS" | awk 'NF')
+          extra_alias=()
+          for tag in "${tags[@]}"; do
+            extra_alias+=(--tag "${REGISTRY}/golang-adk:${tag}")
+          done
+          docker buildx imagetools create \
+            "${extra_alias[@]}" \
+            "${REGISTRY}/appa-kagent-adk-go@${GO_DIGEST}"
+          alias_digest=$(docker buildx imagetools inspect \
+            --format '{{.Manifest.Digest}}' \
+            "${REGISTRY}/golang-adk:${tags[0]}")
+          if [ "$alias_digest" != "$GO_DIGEST" ]; then
+            echo "::error::golang-adk resolves to ${alias_digest}, not ${GO_DIGEST}"
+            exit 1
+          fi

--- a/.github/workflows/publish-oci-images.yml
+++ b/.github/workflows/publish-oci-images.yml
@@ -74,8 +74,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
-      contents: read
-      id-token: write
+      contents: read # Required to check out the source that is published.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -169,9 +169,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: read
-      contents: read
-      id-token: write
+      actions: read # Required to download image digest artifacts.
+      contents: read # Required to check out the source that is published.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -244,8 +244,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
-      id-token: write
+      contents: read # Required to check out the source that is published.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: read # Required to check out the tag-contract script.
     outputs:
       tags: ${{ steps.tags.outputs.tags }}
     steps:
@@ -245,9 +245,9 @@ jobs:
       - release-please
       - oci-tags
     permissions:
-      actions: read
-      contents: read
-      id-token: write
+      actions: read # Required to download image digest artifacts.
+      contents: read # Required to check out the release source.
+      id-token: write # Required for Workload Identity Federation when pushing images.
     uses: ./.github/workflows/publish-oci-images.yml
     with:
       tags: ${{ needs.oci-tags.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,37 +205,16 @@ jobs:
       expected_version: ${{ needs.release-please.outputs.version }}
       plugin_sha256: ${{ needs.plugin-artifact.outputs.sha256 }}
 
-  # Build each shared image on its native architecture. The digest
-  # artifacts let the merge job publish one immutable multi-platform tag.
-  publish-shared-image-legs:
-    name: Build ${{ matrix.image }} (${{ matrix.arch }})
+  oci-tags:
+    name: Resolve release image tags
     if: ${{ needs.release-please.outputs.should_publish == 'true' }}
     needs: release-please
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: appa-runtime
-            arch: amd64
-            platform: linux/amd64
-            runner: ubuntu-latest
-          - image: appa-runtime
-            arch: arm64
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
-          - image: appa-kagent-adk
-            arch: amd64
-            platform: linux/amd64
-            runner: ubuntu-latest
-          - image: appa-kagent-adk
-            arch: arm64
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
-      contents: read # Required to verify and check out the release tag.
-      packages: write # Required to push the image leg by digest.
+      contents: read
+    outputs:
+      tags: ${{ steps.tags.outputs.tags }}
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -244,265 +223,42 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Verify and checkout release source
-        uses: ./.github/actions/verify-release-source
-        with:
-          release_ref: ${{ needs.release-please.outputs.tag_name }}
-          source_commit: ${{ needs.release-please.outputs.source_commit }}
-
-      - name: Free runner disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
-          sudo docker image prune --all --force
-          df -h /
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Log in to the image registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Build and push appa-runtime leg
-        if: ${{ matrix.image == 'appa-runtime' }}
-        id: build-runtime
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: appa-runtime/Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=ghcr.io/archestra-ai/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          provenance: true
-          sbom: true
-          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.image }}-${{ matrix.arch }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.release-please.outputs.source_commit }}
-            org.opencontainers.image.version=${{ needs.release-please.outputs.version }}
-
-      - name: Build and push appa-kagent-adk leg
-        if: ${{ matrix.image == 'appa-kagent-adk' }}
-        id: build-adk
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: integrations/kagent/appa-kagent-adk
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=ghcr.io/archestra-ai/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          provenance: true
-          sbom: true
-          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=min,scope=${{ matrix.image }}-${{ matrix.arch }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.release-please.outputs.source_commit }}
-            org.opencontainers.image.version=${{ needs.release-please.outputs.version }}
-
-      - name: Record image digest
+      - name: Resolve release image tags
+        id: tags
         env:
-          RUNTIME_DIGEST: ${{ steps.build-runtime.outputs.digest }}
-          ADK_DIGEST: ${{ steps.build-adk.outputs.digest }}
+          SOURCE_COMMIT: ${{ needs.release-please.outputs.source_commit }}
+          VERSION: ${{ needs.release-please.outputs.version }}
         run: |
-          DIGEST=${RUNTIME_DIGEST:-$ADK_DIGEST}
-          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::image build did not report a digest"
-            exit 1
-          fi
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${DIGEST#sha256:}"
+          release_tag=$(python3 scripts/appa-oci-tags.py release-image --version "$VERSION")
+          mapfile -t rolling < <(python3 scripts/appa-oci-tags.py rolling \
+            --event push --sha "$SOURCE_COMMIT" --ref refs/heads/main)
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "$release_tag" "${rolling[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Upload image digest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: digests-${{ matrix.image }}-${{ matrix.arch }}
-          path: /tmp/digests/*
-          overwrite: true
-          if-no-files-found: error
-          retention-days: 7
-
-  publish-shared-images:
-    name: Publish shared multi-platform images
+  publish-oci-images:
+    name: Publish OCI images
     if: ${{ needs.release-please.outputs.should_publish == 'true' }}
     needs:
       - release-please
-      - publish-shared-image-legs
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+      - oci-tags
     permissions:
-      actions: read # Required to download image digest artifacts.
-      packages: write # Required to publish the merged manifests.
-    steps:
-      - name: Download appa-runtime digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: digests-appa-runtime-*
-          path: /tmp/digests/appa-runtime
-          merge-multiple: true
-
-      - name: Download appa-kagent-adk digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: digests-appa-kagent-adk-*
-          path: /tmp/digests/appa-kagent-adk
-          merge-multiple: true
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Log in to the image registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Merge and verify image manifests
-        env:
-          VERSION: ${{ needs.release-please.outputs.version }}
-        run: |
-          for image in appa-runtime appa-kagent-adk; do
-            sources=()
-            for digest in "/tmp/digests/${image}"/*; do
-              sources+=("ghcr.io/archestra-ai/${image}@sha256:${digest##*/}")
-            done
-            if [ "${#sources[@]}" -ne 2 ]; then
-              echo "::error::${image} has ${#sources[@]} platform digests, expected 2"
-              exit 1
-            fi
-            docker buildx imagetools create \
-              --tag "ghcr.io/archestra-ai/${image}:${VERSION}" \
-              "${sources[@]}"
-            docker buildx imagetools inspect \
-              "ghcr.io/archestra-ai/${image}:${VERSION}"
-            docker buildx imagetools inspect --raw \
-              "ghcr.io/archestra-ai/${image}:${VERSION}" \
-              | jq -e '[.manifests[].platform | select(.os == "linux") | .architecture] | sort == ["amd64", "arm64"]'
-          done
-
-  # The three amd64 kagent/demo images and the `golang-adk` alias. Each
-  # package needs public visibility, an organization setting made once
-  # after its first publish. The charts default pull anonymously.
-  publish-images:
-    name: Publish container images
-    if: ${{ needs.release-please.outputs.should_publish == 'true' }}
-    needs: release-please
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read # Required to verify and check out the release tag.
-      packages: write # Required to push the images to GitHub Packages.
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-          fetch-depth: 1
-
-      - name: Verify and checkout release source
-        uses: ./.github/actions/verify-release-source
-        with:
-          release_ref: ${{ needs.release-please.outputs.tag_name }}
-          source_commit: ${{ needs.release-please.outputs.source_commit }}
-
-      # Two images pass 1.5 GB. The build needs the space the runner's
-      # preinstalled toolchains hold.
-      - name: Free runner disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup
-          sudo docker image prune --all --force
-          df -h /
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Log in to the image registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Build and push appa-kagent-adk-go
-        id: adk-go
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: integrations/kagent/appa-kagent-adk-go
-          platforms: linux/amd64
-          push: true
-          provenance: true
-          sbom: true
-          tags: ghcr.io/archestra-ai/appa-kagent-adk-go:${{ needs.release-please.outputs.version }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.release-please.outputs.source_commit }}
-            org.opencontainers.image.version=${{ needs.release-please.outputs.version }}
-
-      - name: Build and push appa-demo-tools
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: integrations/kagent/demo
-          platforms: linux/amd64
-          push: true
-          provenance: true
-          sbom: true
-          tags: ghcr.io/archestra-ai/appa-demo-tools:${{ needs.release-please.outputs.version }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.release-please.outputs.source_commit }}
-            org.opencontainers.image.version=${{ needs.release-please.outputs.version }}
-
-      - name: Build and push appa-demo-mocks
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: integrations/kagent/demo/mocks
-          platforms: linux/amd64
-          push: true
-          provenance: true
-          sbom: true
-          tags: ghcr.io/archestra-ai/appa-demo-mocks:${{ needs.release-please.outputs.version }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.release-please.outputs.source_commit }}
-            org.opencontainers.image.version=${{ needs.release-please.outputs.version }}
-
-      # kagent's controller derives the Go runtime image from the python one:
-      # it replaces the last path segment with `golang-adk`. The alias carries
-      # that name and the digest this job pushed.
-      - name: Alias the Go image to the name kagent derives
-        env:
-          GO_DIGEST: ${{ steps.adk-go.outputs.digest }}
-          VERSION: ${{ needs.release-please.outputs.version }}
-        run: |
-          if [[ ! "$GO_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::the Go image build did not report a digest"
-            exit 1
-          fi
-          docker buildx imagetools create \
-            --tag "ghcr.io/archestra-ai/golang-adk:${VERSION}" \
-            "ghcr.io/archestra-ai/appa-kagent-adk-go@${GO_DIGEST}"
-          docker buildx imagetools inspect \
-            "ghcr.io/archestra-ai/appa-kagent-adk-go:${VERSION}"
-          docker buildx imagetools inspect \
-            "ghcr.io/archestra-ai/golang-adk:${VERSION}"
-          alias_digest=$(docker buildx imagetools inspect \
-            --format '{{.Manifest.Digest}}' \
-            "ghcr.io/archestra-ai/golang-adk:${VERSION}")
-          if [ "$alias_digest" != "$GO_DIGEST" ]; then
-            echo "::error::golang-adk resolves to ${alias_digest}, not ${GO_DIGEST}"
-            exit 1
-          fi
-          anonymous_token=$(curl --fail --silent \
-            'https://ghcr.io/token?scope=repository%3Aarchestra-ai%2Fgolang-adk%3Apull&service=ghcr.io' \
-            | jq -r .token)
-          test -n "$anonymous_token"
-          curl --fail --silent --output /dev/null \
-            -H "Authorization: Bearer $anonymous_token" \
-            -H 'Accept: application/vnd.oci.image.index.v1+json' \
-            "https://ghcr.io/v2/archestra-ai/golang-adk/manifests/${VERSION}"
+      actions: read
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-oci-images.yml
+    with:
+      tags: ${{ needs.oci-tags.outputs.tags }}
+      source_commit: ${{ needs.release-please.outputs.source_commit }}
+      version_label: ${{ needs.release-please.outputs.version }}
+      checkout_ref: ${{ github.sha }}
+      verify_release: true
+      release_ref: ${{ needs.release-please.outputs.tag_name }}
+      immutable: true
+    secrets:
+      APPA_GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
   publish-chart:
     name: Publish Helm charts
@@ -512,7 +268,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read # Required to verify and check out the release tag.
-      packages: write # Required to push the OCI chart to GitHub Packages.
+      id-token: write # Required for Workload Identity Federation when pushing charts.
     steps:
       - name: Checkout project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -544,18 +300,22 @@ jobs:
             test "$(helm show chart "$chart" | sed -n 's/^appVersion: *//p')" = "$VERSION"
           done
 
+      - name: Authenticate to Artifact Registry
+        uses: ./.github/actions/auth-to-gar
+        with:
+          service_account: appa-release-publish@friendly-path-465518-r6.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.APPA_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
       - name: Log in to the chart registry
-        env:
-          REGISTRY_TOKEN: ${{ github.token }}
-          REGISTRY_USERNAME: ${{ github.actor }}
-        run: echo "$REGISTRY_TOKEN" | helm registry login ghcr.io --username "$REGISTRY_USERNAME" --password-stdin
+        run: gcloud auth print-access-token | helm registry login europe-west1-docker.pkg.dev --username oauth2accesstoken --password-stdin
 
       - name: Publish the chart
         env:
           VERSION: ${{ needs.release-please.outputs.version }}
         run: |
-          helm push "dist/appa-runtime-${VERSION}.tgz" oci://ghcr.io/archestra-ai/charts
-          helm push "dist/appa-kagent-demo-${VERSION}.tgz" oci://ghcr.io/archestra-ai/charts
+          charts_oci=$(python3 scripts/appa-oci-tags.py charts-oci)
+          helm push "dist/appa-runtime-${VERSION}.tgz" "$charts_oci"
+          helm push "dist/appa-kagent-demo-${VERSION}.tgz" "$charts_oci"
 
       - name: Upload the runtime chart artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -584,8 +344,7 @@ jobs:
       - release-please
       - plugin-artifact
       - build-binaries
-      - publish-shared-images
-      - publish-images
+      - publish-oci-images
       - publish-chart
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/appa-runtime/tests/guide_skill.rs
+++ b/appa-runtime/tests/guide_skill.rs
@@ -198,7 +198,7 @@ fn kagent_guidance_requires_the_shared_runtime_and_direct_port() {
     assert!(website.contains("http://appa-runtime.appa.svc.cluster.local:18787"));
     assert!(website.contains("appaGuide.enabled=true"));
     assert!(website.contains("appa-kagent-adk"));
-    assert!(website.contains("archestra-ai/golang-adk"));
+    assert!(website.contains("friendly-path-465518-r6/appa-public/golang-adk"));
 }
 
 #[test]

--- a/charts/appa-runtime/Chart.yaml
+++ b/charts/appa-runtime/Chart.yaml
@@ -3,8 +3,8 @@ name: appa-runtime
 description: Shared OpenAPPA runtime for a Kubernetes cluster. One process gates every agent that points at it.
 type: application
 version: 0.12.0 # x-release-please-version
-# The released version. The release workflow publishes the image at that
-# version, and release-please bumps this line to it.
+# The released version. The release workflow publishes the image at
+# v<appVersion>, and release-please bumps this line to it.
 appVersion: "0.12.0" # x-release-please-version
 kubeVersion: ">=1.28.0-0"
 keywords: [openappa, appa, policy, agents]

--- a/charts/appa-runtime/README.md
+++ b/charts/appa-runtime/README.md
@@ -4,15 +4,15 @@ Shared OpenAPPA runtime for a Kubernetes cluster. One replica. Agents
 that set `APPA_RUNTIME_URL` to this Service, with `APPA_ENABLED=true`,
 are gated by the policy in the ConfigMap.
 
-The image of this chart version is `ghcr.io/archestra-ai/appa-runtime:0.12.0`. # x-release-please-version
+The image of this chart version is `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-runtime:v0.12.0`. # x-release-please-version
 
 ## Install
 
-Install a released chart from GHCR after setting `APPA_VERSION` to an
-OpenAPPA release that contains the chart:
+Install a released chart from Artifact Registry after setting
+`APPA_VERSION` to an OpenAPPA release that contains the chart:
 
 ```sh
-helm install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runtime \
+helm install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-runtime \
   --version "$APPA_VERSION" --namespace appa --create-namespace
 ```
 
@@ -31,7 +31,7 @@ checkout.
 The chart can install the configuring kagent Agent with the runtime:
 
 ```sh
-helm install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runtime \
+helm install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-runtime \
   --version "$APPA_VERSION" --namespace appa --create-namespace \
   --set appaGuide.enabled=true \
   --set appaGuide.namespace=kagent
@@ -41,10 +41,6 @@ The option is off by default because the runtime chart also supports
 clusters without kagent. The target namespace, kagent model config, and
 tool-server name are configurable under `appaGuide`. An empty
 `appaGuide.skill.ref` pins the skill to the chart's `v<appVersion>` tag.
-
-GHCR packages start private. An organization owner must make the
-`charts/appa-runtime` package public after its first publish before an
-anonymous OCI install can pull it.
 
 The runtime binds the pod network directly. Point agents at:
 

--- a/charts/appa-runtime/templates/_helpers.tpl
+++ b/charts/appa-runtime/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app: appa-runtime
 {{- end -}}
 
 {{- define "appa-runtime.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
 {{- if .Values.image.digest -}}
 {{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
 {{- else -}}

--- a/charts/appa-runtime/tests/render-test.sh
+++ b/charts/appa-runtime/tests/render-test.sh
@@ -50,7 +50,7 @@ must_render
 expect 1 '^kind: Deployment$'
 expect 1 '^kind: Service$'
 expect 1 '^kind: ServiceAccount$'
-must_contain 'image: ghcr.io/archestra-ai/appa-runtime:'
+must_contain "image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-runtime:v${app_version}"
 must_contain '--batteries-dir'
 must_contain '/opt/appa/batteries'
 must_contain 'containerPort: 18787'

--- a/charts/appa-runtime/values.yaml
+++ b/charts/appa-runtime/values.yaml
@@ -1,8 +1,8 @@
 # Shared OpenAPPA runtime. One replica: the trajectory log is SQLite.
 
 image:
-  repository: ghcr.io/archestra-ai/appa-runtime
-  # Empty uses the chart appVersion.
+  repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-runtime
+  # Empty uses v<appVersion>.
   tag: ""
   pullPolicy: IfNotPresent
   digest: ""

--- a/integrations/kagent/IMPLEMENTATION.md
+++ b/integrations/kagent/IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 `appa-adapter-kagent` is the Rust codec crate, a workspace crate compiled into `appa-runtime`. The runtime selects it through its closed `Adapter` enum ([appa-runtime/src/main.rs](../../appa-runtime/src/main.rs)) as `appa_adapter_kagent::codec()`.
 
-The agent side wraps the kagent ADK runtimes and takes its names from them. The `appa-kagent-adk` python package (plugin + entrypoint) builds as the `ghcr.io/archestra-ai/appa-kagent-adk` image from its [Dockerfile](appa-kagent-adk/Dockerfile). The `appa-kagent-adk-go` Go module (plugin + runtime main) builds as the `ghcr.io/archestra-ai/appa-kagent-adk-go` image from its [Dockerfile](appa-kagent-adk-go/Dockerfile). The release workflow publishes both images, and three more, at the release version ([Delivery units](#delivery-units)). Operators can also build them from source. The crate name never names an image.
+The agent side wraps the kagent ADK runtimes and takes its names from them. The `appa-kagent-adk` python package (plugin + entrypoint) builds as the `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-kagent-adk` image from its [Dockerfile](appa-kagent-adk/Dockerfile). The `appa-kagent-adk-go` Go module (plugin + runtime main) builds as the `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-kagent-adk-go` image from its [Dockerfile](appa-kagent-adk-go/Dockerfile). The release workflow publishes both images, and three more, at the immutable `v<version>` tag ([Delivery units](#delivery-units)). Operators can also build them from source. The crate name never names an image.
 
 Both images read `APPA_RUNTIME_URL`, both emit the same adapter wire, and the one codec crate parses it.
 
@@ -141,7 +141,7 @@ kind: Harness
 spec:
   kagent: {}
   workload:
-    image: ghcr.io/archestra-ai/appa-kagent-adk@sha256:<digest>
+    image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-kagent-adk@sha256:<digest>
   env:
     - name: APPA_RUNTIME_URL
       value: http://appa-runtime.appa-system:8787
@@ -572,9 +572,9 @@ appa-kagent-demo release
 
 Every unit lives in this repository.
 
-[release.yml](../../.github/workflows/release.yml) publishes five images to `ghcr.io/archestra-ai` at the release version. `appa-runtime` and `appa-kagent-adk` publish for `linux/amd64` and `linux/arm64`. `appa-kagent-adk-go`, `appa-demo-tools`, and `appa-demo-mocks` publish for `linux/amd64`. Each build attaches an SBOM and provenance. The workflow publishes both Helm charts as OCI artifacts and GitHub release assets. It also tags `golang-adk` on the `appa-kagent-adk-go` digest for kagent 0.9.12.
+[release.yml](../../.github/workflows/release.yml) publishes five images to `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public` at the immutable `v<version>` tag. `appa-runtime` and `appa-kagent-adk` publish for `linux/amd64` and `linux/arm64`. `appa-kagent-adk-go`, `appa-demo-tools`, and `appa-demo-mocks` publish for `linux/amd64`. Each build attaches an SBOM and provenance. The workflow publishes both Helm charts as OCI artifacts under `charts/` with unprefixed SemVer tags, and as GitHub release assets. It also tags `golang-adk` on the `appa-kagent-adk-go` digest for kagent 0.9.12. Image-changing CI pushes rolling `sha-`, `pr-`, `main`, and `latest` tags to the same registry; those prefixes are garbage-collected after 30 days.
 
-Every Dockerfile pins each `FROM` and `COPY --from` base by digest, with the tag beside it for the reader. The image jobs in [ci.yml](../../.github/workflows/ci.yml) build all five on a pull request that can break them, including native arm64 checks for the runtime and Python adapter. They push none. No workflow scans the images.
+Every Dockerfile pins each `FROM` and `COPY --from` base by digest, with the tag beside it for the reader. The image jobs in [ci.yml](../../.github/workflows/ci.yml) build all five on a pull request that can break them, including native arm64 checks for the runtime and Python adapter. They push none. [publish-ci-images.yml](../../.github/workflows/publish-ci-images.yml) publishes the rolling tags. No workflow scans the images.
 
 ## Verification matrix
 

--- a/integrations/kagent/README.md
+++ b/integrations/kagent/README.md
@@ -67,8 +67,8 @@ helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-c
 APPA_VERSION=0.12.0 # x-release-please-version
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent \
-  --set controller.agentImage.registry=ghcr.io \
-  --set controller.agentImage.repository=archestra-ai/appa-kagent-adk \
+  --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
+  --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
   --set providers.default=openAI \
   --set-string providers.openAI.apiKey="$OPENAI_API_KEY" \
   --set k8s-agent.enabled=false \
@@ -83,10 +83,10 @@ helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --set cilium-debug-agent.enabled=false \
   --force-conflicts \
   --wait --timeout 10m \
-  --set controller.agentImage.tag="$APPA_VERSION"
+  --set controller.agentImage.tag="v$APPA_VERSION"
 
 # 3. Install appa
-helm upgrade --install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runtime \
+helm upgrade --install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-runtime \
   --version "$APPA_VERSION" -n appa --create-namespace \
   --set persistence.enabled=true \
   --set appaGuide.enabled=true \
@@ -95,7 +95,7 @@ helm upgrade --install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runti
 
 # 4. Install the demo fixtures
 helm upgrade --install appa-kagent-demo \
-  oci://ghcr.io/archestra-ai/charts/appa-kagent-demo \
+  oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-kagent-demo \
   --version "$APPA_VERSION" -n kagent \
   --set-string runtime.url=http://appa-runtime.appa.svc.cluster.local:18787 \
   --set-string modelConfig.name=default-model-config \

--- a/integrations/kagent/appa-kagent-adk-go/plugin.go
+++ b/integrations/kagent/appa-kagent-adk-go/plugin.go
@@ -1,5 +1,5 @@
 // Package appakagentadk carries AppaPluginKagent — the adk/v2 plugin
-// of the ghcr.io/archestra-ai/appa-kagent-adk-go image.
+// of the appa-kagent-adk-go image.
 //
 // The plugin maps each gated ADK callback onto one wire event, posts
 // it to $APPA_RUNTIME_URL/hook, and enforces the answered decision. It

--- a/integrations/kagent/appa-kagent-adk/README.md
+++ b/integrations/kagent/appa-kagent-adk/README.md
@@ -35,7 +35,7 @@ call and its result.
 
 The [Dockerfile](Dockerfile) builds the package into the
 `appa-kagent-adk` image, one layer over kagent's published runtime
-image. The plan names that image `ghcr.io/archestra-ai/appa-kagent-adk`.
+image. The plan names that image `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-kagent-adk`.
 
 The operator guide lives at `website/content/docs/kagent.md`; the
 implementation plan, per-version mapping tables, and verification

--- a/integrations/kagent/demo/README.md
+++ b/integrations/kagent/demo/README.md
@@ -19,7 +19,7 @@ chart:
 ```sh
 APPA_VERSION=0.12.0 # x-release-please-version
 helm upgrade --install appa-kagent-demo \
-  oci://ghcr.io/archestra-ai/charts/appa-kagent-demo \
+  oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-kagent-demo \
   --version "$APPA_VERSION" -n kagent \
   --set-string runtime.url=http://appa-runtime.appa.svc.cluster.local:18787 \
   --set-string modelConfig.name=default-model-config \

--- a/integrations/kagent/demo/chart/Chart.yaml
+++ b/integrations/kagent/demo/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: appa-kagent-demo
 description: Demo Agents, tools, mock policy services, and seeded chats for an existing OpenAPPA runtime on kagent.
 type: application
 version: 0.12.0 # x-release-please-version
-# The released version. The release workflow publishes every image at that
-# version, and release-please bumps this line to it.
+# The released version. The release workflow publishes every image at
+# v<appVersion>, and release-please bumps this line to it.
 appVersion: "0.12.0" # x-release-please-version
 kubeVersion: ">=1.28.0-0"
 keywords: [openappa, kagent, agents, policy]

--- a/integrations/kagent/demo/chart/README.md
+++ b/integrations/kagent/demo/chart/README.md
@@ -30,7 +30,7 @@ The defaults expect:
 ```sh
 APPA_VERSION=0.12.0 # x-release-please-version
 helm upgrade --install appa-kagent-demo \
-  oci://ghcr.io/archestra-ai/charts/appa-kagent-demo \
+  oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-kagent-demo \
   --version "$APPA_VERSION" -n kagent \
   --set-string runtime.url=http://appa-runtime.appa.svc.cluster.local:18787 \
   --set-string modelConfig.name=default-model-config \
@@ -52,8 +52,8 @@ upgrading this chart cannot change runtime policy.
 | `runtime.url` | `http://appa-runtime.appa.svc.cluster.local:18787` | Existing shared runtime used by every demo Agent. |
 | `runtime.reasoningEffort` | `""` | Optional reasoning effort passed to each Agent model request. |
 | `modelConfig.name` | `default-model-config` | Existing kagent ModelConfig used by every demo Agent. |
-| `tools.image.*` | `ghcr.io/archestra-ai/appa-demo-tools:<appVersion>` | Demo MCP server image. |
-| `mocks.image.*` | `ghcr.io/archestra-ai/appa-demo-mocks:<appVersion>` | Demo policy-service image. |
+| `tools.image.*` | `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-demo-tools:v<appVersion>` | Demo MCP server image. |
+| `mocks.image.*` | `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-demo-mocks:v<appVersion>` | Demo policy-service image. |
 | `mocks.approvalWindowSeconds` | `25` | Change-board ruling window, below the policy's 30-second consult timeout. |
 | `seed.enabled` | `true` | Replay the sixteen showcase chats after install. |
 | `seed.controllerUrl` | controller in the release namespace | kagent controller receiving seeded sessions. |
@@ -91,7 +91,7 @@ answers and exposes the change board at `/pending` and `/decide`.
 ## Images
 
 This chart directly uses only `appa-demo-tools` and `appa-demo-mocks`.
-Both default to the chart `appVersion` in `ghcr.io/archestra-ai`. kagent
+Both default to `v<appVersion>` in `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public`. kagent
 and the runtime releases separately select `appa-kagent-adk`,
 `appa-kagent-adk-go`/`golang-adk`, and `appa-runtime`.
 

--- a/integrations/kagent/demo/chart/templates/_helpers.tpl
+++ b/integrations/kagent/demo/chart/templates/_helpers.tpl
@@ -1,6 +1,6 @@
-{{/* An image reference; an empty tag means the chart's appVersion. */}}
+{{/* An image reference; an empty tag means v<appVersion>. */}}
 {{- define "appa-demo.image" -}}
-{{- printf "%s:%s" .image.repository (.image.tag | default .root.Chart.AppVersion) -}}
+{{- printf "%s:%s" .image.repository (.image.tag | default (printf "v%s" .root.Chart.AppVersion)) -}}
 {{- end -}}
 
 {{/* The existing shared runtime Service used by every demo Agent. */}}

--- a/integrations/kagent/demo/chart/tests/render-test.sh
+++ b/integrations/kagent/demo/chart/tests/render-test.sh
@@ -84,13 +84,13 @@ expect 0 '^kind: Secret$'
 expect 0 '^  name: appa-runtime$'
 expect 0 '^  name: appa-runtime-policy$'
 expect 0 '^  name: appa-guide$'
-expect 0 "image: ghcr.io/archestra-ai/appa-runtime:${app_version}$"
+expect 0 "image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-runtime:v${app_version}$"
 expect 0 '/opt/appa/batteries|/var/lib/appa|APPA_CONFIG|APPA_GUIDE_RUNTIME_URL'
 expect 1 '^  name: appa-kagent-demo-policy$'
 expect 1 '^    app.kubernetes.io/component: policy-template$'
 expect 2 '^  name: appa-demo-mocks$'
-expect 1 "image: ghcr.io/archestra-ai/appa-demo-mocks:${app_version}$"
-expect 1 "image: ghcr.io/archestra-ai/appa-demo-tools:${app_version}$"
+expect 1 "image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-demo-mocks:v${app_version}$"
+expect 1 "image: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-demo-tools:v${app_version}$"
 expect 1 '^        runAsNonRoot: true$'
 expect 1 '^            readOnlyRootFilesystem: true$'
 expect 5 'http://appa-demo-mocks\.kagent\.svc\.cluster\.local:8081/'

--- a/integrations/kagent/demo/chart/values.yaml
+++ b/integrations/kagent/demo/chart/values.yaml
@@ -16,7 +16,7 @@ runtime:
 # through local command adapters; the service never owns runtime resources.
 mocks:
   image:
-    repository: ghcr.io/archestra-ai/appa-demo-mocks
+    repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-demo-mocks
     tag: ""
     pullPolicy: IfNotPresent
   # Seconds a change-board consult waits for a member's ruling before it
@@ -26,7 +26,7 @@ mocks:
 
 tools:
   image:
-    repository: ghcr.io/archestra-ai/appa-demo-tools
+    repository: europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/appa-demo-tools
     tag: ""
     pullPolicy: IfNotPresent
 

--- a/scripts/appa-gar-cleanup-policies.json
+++ b/scripts/appa-gar-cleanup-policies.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "keep-release-tags",
+    "action": "KEEP",
+    "condition": {
+      "tagState": "TAGGED",
+      "tagPrefixes": ["v"]
+    }
+  },
+  {
+    "id": "keep-minimum-ci-versions",
+    "action": "KEEP",
+    "mostRecentVersions": {
+      "keepCount": 10,
+      "packageNamePrefixes": [
+        "appa-runtime",
+        "appa-kagent-adk",
+        "appa-kagent-adk-go",
+        "golang-adk",
+        "appa-demo-tools",
+        "appa-demo-mocks",
+        "charts/appa-runtime",
+        "charts/appa-kagent-demo"
+      ]
+    }
+  },
+  {
+    "id": "delete-old-ci-tags",
+    "action": "DELETE",
+    "condition": {
+      "tagState": "TAGGED",
+      "tagPrefixes": ["sha-", "pr-", "main", "latest"],
+      "olderThan": "2592000s"
+    }
+  }
+]

--- a/scripts/appa-oci-tags.py
+++ b/scripts/appa-oci-tags.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Tag contract for OpenAPPA images and charts in appa-public.
+
+Release images use an immutable v* tag. Rolling CI tags are sha-, pr-,
+main, and latest. Chart versions stay SemVer without a v prefix and live
+under charts/, so GAR prefix matching can garbage-collect CI images
+without deleting releases or charts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+GAR_HOST = "europe-west1-docker.pkg.dev"
+GAR_PROJECT = "friendly-path-465518-r6"
+GAR_REPOSITORY = "appa-public"
+REGISTRY = f"{GAR_HOST}/{GAR_PROJECT}/{GAR_REPOSITORY}"
+CHARTS_OCI = f"oci://{REGISTRY}/charts"
+
+IMAGE_PACKAGES = (
+    "appa-runtime",
+    "appa-kagent-adk",
+    "appa-kagent-adk-go",
+    "appa-demo-tools",
+    "appa-demo-mocks",
+    "golang-adk",
+)
+
+RELEASE_VERSION = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-.][0-9A-Za-z.-]+)?$"
+)
+RELEASE_IMAGE_TAG = re.compile(
+    r"^v[0-9]+\.[0-9]+\.[0-9]+(?:[-.][0-9A-Za-z.-]+)?$"
+)
+CI_SHA_TAG = re.compile(r"^sha-[0-9a-f]{7,40}$")
+CI_PR_TAG = re.compile(r"^pr-[1-9][0-9]*$")
+CI_MOVING_TAGS = frozenset({"main", "latest"})
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+DELETE_TAG_PREFIXES = ("sha-", "pr-", "main", "latest")
+KEEP_TAG_PREFIXES = ("v",)
+KEEP_RECENT = 10
+MAX_AGE_SECONDS = 2592000
+POLICY_PATH = Path(__file__).with_name("appa-gar-cleanup-policies.json")
+
+
+def registry() -> str:
+    return REGISTRY
+
+
+def charts_oci() -> str:
+    return CHARTS_OCI
+
+
+def release_image_tag(version: str) -> str:
+    if not RELEASE_VERSION.fullmatch(version):
+        raise ValueError(f"not a release version: {version}")
+    return f"v{version}"
+
+
+def rolling_tags(
+    *,
+    event: str,
+    sha: str,
+    ref: str = "",
+    pr_number: int | None = None,
+) -> list[str]:
+    if not FULL_SHA.fullmatch(sha):
+        raise ValueError("sha must be a full commit")
+    tags = [f"sha-{sha[:12]}"]
+    if event == "pull_request":
+        if pr_number is None or pr_number < 1:
+            raise ValueError("pull_request requires a PR number")
+        tags.append(f"pr-{pr_number}")
+        return tags
+    if ref == "refs/heads/main":
+        tags.extend(["main", "latest"])
+    return tags
+
+
+def classify_tag(tag: str) -> str:
+    if RELEASE_IMAGE_TAG.fullmatch(tag):
+        return "release"
+    if (
+        CI_SHA_TAG.fullmatch(tag)
+        or CI_PR_TAG.fullmatch(tag)
+        or tag in CI_MOVING_TAGS
+    ):
+        return "ci"
+    if RELEASE_VERSION.fullmatch(tag):
+        return "chart"
+    return "unknown"
+
+
+def is_image_package(package: str) -> bool:
+    return package in IMAGE_PACKAGES
+
+
+def has_prefix(tag: str, prefixes: tuple[str, ...]) -> bool:
+    return any(tag.startswith(prefix) for prefix in prefixes)
+
+
+def deletion_candidates(
+    versions: list[dict],
+    *,
+    now: int,
+    max_age_seconds: int = MAX_AGE_SECONDS,
+    keep_recent: int = KEEP_RECENT,
+) -> list[str]:
+    """Return digests GAR cleanup may delete.
+
+    Mirrors the appa-public policies: keep any digest tagged v*, exclude
+    charts/, keep the newest ``keep_recent`` versions of each image
+    package, and delete remaining image versions whose tags are only
+    rolling CI prefixes and that are older than ``max_age_seconds``.
+    """
+    newest: dict[str, list[tuple[int, str]]] = {}
+    for version in versions:
+        package = version["package"]
+        if not is_image_package(package):
+            continue
+        newest.setdefault(package, []).append(
+            (int(version["created"]), version["digest"])
+        )
+    protected_recent = set()
+    for package, entries in newest.items():
+        entries.sort(reverse=True)
+        for _, digest in entries[:keep_recent]:
+            protected_recent.add((package, digest))
+
+    candidates = []
+    for version in versions:
+        package = version["package"]
+        digest = version["digest"]
+        tags = list(version["tags"])
+        if not is_image_package(package):
+            continue
+        if any(has_prefix(tag, KEEP_TAG_PREFIXES) for tag in tags):
+            continue
+        if (package, digest) in protected_recent:
+            continue
+        if now - int(version["created"]) < max_age_seconds:
+            continue
+        if not tags or not all(
+            has_prefix(tag, DELETE_TAG_PREFIXES) for tag in tags
+        ):
+            continue
+        candidates.append(digest)
+    return candidates
+
+
+def load_policies() -> list[dict]:
+    return json.loads(POLICY_PATH.read_text())
+
+
+def _print_lines(values: list[str]) -> int:
+    sys.stdout.write("\n".join(values) + "\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("registry")
+    sub.add_parser("charts-oci")
+
+    release = sub.add_parser("release-image")
+    release.add_argument("--version", required=True)
+
+    rolling = sub.add_parser("rolling")
+    rolling.add_argument("--event", required=True)
+    rolling.add_argument("--sha", required=True)
+    rolling.add_argument("--ref", default="")
+    rolling.add_argument("--pr", type=int, default=None)
+
+    classify = sub.add_parser("classify")
+    classify.add_argument("--tag", required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "registry":
+        return _print_lines([registry()])
+    if args.command == "charts-oci":
+        return _print_lines([charts_oci()])
+    if args.command == "release-image":
+        return _print_lines([release_image_tag(args.version)])
+    if args.command == "rolling":
+        return _print_lines(
+            rolling_tags(
+                event=args.event,
+                sha=args.sha,
+                ref=args.ref,
+                pr_number=args.pr,
+            )
+        )
+    return _print_lines([classify_tag(args.tag)])
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        sys.exit(1)

--- a/scripts/test_appa_oci_tags.py
+++ b/scripts/test_appa_oci_tags.py
@@ -1,0 +1,174 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).with_name("appa-oci-tags.py")
+SPEC = importlib.util.spec_from_file_location("appa_oci_tags", SCRIPT)
+oci_tags = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(oci_tags)
+
+SHA = "0123456789abcdef0123456789abcdef01234567"
+OLD = 1
+RECENT = 2_600_000
+NOW = 3_000_000
+
+
+def version(package, digest, created, *tags):
+    return {
+        "package": package,
+        "digest": digest,
+        "created": created,
+        "tags": list(tags),
+    }
+
+
+class OciTagContractTests(unittest.TestCase):
+    def test_release_image_tag_is_v_prefixed(self):
+        self.assertEqual(oci_tags.release_image_tag("1.2.3"), "v1.2.3")
+        self.assertEqual(oci_tags.release_image_tag("1.2.3-rc.1"), "v1.2.3-rc.1")
+
+    def test_release_image_tag_rejects_bare_and_already_prefixed(self):
+        with self.assertRaises(ValueError):
+            oci_tags.release_image_tag("v1.2.3")
+        with self.assertRaises(ValueError):
+            oci_tags.release_image_tag("latest")
+
+    def test_rolling_tags_on_pull_request(self):
+        self.assertEqual(
+            oci_tags.rolling_tags(
+                event="pull_request",
+                sha=SHA,
+                pr_number=12,
+            ),
+            [f"sha-{SHA[:12]}", "pr-12"],
+        )
+
+    def test_rolling_tags_on_main(self):
+        self.assertEqual(
+            oci_tags.rolling_tags(
+                event="push",
+                sha=SHA,
+                ref="refs/heads/main",
+            ),
+            [f"sha-{SHA[:12]}", "main", "latest"],
+        )
+
+    def test_rolling_tags_on_other_ref_are_sha_only(self):
+        self.assertEqual(
+            oci_tags.rolling_tags(
+                event="workflow_dispatch",
+                sha=SHA,
+                ref="refs/heads/feat/x",
+            ),
+            [f"sha-{SHA[:12]}"],
+        )
+
+    def test_classify(self):
+        self.assertEqual(oci_tags.classify_tag("v1.2.3"), "release")
+        self.assertEqual(oci_tags.classify_tag("v1.2.3-rc.1"), "release")
+        self.assertEqual(oci_tags.classify_tag(f"sha-{SHA[:12]}"), "ci")
+        self.assertEqual(oci_tags.classify_tag("pr-12"), "ci")
+        self.assertEqual(oci_tags.classify_tag("main"), "ci")
+        self.assertEqual(oci_tags.classify_tag("latest"), "ci")
+        self.assertEqual(oci_tags.classify_tag("1.2.3"), "chart")
+        self.assertEqual(oci_tags.classify_tag("1.2.3-rc.1"), "chart")
+        self.assertEqual(oci_tags.classify_tag("0.2.0"), "chart")
+        self.assertEqual(oci_tags.classify_tag("nightly"), "unknown")
+
+    def test_release_digest_is_kept_even_with_a_ci_tag(self):
+        versions = [
+            version("appa-runtime", "keep-release", OLD, "v1.2.3", "sha-deadbeef"),
+        ]
+        self.assertEqual(
+            oci_tags.deletion_candidates(versions, now=NOW, keep_recent=0),
+            [],
+        )
+
+    def test_chart_semver_is_never_a_delete_candidate(self):
+        versions = [
+            version("charts/appa-runtime", "chart", OLD, "1.2.3"),
+            version("charts/appa-kagent-demo", "demo", OLD, "1.2.3-rc.1"),
+        ]
+        self.assertEqual(
+            oci_tags.deletion_candidates(versions, now=NOW, keep_recent=0),
+            [],
+        )
+
+    def test_old_ci_tags_are_candidates_outside_keep_recent(self):
+        versions = [
+            version("appa-runtime", "old-sha", OLD, f"sha-{SHA[:12]}"),
+            version("appa-runtime", "old-pr", OLD, "pr-12"),
+        ]
+        self.assertEqual(
+            oci_tags.deletion_candidates(versions, now=NOW, keep_recent=0),
+            ["old-sha", "old-pr"],
+        )
+
+    def test_recent_ci_and_current_moving_tags_are_kept(self):
+        versions = [
+            version("appa-runtime", "fresh-sha", RECENT, f"sha-{SHA[:12]}"),
+            version("appa-runtime", "current-main", RECENT, "main", "latest"),
+        ]
+        self.assertEqual(
+            oci_tags.deletion_candidates(versions, now=NOW, keep_recent=0),
+            [],
+        )
+
+    def test_keep_recent_protects_old_ci_versions(self):
+        versions = [
+            version("appa-runtime", f"v{i}", OLD + i, f"sha-{i:012x}")
+            for i in range(12)
+        ]
+        self.assertEqual(
+            oci_tags.deletion_candidates(versions, now=NOW, keep_recent=10),
+            ["v0", "v1"],
+        )
+
+    def test_unknown_and_untagged_are_not_selected(self):
+        versions = [
+            version("appa-runtime", "untagged", OLD),
+            version("appa-runtime", "weird", OLD, "nightly"),
+        ]
+        self.assertEqual(
+            oci_tags.deletion_candidates(versions, now=NOW, keep_recent=0),
+            [],
+        )
+
+    def test_cleanup_policy_file_matches_the_contract(self):
+        policies = {item["id"]: item for item in oci_tags.load_policies()}
+        self.assertEqual(set(policies), {
+            "keep-release-tags",
+            "keep-minimum-ci-versions",
+            "delete-old-ci-tags",
+        })
+        self.assertEqual(policies["keep-release-tags"]["action"], "KEEP")
+        self.assertEqual(
+            policies["keep-release-tags"]["condition"]["tagPrefixes"],
+            list(oci_tags.KEEP_TAG_PREFIXES),
+        )
+        self.assertEqual(
+            policies["keep-minimum-ci-versions"]["mostRecentVersions"]["keepCount"],
+            oci_tags.KEEP_RECENT,
+        )
+        self.assertTrue(
+            set(oci_tags.IMAGE_PACKAGES).issubset(
+                policies["keep-minimum-ci-versions"]["mostRecentVersions"][
+                    "packageNamePrefixes"
+                ]
+            )
+        )
+        delete = policies["delete-old-ci-tags"]
+        self.assertEqual(delete["action"], "DELETE")
+        self.assertEqual(
+            delete["condition"]["tagPrefixes"],
+            list(oci_tags.DELETE_TAG_PREFIXES),
+        )
+        self.assertEqual(
+            delete["condition"]["olderThan"],
+            f"{oci_tags.MAX_AGE_SECONDS}s",
+        )
+        self.assertNotIn("packageNamePrefixes", delete["condition"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -15,9 +15,9 @@ Configure the appa plugin image in the kagent controller Helm values:
 controller:
   # Python declarative runtime image
   agentImage:
-    registry: ghcr.io
-    repository: archestra-ai/appa-kagent-adk
-    tag: 0.12.0 # x-release-please-version
+    registry: europe-west1-docker.pkg.dev
+    repository: friendly-path-465518-r6/appa-public/appa-kagent-adk
+    tag: v0.12.0 # x-release-please-version
 ```
 
 The plugin image replaces kagent's Python Agent image. It stays inert until an Agent sets both variables:
@@ -46,7 +46,7 @@ The Python and Go plugin images run inside Agent pods through the official Googl
 - **Runtime support**: Works with both Python (`appa-kagent-adk`) and Go (`appa-kagent-adk-go`) runtimes.
 - **Subagent return gate**: Delegated child agents stop through `appa_return`. OpenAPPA checks returned data at `SpawnResult` before parent context receives it.
 
-On kagent 0.9.12, Go Agents derive `ghcr.io/archestra-ai/golang-adk` from `controller.agentImage`. OpenAPPA publishes that alias on the `appa-kagent-adk-go` image digest. The stable chart has no `controller.goAgentImage` value.
+On kagent 0.9.12, Go Agents derive `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/golang-adk` from `controller.agentImage`. OpenAPPA publishes that alias on the `appa-kagent-adk-go` image digest. The stable chart has no `controller.goAgentImage` value.
 
 ## Policy scope
 
@@ -87,9 +87,9 @@ helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-c
 
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent \
-  --set controller.agentImage.registry=ghcr.io \
-  --set controller.agentImage.repository=archestra-ai/appa-kagent-adk \
-  --set controller.agentImage.tag="$APPA_VERSION" \
+  --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
+  --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
+  --set controller.agentImage.tag="v$APPA_VERSION" \
   --set providers.default=openAI \
   --set-string providers.openAI.apiKey="$OPENAI_API_KEY" \
   --set k8s-agent.enabled=false \
@@ -115,7 +115,7 @@ Now install the runtime. kagent can reconcile `appa-guide` against the model and
 
 ```sh
 APPA_VERSION=0.12.0 # x-release-please-version
-helm upgrade --install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runtime \
+helm upgrade --install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-runtime \
   --version "$APPA_VERSION" -n appa --create-namespace \
   --set persistence.enabled=true \
   --set persistence.size=8Gi \
@@ -131,7 +131,7 @@ The runtime listens at `http://appa-runtime.appa.svc.cluster.local:18787`. The s
 ```sh
 APPA_VERSION=0.12.0 # x-release-please-version
 helm upgrade --install appa-kagent-demo \
-  oci://ghcr.io/archestra-ai/charts/appa-kagent-demo \
+  oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-kagent-demo \
   --version "$APPA_VERSION" -n kagent \
   --set-string runtime.url=http://appa-runtime.appa.svc.cluster.local:18787 \
   --set-string modelConfig.name=default-model-config \
@@ -186,7 +186,7 @@ Deploy one policy runtime for the agents you want to protect:
 
 ```sh
 APPA_VERSION=0.12.0 # x-release-please-version
-helm upgrade --install appa-runtime oci://ghcr.io/archestra-ai/charts/appa-runtime \
+helm upgrade --install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/charts/appa-runtime \
   --version "$APPA_VERSION" \
   --namespace appa --create-namespace \
   --set persistence.enabled=true \
@@ -221,9 +221,9 @@ The new adapter refuses an enabled Agent with no URL. Updating the URL first pre
 ```sh
 helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent --reuse-values \
-  --set controller.agentImage.registry=ghcr.io \
-  --set controller.agentImage.repository=archestra-ai/appa-kagent-adk \
-  --set controller.agentImage.tag="$APPA_VERSION" \
+  --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
+  --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
+  --set controller.agentImage.tag="v$APPA_VERSION" \
   --force-conflicts --wait --timeout 10m
 ```
 


### PR DESCRIPTION
Release images publish to `appa-public` as immutable `v*` tags. Trusted main CI attaches rolling `sha-`/`main`/`latest` tags so GAR can collect old digests without deleting releases. Charts stay unprefixed SemVer under `charts/`.

Publishing uses `appa-release-publish`, not the demo pusher. Pull requests do not receive registry credentials.

Requires the infra `appa-public` repository and publisher identity to be applied before the first publish.