### PR TITLE
docs: simplify How it works and reorganize reference sections

### DIFF
--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -195,6 +195,12 @@ function Markdown({ content, terms = true }: { content: string; terms?: boolean 
         [rehypeHighlight, { languages: { ...common, appa: appaTraceLanguage } }],
       ]}
       components={{
+        p: ({ children }) => {
+          // Indented directives stay inside their Markdown list item.
+          const match = typeof children === "string" ? children.match(/^:::([a-z0-9-]+):::$/) : null;
+          const render = match ? DIRECTIVES[match[1]] : undefined;
+          return render ? <>{render()}</> : <p>{children}</p>;
+        },
         pre: (props) => <CodeBlock {...props} />,
         code: terms ? MarkdownCode : PlainCode,
         a: MarkdownLink,

--- a/website/components/figures/TwoEndingsFigure.tsx
+++ b/website/components/figures/TwoEndingsFigure.tsx
@@ -149,12 +149,12 @@ function draw(ctx: CanvasRenderingContext2D, t: number, th: Theme) {
   panel(ctx, th, B.sanitizer, "remove_pii");
 
   /* lane titles, over everything static */
-  ctx.fillStyle = th.textWeak;
-  ctx.font = font(12, 500);
+  ctx.fillStyle = th.textStrong;
+  ctx.font = font(16, 600);
   ctx.textAlign = "left";
   ctx.textBaseline = "middle";
-  ctx.fillText("ending one · accept the narrowing", 40, 48);
-  ctx.fillText("ending two · fetch in a child", 40, 340);
+  ctx.fillText("Read the ticket directly", 40, 48);
+  ctx.fillText("Read through a subagent", 40, 340);
 
   /* ---- ending one ---- */
   const ticketFrom = center(TICKET);

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -118,9 +118,12 @@ timeout_ms = 5000
 max_body_bytes = 65536
 
 [externals.claude_code]
-command = "/usr/local/bin/claude"   # the executable; a service environment often strips PATH
-model = "sonnet"                    # pin a model id here for stable classifications
-timeout_ms = 60000                  # the consult's own budget — a model call is slower than an endpoint
+# the executable; a service environment often strips PATH
+command = "/usr/local/bin/claude"
+# pin a model id here for stable classifications
+model = "sonnet"
+# the consult's own budget — a model call is slower than an endpoint
+timeout_ms = 60000
 
 [externals.authorities.operator]
 builtin = "hitl"

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -71,12 +71,14 @@ from = ["google-workspace:viewer", "slack:viewer", "github:viewer"]
 from = [
   "google-workspace:full-members",
   "slack:full-members",
-  "github:org/archestra-ai/members",   # only this organization; selected explicitly
+# only this organization; selected explicitly
+  "github:org/archestra-ai/members",
 ]
 
 [[audience.group]]
 name   = "finance"
-within = "internal"                    # a trusted policy assertion: @finance ⊆ internal
+# a trusted policy assertion: @finance ⊆ internal
+within = "internal"
 from   = ["google-workspace:group/finance@corp.com", "github:org/archestra-ai/team/finance"]
 ```
 
@@ -97,7 +99,8 @@ implementation = "verified-email"      # the shipped default
 
 ```toml
 [identity]
-implementation = "corp-identity"       # bound under [externals.identity.corp-identity]
+# bound under [externals.identity.corp-identity]
+implementation = "corp-identity"
 ```
 
 A custom implementation answers one principal per member, is pinned per act like any membership answer, and must be deterministic. If it fails or answers an invalid principal, the act fails operationally and records nothing.
@@ -162,7 +165,8 @@ Omit `inputs` to pass the complete tool call: its name, its description when the
 ```toml
 [[annotator]]
 name  = "classify-command"
-ranks = ["suspicious", "trusted"]              # The trust ranks its answers may use
+# The trust ranks its answers may use
+ranks = ["suspicious", "trusted"]
 hint  = "Use suspicious for output from network or unvetted sources. Use trusted only for local computation over trusted inputs."
 
 [[tool]]
@@ -195,7 +199,8 @@ This form does not need a tool parameter schema. It does not need a `description
 name      = "classify-customer"
 inputs    = { subject = "$tool_call.arguments.customer_id" }
 ranks     = ["suspicious", "trusted"]
-audiences = ["finance", "support"]             # The audiences a restricted answer may name
+# The audiences a restricted answer may name
+audiences = ["finance", "support"]
 hint      = "finance may read billing records. support may read records assigned to a support case."
 
 [[tool]]
@@ -360,24 +365,30 @@ A `[[tool]]` entry defines its name and `description`, then its output restricti
 ```toml
 [[tool]]
 name = "fetch_support_ticket"
-tags = ["support"]                                     # Authorities and sanitizers select tools by tag
+# Authorities and sanitizers select tools by tag
+tags = ["support"]
 
 [tool.delta]
-trust    = "suspicious"                                # The ticket body is customer-written text
-audience = ["support"]                                 # The record is for the support desk only
+# The ticket body is customer-written text
+trust    = "suspicious"
+# The record is for the support desk only
+audience = ["support"]
 
 [[tool]]
 name     = "apply_db_migration"
 effects  = ["migration.applied", "mutation"]           # Emitted side effects
-delta    = {}                                          # Status string carries no label
+# Status string carries no label
+delta    = {}
 
 [tool.requires]
 trust     = "trusted"
 attention = ["sre-signoff"]                            # Fresh per-call demand
 
 [tool.requires.effects]
-contains = ["backup.completed"]                        # Already recorded in the trajectory
-excludes = ["migration.applied"]                       # Neither recorded nor reserved by an unsettled dispatch
+# Already recorded in the trajectory
+contains = ["backup.completed"]
+# Neither recorded nor reserved by an unsettled dispatch
+excludes = ["migration.applied"]
 ```
 
 ### Key contract rules
@@ -399,15 +410,20 @@ An `[[authority]]` provides dynamic judgment to clear specific requirement gaps 
 ```toml
 [[authority]]
 name = "finance-officer"
-hint = "The desk that signs off spend. Consult it to release a payment."  # Advisory; grants nothing
-tags = ["finance"]                             # The tools it can answer; omitted, every tool.
-                                               # Attention routing ignores tags: a mark routes to every
-                                               # authority whose `permits.attention` names it.
+# Advisory; grants nothing
+hint = "The desk that signs off spend. Consult it to release a payment."
+# The tools it can answer; omitted, every tool.
+tags = ["finance"]
+# Attention routing ignores tags: a mark routes to every
+# authority whose `permits.attention` names it.
 
 [authority.permits]
-trust_below        = "trusted"                 # A call whose trust requirement is unmet, for requirements up to this rank
-audience_missing   = ["public"]                # A call whose audience is missing required readers, up to these readers
-effects_containing = ["email.sent"]            # A call although the trajectory already contains one of these effects
+# A call whose trust requirement is unmet, for requirements up to this rank
+trust_below        = "trusted"
+# A call whose audience is missing required readers, up to these readers
+audience_missing   = ["public"]
+# A call although the trajectory already contains one of these effects
+effects_containing = ["email.sent"]
 attention          = ["finance-signoff"]       # The marks its rulings satisfy
 ```
 
@@ -423,8 +439,11 @@ token_env = "APPA_APPROVER_TOKEN"            # sent as a bearer token
 # builtin = "hitl"                             # Human-in-the-loop elicitation
 # builtin = "approve"                          # In-process auto-approval
 # builtin = "claude-code"                      # A model rules, within `permits`
-# builtin = "llm"                              # A model rules through [externals.llm]
+# A model rules through [externals.llm]
+# builtin = "llm"
 ```
+
+An offered remedy is not an approval. An authority can deny the request; that denial is recorded so the agent cannot repeat the same approval request for that specific call.
 
 A missing authority binding does not stop the deployment. That authority
 returns no answer, so a remedy that names it cannot release the call.
@@ -453,24 +472,33 @@ delta = { trust = "suspicious", audience = ["finance"] }
 
 [[sanitizer]]
 name = "pii-redactor"
-on   = ["tool_output"]                         # Tool results and child sub-execution returns
-# on = ["tool_input"]                          # Whole-argument substitution at dispatch
-hint = "Removes personal details from a finance record."  # Advisory; grants nothing
-tags = ["support"]                             # Applies only to values from tools with these tags
+# Tool results and child sub-execution returns
+on   = ["tool_output"]
+# Whole-argument substitution at dispatch
+# on = ["tool_input"]
+# Advisory; grants nothing
+hint = "Removes personal details from a finance record."
+# Applies only to values from tools with these tags
+tags = ["support"]
 
 [sanitizer.permits]
-# `from`: the source audience must contain these readers; `to`: the output gets exactly this audience
+# `from`: the source audience must contain these readers; `to`: the output gets
+# exactly this audience
 audience = { from = ["finance"], to = ["public"] }
 
 [deployment]
-confined_results = ["fetch_support_ticket"]    # The host can withhold this tool's raw result
+# The host can withhold this tool's raw result
+confined_results = ["fetch_support_ticket"]
 ```
 
 ```toml
-[externals.sanitizers.pii-redactor]            # the deployment binds the scrubber
+# the deployment binds the scrubber
+[externals.sanitizers.pii-redactor]
 builtin = "redact-email"
-# builtin = "claude-code"                      # A model rewrites the value, within `permits`
-# builtin = "llm"                              # A model rewrites it through [externals.llm]
+# A model rewrites the value, within `permits`
+# builtin = "claude-code"
+# A model rewrites it through [externals.llm]
+# builtin = "llm"
 ```
 
 ### Sanitizer implementation modes
@@ -493,10 +521,12 @@ name = "vouch-fetched-text"
 on   = ["tool_output"]
 
 [sanitizer.permits]
-trust = { from = "suspicious", to = "trusted" } # Instead of `audience`, never alongside it
+# Instead of `audience`, never alongside it
+trust = { from = "suspicious", to = "trusted" }
 
 [deployment]
-context_control = true                          # A child's return is an application point
+# A child's return is an application point
+context_control = true
 ```
 
 When a tool result would narrow the trajectory label, OpenAPPA checks if a registered `tool_output` sanitizer can improve the label. If selected, the host withholds the raw result and runs the sanitizer. If the cleaned derivation prevents narrowing, it enters the trajectory label. If residual narrowing remains, the agent can accept the residual or apply another compatible sanitizer. A sanitizer whose declared transition cannot improve the label is never offered.
@@ -504,6 +534,8 @@ When a tool result would narrow the trajectory label, OpenAPPA checks if a regis
 Like an authority, a sanitizer can name `tags`: it then applies only to values whose originating tool carries one of them. A child sub-execution return originates from no tool, so only a sanitizer without `tags` applies at that crossing.
 
 At `tool_input`, the sanitizer derives a replacement for the whole argument set of one call, and the harness dispatches exactly the substituted bytes. This substitution can satisfy an unmet `contains` audience requirement, but cannot clear a `within` or trust requirement (`within` bounds the trajectory's own reach, and rewriting arguments does not change the decision to invoke the tool). A rewritten call is judged by the ordered contract its rewritten arguments select: the sanitizer's `tags` must reach that contract too, and its effects and requirements apply. An annotation binds the exact call, so a rewrite of an annotator-backed tool is annotated afresh, whichever contract it selects; membership answers are pinned to the act, so the substituted call is judged under the same pinned evidence.
+
+### Subagent Returns
 
 A parent declares what a child's return may carry when it spawns the child. Under `context_control`, a spawn is held until the parent takes one plan from the block's menu: the first plan takes the return as spoken; each plan after it routes the return through one registered `tool_output` sanitizer without `tags`, in registry order. Every plan takes a `label`, the lowest label the parent accepts from the return (`{}` for the parent's own); the `attest-schema` plan also takes `return_schema`. The declaration bounds the child: it can narrow no further than the declared floor, or, on a sanitized route, than the sanitizer lifts back to it. The child learns the declared shape when it starts, and returns by ending its turn. A return the declaration does not cover is blocked at the child with the reason, and the child may stop again with what does cross.
 
@@ -516,7 +548,8 @@ on   = ["tool_output"]
 audience = { from = ["finance"], to = ["public"] }
 
 [deployment]
-context_control = true              # Children run on their own context; their returns are an application point
+# Children run on their own context; their returns are an application point
+context_control = true
 ```
 
 ```json
@@ -547,6 +580,77 @@ context_control = true
 
 Registering `name = "attest-schema"` is sufficient; OpenAPPA applies it natively without an `[externals]` entry (binding one is a load error).
 
+## Example: Customer Ticket Policy
+
+This configuration accompanies [the customer-ticket walkthrough](/how-it-works#example-sharing-information-from-a-private-customer-ticket). CRM tickets are internal, email recipients must be allowed to see the session's data, and public GitHub issues require data that may be shared publicly.
+
+The sanitizer produces a version without customer identities; the authority can approve a specific action that shares data outside the company. The integration must withhold the original ticket when sanitizing its output and support separate subagent contexts for the subagent option. See [Deployment coverage](#deployment-coverage) for these requirements.
+
+```toml
+version = 2
+
+[deployment]
+# The integration must support separate subagent contexts and withholding raw
+# results.
+context_control = true
+confined_results = ["get_ticket_from_crm"]
+
+[audience.internal]
+# Use Google Workspace membership to identify people inside the company.
+from = ["google-workspace:full-members"]
+
+[[tool]]
+name  = "get_ticket_from_crm"
+# Reading the original ticket makes the agent's session internal.
+delta = { audience = ["internal"] }
+
+[[tool]]
+name       = "send_email"
+parameters = { type = "object", properties = { recipient = { type = "string" }, body = { type = "string" } }, required = ["recipient", "body"] }
+# The recipient must be allowed to see the session's data.
+requires   = { audience = { contains = ["$recipient"] } }
+delta      = {}
+effects    = ["egress"]
+
+[[tool]]
+name     = "file_github_issue"
+# Creating a public issue requires data that can be shared publicly.
+requires = { audience = { contains = ["public"] } }
+delta    = {}
+effects  = ["egress", "mutation"]
+
+[[sanitizer]]
+name = "remove_pii"
+on   = ["tool_output"]
+hint = "Removes customer identities from a CRM record."
+[sanitizer.permits]
+# Allow this sanitizer to produce a version that can be shared publicly.
+audience = { from = ["internal"], to = ["public"] }
+
+[[authority]]
+name = "user"
+[authority.permits]
+# Allow a person to approve sharing outside the company.
+audience_missing = ["public"]
+```
+
+The following configuration connects the policy to a service that removes customer details, a human approval prompt, and a service that checks company membership. The URLs are examples to replace with your own services:
+
+```toml
+[externals.sanitizers.remove_pii]
+url       = "https://pii.corp/redact"
+# Read the service's authentication token from this environment variable.
+token_env = "APPA_PII_TOKEN"
+
+[externals.authorities.user]
+# Ask a person for approval.
+builtin = "hitl"
+
+[externals.audience.google-workspace]
+# Check who belongs to the company.
+url = "https://audience.corp/google-workspace"
+```
+
 ## Externals
 
 The policy registers components by name. The deployment binds each name in the `[externals]` table:
@@ -558,7 +662,8 @@ max_body_bytes = 65536       # the largest answer accepted
 
 [externals.authorities.finance-officer]
 url       = "https://approver.corp/rule"
-token_env = "APPA_APPROVER_TOKEN"     # an APPA_* variable; its value is sent as a bearer token
+# an APPA_* variable; its value is sent as a bearer token
+token_env = "APPA_APPROVER_TOKEN"
 
 [externals.sanitizers.pii-redactor]
 builtin = "redact-email"
@@ -641,7 +746,8 @@ A model answer can do what the kind allows any implementation: an authority's ru
 provider       = "anthropic"          # anthropic | openai | gemini | ollama
 model          = "claude-sonnet-4-5"
 token_env      = "APPA_LLM_TOKEN"     # required, except for ollama
-# url          = "https://gateway.corp/v1"   # optional; validated like a `url` binding
+# optional; validated like a `url` binding
+# url          = "https://gateway.corp/v1"
 timeout_ms     = 30000                # this profile's own consult budget
 max_concurrent = 4                    # consults in flight at once
 ```

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -102,7 +102,7 @@ See [Sanitizers in the policy reference](/contracts#sanitizers) for service conf
 
 ### Annotators
 
-An annotator applies policy dynamically when that is more convenient than writing a separate tool contract for every case. It describes what the tool call requires, the restrictions on its output, and its effects.
+An annotator classifies a tool call to determine its output restrictions (`delta`), requirements (`requires`), and effects. Use one when these depend on the specific call, such as which file the agent reads or who receives an email. OpenAPPA checks the resulting contract before allowing the call.
 
 For example, a Python script can check which directory a file comes from. Files in `/srv/public-docs` can be shared publicly; all other files are restricted to internal users. This example treats all file contents as untrusted.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -152,13 +152,11 @@ The script and file-reading tool must use the same filesystem. `/srv/public-docs
 
 ### Subagents Isolate Sensitive Reads
 
-A subagent can read sensitive or untrusted data in its own session. The main agent receives only the result the policy allows, so it can keep working without taking on all the restrictions of the original data.
+A subagent reads sensitive data in a separate context and returns only what the policy allows. For example, it can summarize a private ticket and pass the summary through a sanitizer, letting the main agent use the cleaned result in a public bug report if the policy permits.
 
-For example, a subagent reads a private customer ticket and prepares a summary. A sanitizer removes customer names and email addresses before the summary reaches the main agent. If the policy allows that cleaned summary to be shared publicly, the main agent can use it in a public bug report.
+Before the subagent starts, the main agent sets the return requirements, including any cleaning. These also limit what the subagent can read. OpenAPPA blocks results that do not meet them.
 
-The main agent sets the rules for the result before the subagent starts, including whether it needs cleaning. Those rules also limit what the subagent can read. OpenAPPA blocks any result that does not meet them. Both agents' actions and approvals appear in the same audit log.
-
-This requires an integration that keeps the agents' contexts separate. See [Subagent Returns in the policy reference](/contracts#subagent-returns) for configuration.
+See [Subagent Returns](/contracts#subagent-returns) for integration requirements and configuration.
 
 ### Audience Sources
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -9,206 +9,173 @@ description: Deterministic security guarantees, flow tracking, and how agents se
 
 OpenAPPA sits between an agent and its tools to answer one question before every action: *is this data allowed to go to this destination?*
 
-Powered by **APPA** (Agentic Permissions Policy Algebra), it provides a formal system to track data sensitivity and trust deterministically across heterogeneous tools. Security context, policy labels, and audit trails flow entirely out-of-band—outside the agent's prompt and token stream. Because enforcement lives at the runtime boundary rather than inside the model's context, prompt injections cannot alter or bypass policy rules.
+Powered by **APPA** (Agentic Permissions Policy Algebra), OpenAPPA tracks data sensitivity and trust across the tools an agent uses. The security engine stays outside the agent loop, so prompt injections cannot alter or bypass policy rules.
 
-When an action cannot proceed as proposed, OpenAPPA does not simply throw a dead-end error. It returns a structured **remedy plan**—such as requesting human approval, scrubbing sensitive fields, or isolating reads in a sub-execution—giving the agent the exact playbook to self-correct and finish its task safely.
+OpenAPPA also helps the agent remain useful under security restrictions. If an action is blocked by policy, OpenAPPA returns ways to continue: request human approval, clean sensitive fields, or isolate a read in a subagent.
 
-Because policy checks happen prospectively before tools run, sensitive data is never exposed to unauthorized tools, and the agent is never left stranded mid-workflow.
+## The Core Concepts
 
-### The core mental model
+OpenAPPA operates with three concepts:
 
-OpenAPPA operates on three runtime concepts:
+1. **Security Label**
 
-1. **Security Labels** (`label`)  
-   Attached to every running trajectory. A label tracks audience (who is authorized to receive the trajectory's data) and trust rank (whether data comes from a vetted internal source or untrusted external data). An audience can name readers exactly, or symbolically: OpenAPPA ships the built-in chain `self` ⊆ `internal` ⊆ `public`, and policies declare named audiences such as `@finance` on top of it. A symbolic audience stays symbolic in the label and the log; when a decision needs actual membership, OpenAPPA reads the configured sources — Google Workspace, Slack, or GitHub, each bound to your own endpoint or command — for that one act, pins the answer, and replays from the pin without ever consulting a source again.
+   A trajectory is an agent's work on a conversation or task, including its tool calls. For each trajectory, OpenAPPA keeps a security label and the policy configuration needed to evaluate its next action. Each decision accounts for what the agent has already read and done.
 
-2. **Tool Contracts** (`delta` & `requires`)  
-   Declarative rules configured per tool. Reading data restricts the trajectory's label (`delta`), while invoking an outbound tool verifies that the destination is permitted by the trajectory's current label (`requires`).
+   The security label can become more restrictive as the agent works, but it cannot become less restrictive. Once the agent reads restricted or untrusted data, those restrictions stay with the session.
 
-3. **Policy Remedies** (`remedy_plans`)  
-   When a proposed tool dispatch exceeds the trajectory's current permissions, OpenAPPA returns a structured refusal containing actionable remedy plans:
-   - Narrowing: accept restricted reach to continue internal tasks.
-   - Sanitizers: clean data through a registered sanitizer to preserve reach.
-   - Authorities: request targeted approval (e.g. human-in-the-loop) for an out-of-bounds call.
-   - Child Branches: spin off a sub-execution to isolate sensitive reads from the main workflow.
+   :::fig-label-fold:::
 
-## Labels only move one way
+   Audience and Trust make up the security label. OpenAPPA also tracks Effects and checks Attention requirements:
 
-A tool contract declares a `delta` to define how fetching its result restricts the agent's current security label. A `delta` can only restrict permissions—it intersects allowed readers, lowers trust levels, or leaves the label unchanged.
+   1. **Audience:** Who is authorized to access data in this agent session. Reading data for a smaller audience restricts where the agent can send data later. For example, after reading an internal customer record, the agent cannot send session data to a public destination.
+   2. **Trust:** How much the data in the session can be trusted. Reading an untrusted web page can lower the session's trust, and tools that require trusted input will no longer be allowed to run.
+   3. **Effect:** What the agent has already done, such as sending an email or changing a system. Effects accumulate in the session history. A policy can require an effect to have happened, or prevent an action after an effect has happened.
+   4. **Attention:** Approval or review required for a specific action. Unlike effects, attention does not accumulate. An approval clears the attention requirement for that action only, and later calls must request attention again.
 
-Because permissions only tighten over time, **data cannot be laundered** by passing it through intermediate steps or LLM prompts. Reading internal system records permanently marks the execution context as internal, and ingesting untrusted external data permanently drops its trust level.
+2. **Tool Contracts**
 
-Restricting permissions doesn't mean blocking external work: an `authority` can approve a specific outbound call without changing the overall label, or the agent can spin off a child execution to isolate sensitive reads from its main workflow.
+   Every tool has a contract in the OpenAPPA policy. The contract tells OpenAPPA how the tool interacts with the agent's security state:
 
-:::fig-label-fold:::
+   - **`delta`:** How data returned by the tool changes the security label.
+   - **`requires`:** Which requirements the session must satisfy for OpenAPPA to allow the action.
+   - **`effects`:** Which effects are recorded after a tool runs successfully.
 
-The current label is computed directly from all values admitted so far—combining tool result restrictions and sanitized derivations—eliminating the need to re-evaluate full trajectory history:
+   For example, a CRM tool can label its result as internal, while an email tool can require the recipient to be included in the session's audience.
 
-```ts
-label = admittedLabels.reduce(narrow, startingLabel)   // narrow only ever restricts
-```
+3. **Remedy Plans**
 
-This monotonic structure provides a **formally provable non-interference guarantee**: because label transitions strictly narrow permitted reader sets over an execution trace, sensitive data is mathematically prevented from leaking to unauthorized destinations across arbitrary multi-step tool sequences.
+   When an action does not meet its tool contract, OpenAPPA blocks it and returns the remedy plans allowed by the policy. A plan can involve cleaning data with a [sanitizer](#sanitizers), receiving approval from an [authority](#authorities), accepting a narrower audience, or isolating a sensitive read in a subagent.
 
-## Worked example: preserve reach or approve the exact call
+   An offered plan can still be denied by an approval service or fail during data cleaning. If no permitted remedy succeeds, the action remains blocked.
 
-To see how this works in practice, consider an agent configured with three tools: `get_ticket_from_crm`, `send_email`, and `file_github_issue`:
+   :::fig-remedy-plan:::
+
+## Keeping Agents Useful Under Restrictions
+
+If the security label becomes more restrictive as the agent works, how can the agent still do something useful?
+
+OpenAPPA can ask for approval for a specific action or clean data before the agent sees it. It also uses information about each tool call and who may access the data to apply the appropriate restrictions. The policy configuration defines when these options are available.
+
+### Authorities
+
+An authority can approve a specific action that the session's restrictions would otherwise block. It can be a person, an approval service, or an LLM evaluator. Approval does not make the security label less restrictive; it only allows that one action.
+
+For example, an agent has read a private customer report and wants to email it to an external auditor. An authority can approve that email without approving future emails or changing the session's restrictions.
 
 ```toml
-[audience.internal]
-from = ["google-workspace:full-members"]   # who "internal" means, read from the directory per act
-
-[[tool]]
-name  = "get_ticket_from_crm"
-delta = { audience = ["internal"] }   # reading CRM data restricts the trajectory to the built-in internal audience
-
-[[tool]]
-name       = "send_email"
-parameters = { type = "object", properties = { recipient = { type = "string" }, body = { type = "string" } }, required = ["recipient", "body"] }
-requires   = { audience = { contains = ["$recipient"] } }   # recipient must be in current audience
-delta      = {}
-effects    = ["egress"]
-
-[[tool]]
-name     = "file_github_issue"
-requires = { audience = { contains = ["public"] } }         # requires public reach
-delta    = {}
-effects  = ["egress", "mutation"]
-
-[[sanitizer]]
-name = "remove_pii"
-on   = ["tool_output"]
-hint = "Removes customer identities from a CRM record."
-[sanitizer.permits]
-audience = { from = ["internal"], to = ["public"] }         # declassifies internal to public
-
 [[authority]]
-name = "user"
+name = "reviewer"
+
 [authority.permits]
-audience_missing = ["public"]                                # user can approve public egress
+# Allow the reviewer to approve sharing
+# outside the session's audience.
+audience_missing = ["public"]
+
+[externals.authorities.reviewer]
+# OpenAPPA's built-in human-in-the-loop authority.
+builtin = "hitl"
 ```
 
-The policy declares the security bounds. The deployment specifies who executes them in a separate `[externals]` table (e.g. binding `user` to a human approval prompt or `remove_pii` to an HTTP sanitizer endpoint):
+See [Authorities in the policy reference](/contracts#authorities) for configuration and supported implementations.
+
+### Sanitizers
+
+A sanitizer cleans data before the agent receives it or sends it to a tool. Cleaning data before the agent sends it can allow an action that would otherwise be blocked.
+
+For example, a sanitizer removes customer names and email addresses from a support ticket. The policy permits the agent to share that cleaned version in a public bug report.
 
 ```toml
-[externals.sanitizers.remove_pii]
-url       = "https://pii.corp/redact"
-token_env = "APPA_PII_TOKEN"               # sent as a bearer token
+[[sanitizer]]
+name = "remove_customer_details"
+on = ["tool_output"]
 
-[externals.authorities.user]
-builtin = "hitl"                           # ask a person
+[sanitizer.permits]
+# Allow the cleaned result to be shared publicly.
+audience = { from = ["internal"], to = ["public"] }
 
-[externals.audience.google-workspace]
-url = "https://audience.corp/google-workspace"   # answers the internal membership reads
+[externals.sanitizers.remove_customer_details]
+# Replace with your internal sanitization service URL.
+url = "https://sanitizer.corp.example/sanitize"
 ```
+
+See [Sanitizers in the policy reference](/contracts#sanitizers) for service configuration and where cleaning can happen.
+
+### Annotators
+
+An annotator applies policy dynamically when that is more convenient than writing a separate tool contract for every case. It describes what the tool call requires, the restrictions on its output, and its effects.
+
+For example, when an agent reads a file, an annotator can check which directory it comes from. Files in a public documentation directory can have a public audience, while files in a customer records directory are restricted to internal users. The policy also defines how much data from each directory can be trusted.
+
+```toml
+[[annotator]]
+name = "classify_file"
+builtin = "llm"
+hint = "Use the file's directory to determine its audience and trust."
+
+[[tool]]
+name = "read_file"
+# Ask the annotator to classify the file being read.
+annotator = "classify_file"
+```
+
+The built-in `llm` annotator runs in-process and calls the model configured in `[externals.llm]`. See [Model transports](/contracts#model-transports) for that configuration and [Annotators in the policy reference](/contracts#annotators) for limits on the rules it can return.
+
+### Audience Sources
+
+An audience source tells OpenAPPA who belongs to an allowed group. Even when a session is restricted to a group, the agent can still share data with its members. OpenAPPA can check your company's existing directory to find out who those members are.
+
+For example, before sending a Finance report, OpenAPPA checks whether the recipient belongs to the Finance group in Google Workspace.
+
+```toml
+[[audience.group]]
+name = "finance"
+from = ["google-workspace:group/finance@corp.com"]
+
+[[tool]]
+name = "get_finance_report"
+# Restrict the report to members of the Finance group.
+delta = { audience = ["@finance"] }
+```
+
+Connect the Google Workspace audience source to your directory service. See [Audience sources in the policy reference](/contracts#audience-sources) for supported providers and configuration.
+
+## Example: sharing information from a private customer ticket
+
+The example shows an agent reading a private customer ticket and then trying to share information from it.
+
+The agent has three tools:
+
+- **`get_ticket_from_crm`:** Read a customer support ticket.
+- **`send_email`:** Send an email to a recipient.
+- **`file_github_issue`:** Create a public GitHub issue.
+
+The policy says:
+
+- CRM tickets are internal.
+- Emails may only go to people authorized to see the session's data.
+- Public GitHub issues cannot contain internal data.
+
+The policy also allows a sanitizer to remove customer details and a person to approve sharing outside the company.
+
+See the [customer-ticket policy example](/contracts#example-customer-ticket-policy) for the tool rules and service configuration.
 
 ### What happens when the agent reads a ticket?
 
-When the agent calls `get_ticket_from_crm()`, OpenAPPA intercepts the dispatch before execution and presents three clear paths:
+The agent has three options when reading the ticket:
 
-| Execution Path | Trajectory Label Impact | Downstream Dispatch Impact |
-|---|---|---|
-| **Accept Narrowing** | Trajectory becomes `internal`. | `file_github_issue` is blocked; `send_email` requires authority approval for external recipients. |
-| **Sanitize the Result** | Trajectory stays `{public, trusted}`. | Raw ticket is withheld from the model; `remove_pii`'s sanitized derivation is admitted in its place. |
-| **Child Branch + Sanitizer** | Parent stays `{public, trusted}`; child narrows to `internal`. | Parent declares the sanitized route at the spawn; child reads raw ticket, reasons over it, and returns the sanitized derivation across the merge boundary. |
+1. **Read the original ticket itself.** Its session becomes internal. It can email colleagues, but posting publicly or emailing an external recipient requires approval.
+2. **Have a sanitizer remove customer details first.** The agent sees only the cleaned ticket. This example's policy permits that cleaned version to be shared publicly.
+3. **Have a subagent read the original ticket.** The subagent examines the private information and returns a sanitized result. The main agent never sees the private details and can use the cleaned result in public tools.
 
 :::fig-two-endings:::
 
-If the agent accepts narrowing to `internal` and later attempts `send_email(body, "auditor@external.com")`, OpenAPPA reads the configured `internal` sources for this act, finds `auditor@external.com` is not a member, halts dispatch, and returns a remedy plan pointing to the `user` authority. Once the human approves, the email dispatches and the event is permanently logged — with the membership answer pinned to it, so replay reaches the same decision without a directory call.
+Suppose the agent takes the first option: it reads the original ticket and tries to email an external auditor at `auditor@external.com`. OpenAPPA blocks the email and offers human approval. If approved, that particular email is sent. Future external emails still need their own approval.
 
-## Sub-agents isolate sensitive reads
-
-Reading untrusted external files, third-party APIs, or confidential internal records normally restricts the entire agent session. Child trajectories isolate these label modifications within host-managed sub-executions.
-
-A child process can read and reason over raw, untrusted data in its own sandboxed context without restricting the parent. The parent declares, when it spawns the child, the lowest label it accepts from the child's return and whether a sanitizer rewrites the return first; the child can narrow no further than that declaration allows. When the child completes, it returns only what the declaration covers across the merge boundary, and a return outside it is blocked at the child, never quietly widened. The main agent stays clean and retains its full reach to interact with public tools. Parent and child branches share a single append-only log so that all sends and approvals remain globally auditable.
-
-## Engine refusals enumerate every valid remedy
-
-Traditional guardrails act like a brick wall: they throw a generic exception that leaves the agent confused, trapped in retry loops, or crashed. OpenAPPA acts like a detour sign.
-
-When an action cannot proceed as proposed, OpenAPPA returns a typed refusal listing the exact prerequisites needed to proceed safely: requesting authority approval, cleaning data with a sanitizer, running a prerequisite tool, or accepting a narrowing prompt. The agent takes the structured hint, executes the remedy, and completes its task.
-
-:::fig-remedy-plan:::
-
-```ts
-{ outcome: "block",
-  requirement_gaps: [...],  // unmet entries from `requires`
-  narrowing: {...},         // present when the call's own delta narrows
-  remedy_plans: [...] }     // valid remedy plans executable by id or tool call
-```
-
-A non-empty remedy list indicates that candidate paths exist, though external components may still decline a requested ruling. When an authority denies a request, that denial is appended to the log to prevent repeating the request for that specific call.
-
-## Declarative contracts and annotators
-
-Tool contracts are strictly declarative TOML. Instead of writing imperative access checks across code, developers declare tool requirements (`requires`), label restrictions (`delta`), and side effects (`effects`).
-
-Every released tool call carries one complete annotation — its `delta`, its `requires`, and the effects it emits, with every dimension concrete. The policy produces that annotation in one of two ways:
-
-- **Static declaration**: The `[[tool]]` entry writes the whole contract, and every call to the tool carries it.
-- **Annotator**: Where the right contract depends on the call itself (a document path, a recipient, a command line), the `[[tool]]` entry names a registered **annotator** instead. The annotator reads the proposed call and answers the complete contract for that one call, inside the vocabulary its declaration bounds — its **mandate**.
-
-An Annotator declaration can include a trusted policy `hint`. The hint defines policy-specific values and their selection criteria, but cannot expand the mandate. An input mapping can restrict which call values cross the consult boundary.
-
-An annotation is pinned to the exact call it was produced for. A sanitizer rewrite that changes the arguments is annotated afresh, so no call ever runs under another call's annotation, and replay reconstructs every decision without consulting an annotator again.
-
-An annotator that gives no valid answer — no route to it, a timeout, a malformed or out-of-mandate answer — stops the call before it runs. That refusal is operational, not a policy denial: the call was never judged, and nothing is appended to the log.
-
-*(For complete syntax on ordered contracts, argument matching, and annotator declarations, see the [Policy reference](/contracts).)*
-
-## A wildcard annotator covers the tools the policy never names
-
-Real-world systems rarely annotate every tool up front. OpenAPPA supports partial coverage without a partial label: incompleteness lives at the policy boundary, never inside the algebra, so every admitted value carries one concrete label and every check has a two-valued answer.
-
-A policy covers a proposed call in exactly one of these ways:
-
-| Proposed call | What decides it |
-|---|---|
-| **Declared tool** | The first matching `[[tool]]` contract, written in full in the policy. |
-| **Annotator-backed tool** | The annotator the matching `[[tool]]` entry names, answering the complete contract for this call. |
-| **Any other tool, with a wildcard** | The wildcard entry `name = "*"` routes the call to its annotator, and the call is annotated like any other. |
-| **Any other tool, without a wildcard** | The call is refused before it runs: the tool is not declared and no wildcard covers it. The refusal is typed and operational, not a policy denial. |
-
-The wildcard entry carries no static contract and no metadata: it exists only to name the annotator that answers for the long tail. An exact declaration always wins over it. This lets teams annotate high-risk tools first and expand coverage incrementally — five declared tools and one wildcard annotator cover a deployment whose remaining tools the policy never names.
-
-To inspect data before the LLM sees it, the deployment can list a tool in `confined_results`: the host then withholds the raw result, and a `tool_output` sanitizer's derivation can be admitted in its place. If the admitted label restricts the trajectory, OpenAPPA offers the agent the narrowing choice before delivery.
-
-## Deployment: Where OpenAPPA fits in your stack
-
-You can drop OpenAPPA into your architecture at three levels:
-
-| Deployment Option | How it works | Best for |
-|---|---|---|
-| **LLM Gateway** | Point your agent's `BASE_URL` to OpenAPPA. It intercepts tool calls directly in the inference stream. | Zero-code integration across existing agent stacks. |
-| **Agent Middleware / Hooks** | Add pre-tool hooks inside your agent loop (e.g. Claude Code, LangChain, PydanticAI). | Local CLI tools and custom Python/TypeScript agents. |
-| **Tool Proxy** | Run OpenAPPA in front of your remote APIs or MCP servers. | Shared enterprise tool infrastructure and microservices. |
-
-## Threat model: What OpenAPPA protects
-
-OpenAPPA is designed for real-world enterprise agent workflows:
-
-- **What it protects against:** Prompt injections, poisoned external data, confused agent actions, and accidental data leaks across multi-step workflows.
-- **How it stops attacks:** At the deterministic runtime boundary. Even if the LLM is completely tricked by an attacker, unauthorized tool calls physically cannot dispatch.
-- **System boundaries:** Pre-vetted internal data is trusted by configuration. Custom authorities (like human review queues) are trusted within their declared permissions.
-- **Auditability:** Every check, dispatch, and remedy decision is recorded in an append-only, tamper-evident log for post-hoc audit and deterministic replay.
-
-## Migrating existing controls to OpenAPPA
-
-You don't need to throw away existing security controls. OpenAPPA unifies them as declarative policy components:
-
-| Existing Security Control | OpenAPPA Component |
-|---|---|
-| Human review / HITL prompts | `builtin = "hitl"` Authority |
-| Custom approval webhooks / LLM evaluators | Authority (`url`, `command`, or model builtin) |
-| Content scanners & argument-aware trust, audience, and review classifiers | Annotator (endpoint, command, or model builtin) inside its declared mandate |
-| PII redactors & sanitizers | Sanitizer (`builtin = "redact-email"`, endpoint, command, or model builtin) |
-| Directory / IAM group lookups | Audience sources (`[audience.self]`, `[audience.internal]`, `[[audience.group]]`): the Google Workspace, Slack, and GitHub catalogs, each bound to your own endpoint or command |
-| Imperative `if/else` access checks | Tool Contracts (`delta` & `requires`) |
-
-Crucially, an authority or sanitizer can do only what its `permits` declares, and an annotator can answer only inside its declared mandate. Even if a third-party scanner or classifier makes a mistake, it cannot grant permissions beyond its pre-configured bounds.
+The agent can still finish useful work with private data, but sharing it outside the company requires either cleaning it or obtaining permission.
 
 ## Next steps
 
-- [Reading a policy](/contracts): Guide to reviewing and writing policy configuration.
+- [Policy Reference](/contracts): Guide to reviewing and writing policy configuration.
+- [How to add it to your agent](/writing-an-integration): Integration guide, deployment models, and existing integrations.
 - [Benchmarks](/evaluation): Empirical paper results on multi-step workflows and bench-corp.
 - [OpenAPPA Paper](/paper): Formal information-flow model, theorems, and experimental methodology.

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -104,7 +104,7 @@ See [Sanitizers in the policy reference](/contracts#sanitizers) for service conf
 
 An annotator classifies a tool call to determine its output restrictions (`delta`), requirements (`requires`), and effects. Use one when these depend on the specific call, such as which file the agent reads or who receives an email. OpenAPPA checks the resulting contract before allowing the call.
 
-For example, a Python script can check which directory a file comes from. Files in `/srv/public-docs` can be shared publicly; all other files are restricted to internal users. This example treats all file contents as untrusted.
+For example, a Python script can check which directory a file comes from. Files in `/srv/public-docs` can be shared publicly; all other files are restricted to internal users.
 
 ```toml
 [[annotator]]

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -167,25 +167,6 @@ Suppose the agent takes the first option: it reads the original ticket and tries
 
 The agent can still finish useful work with private data, but sharing it outside the company requires either cleaning it or obtaining permission.
 
-## Audience Sources
-
-An audience source tells OpenAPPA who belongs to a group, such as your company's Finance team. When a policy restricts data to that group, OpenAPPA uses membership from your company's directory to check who may receive it.
-
-For example, before sending a Finance report, OpenAPPA checks whether the recipient belongs to the Finance group in Google Workspace.
-
-```toml
-[[audience.group]]
-name = "finance"
-from = ["google-workspace:group/finance@corp.com"]
-
-[[tool]]
-name = "get_finance_report"
-# Restrict the report to members of the Finance group.
-delta = { audience = ["@finance"] }
-```
-
-Connect the Google Workspace audience source to your directory service. See [Audience sources in the policy reference](/contracts#audience-sources) for supported providers and configuration.
-
 ## Next steps
 
 - [Policy Reference](/contracts): Guide to reviewing and writing policy configuration.

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -27,8 +27,8 @@ OpenAPPA operates with three concepts:
 
    Audience and Trust make up the security label. OpenAPPA also tracks Effects and checks Attention requirements:
 
-   1. **Audience:** Who is authorized to access data in this agent session. Reading data for a smaller audience restricts where the agent can send data later. For example, after reading an internal customer record, the agent cannot send session data to a public destination.
-   2. **Trust:** How much the data in the session can be trusted. Reading an untrusted web page can lower the session's trust, and tools that require trusted input will no longer be allowed to run.
+   1. **Audience:** Who is authorized to access data in this agent session. The built-in audiences are `self` (the identity the agent acts as), `internal` (the organization), and `public` (everyone). `self` is narrower than `internal`, which is narrower than `public`. Reading a customer record labeled `internal` restricts a public session to that audience, so sharing publicly then requires a remedy. See [Audience configuration](/contracts#audiences).
+   2. **Trust:** How much the data in the session can be trusted. The default levels are `suspicious` and `trusted`, with `suspicious` below `trusted`. For example, reading a web page labeled `suspicious` lowers a trusted session to `suspicious`. A tool requiring `trusted` input is then blocked unless a remedy clears the requirement. See [Trust chain configuration](/contracts) and [tool requirements](/contracts#tools).
    3. **Effect:** What the agent has already done, such as sending an email or changing a system. Effects accumulate in the session history. A policy can require an effect to have happened, or prevent an action after an effect has happened.
    4. **Attention:** Approval or review required for a specific action. Unlike effects, attention does not accumulate. An approval clears the attention requirement for that action only, and later calls must request attention again.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -125,7 +125,7 @@ command = ["python3", "./classify_file.py"]
 
 An annotator can run as a local script or an external service. See [Annotators in the policy reference](/contracts#annotators) for configuration, the request and response format, and limits on its answers.
 
-### Subagents Isolate Sensitive Reads
+### Subagent Reads
 
 A subagent reads sensitive data in a separate context and returns only what the policy allows. For example, it can summarize a private ticket and pass the summary through a sanitizer, letting the main agent use the cleaned result in a public bug report if the policy permits.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -104,7 +104,7 @@ See [Sanitizers in the policy reference](/contracts#sanitizers) for service conf
 
 An annotator classifies a tool call to determine its output restrictions (`delta`), requirements (`requires`), and effects. OpenAPPA checks the resulting contract before allowing the call.
 
-For example, a Python script can classify files by directory: public documentation can be shared publicly, while customer records are restricted to internal users.
+For example, a Python script can classify files by directory: files in `/srv/public-docs` can be shared publicly, while files in `/srv/customer-records` are restricted to internal users.
 
 ```toml
 [[annotator]]

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -123,8 +123,6 @@ annotator = "classify_file"
 command = ["python3", "./classify_file.py"]
 ```
 
-Save this as `classify_file.py` beside the configuration file. The script reads the proposed call from standard input and writes its annotation as JSON:
-
 ```python
 import json
 import sys

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -104,21 +104,53 @@ See [Sanitizers in the policy reference](/contracts#sanitizers) for service conf
 
 An annotator applies policy dynamically when that is more convenient than writing a separate tool contract for every case. It describes what the tool call requires, the restrictions on its output, and its effects.
 
-For example, when an agent reads a file, an annotator can check which directory it comes from. Files in a public documentation directory can have a public audience, while files in a customer records directory are restricted to internal users. The policy also defines how much data from each directory can be trusted.
+For example, a Python script can check which directory a file comes from. Files in `/srv/public-docs` can be shared publicly; all other files are restricted to internal users. This example treats all file contents as untrusted.
 
 ```toml
 [[annotator]]
 name = "classify_file"
-builtin = "llm"
-hint = "Use the file's directory to determine its audience and trust."
+ranks = ["suspicious"]
+audiences = ["public", "internal"]
+marks = []
+effects = []
 
 [[tool]]
 name = "read_file"
 # Ask the annotator to classify the file being read.
 annotator = "classify_file"
+
+[externals.annotators.classify_file]
+command = ["python3", "./classify_file.py"]
 ```
 
-The built-in `llm` annotator runs in-process and calls the model configured in `[externals.llm]`. See [Model transports](/contracts#model-transports) for that configuration and [Annotators in the policy reference](/contracts#annotators) for limits on the rules it can return.
+Save this as `classify_file.py` beside the configuration file. The script reads the proposed call from standard input and writes its annotation as JSON:
+
+```python
+import json
+import sys
+from pathlib import Path
+
+request = json.load(sys.stdin)
+call = request["artifact"]["args"]
+path = Path(call["arguments"]["path"])
+if not path.is_absolute():
+    raise ValueError("read_file requires an absolute path")
+
+public_docs = Path("/srv/public-docs").resolve(strict=True)
+path = path.resolve(strict=True)
+audience = "public" if path.is_relative_to(public_docs) else "internal"
+
+json.dump({
+    "version": 1,
+    "answer": {
+        "delta": {"audience": [audience], "trust": "suspicious"},
+        "requires": {"history": [], "attention": []},
+        "emits": [],
+    },
+}, sys.stdout)
+```
+
+The script and file-reading tool must use the same filesystem. `/srv/public-docs` must exist and contain only files approved for public access. See [Annotators in the policy reference](/contracts#annotators) for the script protocol and limits on the rules it can return.
 
 ### Subagents Isolate Sensitive Reads
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -102,7 +102,7 @@ See [Sanitizers in the policy reference](/contracts#sanitizers) for service conf
 
 ### Annotators
 
-An annotator classifies a tool call to determine its output restrictions (`delta`), requirements (`requires`), and effects. Use one when these depend on the specific call, such as which file the agent reads or who receives an email. OpenAPPA checks the resulting contract before allowing the call.
+An annotator classifies a tool call to determine its output restrictions (`delta`), requirements (`requires`), and effects. OpenAPPA checks the resulting contract before allowing the call.
 
 For example, a Python script can classify files by directory: public documentation can be shared publicly, while customer records are restricted to internal users.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -133,25 +133,6 @@ Before the subagent starts, the main agent sets the return requirements, includi
 
 See [Subagent Returns](/contracts#subagent-returns) for integration requirements and configuration.
 
-### Audience Sources
-
-An audience source tells OpenAPPA who belongs to an allowed group. Even when a session is restricted to a group, the agent can still share data with its members. OpenAPPA can check your company's existing directory to find out who those members are.
-
-For example, before sending a Finance report, OpenAPPA checks whether the recipient belongs to the Finance group in Google Workspace.
-
-```toml
-[[audience.group]]
-name = "finance"
-from = ["google-workspace:group/finance@corp.com"]
-
-[[tool]]
-name = "get_finance_report"
-# Restrict the report to members of the Finance group.
-delta = { audience = ["@finance"] }
-```
-
-Connect the Google Workspace audience source to your directory service. See [Audience sources in the policy reference](/contracts#audience-sources) for supported providers and configuration.
-
 ## Example: sharing information from a private customer ticket
 
 The example shows an agent reading a private customer ticket and then trying to share information from it.
@@ -185,6 +166,25 @@ The agent has three options when reading the ticket:
 Suppose the agent takes the first option: it reads the original ticket and tries to email an external auditor at `auditor@external.com`. OpenAPPA blocks the email and offers human approval. If approved, that particular email is sent. Future external emails still need their own approval.
 
 The agent can still finish useful work with private data, but sharing it outside the company requires either cleaning it or obtaining permission.
+
+## Audience Sources
+
+An audience source tells OpenAPPA who belongs to an allowed group. Even when a session is restricted to a group, the agent can still share data with its members. OpenAPPA can check your company's existing directory to find out who those members are.
+
+For example, before sending a Finance report, OpenAPPA checks whether the recipient belongs to the Finance group in Google Workspace.
+
+```toml
+[[audience.group]]
+name = "finance"
+from = ["google-workspace:group/finance@corp.com"]
+
+[[tool]]
+name = "get_finance_report"
+# Restrict the report to members of the Finance group.
+delta = { audience = ["@finance"] }
+```
+
+Connect the Google Workspace audience source to your directory service. See [Audience sources in the policy reference](/contracts#audience-sources) for supported providers and configuration.
 
 ## Next steps
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -120,6 +120,16 @@ annotator = "classify_file"
 
 The built-in `llm` annotator runs in-process and calls the model configured in `[externals.llm]`. See [Model transports](/contracts#model-transports) for that configuration and [Annotators in the policy reference](/contracts#annotators) for limits on the rules it can return.
 
+### Subagents Isolate Sensitive Reads
+
+Reading confidential records or untrusted external data can restrict the main agent's whole session. A subagent can read and reason over that data in a separate context, keeping those restrictions local to its own session.
+
+Before the subagent starts, the main agent declares what restrictions it will accept on the returned result and whether a sanitizer must clean it first. That declaration also limits what the subagent may read. A result that does not meet the declaration is blocked before it reaches the main agent.
+
+For example, a subagent can examine a private customer ticket and return a summary through a sanitizer that removes customer identities. If the policy permits that cleaned result to be shared publicly, the main agent can use it in a public bug report without reading the private ticket itself. Both agents' actions and approvals remain in the same audit log.
+
+The integration must support separate subagent contexts. See [Subagent Returns in the policy reference](/contracts#subagent-returns) for configuration and return rules.
+
 ### Audience Sources
 
 An audience source tells OpenAPPA who belongs to an allowed group. Even when a session is restricted to a group, the agent can still share data with its members. OpenAPPA can check your company's existing directory to find out who those members are.

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -44,7 +44,7 @@ OpenAPPA operates with three concepts:
 
 3. **Remedy Plans**
 
-   When an action does not meet its tool contract, OpenAPPA blocks it and returns the remedy plans allowed by the policy. A plan can involve cleaning data with a [sanitizer](#sanitizers), receiving approval from an [authority](#authorities), accepting a narrower audience, or isolating a sensitive read in a subagent.
+   When an action does not meet its tool contract, OpenAPPA blocks it and returns the remedy plans allowed by the policy. A plan can involve cleaning data with a [sanitizer](#sanitizers), receiving approval from an [authority](#authorities), accepting a narrower audience, or isolating a sensitive read in a [subagent](#subagent-reads).
 
    An offered plan can still be denied by an approval service or fail during data cleaning. If no permitted remedy succeeds, the action remains blocked.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -104,7 +104,7 @@ See [Sanitizers in the policy reference](/contracts#sanitizers) for service conf
 
 An annotator classifies a tool call to determine its output restrictions (`delta`), requirements (`requires`), and effects. Use one when these depend on the specific call, such as which file the agent reads or who receives an email. OpenAPPA checks the resulting contract before allowing the call.
 
-For example, a Python script can check which directory a file comes from. Files in `/srv/public-docs` can be shared publicly; all other files are restricted to internal users.
+For example, a Python script can classify files by directory: public documentation can be shared publicly, while customer records are restricted to internal users.
 
 ```toml
 [[annotator]]
@@ -123,32 +123,7 @@ annotator = "classify_file"
 command = ["python3", "./classify_file.py"]
 ```
 
-```python
-import json
-import sys
-from pathlib import Path
-
-request = json.load(sys.stdin)
-call = request["artifact"]["args"]
-path = Path(call["arguments"]["path"])
-if not path.is_absolute():
-    raise ValueError("read_file requires an absolute path")
-
-public_docs = Path("/srv/public-docs").resolve(strict=True)
-path = path.resolve(strict=True)
-audience = "public" if path.is_relative_to(public_docs) else "internal"
-
-json.dump({
-    "version": 1,
-    "answer": {
-        "delta": {"audience": [audience], "trust": "suspicious"},
-        "requires": {"history": [], "attention": []},
-        "emits": [],
-    },
-}, sys.stdout)
-```
-
-The script and file-reading tool must use the same filesystem. `/srv/public-docs` must exist and contain only files approved for public access. See [Annotators in the policy reference](/contracts#annotators) for the script protocol and limits on the rules it can return.
+An annotator can run as a local script or an external service. See [Annotators in the policy reference](/contracts#annotators) for configuration, the request and response format, and limits on its answers.
 
 ### Subagents Isolate Sensitive Reads
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -122,13 +122,13 @@ The built-in `llm` annotator runs in-process and calls the model configured in `
 
 ### Subagents Isolate Sensitive Reads
 
-Reading confidential records or untrusted external data can restrict the main agent's whole session. A subagent can read and reason over that data in a separate context, keeping those restrictions local to its own session.
+A subagent can read sensitive or untrusted data in its own session. The main agent receives only the result the policy allows, so it can keep working without taking on all the restrictions of the original data.
 
-Before the subagent starts, the main agent declares what restrictions it will accept on the returned result and whether a sanitizer must clean it first. That declaration also limits what the subagent may read. A result that does not meet the declaration is blocked before it reaches the main agent.
+For example, a subagent reads a private customer ticket and prepares a summary. A sanitizer removes customer names and email addresses before the summary reaches the main agent. If the policy allows that cleaned summary to be shared publicly, the main agent can use it in a public bug report.
 
-For example, a subagent can examine a private customer ticket and return a summary through a sanitizer that removes customer identities. If the policy permits that cleaned result to be shared publicly, the main agent can use it in a public bug report without reading the private ticket itself. Both agents' actions and approvals remain in the same audit log.
+The main agent sets the rules for the result before the subagent starts, including whether it needs cleaning. Those rules also limit what the subagent can read. OpenAPPA blocks any result that does not meet them. Both agents' actions and approvals appear in the same audit log.
 
-The integration must support separate subagent contexts. See [Subagent Returns in the policy reference](/contracts#subagent-returns) for configuration and return rules.
+This requires an integration that keeps the agents' contexts separate. See [Subagent Returns in the policy reference](/contracts#subagent-returns) for configuration.
 
 ### Audience Sources
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -169,7 +169,7 @@ The agent can still finish useful work with private data, but sharing it outside
 
 ## Audience Sources
 
-An audience source tells OpenAPPA who belongs to an allowed group. Even when a session is restricted to a group, the agent can still share data with its members. OpenAPPA can check your company's existing directory to find out who those members are.
+An audience source tells OpenAPPA who belongs to a group, such as your company's Finance team. When a policy restricts data to that group, OpenAPPA uses membership from your company's directory to check who may receive it.
 
 For example, before sending a Finance report, OpenAPPA checks whether the recipient belongs to the Finance group in Google Workspace.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -27,8 +27,8 @@ OpenAPPA operates with three concepts:
 
    Audience and Trust make up the security label. OpenAPPA also tracks Effects and checks Attention requirements:
 
-   1. **Audience:** Who is authorized to access data in this agent session. The built-in audiences are `self` (the identity the agent acts as), `internal` (the organization), and `public` (everyone). `self` is narrower than `internal`, which is narrower than `public`. Reading a customer record labeled `internal` restricts a public session to that audience, so sharing publicly then requires a remedy. See [Audience configuration](/contracts#audiences).
-   2. **Trust:** How much the data in the session can be trusted. The default levels are `suspicious` and `trusted`, with `suspicious` below `trusted`. For example, reading a web page labeled `suspicious` lowers a trusted session to `suspicious`. A tool requiring `trusted` input is then blocked unless a remedy clears the requirement. See [Trust chain configuration](/contracts) and [tool requirements](/contracts#tools).
+   1. **Audience:** Who is authorized to access data in this agent session. Reading data for a smaller audience restricts where the agent can send data later. For example, after reading an internal customer record, the agent cannot send session data to a public destination.
+   2. **Trust:** How much the data in the session can be trusted. Reading an untrusted web page can lower the session's trust, and tools that require trusted input will no longer be allowed to run.
    3. **Effect:** What the agent has already done, such as sending an email or changing a system. Effects accumulate in the session history. A policy can require an effect to have happened, or prevent an action after an effect has happened.
    4. **Attention:** Approval or review required for a specific action. Unlike effects, attention does not accumulate. An approval clears the attention requirement for that action only, and later calls must request attention again.
 

--- a/website/content/docs/index.md
+++ b/website/content/docs/index.md
@@ -29,6 +29,15 @@ The foundation of OpenAPPA is data-flow tracking. In other words, it answers one
 
 And where it is genuinely unavoidable, OpenAPPA also lets you plug in non-deterministic agent-security tools.
 
+### Threat Model: What OpenAPPA Protects Against
+
+OpenAPPA is designed for real-world enterprise agent workflows:
+
+- **What it protects against:** Prompt injections, poisoned external data, confused agent actions, and accidental data leaks across multi-step workflows.
+- **How it stops attacks:** At the deterministic runtime boundary. Even if the LLM is completely tricked by an attacker, unauthorized tool calls physically cannot dispatch.
+- **System boundaries:** Pre-vetted internal data is trusted by configuration. Custom authorities (like human review queues) are trusted within their declared permissions.
+- **Auditability:** Every check, dispatch, and remedy decision is recorded in an append-only, tamper-evident log for post-hoc audit and deterministic replay.
+
 ## Where next
 
 - [How OpenAPPA works](/how-it-works) — the whole model in one sitting.

--- a/website/content/docs/writing-an-integration.md
+++ b/website/content/docs/writing-an-integration.md
@@ -42,6 +42,21 @@ To keep track of agent actions and enforce policies, OpenAPPA reconstructs each 
 | **Shared internal service** | Gates multiple internal agents through a centralized runtime and shared policy configuration. |
 | **SaaS-managed service** | Protects user-facing agents directly inside your application infrastructure and private network. |
 
+See [Add an Integration](#add-an-integration) for the required events and decision handling.
+
+### Use Your Existing Security Controls
+
+OpenAPPA can work with the approval processes, data-cleaning services, and company directories you already use. Connect them to OpenAPPA and define when the agent must use them:
+
+| What you already use | OpenAPPA component | How it works |
+|---|---|---|
+| **Human review & automated approval services** | [Authority](/contracts#authorities) | Ask a person, webhook, or LLM evaluator to approve or deny a specific action before the agent proceeds. |
+| **Data and Action Classification** | [Annotator](/contracts#annotators) | Use a scanner or classifier to determine who may see data, how much it can be trusted, or whether an action needs review. |
+| **PII redactors & sanitizers** | [Sanitizer](/contracts#sanitizers) | Remove sensitive information before the agent receives data or shares it with another tool. |
+| **IAM Groups based access control** | [Audience sources](/contracts#audience-sources) | Use membership from Google Workspace, Slack, or GitHub to check who is allowed to access data. |
+
+See the [Policy reference](/contracts) for configuration examples.
+
 ## Why Add OpenAPPA?
 
 ### Benefits for a SaaS Product


### PR DESCRIPTION
“How it works” mixed the introductory model with deployment guidance and detailed policy configuration. This change makes it a conceptual walkthrough with short examples and links to the reference material.

### What changed

- Explain security labels, tool contracts, and remedy plans in plain language, then introduce authorities, sanitizers, annotators, and subagent reads. Include focused TOML examples for the policy components.
- Keep the customer-ticket walkthrough focused on its three paths: read directly, sanitize the result, or read through a subagent. Clarify that approval permits one action and does not relax the session label.
- Explain that annotators classify a call’s delta, requirements, and effects, while OpenAPPA checks the resulting contract. Show a TOML command binding to a Python script, using `/srv/public-docs` and `/srv/customer-records` as directory examples. Link to the policy reference for implementation details and note that annotators can also run as external services.
- Render figure directives inside Markdown list items so the label and remedy diagrams appear alongside their concepts. Make the ticket diagram headings larger and rename them “Read the ticket directly” and “Read through a subagent.”
- Move long inline TOML comments onto separate lines in the policy reference and Claude Code guide.

### Where the sections went

| Previous section in How it works | New location or treatment |
| --- | --- |
| The core mental model; Labels only move one way | Combined into **The Core Concepts**, with the label diagram inside Security Label and the remedy diagram inside Remedy Plans. |
| Worked example: preserve reach or approve the exact call | Rewritten as **Example: sharing information from a private customer ticket** on the same page. The full TOML policy and external bindings move to **Policy Reference → Example: Customer Ticket Policy**, with links in both directions. |
| Sub-agents isolate sensitive reads | Rewritten as **Keeping Agents Useful Under Restrictions → Subagent Reads**, after Annotators and before the customer-ticket example, covering separate contexts, return requirements, and sanitizer use in two short paragraphs. Existing detailed return rules in **Policy Reference → Sanitizers** now have a **Subagent Returns** heading. |
| Engine refusals enumerate every valid remedy | Folded into **The Core Concepts → Remedy Plans** and **Keeping Agents Useful Under Restrictions**. The denial-recording explanation moves to **Policy Reference → Authorities**; the low-level refusal object is removed from the introduction. |
| Declarative contracts and annotators | Replaced with short **Tool Contracts** and **Annotators** explanations. Detailed syntax, mandates, replay, and failure rules remain in **Policy Reference → Annotators**. |
| A wildcard annotator covers the tools the policy never names | Removed from the conceptual walkthrough; wildcard and confinement details remain in the policy reference. |
| Deployment: Where OpenAPPA fits in your stack | Removed the duplicate table; **How to add it to your agent → Deployment Models** remains the destination, linked from Next steps. |
| Threat model: What OpenAPPA protects | Moved to the **Introduction → Threat Model: What OpenAPPA Protects Against**. |
| Migrating existing controls to OpenAPPA | Reworked as **How to add it to your agent → Use Your Existing Security Controls**, mapping approval services, classifiers, sanitizers, and IAM groups to OpenAPPA components. |

### Validation

- `pnpm typecheck` — passed before the subsequent Markdown-only edits.
- `pnpm build` — passed before the subsequent Markdown-only edits; generated all 26 static pages. Next.js reported a workspace-root warning because multiple lockfiles are present.
- `git diff --check` — passed.
