### PR TITLE
ci(appa-yell): name the build account on deploy

### DIFF
--- a/.github/workflows/appa-yell.yml
+++ b/.github/workflows/appa-yell.yml
@@ -6,8 +6,11 @@ name: Deploy appa-yell
 # This workflow owns the function's *code* and nothing else. Scaling, ingress,
 # IAM, the runtime service account, the bucket and its retention belong to the
 # Terraform root in the infra repository, which is applied separately. That is
-# why the deploy below passes no such flag: `gcloud functions deploy` leaves
-# every setting it is not given alone, so CI cannot roll infrastructure back.
+# why the deploy below passes almost no such flag: `gcloud functions deploy`
+# leaves every setting it is not given alone, so CI cannot roll infrastructure
+# back. The one exception is the build account, named below because when the
+# flag is absent gcloud asks Cloud Build for the project's default, a call the
+# deploy identity is not permitted to make. Terraform sets the same value.
 #
 # Required repository secrets: APPA_YELL_GCP_SERVICE_ACCOUNT,
 # APPA_YELL_GCP_WORKLOAD_IDENTITY_PROVIDER (a deploy identity of its own, not
@@ -58,12 +61,14 @@ jobs:
 
       - name: Deploy the function source
         run: |
+          # CLOUDSDK_CORE_PROJECT is set by the auth step from the deploy identity.
           gcloud functions deploy "$FUNCTION" \
             --gen2 \
             --region "$REGION" \
             --source receiver/appa-yell \
             --runtime python312 \
-            --entry-point receive
+            --entry-point receive \
+            --build-service-account "projects/$CLOUDSDK_CORE_PROJECT/serviceAccounts/appa-yell-build@$CLOUDSDK_CORE_PROJECT.iam.gserviceaccount.com"
 
       - name: Smoke test the deployed endpoint
         env:


### PR DESCRIPTION
## Why

`Deploy appa-yell` fails with a bare 403 before the build starts (run 34126896827). gcloud's deploy command, when `--build-service-account` is absent, asks Cloud Build for the project's default build account right before patching the function. That is a project-scoped call the deploy identity is not permitted to make, its denial is not audit-logged, and gcloud does not catch it.

## What

The deploy step passes `--build-service-account` naming `appa-yell-build`, the account the infra root already set on the function (archestra-ai/infra#249). Same value, so the patch changes nothing on the function; gcloud just stops asking. The project id comes from `CLOUDSDK_CORE_PROJECT`, which the auth step exports.

Header comment updated: the workflow now passes exactly one setting flag, and says why.

Pairs with archestra-ai/infra#250, which grants the two remaining project-scoped reads. Both need to land before the next dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPYy9VxiMkBEnfwbjyGYLz
