### PR TITLE
docs(kagent): install the adapter image before the runtime

### DIFF
--- a/appa-runtime/tests/guide_skill.rs
+++ b/appa-runtime/tests/guide_skill.rs
@@ -267,10 +267,6 @@ fn kagent_guidance_requires_the_shared_runtime_and_direct_port() {
     assert!(website.contains("runtime.reasoningEffort=none"));
     assert!(website.contains("appa-kagent-adk"));
     assert!(website.contains("friendly-path-465518-r6/appa-public/golang-adk"));
-    assert!(website.contains("kubectl get agent -A -o json"));
-    assert!(website.contains("It preserves the Agent environment and adds a missing runtime URL:"));
-    assert!(website.contains("`appa-guide` uses the existing `controller.agentImage`"));
-    assert!(website.contains("cannot guarantee enforced write approval"));
 }
 
 #[test]
@@ -321,6 +317,43 @@ fn the_website_quickstart_is_copy_safe_and_dependency_ordered() {
     assert!(install_block.contains("querydoc.enabled=false"));
     assert!(!install_block.contains("<your-api-key>"));
     assert!(!quickstart.contains("quickstart-ops"));
+}
+
+#[test]
+fn the_website_existing_agent_guide_is_dependency_ordered() {
+    let website = fs::read_to_string(repo_root().join("website/content/docs/kagent.md")).expect("read website guide");
+    let protect = website
+        .split("## Protect existing Agents")
+        .nth(1)
+        .expect("the guide has existing-Agent guidance")
+        .split("## Manage integration with appa-guide")
+        .next()
+        .expect("existing-Agent guidance ends before manage-integration");
+
+    for heading in [
+        "### 1. Install the OpenAPPA Agent image",
+        "### 2. Install OpenAPPA",
+        "### 3. Protect your Agents",
+    ] {
+        assert!(protect.contains(heading), "existing-Agent guidance carries {heading:?}");
+    }
+
+    let image = protect
+        .find("helm upgrade kagent oci://")
+        .expect("controller image install");
+    let runtime = protect
+        .find("helm upgrade --install appa-runtime")
+        .expect("runtime install");
+    let wait = protect.find("kubectl wait agent/appa-guide").expect("appa-guide wait");
+    let protect_one = protect
+        .find("protect sre-agent with the shared OpenAPPA runtime")
+        .expect("protect-one prompt");
+    let protect_all = protect
+        .find("enable OpenAPPA for all agents using the shared runtime")
+        .expect("protect-all prompt");
+    assert!(image < runtime && runtime < wait && wait < protect_one && protect_one < protect_all);
+    assert!(!protect.contains("`appa-guide` uses the existing `controller.agentImage`"));
+    assert!(!protect.contains("cannot guarantee enforced write approval"));
 }
 
 #[test]

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -66,7 +66,6 @@ Make sure you have installed:
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or an existing Kubernetes cluster
 - [Helm](https://helm.sh/docs/intro/install/) v4
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- [jq](https://jqlang.org/download/)
 - An [OpenAI API key](https://platform.openai.com/api-keys) (or credentials for another [supported kagent provider](https://kagent.dev/docs/kagent/supported-providers/))
 
 ### 1. Install kagent with appa plugin
@@ -212,9 +211,23 @@ kubectl logs -n appa deployment/appa-runtime -c runtime --tail=50
 
 If you already run kagent, use this sequence to install OpenAPPA without interrupting existing Agents.
 
-### 1. Install OpenAPPA
+### 1. Install the OpenAPPA Agent image
 
-First, deploy one policy runtime for the Agents you want to protect:
+The image preserves stock behavior unless an Agent enables OpenAPPA. On kagent 0.9.12, Go Agents use the published `golang-adk` alias at the same tag.
+
+```sh
+APPA_VERSION=0.14.0 # x-release-please-version
+helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
+  --version 0.9.12 -n kagent --reuse-values \
+  --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
+  --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
+  --set controller.agentImage.tag="v$APPA_VERSION" \
+  --force-conflicts --wait --timeout 10m
+```
+
+### 2. Install OpenAPPA
+
+Install the policy runtime and wait for `appa-guide`:
 
 ```sh
 APPA_VERSION=0.14.0 # x-release-please-version
@@ -227,58 +240,15 @@ helm upgrade --install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-p
   --set appaGuide.namespace=kagent \
   --force-conflicts \
   --wait --timeout 10m
-```
-
-Agents reach this runtime at `http://appa-runtime.appa.svc.cluster.local:18787`. The runtime stores its trajectory log on the persistent volume. It reads policy from `appa-runtime-policy`. The release also installs `appa-guide` in `kagent`.
-
-If any Agent already has `APPA_ENABLED=true`, run this compatibility check. It preserves the Agent environment and adds a missing runtime URL:
-
-```sh
-APPA_RUNTIME_URL=http://appa-runtime.appa.svc.cluster.local:18787
-
-kubectl get agent -A -o json |
-jq -c --arg url "$APPA_RUNTIME_URL" '
-  .items[]
-  | select(any(.spec.declarative.deployment.env[]?;
-      .name == "APPA_ENABLED" and .value == "true"))
-  | {
-      namespace: .metadata.namespace,
-      name: .metadata.name,
-      env: (
-        [.spec.declarative.deployment.env[]?
-          | select(.name != "APPA_RUNTIME_URL")]
-        + [{"name": "APPA_RUNTIME_URL", "value": $url}]
-      )
-    }
-' |
-while IFS= read -r agent; do
-  namespace=$(jq -r '.namespace' <<<"$agent")
-  name=$(jq -r '.name' <<<"$agent")
-  patch=$(jq -c '{spec:{declarative:{deployment:{env:.env}}}}' <<<"$agent")
-  kubectl patch agent "$name" -n "$namespace" --type=merge --patch "$patch"
-done
-```
-
-The new adapter refuses an enabled Agent with no URL. This check prevents the controller rollout from replacing a running pod with a refused pod.
-
-Finally, install the OpenAPPA Agent image and wait for `appa-guide`:
-
-```sh
-helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
-  --version 0.9.12 -n kagent --reuse-values \
-  --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
-  --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
-  --set controller.agentImage.tag="v$APPA_VERSION" \
-  --force-conflicts --wait --timeout 10m
 kubectl wait agent/appa-guide -n kagent \
   --for=condition=Ready=True --timeout=5m
 ```
 
-The image preserves stock behavior unless an Agent enables OpenAPPA. On kagent 0.9.12, Go Agents use the published `golang-adk` alias at the same tag.
+Agents reach this runtime at `http://appa-runtime.appa.svc.cluster.local:18787`. The runtime stores its trajectory log on the persistent volume. It reads policy from `appa-runtime-policy`. The release also installs `appa-guide` in `kagent`.
 
-Use `appa-guide` for later Agent, runtime, and controller changes. Its write tools are now gated by the adapter. Before this controller update, `appa-guide` uses the existing `controller.agentImage`. OpenAPPA cannot guarantee enforced write approval until that value selects the OpenAPPA adapter and `appa-guide` becomes Ready.
+Use `appa-guide` for later Agent, runtime, and controller changes. Its write tools are gated by the adapter.
 
-### 2. Protect your Agents
+### 3. Protect your Agents
 
 Send `appa-guide`:
 
@@ -315,7 +285,7 @@ APPA_ENABLED is true. This agent runs gated by the OpenAPPA runtime at http://ap
 
 If the runtime is unreachable, tool calls stop fail-closed before execution.
 
-### 3. Configure and test the policy
+### 4. Configure and test the policy
 
 Open **Agents → appa-guide → Chat** and send `init`. Review and approve the proposed behavior and the kagent confirmation card. The guide installs applicable batteries, reloads the runtime, and verifies the integration.
 
@@ -327,7 +297,7 @@ kubectl logs -n appa deployment/appa-runtime -c runtime --tail=50
 
 ## Manage integration with appa-guide
 
-Only the shared runtime chart installs `appa-guide`. Step 1 installs it and waits until it is ready. Its two modes match the Claude Code experience: `init` creates the initial configuration, and `adjust` changes an existing configuration.
+Only the shared runtime chart installs `appa-guide`. Step 2 installs it and waits until it is ready. Its two modes match the Claude Code experience: `init` creates the initial configuration, and `adjust` changes an existing configuration.
 
 Run these interactions in order:
 


### PR DESCRIPTION
Protect existing kagent Agents by installing the OpenAPPA adapter image first, then the runtime and `appa-guide`, then asking the guide to gate specific Agents or the whole fleet.

The adapter image stays inert until an Agent enables OpenAPPA, so existing workloads keep running. `appa-guide` is then born on the gated image and can apply both environment variables together. The previous jq compatibility pass is gone: it only mattered for Agents that already had `APPA_ENABLED=true` without a URL, which this path does not create.