### PR TITLE
fix(kagent): restore guide-skill pins after the docs polish

### DIFF
--- a/appa-runtime/tests/guide_skill.rs
+++ b/appa-runtime/tests/guide_skill.rs
@@ -276,14 +276,14 @@ fn the_website_quickstart_is_copy_safe_and_dependency_ordered() {
         .split("## Quickstart")
         .nth(1)
         .expect("the guide has a Quickstart")
-        .split("## Protect existing Agents")
+        .split("## Protect existing agents")
         .next()
         .expect("the Quickstart ends before existing-Agent guidance");
 
     for heading in [
-        "### 1. Install kagent with appa plugin",
-        "### 2. Install appa",
-        "### 3. Install the demo Agents",
+        "### 1. Install kagent with the OpenAPPA plugin",
+        "### 2. Deploy the OpenAPPA runtime",
+        "### 3. Deploy the demo agents",
     ] {
         assert!(quickstart.contains(heading), "the Quickstart carries {heading:?}");
     }
@@ -323,17 +323,17 @@ fn the_website_quickstart_is_copy_safe_and_dependency_ordered() {
 fn the_website_existing_agent_guide_is_dependency_ordered() {
     let website = fs::read_to_string(repo_root().join("website/content/docs/kagent.md")).expect("read website guide");
     let protect = website
-        .split("## Protect existing Agents")
+        .split("## Protect existing agents")
         .nth(1)
         .expect("the guide has existing-Agent guidance")
-        .split("## Manage integration with appa-guide")
+        .split("## Manage policy with appa-guide")
         .next()
         .expect("existing-Agent guidance ends before manage-integration");
 
     for heading in [
-        "### 1. Install the OpenAPPA Agent image",
-        "### 2. Install OpenAPPA",
-        "### 3. Protect your Agents",
+        "### 1. Update the controller image",
+        "### 2. Deploy appa-runtime",
+        "### 3. Enable gating on an Agent",
     ] {
         assert!(protect.contains(heading), "existing-Agent guidance carries {heading:?}");
     }

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -12,7 +12,7 @@ An OpenAPPA plugin runs inside agent pods via Google ADK plugin APIs. The plugin
 
 ## How it works
 
-The OpenAPPA integration uses plugin images for Python (`appa-kagent-adk`) and Go (`appa-kagent-adk-go`).
+The OpenAPPA integration uses plugin images for Python (`appa-kagent-adk`) and Go (`appa-kagent-adk-go`). On kagent 0.9.12, Go agents derive `europe-west1-docker.pkg.dev/friendly-path-465518-r6/appa-public/golang-adk` from `controller.agentImage`. OpenAPPA publishes that alias on the `appa-kagent-adk-go` image digest.
 
 :::fig-kagent:::
 
@@ -277,6 +277,8 @@ helm upgrade --install appa-runtime oci://europe-west1-docker.pkg.dev/friendly-p
   --set appaGuide.enabled=true \
   --set appaGuide.namespace=kagent \
   --force-conflicts --wait --timeout 10m
+kubectl wait agent/appa-guide -n kagent \
+  --for=condition=Ready=True --timeout=5m
 ```
 
 ### 3. Enable gating on an Agent
@@ -308,6 +310,12 @@ You can also prompt `appa-guide` to automate onboarding:
 
 ```text
 protect sre-agent with the shared OpenAPPA runtime and verify its rollout
+```
+
+To protect every eligible declarative Agent, send:
+
+```text
+enable OpenAPPA for all agents using the shared runtime; show me the affected agents before applying
 ```
 
 ## Manage policy with appa-guide


### PR DESCRIPTION
#245 rewrote kagent.md headings and dropped a few install pins that `guide_skill` still checks. Rust Tests on the 0.14.1 release PR fail without them.

- Match the tests to the current Quickstart / Protect headings
- Put `golang-adk`, the `appa-guide` wait, and the protect-all prompt back so the install order stays copy-safe

This unblocks [chore(main): release 0.14.1](https://github.com/archestra-ai/OpenAPPA/pull/242).