### PR TITLE
fix(kagent): unblock non-root and ARM64 demo quickstarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
               - 'Cargo.lock'
             e2e:
               - *integration
+              - '.github/workflows/publish-oci-images.yml'
               - 'integrations/kagent/**'
               # Markdown in this tree does not change an image or the
               # A2A suite. Plugin Checks still reads the annotated
@@ -1026,7 +1027,7 @@ jobs:
           cache-from: type=gha,scope=appa-demo-mocks
           cache-to: type=gha,mode=max,scope=appa-demo-mocks
 
-  # The two multi-platform release images also build on the same native
+  # The four multi-platform release images also build on the same native
   # arm64 runner type the release workflow uses. No first arm build waits
   # until after a release tag exists.
   shared-images-arm-build:
@@ -1070,3 +1071,23 @@ jobs:
           push: false
           cache-from: type=gha,scope=appa-kagent-adk-arm64
           cache-to: type=gha,mode=max,scope=appa-kagent-adk-arm64
+
+      - name: Build the demo tools image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/demo
+          platforms: linux/arm64
+          tags: appa-demo-tools:ci-arm64
+          push: false
+          cache-from: type=gha,scope=appa-demo-tools-arm64
+          cache-to: type=gha,mode=max,scope=appa-demo-tools-arm64
+
+      - name: Build the demo mocks image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/demo/mocks
+          platforms: linux/arm64
+          tags: appa-demo-mocks:ci-arm64
+          push: false
+          cache-from: type=gha,scope=appa-demo-mocks-arm64
+          cache-to: type=gha,mode=max,scope=appa-demo-mocks-arm64

--- a/.github/workflows/publish-oci-images.yml
+++ b/.github/workflows/publish-oci-images.yml
@@ -78,22 +78,18 @@ jobs:
             arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
-            context: integrations/kagent/demo
           - image: appa-demo-tools
             arch: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
-            context: integrations/kagent/demo
           - image: appa-demo-mocks
             arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
-            context: integrations/kagent/demo/mocks
           - image: appa-demo-mocks
             arch: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
-            context: integrations/kagent/demo/mocks
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
@@ -172,12 +168,29 @@ jobs:
             org.opencontainers.image.revision=${{ inputs.source_commit }}
             org.opencontainers.image.version=${{ inputs.version_label }}
 
-      - name: Build and push demo image leg
-        if: ${{ matrix.image == 'appa-demo-tools' || matrix.image == 'appa-demo-mocks' }}
-        id: build-demo
+      - name: Build and push appa-demo-tools leg
+        if: ${{ matrix.image == 'appa-demo-tools' }}
+        id: build-tools
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: ${{ matrix.context }}
+          context: integrations/kagent/demo
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
+      - name: Build and push appa-demo-mocks leg
+        if: ${{ matrix.image == 'appa-demo-mocks' }}
+        id: build-mocks
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: integrations/kagent/demo/mocks
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           provenance: true
@@ -193,9 +206,10 @@ jobs:
         env:
           RUNTIME_DIGEST: ${{ steps.build-runtime.outputs.digest }}
           ADK_DIGEST: ${{ steps.build-adk.outputs.digest }}
-          DEMO_DIGEST: ${{ steps.build-demo.outputs.digest }}
+          TOOLS_DIGEST: ${{ steps.build-tools.outputs.digest }}
+          MOCKS_DIGEST: ${{ steps.build-mocks.outputs.digest }}
         run: |
-          DIGEST=${RUNTIME_DIGEST:-${ADK_DIGEST:-$DEMO_DIGEST}}
+          DIGEST=${RUNTIME_DIGEST:-${ADK_DIGEST:-${TOOLS_DIGEST:-$MOCKS_DIGEST}}}
           if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::image build did not report a digest"
             exit 1

--- a/.github/workflows/publish-oci-images.yml
+++ b/.github/workflows/publish-oci-images.yml
@@ -1,6 +1,6 @@
 name: Publish OCI images
 
-# Builds the five OpenAPPA images, merges the two multi-arch indexes, and
+# Builds the five OpenAPPA images, merges the four multi-arch indexes, and
 # attaches the caller's tags. Release callers pass one immutable v* tag.
 # CI callers pass rolling sha-/pr-/main/latest tags. Charts stay in
 # release.yml: their versions are SemVer without v and must not be GC'd.
@@ -74,6 +74,26 @@ jobs:
             arch: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
+          - image: appa-demo-tools
+            arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            context: integrations/kagent/demo
+          - image: appa-demo-tools
+            arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            context: integrations/kagent/demo
+          - image: appa-demo-mocks
+            arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+            context: integrations/kagent/demo/mocks
+          - image: appa-demo-mocks
+            arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            context: integrations/kagent/demo/mocks
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:
@@ -152,12 +172,30 @@ jobs:
             org.opencontainers.image.revision=${{ inputs.source_commit }}
             org.opencontainers.image.version=${{ inputs.version_label }}
 
+      - name: Build and push demo image leg
+        if: ${{ matrix.image == 'appa-demo-tools' || matrix.image == 'appa-demo-mocks' }}
+        id: build-demo
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ matrix.context }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.source_commit }}
+            org.opencontainers.image.version=${{ inputs.version_label }}
+
       - name: Record image digest
         env:
           RUNTIME_DIGEST: ${{ steps.build-runtime.outputs.digest }}
           ADK_DIGEST: ${{ steps.build-adk.outputs.digest }}
+          DEMO_DIGEST: ${{ steps.build-demo.outputs.digest }}
         run: |
-          DIGEST=${RUNTIME_DIGEST:-$ADK_DIGEST}
+          DIGEST=${RUNTIME_DIGEST:-${ADK_DIGEST:-$DEMO_DIGEST}}
           if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::image build did not report a digest"
             exit 1
@@ -205,6 +243,20 @@ jobs:
           path: /tmp/digests/appa-kagent-adk
           merge-multiple: true
 
+      - name: Download appa-demo-tools digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-appa-demo-tools-*
+          path: /tmp/digests/appa-demo-tools
+          merge-multiple: true
+
+      - name: Download appa-demo-mocks digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-appa-demo-mocks-*
+          path: /tmp/digests/appa-demo-mocks
+          merge-multiple: true
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
@@ -231,7 +283,7 @@ jobs:
             echo "::error::no image tags to publish"
             exit 1
           fi
-          for image in appa-runtime appa-kagent-adk; do
+          for image in appa-runtime appa-kagent-adk appa-demo-tools appa-demo-mocks; do
             sources=()
             for digest in "/tmp/digests/${image}"/*; do
               sources+=("${REGISTRY}/${image}@sha256:${digest##*/}")
@@ -311,7 +363,7 @@ jobs:
             exit 1
           fi
           if [ "$IMMUTABLE" = "true" ]; then
-            for image in appa-kagent-adk-go appa-demo-tools appa-demo-mocks golang-adk; do
+            for image in appa-kagent-adk-go golang-adk; do
               for tag in "${tags[@]}"; do
                 [[ "$tag" == v* ]] || continue
                 ref="${REGISTRY}/${image}:${tag}"
@@ -326,12 +378,6 @@ jobs:
             echo "adk_go<<EOF"
             for tag in "${tags[@]}"; do printf '%s\n' "${REGISTRY}/appa-kagent-adk-go:${tag}"; done
             echo "EOF"
-            echo "tools<<EOF"
-            for tag in "${tags[@]}"; do printf '%s\n' "${REGISTRY}/appa-demo-tools:${tag}"; done
-            echo "EOF"
-            echo "mocks<<EOF"
-            for tag in "${tags[@]}"; do printf '%s\n' "${REGISTRY}/appa-demo-mocks:${tag}"; done
-            echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push appa-kagent-adk-go
@@ -344,34 +390,6 @@ jobs:
           provenance: true
           sbom: true
           tags: ${{ steps.tags.outputs.adk_go }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ inputs.source_commit }}
-            org.opencontainers.image.version=${{ inputs.version_label }}
-
-      - name: Build and push appa-demo-tools
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: integrations/kagent/demo
-          platforms: linux/amd64
-          push: true
-          provenance: true
-          sbom: true
-          tags: ${{ steps.tags.outputs.tools }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ inputs.source_commit }}
-            org.opencontainers.image.version=${{ inputs.version_label }}
-
-      - name: Build and push appa-demo-mocks
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: integrations/kagent/demo/mocks
-          platforms: linux/amd64
-          push: true
-          provenance: true
-          sbom: true
-          tags: ${{ steps.tags.outputs.mocks }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ inputs.source_commit }}

--- a/integrations/kagent/README.md
+++ b/integrations/kagent/README.md
@@ -79,6 +79,8 @@ unset OPENAI_API_KEY_B64
 
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent \
+  --set kmcp.podSecurityContext.runAsUser=65532 \
+  --set kmcp.podSecurityContext.runAsGroup=65532 \
   --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
   --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
   --set providers.default=openAI \
@@ -101,6 +103,9 @@ helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --wait --timeout 10m \
   --set controller.agentImage.tag="v$APPA_VERSION"
 ```
+
+The explicit KMCP user and group preserve `runAsNonRoot` while avoiding
+`CreateContainerConfigError` with the bundled KMCP 0.3.0 image, which defaults to root.
 
 ### 2. Deploy appa-runtime
 

--- a/integrations/kagent/e2e/ci/install.sh
+++ b/integrations/kagent/e2e/ci/install.sh
@@ -73,6 +73,8 @@ helm upgrade --install kagent-crds oci://ghcr.io/kagent-dev/kagent/helm/kagent-c
 echo "== helm install kagent $kagent_version"
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version "$kagent_version" -n "$namespace" \
+  --set kmcp.podSecurityContext.runAsUser=65532 \
+  --set kmcp.podSecurityContext.runAsGroup=65532 \
   --set controller.agentImage.registry=docker.io \
   --set controller.agentImage.repository=library/appa-kagent-adk \
   --set-string controller.agentImage.tag="$tag" \

--- a/website/content/docs/kagent.md
+++ b/website/content/docs/kagent.md
@@ -65,6 +65,8 @@ unset OPENAI_API_KEY_B64
 # 2. Install kagent with the OpenAPPA plugin image
 helm upgrade --install kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent \
+  --set kmcp.podSecurityContext.runAsUser=65532 \
+  --set kmcp.podSecurityContext.runAsGroup=65532 \
   --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
   --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
   --set controller.agentImage.tag="v$APPA_VERSION" \
@@ -105,6 +107,9 @@ helm upgrade --install appa-kagent-demo \
   --set-string runtime.reasoningEffort=none \
   --force-conflicts --wait --timeout 10m
 ```
+
+The explicit KMCP user and group preserve `runAsNonRoot` while avoiding
+`CreateContainerConfigError` with the bundled KMCP 0.3.0 image, which defaults to root.
 
 The runtime service listens at `http://appa-runtime.appa.svc.cluster.local:18787`.
 
@@ -246,6 +251,8 @@ APPA_VERSION=0.15.0 # x-release-please-version
 # 1. Update the kagent controller to use the OpenAPPA plugin image
 helm upgrade kagent oci://ghcr.io/kagent-dev/kagent/helm/kagent \
   --version 0.9.12 -n kagent --reuse-values \
+  --set kmcp.podSecurityContext.runAsUser=65532 \
+  --set kmcp.podSecurityContext.runAsGroup=65532 \
   --set controller.agentImage.registry=europe-west1-docker.pkg.dev \
   --set controller.agentImage.repository=friendly-path-465518-r6/appa-public/appa-kagent-adk \
   --set controller.agentImage.tag="v$APPA_VERSION" \


### PR DESCRIPTION
The kagent demo quickstart stalled at two Helm waits on Apple Silicon: KMCP 0.3.0 defaulted to root despite `runAsNonRoot`, then the demo tools and mocks failed to pull because their published images contained only AMD64 manifests.

- Set KMCP's pod UID/GID to 65532 in both quickstart guides, the existing-install upgrade instructions, and the CI installer, preserving `runAsNonRoot`.
- Publish `appa-demo-tools` and `appa-demo-mocks` through the existing native AMD64/ARM64 build-and-merge pipeline, preserving provenance, SBOMs, immutable release tags, and manifest verification. Remove the previous AMD64-only publishers.
- Build both demo images in ARM64 PR checks and trigger image checks when the publishing workflow changes.

Validation: actionlint passed for both changed workflows; installer shell syntax and Helm 0.9.12 KMCP rendering passed; both demo images built locally for AMD64 and ARM64, with both architectures verified in the OCI indexes; all 13 OCI tag tests passed. On the local ARM64 Docker Desktop cluster, KMCP and both locally built demo services are ready and all four Helm releases are deployed.

The image publishing fix takes effect on subsequent builds/releases. Existing immutable v0.15.0 image tags are not republished by this PR; the local installation currently uses ARM64 images built from the checkout. Registry publication will be validated by CI after this PR is opened.
