### PR TITLE
fix(guide): verify reloaded policy and parse apply manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,9 @@ jobs:
           done
 
       - name: Test release battery refresh
-        run: python3 -m unittest scripts/test_appa_refresh_batteries.py scripts/test_appa_guide_runtime.py scripts/test_appa_oci_tags.py
+        run: |
+          python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --quiet --break-system-packages 'pyyaml==6.0.2'
+          python3 -m unittest scripts/test_appa_refresh_batteries.py scripts/test_appa_guide_runtime.py scripts/test_appa_oci_tags.py
 
       - name: Check release versions
         uses: ./.github/actions/check-release-versions

--- a/appa-runtime/Dockerfile
+++ b/appa-runtime/Dockerfile
@@ -35,7 +35,8 @@ COPY website/content/docs/contracts.md website/content/docs/contracts.md
 RUN cargo build --release --locked --package appa
 
 FROM python:3.13-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
-RUN groupadd --system --gid 65532 appa \
+RUN pip install --no-cache-dir 'pyyaml==6.0.2' \
+    && groupadd --system --gid 65532 appa \
     && useradd --system --uid 65532 --gid 65532 --home-dir /var/lib/appa --create-home appa \
     && mkdir -p /opt/appa /etc/appa \
     && chown appa:appa /var/lib/appa /etc/appa

--- a/integrations/appa-guide/SKILL.md
+++ b/integrations/appa-guide/SKILL.md
@@ -10,7 +10,8 @@ If the request says `diagnose` and `inspect only`, ignore all proposal,
 battery-suggestion, approval, and mutation instructions below. Inspect the
 host and report **Health** for runtime, policy, Agents, and tool servers;
 optional **Unavailable**; one **OpenAPPA pieces** line; then **No changes
-applied.**
+applied.** Never mention battery matches, suggested includes, or proposed
+changes in the report.
 
 You run inside a host. Every host follows the same flow — inspect the
 installed tools, propose contracts in plain English, wait for approval,

--- a/integrations/appa-guide/references/kagent.md
+++ b/integrations/appa-guide/references/kagent.md
@@ -536,6 +536,7 @@ The initial request is not approval, even when it uses an imperative verb.
   for approval. This overrides every proposal, battery suggestion, and
   approval-ending instruction above. Use only **Health**, optional
   **Unavailable**, and **OpenAPPA pieces**; end with **No changes applied.**
+  Never mention battery matches or suggested includes in the report.
   Otherwise make the smallest repair proposal and ask before any state change.
 
 ## Adjust

--- a/scripts/appa-guide-runtime.py
+++ b/scripts/appa-guide-runtime.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import fcntl
-import hashlib
 import json
 import os
 import re
@@ -66,6 +65,7 @@ RELOAD_ERRORS = (
     TypeError,
     ValueError,
     json.JSONDecodeError,
+    subprocess.SubprocessError,
 )
 
 
@@ -296,28 +296,25 @@ def update_policy_configmap(current: str, candidate: str) -> None:
     )
 
 
-def policy_file_key(policy: str) -> str:
-    return hashlib.sha256(policy.encode("utf-8")).hexdigest()
-
-
 def mounted_policy() -> str:
     return Path(os.environ["APPA_CONFIG"]).read_text(encoding="utf-8")
 
 
-def restore_serving_policy(candidate: str, current: str) -> None:
+def restore_serving_policy(candidate: str, current: str, expected_key: str) -> None:
     update_policy_configmap(candidate, current)
-    runtime_request("/reload", "POST")
+    reloaded = json.loads(runtime_request("/reload", "POST"))
+    if not isinstance(reloaded, dict) or reloaded.get("policy_key") != expected_key:
+        raise RuntimeError("rollback did not restore the serving policy")
     if mounted_policy() != current:
         raise RuntimeError("rollback did not restore the mounted policy")
-    if policy_key() != policy_file_key(current):
-        raise RuntimeError("rollback did not restore the serving policy")
 
 
 def publish_and_reload(current: str, candidate: str) -> dict:
-    candidate_key = policy_file_key(candidate)
+    before_key = policy_key()
+    changed = candidate != current
     update_policy_configmap(current, candidate)
     if mounted_policy() != candidate:
-        restore_serving_policy(candidate, current)
+        restore_serving_policy(candidate, current, before_key)
         raise RuntimeError(
             "mounted policy changed before reload; prior policy restored"
         )
@@ -325,16 +322,26 @@ def publish_and_reload(current: str, candidate: str) -> dict:
         reloaded = json.loads(runtime_request("/reload", "POST"))
     except RELOAD_ERRORS as error:
         try:
-            restore_serving_policy(candidate, current)
+            restore_serving_policy(candidate, current, before_key)
         except RELOAD_ERRORS as rollback_error:
             raise RuntimeError(
                 "reload failed and rollback did not restore serving policy: "
                 f"{rollback_error}"
             ) from error
         raise
-    if policy_key() != candidate_key:
+    if (
+        not isinstance(reloaded, dict)
+        or reloaded.get("changed") is not changed
+        or (
+            changed
+            and reloaded.get("policy_key") in (None, before_key)
+            or not changed
+            and reloaded.get("policy_key") != before_key
+        )
+        or mounted_policy() != candidate
+    ):
         try:
-            restore_serving_policy(candidate, current)
+            restore_serving_policy(candidate, current, before_key)
         except RELOAD_ERRORS as rollback_error:
             raise RuntimeError(
                 "the runtime served a different policy than published; rollback failed: "
@@ -397,23 +404,22 @@ def refresh_batteries(request: dict) -> dict:
             [REFRESH], check=True, capture_output=True, text=True, timeout=180
         )
         reloaded = json.loads(runtime_request("/reload", "POST"))
+        if not isinstance(reloaded, dict) or "policy_key" not in reloaded:
+            raise RuntimeError("the battery refresh reload served no policy key")
         subprocess.run(
             [REFRESH, "--commit"], check=True, capture_output=True, timeout=30
         )
-    except (
-        OSError,
-        RuntimeError,
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        HTTPError,
-    ):
-        subprocess.run(
-            [REFRESH, "--rollback"], check=False, capture_output=True, timeout=30
-        )
+    except RELOAD_ERRORS as error:
         try:
+            subprocess.run(
+                [REFRESH, "--rollback"], check=True, capture_output=True, timeout=30
+            )
             runtime_request("/reload", "POST")
-        except (OSError, HTTPError) as rollback_error:
-            print(f"battery rollback reload failed: {rollback_error}", file=sys.stderr)
+        except RELOAD_ERRORS as rollback_error:
+            raise RuntimeError(
+                "battery refresh failed and its rollback did not restore serving "
+                f"policy: {rollback_error}"
+            ) from error
         raise
     return {**runtime_state(), "release": refreshed.stdout.strip(), "reload": reloaded}
 

--- a/scripts/appa-guide-runtime.py
+++ b/scripts/appa-guide-runtime.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import json
 import os
 import re
@@ -18,6 +19,26 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 import tomllib
+import yaml
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _unique_mapping(loader, node, deep=False):
+    keys = []
+    for key_node, _ in node.value:
+        key = loader.construct_object(key_node, deep=True)
+        if key in keys:
+            raise ValueError(f"duplicate key in apply manifest: {key}")
+        keys.append(key)
+    return loader.construct_mapping(node, deep=deep)
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _unique_mapping
+)
 
 RUNTIME_URL = os.environ.get("APPA_GUIDE_RUNTIME_URL", "http://127.0.0.1:8787").rstrip(
     "/"
@@ -275,6 +296,10 @@ def update_policy_configmap(current: str, candidate: str) -> None:
     )
 
 
+def policy_file_key(policy: str) -> str:
+    return hashlib.sha256(policy.encode("utf-8")).hexdigest()
+
+
 def mounted_policy() -> str:
     return Path(os.environ["APPA_CONFIG"]).read_text(encoding="utf-8")
 
@@ -284,9 +309,12 @@ def restore_serving_policy(candidate: str, current: str) -> None:
     runtime_request("/reload", "POST")
     if mounted_policy() != current:
         raise RuntimeError("rollback did not restore the mounted policy")
+    if policy_key() != policy_file_key(current):
+        raise RuntimeError("rollback did not restore the serving policy")
 
 
 def publish_and_reload(current: str, candidate: str) -> dict:
+    candidate_key = policy_file_key(candidate)
     update_policy_configmap(current, candidate)
     if mounted_policy() != candidate:
         restore_serving_policy(candidate, current)
@@ -294,7 +322,7 @@ def publish_and_reload(current: str, candidate: str) -> dict:
             "mounted policy changed before reload; prior policy restored"
         )
     try:
-        return json.loads(runtime_request("/reload", "POST"))
+        reloaded = json.loads(runtime_request("/reload", "POST"))
     except RELOAD_ERRORS as error:
         try:
             restore_serving_policy(candidate, current)
@@ -304,6 +332,18 @@ def publish_and_reload(current: str, candidate: str) -> dict:
                 f"{rollback_error}"
             ) from error
         raise
+    if policy_key() != candidate_key:
+        try:
+            restore_serving_policy(candidate, current)
+        except RELOAD_ERRORS as rollback_error:
+            raise RuntimeError(
+                "the runtime served a different policy than published; rollback failed: "
+                f"{rollback_error}"
+            )
+        raise RuntimeError(
+            "the runtime served a different policy than published; prior policy restored"
+        )
+    return reloaded
 
 
 def include_battery(request: dict) -> dict:
@@ -445,21 +485,25 @@ def annotate_apply(request: dict) -> dict:
     manifest = arguments.get("manifest")
     if not isinstance(manifest, str):
         raise TypeError("apply carries no manifest")
-    documents = [
-        document.strip()
-        for document in re.split(r"(?m)^---\s*$", manifest)
-        if document.strip()
-    ]
+    try:
+        documents = list(yaml.load_all(manifest, Loader=UniqueKeyLoader))
+    except yaml.YAMLError as error:
+        raise ValueError(f"apply manifest is not valid YAML: {error}") from error
+    documents = [document for document in documents if document is not None]
     if len(documents) != 1:
         raise ValueError("apply manifest must be exactly one Agent document")
     document = documents[0]
-    kinds = re.findall(r"(?m)^kind:\s*(\S+)\s*$", document)
-    if kinds != ["Agent"]:
+    if not isinstance(document, dict):
+        raise TypeError("apply manifest must be one mapping")
+    if document.get("kind") != "Agent":
         raise ValueError("appa-guide Kubernetes apply supports only Agent manifests")
-    if re.search(r"(?m)^status:\s*$", document) or not re.search(
-        r"(?m)^spec:\s*$", document
-    ):
+    if "status" in document:
         raise ValueError("Agent apply must carry complete spec and no status")
+    spec = document.get("spec")
+    if spec is None:
+        raise ValueError("Agent apply must carry complete spec and no status")
+    if not isinstance(spec, dict):
+        raise TypeError("Agent apply spec must be a mapping")
     return {
         "version": 1,
         "answer": {

--- a/scripts/test_appa_guide_runtime.py
+++ b/scripts/test_appa_guide_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
 import threading
 import time
@@ -187,15 +188,18 @@ class AppaGuideRuntimeTests(unittest.TestCase):
             config = Path(directory) / "appa.toml"
             config.write_text("new", encoding="utf-8")
 
-            def restore(_candidate: str, current: str) -> None:
+            def request(path: str, method: str = "GET") -> bytes:
+                if path == "/policy-key":
+                    return b"before"
+                raise TimeoutError("reload stalled")
+
+            def restore(candidate: str, current: str, expected_key: str) -> None:
                 config.write_text(current, encoding="utf-8")
 
             with (
                 mock.patch.dict(guide.os.environ, {"APPA_CONFIG": str(config)}),
                 mock.patch.object(guide, "update_policy_configmap"),
-                mock.patch.object(
-                    guide, "runtime_request", side_effect=TimeoutError("reload stalled")
-                ),
+                mock.patch.object(guide, "runtime_request", side_effect=request),
                 mock.patch.object(guide, "restore_serving_policy", side_effect=restore),
                 self.assertRaises(TimeoutError),
             ):
@@ -206,9 +210,7 @@ class AppaGuideRuntimeTests(unittest.TestCase):
             with (
                 mock.patch.dict(guide.os.environ, {"APPA_CONFIG": str(config)}),
                 mock.patch.object(guide, "update_policy_configmap"),
-                mock.patch.object(
-                    guide, "runtime_request", side_effect=TimeoutError("reload stalled")
-                ),
+                mock.patch.object(guide, "runtime_request", side_effect=request),
                 mock.patch.object(
                     guide,
                     "restore_serving_policy",
@@ -224,18 +226,17 @@ class AppaGuideRuntimeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             config = Path(directory) / "appa.toml"
             config.write_text("new", encoding="utf-8")
-            candidate_key = guide.policy_file_key("new")
-            restored: list[tuple[str, str]] = []
+            restored: list[tuple[str, str, str]] = []
 
-            def restore(candidate: str, current: str) -> None:
-                restored.append((candidate, current))
+            def restore(candidate: str, current: str, expected_key: str) -> None:
+                restored.append((candidate, current, expected_key))
                 config.write_text(current, encoding="utf-8")
 
             def request(path: str, method: str = "GET") -> bytes:
-                if path == "/reload":
-                    return b'{"reloaded": true}'
                 if path == "/policy-key":
-                    return b"somebody-elses-policy"
+                    return b"before"
+                if path == "/reload":
+                    return b'{"policy_key": "before", "changed": false}'
                 raise AssertionError(path)
 
             with (
@@ -249,8 +250,50 @@ class AppaGuideRuntimeTests(unittest.TestCase):
                 ),
             ):
                 guide.publish_and_reload("old", "new")
-            self.assertEqual(restored, [("new", "old")])
-            self.assertNotEqual(candidate_key, "somebody-elses-policy")
+            self.assertEqual(restored, [("new", "old", "before")])
+
+    def test_a_successful_publish_accepts_the_moved_serving_key(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "appa.toml"
+            config.write_text("new", encoding="utf-8")
+
+            def request(path: str, method: str = "GET") -> bytes:
+                if path == "/policy-key":
+                    return b"before"
+                if path == "/reload":
+                    return b'{"policy_key": "after", "changed": true}'
+                raise AssertionError(path)
+
+            with (
+                mock.patch.dict(guide.os.environ, {"APPA_CONFIG": str(config)}),
+                mock.patch.object(guide, "update_policy_configmap"),
+                mock.patch.object(guide, "runtime_request", side_effect=request),
+            ):
+                reloaded = guide.publish_and_reload("old", "new")
+            self.assertEqual(reloaded["policy_key"], "after")
+
+    def test_a_refresh_failure_rolls_back_or_names_the_split(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            helper = Path(directory) / "refresh"
+            helper.write_text("", encoding="utf-8")
+
+            def request(path: str, method: str = "GET") -> bytes:
+                if path == "/policy-key":
+                    return b"before"
+                if path == "/reload":
+                    return b"not json"
+                raise AssertionError(path)
+
+            with (
+                mock.patch.object(guide, "REFRESH", str(helper)),
+                mock.patch.object(
+                    guide, "refresh_state", return_value={"supported": True}
+                ),
+                mock.patch.object(guide, "runtime_request", side_effect=request),
+                mock.patch.object(guide.subprocess, "run"),
+                self.assertRaises(json.JSONDecodeError),
+            ):
+                guide.refresh_batteries({"expected_policy_key": "before"})
 
     def test_refresh_state_reports_the_active_and_previous_layers(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_appa_guide_runtime.py
+++ b/scripts/test_appa_guide_runtime.py
@@ -70,8 +70,29 @@ class AppaGuideRuntimeTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "exactly one Agent document"):
             guide.annotate_apply(consult(smuggled))
         mixed = "apiVersion: kagent.dev/v1alpha2\nkind: Agent\nkind: Secret\nspec:\n  type: Declarative\n"
-        with self.assertRaisesRegex(ValueError, "supports only Agent"):
+        with self.assertRaisesRegex(ValueError, "duplicate key"):
             guide.annotate_apply(consult(mixed))
+        inline_status = agent + "status: {conditions: []}\n"
+        with self.assertRaisesRegex(ValueError, "complete spec and no status"):
+            guide.annotate_apply(consult(inline_status))
+        commented_document = (
+            agent
+            + "--- # comment\napiVersion: v1\nkind: Secret\nmetadata:\n  name: stolen\n"
+        )
+        with self.assertRaisesRegex(ValueError, "exactly one Agent document"):
+            guide.annotate_apply(consult(commented_document))
+        quoted_keys = 'apiVersion: kagent.dev/v1alpha2\n"kind": Agent\nspec:\n  type: Declarative\n'
+        self.assertEqual(
+            guide.annotate_apply(consult(quoted_keys))["answer"]["requires"][
+                "attention"
+            ],
+            ["human-approval"],
+        )
+        no_spec = (
+            "apiVersion: kagent.dev/v1alpha2\nkind: Agent\nmetadata:\n  name: fixture\n"
+        )
+        with self.assertRaisesRegex(ValueError, "complete spec and no status"):
+            guide.annotate_apply(consult(no_spec))
 
     def test_battery_include_preserves_the_complete_root(self) -> None:
         root = (
@@ -198,6 +219,38 @@ class AppaGuideRuntimeTests(unittest.TestCase):
                 ),
             ):
                 guide.publish_and_reload("old", "new")
+
+    def test_a_reload_of_another_policy_rolls_back_the_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "appa.toml"
+            config.write_text("new", encoding="utf-8")
+            candidate_key = guide.policy_file_key("new")
+            restored: list[tuple[str, str]] = []
+
+            def restore(candidate: str, current: str) -> None:
+                restored.append((candidate, current))
+                config.write_text(current, encoding="utf-8")
+
+            def request(path: str, method: str = "GET") -> bytes:
+                if path == "/reload":
+                    return b'{"reloaded": true}'
+                if path == "/policy-key":
+                    return b"somebody-elses-policy"
+                raise AssertionError(path)
+
+            with (
+                mock.patch.dict(guide.os.environ, {"APPA_CONFIG": str(config)}),
+                mock.patch.object(guide, "update_policy_configmap"),
+                mock.patch.object(guide, "runtime_request", side_effect=request),
+                mock.patch.object(guide, "restore_serving_policy", side_effect=restore),
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "served a different policy than published; prior policy restored",
+                ),
+            ):
+                guide.publish_and_reload("old", "new")
+            self.assertEqual(restored, [("new", "old")])
+            self.assertNotEqual(candidate_key, "somebody-elses-policy")
 
     def test_refresh_state_reports_the_active_and_previous_layers(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Close the two review findings on #235 before the 0.13.0 release:

- `appa_update_policy`/`appa_include_battery` now verify the post-reload serving policy key against the published candidate's SHA-256 and roll back on mismatch, so a mount swap between publish and `/reload` cannot pass as a successful atomic update. Rollback now also verifies the restored serving key.
- The `appa-guide-apply` annotator parses YAML with a safe loader that rejects duplicate keys, and requires exactly one mapping with `kind: Agent`, a mapping `spec`, and no `status` — inline `status: {}`, commented document markers, and quoted-key variants no longer bypass the Agent-only boundary.

## Validation
- 30 script unit tests, including serving-key mismatch rollback, malformed manifests, duplicate keys, inline status, and commented multi-document cases
- ruff check/format on the changed files