### PR TITLE
fix(kagent): refresh unmodified bootstrap policy on helm upgrade

### DIFF
--- a/charts/appa-runtime/README.md
+++ b/charts/appa-runtime/README.md
@@ -108,10 +108,11 @@ unrelated tool remains fail-closed. Typed runtime MCP tools validate,
 publish, reload, and roll back policy and battery changes. Set
 `config.existingConfigMap` to manage that ConfigMap yourself.
 
-When `config.contents` stays empty, an upgrade preserves the live policy
-key that appa-guide changed. Setting `config.contents` explicitly makes
-Helm replace that key. An existing ConfigMap always remains under the
-operator's ownership.
+When `config.contents` stays empty, an upgrade replaces the live policy
+key if it is still the packaged bootstrap. It preserves that key when
+appa-guide or an operator has changed it. Setting `config.contents`
+explicitly makes Helm replace that key. An existing ConfigMap always
+remains under the operator's ownership.
 
 Keep `config.key` unchanged after appa-guide manages that key. Helm
 treats another key as a new policy and initializes it from chart values.

--- a/charts/appa-runtime/templates/NOTES.txt
+++ b/charts/appa-runtime/templates/NOTES.txt
@@ -11,7 +11,7 @@ Persistent volume: {{ if .Values.persistence.enabled }}on ({{ include "appa-runt
 {{- if and .Values.persistence.enabled .Values.persistence.keep (not .Values.persistence.existingClaim) }}
 The chart-created PVC stays after helm uninstall because persistence.keep is true.
 {{- end }}
-Policy upgrades: {{ if .Values.config.existingConfigMap }}operator-owned ConfigMap {{ .Values.config.existingConfigMap }}{{ else if .Values.config.contents }}Helm replaces the key from config.contents{{ else }}Helm preserves the live chart-created key{{ end }}.
+Policy upgrades: {{ if .Values.config.existingConfigMap }}operator-owned ConfigMap {{ .Values.config.existingConfigMap }}{{ else if .Values.config.contents }}Helm replaces the key from config.contents{{ else }}Helm replaces an unchanged packaged bootstrap and preserves a key appa-guide changed{{ end }}.
 {{- if .Values.persistence.enabled }}
 The skill refreshes /var/lib/appa/release-batteries from the latest verified semver release and preserves /var/lib/appa/batteries.
 {{- end }}

--- a/charts/appa-runtime/templates/_helpers.tpl
+++ b/charts/appa-runtime/templates/_helpers.tpl
@@ -74,13 +74,49 @@ app: appa-runtime
 {{- end -}}
 {{- end -}}
 
-{{- define "appa-runtime.managedPolicy" -}}
-{{- $policy := include "appa-runtime.policy" . -}}
+{{- define "appa-runtime.packagedPolicyHash" -}}
+{{- include "appa-runtime.policy" . | trim | sha256sum -}}
+{{- end -}}
+
+{{- define "appa-runtime.preserveLive" -}}
+{{- $preserve := "" -}}
 {{- if and .Release.IsUpgrade (not .Values.config.existingConfigMap) (not .Values.config.contents) -}}
 {{- $live := lookup "v1" "ConfigMap" .Release.Namespace (include "appa-runtime.configMapName" .) -}}
 {{- if and $live $live.data (hasKey $live.data .Values.config.key) -}}
-{{- $policy = index $live.data .Values.config.key -}}
+{{- $data := index $live.data .Values.config.key -}}
+{{- $ann := "" -}}
+{{- if $live.metadata.annotations -}}
+{{- $ann = index $live.metadata.annotations "appa.dev/packaged-policy-sha256" | default "" -}}
+{{- end -}}
+{{- $unmodifiedBootstrap := and (contains "# Bootstrap policy for the shared kagent runtime." $data) (not (contains "include =" $data)) -}}
+{{- if $ann -}}
+{{- if ne ($data | trim | sha256sum) $ann -}}
+{{- $preserve = "true" -}}
+{{- end -}}
+{{- else if not $unmodifiedBootstrap -}}
+{{- $preserve = "true" -}}
 {{- end -}}
 {{- end -}}
-{{- $policy -}}
+{{- end -}}
+{{- $preserve -}}
+{{- end -}}
+
+{{- define "appa-runtime.managedPolicy" -}}
+{{- if eq (include "appa-runtime.preserveLive" . | trim) "true" -}}
+{{- $live := lookup "v1" "ConfigMap" .Release.Namespace (include "appa-runtime.configMapName" .) -}}
+{{- index $live.data .Values.config.key -}}
+{{- else -}}
+{{- include "appa-runtime.policy" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "appa-runtime.policyHashAnnotation" -}}
+{{- if eq (include "appa-runtime.preserveLive" . | trim) "true" -}}
+{{- $live := lookup "v1" "ConfigMap" .Release.Namespace (include "appa-runtime.configMapName" .) -}}
+{{- if $live.metadata.annotations -}}
+{{- index $live.metadata.annotations "appa.dev/packaged-policy-sha256" | default "" -}}
+{{- end -}}
+{{- else -}}
+{{- include "appa-runtime.packagedPolicyHash" . -}}
+{{- end -}}
 {{- end -}}

--- a/charts/appa-runtime/templates/configmap.yaml
+++ b/charts/appa-runtime/templates/configmap.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "appa-runtime.labels" . | nindent 4 }}
+  {{- $policyHash := include "appa-runtime.policyHashAnnotation" . | trim }}
+  {{- if $policyHash }}
+  annotations:
+    appa.dev/packaged-policy-sha256: {{ $policyHash | quote }}
+  {{- end }}
 data:
   {{ .Values.config.key }}: |
 {{ include "appa-runtime.managedPolicy" . | indent 4 }}

--- a/charts/appa-runtime/tests/render-test.sh
+++ b/charts/appa-runtime/tests/render-test.sh
@@ -76,6 +76,10 @@ must_contain 'runAsNonRoot: true'
 must_contain 'runAsUser: 65532'
 must_contain 'readOnlyRootFilesystem: true'
 must_contain 'checksum/policy:'
+must_contain 'appa.dev/packaged-policy-sha256:'
+must_contain 'annotator = "appa-guide-apply"'
+must_not_contain 'appa-guide-command'
+must_not_contain 'k8s_execute_command'
 must_contain 'name: APPA_CONFIG'
 must_contain 'value: "/etc/appa/appa.toml"'
 must_contain 'name: APPA_GUIDE_RUNTIME_URL'
@@ -171,6 +175,7 @@ must_contain 'name: APPA_POLICY_CONFIGMAP_KEY'
 must_contain 'name: APPA_RUNTIME_RELEASE_NAME'
 must_not_contain 'name: appa-runtime-policy'
 must_not_contain 'checksum/policy:'
+must_not_contain 'appa.dev/packaged-policy-sha256:'
 
 printf '%s\n' 'include = ["batteries/slack/appa.toml"]' >"$work/policy.toml"
 must_render --set-file config.contents="$work/policy.toml"


### PR DESCRIPTION
Helm upgrades were preserving every live policy ConfigMap, including an unchanged packaged bootstrap. After 0.12→0.13 that left `k8s_execute_command` bound to `appa-guide-command-annotator`, a binary the 0.13 image does not ship, so `appa-guide init` failed closed with `annotator=appa-guide-command error=unreachable`.

An upgrade now replaces the live key when it is still the packaged bootstrap (hash annotation, or the bootstrap comment with no `include`), and still preserves a key that appa-guide or an operator changed.