### PR TITLE
fix(yell): clarify agent tool description and confusion guidance

### DIFF
--- a/appa-policy/tests/docs_examples.rs
+++ b/appa-policy/tests/docs_examples.rs
@@ -36,6 +36,19 @@ fn as_policy(fence: &str) -> String {
     }
 }
 
+/// The guide shows both raw policy fragments and full deployment files under `[policy]`.
+/// If a deployment file is shown, extract its policy table; otherwise wrap with `version = 2`.
+fn policy_of_fence(fence: &str, table: &toml::Table) -> String {
+    if let Some(policy) = table.get("policy") {
+        if policy.get("version").is_some() {
+            return toml::to_string(policy).expect("a parsed table renders");
+        }
+        let policy_str = toml::to_string(policy).expect("a parsed table renders");
+        return format!("version = 2\n\n{policy_str}");
+    }
+    as_policy(fence)
+}
+
 /// A fence holding only `[externals.…]` entries is a deployment-binding example. The policy
 /// dialect this crate loads has no `[externals]` table — the deployment owns it — so such a
 /// fence answers only to TOML syntax here.
@@ -55,7 +68,7 @@ fn every_toml_fence_in_the_policy_reference_loads() {
         if is_externals_example(&table) {
             continue;
         }
-        let policy = as_policy(fence);
+        let policy = policy_of_fence(fence, &table);
         if let Err(error) = Config::from_toml_str(&policy) {
             panic!("a policy example does not load: {error}\n{policy}");
         }

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -250,11 +250,14 @@ impl RuntimeTools {
         execute_remedy(&self.runtime, args, request).await
     }
 
-    #[tool(description = "Report to the OpenAPPA team that APPA is broken, confusing, or in \
-                       the way. Say in `message` what you were trying to do and what APPA \
-                       did. Set `with_trajectory` to include this session's APPA decisions \
-                       — its rulings, remedies and label changes, never your prompts, tool \
-                       arguments or tool outputs — or leave it false to report on the \
+    #[tool(description = "Report to the OpenAPPA developers when APPA is malfunctioning, \
+                       contradictory, or its blocking feedback or remedies are \
+                       confusing and leave no clear way forward. Say in `message` what you were \
+                       trying to do, what APPA did or demanded, and why you are stuck. This \
+                       sends diagnostic telemetry and will not bypass the policy or grant \
+                       tool permissions. Set `with_trajectory` to include this session's APPA \
+                       decisions — its rulings, remedies and label changes, never your prompts, \
+                       tool arguments or tool outputs — or leave it false to report on the \
                        policy alone.")]
     pub(crate) async fn yell(&self, Parameters(args): Parameters<YellArgs>) -> CallToolResult {
         match crate::yell::agent::yell(&self.runtime, self.harness, &args).await {

--- a/appa-runtime/src/yell/agent.rs
+++ b/appa-runtime/src/yell/agent.rs
@@ -25,7 +25,7 @@ use super::{Mode, Selection};
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct YellArgs {
-    /// What APPA did that is in the way, in the agent's own words.
+    /// What you were trying to do, what APPA did or demanded, and why the feedback is confusing or impossible to satisfy.
     pub(crate) message: String,
     /// Whether the report carries this session's decisions as well as the policy.
     pub(crate) with_trajectory: bool,

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -149,11 +149,13 @@ The backslash tells OpenAPPA that the comma belongs to the query value. It does 
 Use single quotes around the name to preserve backslashes as written. If you use double quotes, TOML requires each backslash to be doubled. These two lines mean the same thing:
 
 ```toml
+[[policy.tool]]
 # Single quotes:
 name = 'search(query:a\,b)'
 ```
 
 ```toml
+[[policy.tool]]
 # Equivalent form with double quotes:
 name = "search(query:a\\,b)"
 ```
@@ -167,6 +169,10 @@ OpenAPPA selects a contract before it validates the contract's `parameters` sche
 The tool name `"*"` covers tool names that the policy does not declare. The current format requires an annotator for this entry:
 
 ```toml
+[[policy.annotator]]
+name = "classify_unknown_tool"
+ranks = ["suspicious"]
+
 [[policy.tool]]
 name = "*"
 annotator = "classify_unknown_tool"
@@ -727,6 +733,9 @@ A sanitizer can change either the audience or the trust rank of its result. Its 
 For example, the following declaration permits a sanitizer to validate or clean suspicious data and return a trusted result:
 
 ```toml
+[policy.deployment]
+context_control = true
+
 [[policy.sanitizer]]
 name = "vouch-fetched-text"
 on = ["tool_output"]
@@ -828,6 +837,9 @@ Each field in `permits` allows the authority to approve a different type of requ
 For example, these permissions let an authority approve a call that needs `trusted` data, a public audience, an exception for an earlier `email.sent` effect, or `finance-signoff`:
 
 ```toml
+[[policy.authority]]
+name = "finance-officer"
+
 [policy.authority.permits]
 trust_below = "trusted"
 audience_missing = ["public"]
@@ -1065,6 +1077,10 @@ These settings describe what the agent integration can control: which tool resul
 [policy.deployment]
 confined_results = ["get_ticket_from_crm"]
 context_control = true
+
+[[policy.tool]]
+name = "get_ticket_from_crm"
+delta = { audience = ["internal"] }
 ```
 
 `confined_results` lists tools whose results the integration can withhold from the agent.


### PR DESCRIPTION
### What this does

Refines the MCP `yell` tool description and the `YellArgs.message` parameter schema documentation to give agents actionable guidance when reporting issues to the OpenAPPA team.

### Changes
- **Tool description**: Clarifies that `yell` is for cases when APPA is malfunctioning, contradictory, or its blocking feedback/remedies are confusing and leave no clear way forward.
- **Permission guardrail**: Explicitly notes that `yell` sends diagnostic telemetry and does not bypass policy or grant tool permissions (preventing models from using it as an override request or retry loop).
- **Parameter docs**: Updates `YellArgs.message` doc comment to prompt the agent to describe what it was trying to do, what APPA demanded, and why the feedback was confusing or impossible to satisfy.