### PR TITLE
fix(website): keep docs table headers and kagent prompts from wrapping

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1055,7 +1055,7 @@ samp {
 
 /* Keep identifiers intact in tables. The table wrapper provides horizontal
    scrolling when an identifier is wider than the available viewport. */
-.prose td code {
+.prose :is(th, td) code {
   overflow-wrap: normal;
   word-break: normal;
   white-space: nowrap;

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -270,9 +270,17 @@ kubectl wait agent/appa-guide -n kagent \
 
 ### 5. Wire existing agents to the runtime
 
-Send `appa-guide`: `protect sre-agent with the shared OpenAPPA runtime and verify its rollout`.
+Send `appa-guide`:
 
-To protect every eligible declarative Agent, send: `enable OpenAPPA for all agents using the shared runtime; show me the affected agents before applying`.
+```text
+protect sre-agent with the shared OpenAPPA runtime and verify its rollout
+```
+
+To protect every eligible declarative Agent, send:
+
+```text
+enable OpenAPPA for all agents using the shared runtime; show me the affected agents before applying
+```
 
 The guide inventories the Agents, proposes the exact manifest, waits for approval, applies the complete observed spec through `k8s_apply_manifest`, and verifies the rollout. If the guide is unavailable, edit the complete resource and preserve every existing environment entry:
 


### PR DESCRIPTION
Table header env vars on the kagent docs page wrapped mid-identifier (`APPA_ENABLE` / `D`) because nowrap applied only to `td code`. Long chat prompts were inline chips, so line wrapping split them into extra chips.

Keep identifiers on one line in both `th` and `td`, and put those prompts in the same `text` fences the rest of the guide already uses.