### PR TITLE
feat(yell): default send prompt to [Y/n] and forward reports to Slack

### DIFF
--- a/.github/workflows/appa-yell.yml
+++ b/.github/workflows/appa-yell.yml
@@ -14,7 +14,8 @@ name: Deploy appa-yell
 #
 # Required repository secrets: APPA_YELL_GCP_SERVICE_ACCOUNT,
 # APPA_YELL_GCP_WORKLOAD_IDENTITY_PROVIDER (a deploy identity of its own, not
-# appa-demo's). Required repository variable: APPA_YELL_ENDPOINT.
+# appa-demo's). Optional repository secret: APPA_YELL_SLACK_WEBHOOK.
+# Required repository variable: APPA_YELL_ENDPOINT.
 #
 # The deploy identity is bound to *this file at this path on main* — Google
 # checks the `job_workflow_ref` claim, because every workflow on a ref mints
@@ -60,15 +61,22 @@ jobs:
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Deploy the function source
+        env:
+          SLACK_WEBHOOK: ${{ secrets.APPA_YELL_SLACK_WEBHOOK }}
         run: |
           # CLOUDSDK_CORE_PROJECT is set by the auth step from the deploy identity.
+          env_args=()
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            env_args+=(--update-env-vars "APPA_YELL_SLACK_WEBHOOK=$SLACK_WEBHOOK")
+          fi
           gcloud functions deploy "$FUNCTION" \
             --gen2 \
             --region "$REGION" \
             --source receiver/appa-yell \
             --runtime python312 \
             --entry-point receive \
-            --build-service-account "projects/$CLOUDSDK_CORE_PROJECT/serviceAccounts/appa-yell-build@$CLOUDSDK_CORE_PROJECT.iam.gserviceaccount.com"
+            --build-service-account "projects/$CLOUDSDK_CORE_PROJECT/serviceAccounts/appa-yell-build@$CLOUDSDK_CORE_PROJECT.iam.gserviceaccount.com" \
+            "${env_args[@]}"
 
       - name: Smoke test the deployed endpoint
         env:

--- a/.github/workflows/appa-yell.yml
+++ b/.github/workflows/appa-yell.yml
@@ -65,10 +65,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.APPA_YELL_SLACK_WEBHOOK }}
         run: |
           # CLOUDSDK_CORE_PROJECT is set by the auth step from the deploy identity.
-          env_args=()
-          if [ -n "$SLACK_WEBHOOK" ]; then
-            env_args+=(--update-env-vars "APPA_YELL_SLACK_WEBHOOK=$SLACK_WEBHOOK")
-          fi
+          # Always set APPA_YELL_SLACK_WEBHOOK so deleting the secret clears the variable.
           gcloud functions deploy "$FUNCTION" \
             --gen2 \
             --region "$REGION" \
@@ -76,7 +73,7 @@ jobs:
             --runtime python312 \
             --entry-point receive \
             --build-service-account "projects/$CLOUDSDK_CORE_PROJECT/serviceAccounts/appa-yell-build@$CLOUDSDK_CORE_PROJECT.iam.gserviceaccount.com" \
-            "${env_args[@]}"
+            --update-env-vars "APPA_YELL_SLACK_WEBHOOK=$SLACK_WEBHOOK"
 
       - name: Smoke test the deployed endpoint
         env:

--- a/appa-runtime/src/yell/cli.rs
+++ b/appa-runtime/src/yell/cli.rs
@@ -73,7 +73,7 @@ async fn yell(
     match yes {
         true => println!("Sending it to {destination}."),
         false => {
-            if !confirm(&format!("Share it with {destination}?"), false) {
+            if !confirm(&format!("Share it with {destination}?"), true) {
                 println!();
                 println!("Not sent. The report stays at {path}.");
                 return ExitCode::SUCCESS;

--- a/appa-runtime/src/yell/cli.rs
+++ b/appa-runtime/src/yell/cli.rs
@@ -248,8 +248,8 @@ fn ask_pseudonymization() -> Mode {
     }
 }
 
-/// A yes/no question. Anything but an explicit answer takes the default, including a closed
-/// stdin: a pipe that ran out of input has not said yes to sending anything.
+/// A yes/no question. Anything but an explicit answer takes the caller-supplied default,
+/// including a closed stdin or empty input.
 fn confirm(question: &str, default: bool) -> bool {
     let suffix = match default {
         true => "[Y/n]",

--- a/receiver/appa-yell/main.py
+++ b/receiver/appa-yell/main.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import urllib.request
 import zlib
 from dataclasses import dataclass
 from pathlib import Path
@@ -233,6 +234,39 @@ def store(plain: bytes, compressed: bytes, kind: str) -> tuple[str, bool]:
     return digest, False
 
 
+def format_slack_message(document: dict[str, Any], digest: str, kind: str, bucket_name: str) -> str:
+    """The concise Slack alert: only the message, whether trajectory is present, and a link to the gzip."""
+    message = document.get("message", "").strip()
+    has_trajectory = "yes" if entries(document) > 0 else "no"
+    object_path = f"reports/{kind}/{digest}.json.gz"
+    gcs_link = f"https://console.cloud.google.com/storage/browser/_details/{bucket_name}/{object_path}"
+    return f"{message}\n\n*Trajectory*: {has_trajectory}\n*Gzip*: <{gcs_link}|{object_path}>"
+
+
+def notify_slack(document: dict[str, Any], digest: str, kind: str) -> None:
+    """Forward a new report to Slack if APPA_YELL_SLACK_WEBHOOK is set.
+
+    Any failure is logged and never bubbles up: a Slack outage must not refuse
+    a report that has already been stored safely in GCS.
+    """
+    webhook = os.environ.get("APPA_YELL_SLACK_WEBHOOK")
+    if not webhook:
+        return
+    bucket_name = os.environ.get("APPA_YELL_BUCKET", "archestra-appa-yell-reports")
+    text = format_slack_message(document, digest, kind, bucket_name)
+    payload = json.dumps({"text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        webhook,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3):
+            pass
+    except Exception:
+        logger.exception("could not notify slack of yell report")
+
+
 @functions_framework.http
 def receive(request: Any) -> tuple[Any, int, dict[str, str]]:
     """One report in, one receipt out."""
@@ -258,4 +292,7 @@ def receive(request: Any) -> tuple[Any, int, dict[str, str]]:
             "entries": entries(document),
         },
     )
+    if not duplicate:
+        notify_slack(document, digest, kind)
+
     return {"receipt_id": f"r-{digest[:32]}", "duplicate": duplicate}, 200, json_headers

--- a/receiver/appa-yell/main.py
+++ b/receiver/appa-yell/main.py
@@ -15,6 +15,8 @@ import json
 import logging
 import os
 import re
+import threading
+import time
 import urllib.request
 import zlib
 from dataclasses import dataclass
@@ -234,37 +236,96 @@ def store(plain: bytes, compressed: bytes, kind: str) -> tuple[str, bool]:
     return digest, False
 
 
-def format_slack_message(document: dict[str, Any], digest: str, kind: str, bucket_name: str) -> str:
-    """The concise Slack alert: only the message, whether trajectory is present, and a link to the gzip."""
-    message = document.get("message", "").strip()
+_SLACK_LOCK = threading.Lock()
+_SLACK_DISPATCH_TIMESTAMPS: list[float] = []
+SLACK_RATE_LIMIT_BURST = 10
+SLACK_RATE_LIMIT_WINDOW_SECS = 60.0
+MAX_SLACK_MESSAGE_CHARS = 2500
+
+
+def _allow_slack_dispatch() -> bool:
+    """Thread-safe rate limiter: allow at most SLACK_RATE_LIMIT_BURST notifications per window."""
+    now = time.monotonic()
+    cutoff = now - SLACK_RATE_LIMIT_WINDOW_SECS
+    with _SLACK_LOCK:
+        while _SLACK_DISPATCH_TIMESTAMPS and _SLACK_DISPATCH_TIMESTAMPS[0] < cutoff:
+            _SLACK_DISPATCH_TIMESTAMPS.pop(0)
+        if len(_SLACK_DISPATCH_TIMESTAMPS) >= SLACK_RATE_LIMIT_BURST:
+            return False
+        _SLACK_DISPATCH_TIMESTAMPS.append(now)
+        return True
+
+
+def sanitize_message_for_slack(message: str) -> str:
+    """Break mentions and truncate long messages to avoid Block Kit overflows."""
+    # Inserting a zero-width space after '@' neuters @channel, @here, @everyone, and user mentions.
+    neutered = message.replace("@", "@\u200b").strip()
+    if not neutered:
+        return "(empty message)"
+    if len(neutered) > MAX_SLACK_MESSAGE_CHARS:
+        return neutered[:MAX_SLACK_MESSAGE_CHARS] + "… (truncated)"
+    return neutered
+
+
+def format_slack_payload(document: dict[str, Any], digest: str, kind: str, bucket_name: str) -> dict[str, Any]:
+    """Structure the Slack alert: plain_text message body, and a context footer with metadata."""
+    raw_message = document.get("message", "")
+    safe_message = sanitize_message_for_slack(raw_message if isinstance(raw_message, str) else "")
     has_trajectory = "yes" if entries(document) > 0 else "no"
     object_path = f"reports/{kind}/{digest}.json.gz"
     gcs_link = f"https://console.cloud.google.com/storage/browser/_details/{bucket_name}/{object_path}"
-    return f"{message}\n\n*Trajectory*: {has_trajectory}\n*Gzip*: <{gcs_link}|{object_path}>"
+    fallback = f"Yell report ({digest[:8]}): {safe_message[:200]}"
+
+    return {
+        "text": fallback,
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "plain_text",
+                    "text": safe_message,
+                    "emoji": False,
+                },
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Trajectory*: {has_trajectory} | *Gzip*: <{gcs_link}|{object_path}>",
+                    }
+                ],
+            },
+        ],
+    }
 
 
-def notify_slack(document: dict[str, Any], digest: str, kind: str) -> None:
-    """Forward a new report to Slack if APPA_YELL_SLACK_WEBHOOK is set.
-
-    Any failure is logged and never bubbles up: a Slack outage must not refuse
-    a report that has already been stored safely in GCS.
-    """
+def notify_slack(document: dict[str, Any], digest: str, kind: str) -> bool:
+    """Forward a new report to Slack if configured and within rate limits."""
     webhook = os.environ.get("APPA_YELL_SLACK_WEBHOOK")
     if not webhook:
-        return
-    bucket_name = os.environ.get("APPA_YELL_BUCKET", "archestra-appa-yell-reports")
-    text = format_slack_message(document, digest, kind, bucket_name)
-    payload = json.dumps({"text": text}).encode("utf-8")
+        return False
+    bucket_name = os.environ.get("APPA_YELL_BUCKET")
+    if not bucket_name:
+        logger.warning("APPA_YELL_BUCKET unset; skipping slack notification")
+        return False
+    if not _allow_slack_dispatch():
+        logger.warning("slack notification rate limit reached; dropping alert for %s", digest[:8])
+        return False
+
+    payload = format_slack_payload(document, digest, kind, bucket_name)
+    data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         webhook,
-        data=payload,
+        data=data,
         headers={"Content-Type": "application/json"},
     )
     try:
-        with urllib.request.urlopen(req, timeout=3):
-            pass
+        with urllib.request.urlopen(req, timeout=1.5):
+            return True
     except Exception:
         logger.exception("could not notify slack of yell report")
+        return False
 
 
 @functions_framework.http

--- a/receiver/appa-yell/test_main.py
+++ b/receiver/appa-yell/test_main.py
@@ -233,3 +233,80 @@ def test_the_salt_is_the_one_the_client_compiles_in():
     assert included, "the client still compiles in a salt file"
     compiled = (Path(__file__).parents[2] / "appa-runtime/src/yell" / included.group(1)).resolve()
     assert compiled == (Path(__file__).parent / "salt.txt").resolve()
+
+
+def test_format_slack_message_with_empty_trajectory():
+    doc = one_report(message="something broke", trajectory={"omitted_reason": "no_recent_trajectory"})
+    msg = main.format_slack_message(doc, "abcd1234abcd", "release", "test-bucket")
+    assert msg.startswith("something broke\n\n")
+    assert "*Trajectory*: no" in msg
+    expected_url = (
+        "https://console.cloud.google.com/storage/browser/_details/test-bucket/reports/release/abcd1234abcd.json.gz"
+    )
+    assert f"*Gzip*: <{expected_url}|reports/release/abcd1234abcd.json.gz>" in msg
+
+
+def test_format_slack_message_with_non_empty_trajectory():
+    doc = one_report(
+        message="tool failed",
+        trajectory={"facts": [{"seq": 1}], "runtime_events": [{"event": "x"}]},
+    )
+    msg = main.format_slack_message(doc, "11223344", "commit", "test-bucket")
+    assert msg.startswith("tool failed\n\n")
+    assert "*Trajectory*: yes" in msg
+    expected_url = (
+        "https://console.cloud.google.com/storage/browser/_details/test-bucket/reports/commit/11223344.json.gz"
+    )
+    assert f"*Gzip*: <{expected_url}|reports/commit/11223344.json.gz>" in msg
+
+
+def test_notify_slack_sends_payload_when_configured(monkeypatch):
+    sent = []
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def dummy_urlopen(req, timeout=None):
+        sent.append((req, timeout))
+        return DummyResponse()
+
+    monkeypatch.setenv("APPA_YELL_SLACK_WEBHOOK", "https://hooks.slack.com/services/T/B/X")
+    monkeypatch.setenv("APPA_YELL_BUCKET", "my-reports")
+    monkeypatch.setattr(main.urllib.request, "urlopen", dummy_urlopen)
+
+    doc = one_report(message="alert test", trajectory={"omitted_reason": "none"})
+    main.notify_slack(doc, "deadbeef", "release")
+
+    assert len(sent) == 1
+    req, timeout = sent[0]
+    assert req.full_url == "https://hooks.slack.com/services/T/B/X"
+    assert timeout == 3
+    body = json.loads(req.data.decode("utf-8"))
+    assert "alert test" in body["text"]
+    assert "*Trajectory*: no" in body["text"]
+    expected_link = (
+        "https://console.cloud.google.com/storage/browser/_details/my-reports/reports/release/deadbeef.json.gz"
+    )
+    assert expected_link in body["text"]
+
+
+def test_notify_slack_silent_when_not_configured(monkeypatch):
+    called = []
+    monkeypatch.delenv("APPA_YELL_SLACK_WEBHOOK", raising=False)
+    monkeypatch.setattr(main.urllib.request, "urlopen", lambda *a, **kw: called.append(True))
+    main.notify_slack(one_report(), "deadbeef", "release")
+    assert not called
+
+
+def test_notify_slack_failure_does_not_raise(monkeypatch):
+    def failing_urlopen(*args, **kwargs):
+        raise OSError("connection error")
+
+    monkeypatch.setenv("APPA_YELL_SLACK_WEBHOOK", "https://hooks.slack.com/services/T/B/X")
+    monkeypatch.setattr(main.urllib.request, "urlopen", failing_urlopen)
+    # Must not raise
+    main.notify_slack(one_report(), "deadbeef", "release")

--- a/receiver/appa-yell/test_main.py
+++ b/receiver/appa-yell/test_main.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import functions_framework
 import pytest
+from flask import Request
+from werkzeug.test import EnvironBuilder
 
 import main
 
@@ -235,29 +237,43 @@ def test_the_salt_is_the_one_the_client_compiles_in():
     assert compiled == (Path(__file__).parent / "salt.txt").resolve()
 
 
-def test_format_slack_message_with_empty_trajectory():
-    doc = one_report(message="something broke", trajectory={"omitted_reason": "no_recent_trajectory"})
-    msg = main.format_slack_message(doc, "abcd1234abcd", "release", "test-bucket")
-    assert msg.startswith("something broke\n\n")
-    assert "*Trajectory*: no" in msg
+@pytest.mark.parametrize(
+    ("trajectory", "expected_status"),
+    [
+        ({"omitted_reason": "no_recent_trajectory"}, "no"),
+        ({"facts": [{"seq": 1}], "runtime_events": [{"event": "x"}]}, "yes"),
+    ],
+)
+def test_format_slack_payload_structure(trajectory, expected_status):
+    doc = one_report(message="something broke", trajectory=trajectory)
+    payload = main.format_slack_payload(doc, "abcd1234abcd", "release", "test-bucket")
+
+    # The caller message sits in a plain_text section block (no mrkdwn, no mention parsing)
+    assert payload["blocks"][0]["type"] == "section"
+    assert payload["blocks"][0]["text"] == {"type": "plain_text", "text": "something broke", "emoji": False}
+
+    # The context footer carries metadata and the GCS object link
+    context = payload["blocks"][1]["elements"][0]["text"]
+    assert f"*Trajectory*: {expected_status}" in context
     expected_url = (
         "https://console.cloud.google.com/storage/browser/_details/test-bucket/reports/release/abcd1234abcd.json.gz"
     )
-    assert f"*Gzip*: <{expected_url}|reports/release/abcd1234abcd.json.gz>" in msg
+    assert f"<{expected_url}|reports/release/abcd1234abcd.json.gz>" in context
 
 
-def test_format_slack_message_with_non_empty_trajectory():
-    doc = one_report(
-        message="tool failed",
-        trajectory={"facts": [{"seq": 1}], "runtime_events": [{"event": "x"}]},
+def test_sanitize_message_for_slack_breaks_mentions_and_truncates():
+    # Mentions are broken with zero-width space
+    assert (
+        main.sanitize_message_for_slack("@channel test @here <@U123>")
+        == "@\u200bchannel test @\u200bhere <@\u200bU123>"
     )
-    msg = main.format_slack_message(doc, "11223344", "commit", "test-bucket")
-    assert msg.startswith("tool failed\n\n")
-    assert "*Trajectory*: yes" in msg
-    expected_url = (
-        "https://console.cloud.google.com/storage/browser/_details/test-bucket/reports/commit/11223344.json.gz"
-    )
-    assert f"*Gzip*: <{expected_url}|reports/commit/11223344.json.gz>" in msg
+    assert main.sanitize_message_for_slack("   ") == "(empty message)"
+
+    # Oversized messages are truncated to avoid Block Kit limit
+    long_msg = "x" * 3000
+    sanitized = main.sanitize_message_for_slack(long_msg)
+    assert len(sanitized) < 3000
+    assert sanitized.endswith("… (truncated)")
 
 
 def test_notify_slack_sends_payload_when_configured(monkeypatch):
@@ -277,29 +293,61 @@ def test_notify_slack_sends_payload_when_configured(monkeypatch):
     monkeypatch.setenv("APPA_YELL_SLACK_WEBHOOK", "https://hooks.slack.com/services/T/B/X")
     monkeypatch.setenv("APPA_YELL_BUCKET", "my-reports")
     monkeypatch.setattr(main.urllib.request, "urlopen", dummy_urlopen)
+    monkeypatch.setattr(main, "_allow_slack_dispatch", lambda: True)
 
     doc = one_report(message="alert test", trajectory={"omitted_reason": "none"})
-    main.notify_slack(doc, "deadbeef", "release")
+    assert main.notify_slack(doc, "deadbeef", "release") is True
 
     assert len(sent) == 1
     req, timeout = sent[0]
     assert req.full_url == "https://hooks.slack.com/services/T/B/X"
-    assert timeout == 3
+    assert timeout == 1.5
     body = json.loads(req.data.decode("utf-8"))
-    assert "alert test" in body["text"]
-    assert "*Trajectory*: no" in body["text"]
-    expected_link = (
-        "https://console.cloud.google.com/storage/browser/_details/my-reports/reports/release/deadbeef.json.gz"
-    )
-    assert expected_link in body["text"]
+    assert body == main.format_slack_payload(doc, "deadbeef", "release", "my-reports")
 
 
 def test_notify_slack_silent_when_not_configured(monkeypatch):
     called = []
     monkeypatch.delenv("APPA_YELL_SLACK_WEBHOOK", raising=False)
     monkeypatch.setattr(main.urllib.request, "urlopen", lambda *a, **kw: called.append(True))
-    main.notify_slack(one_report(), "deadbeef", "release")
+    assert main.notify_slack(one_report(), "deadbeef", "release") is False
     assert not called
+
+
+def test_notify_slack_skips_when_bucket_unset(monkeypatch):
+    called = []
+    monkeypatch.setenv("APPA_YELL_SLACK_WEBHOOK", "https://hooks.slack.com/services/T/B/X")
+    monkeypatch.delenv("APPA_YELL_BUCKET", raising=False)
+    monkeypatch.setattr(main.urllib.request, "urlopen", lambda *a, **kw: called.append(True))
+    assert main.notify_slack(one_report(), "deadbeef", "release") is False
+    assert not called
+
+
+def test_notify_slack_rate_limiting(monkeypatch):
+    dispatched = []
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setenv("APPA_YELL_SLACK_WEBHOOK", "https://hooks.slack.com/services/T/B/X")
+    monkeypatch.setenv("APPA_YELL_BUCKET", "my-reports")
+    monkeypatch.setattr(main.urllib.request, "urlopen", lambda *a, **kw: DummyResponse())
+
+    with main._SLACK_LOCK:
+        main._SLACK_DISPATCH_TIMESTAMPS.clear()
+
+    doc = one_report(message="spam")
+    for _ in range(main.SLACK_RATE_LIMIT_BURST):
+        dispatched.append(main.notify_slack(doc, "d1", "release"))
+    # One more within window must be rejected by rate limiter
+    rejected = main.notify_slack(doc, "d2", "release")
+
+    assert all(dispatched)
+    assert rejected is False
 
 
 def test_notify_slack_failure_does_not_raise(monkeypatch):
@@ -307,6 +355,48 @@ def test_notify_slack_failure_does_not_raise(monkeypatch):
         raise OSError("connection error")
 
     monkeypatch.setenv("APPA_YELL_SLACK_WEBHOOK", "https://hooks.slack.com/services/T/B/X")
+    monkeypatch.setenv("APPA_YELL_BUCKET", "my-reports")
     monkeypatch.setattr(main.urllib.request, "urlopen", failing_urlopen)
+    monkeypatch.setattr(main, "_allow_slack_dispatch", lambda: True)
+
     # Must not raise
-    main.notify_slack(one_report(), "deadbeef", "release")
+    assert main.notify_slack(one_report(), "deadbeef", "release") is False
+
+
+def _make_post_request(doc: dict) -> Request:
+    plain = json.dumps(doc).encode()
+    sig = "v1=" + hmac.new(main.SALT, plain, hashlib.sha256).hexdigest()
+    builder = EnvironBuilder(
+        method="POST",
+        data=gzip.compress(plain),
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            "X-Appa-Signature": sig,
+        },
+    )
+    return Request(builder.get_environ())
+
+
+def test_receive_dispatches_slack_on_new_report(monkeypatch):
+    dispatched = []
+    monkeypatch.setattr(main, "store", lambda plain, compressed, kind: ("fake-digest-1234", False))
+    monkeypatch.setattr(main, "notify_slack", lambda doc, digest, kind: dispatched.append((digest, kind)))
+
+    doc = one_report()
+    body, status, headers = main.receive(_make_post_request(doc))
+    assert status == 200
+    assert body["receipt_id"] == "r-fake-digest-1234"
+    assert dispatched == [("fake-digest-1234", "local")]
+
+
+def test_receive_skips_slack_on_duplicate(monkeypatch):
+    dispatched = []
+    monkeypatch.setattr(main, "store", lambda plain, compressed, kind: ("fake-digest-1234", True))
+    monkeypatch.setattr(main, "notify_slack", lambda doc, digest, kind: dispatched.append((digest, kind)))
+
+    doc = one_report()
+    body, status, headers = main.receive(_make_post_request(doc))
+    assert status == 200
+    assert body["duplicate"] is True
+    assert dispatched == []


### PR DESCRIPTION
## Summary
- **CLI prompt default**: In `appa yell`, default the confirmation prompt for sharing the report to `[Y/n]` (pressing Enter now sends), and align docstring to match caller-supplied default semantics.
- **Slack notifications & hardening**: In `receiver/appa-yell`, forward new (non-duplicate) reports to Slack when `APPA_YELL_SLACK_WEBHOOK` is set:
  - Caller message rendered strictly in Slack Block Kit `plain_text` to neuter mrkdwn injection.
  - Zero-width space inserted after `@` (`@\u200b`) to break mention storms (`@channel`, `@here`, user tags).
  - Visual hierarchy separated: caller message lives in a top section block; system metadata (`Trajectory: yes/no`, GCS gzip link) lives in a distinct `context` footer.
  - Message length capped at 2,500 chars with truncation indicator.
  - In-memory rate limiting (max 10 bursts / 60s per container) to guard against webhook flooding.
  - Synchronous dispatch with tight 1.5s timeout and full exception swallowing to guarantee Cloud Run CPU availability without impacting report receipt.
  - Hardcoded bucket fallback removed.
- **CI deployment**: In `.github/workflows/appa-yell.yml`, unconditionally set `APPA_YELL_SLACK_WEBHOOK=$SLACK_WEBHOOK` on deploy so deleting the GitHub secret cleanly clears the environment variable in Cloud Run.

## Verification
- `cargo fmt --check` passed
- `cargo test --package appa --lib yell` (80/80 passed)
- `uv run --project receiver/appa-yell pytest receiver/appa-yell` (36/36 passed)
- `uv run --project receiver/appa-yell ruff check receiver/appa-yell` passed
- `uv run --project receiver/appa-yell ruff format --check receiver/appa-yell` passed