### PR TITLE
docs: compare OpenAPPA with Cedar

### DIFF
--- a/website/components/DocContent.tsx
+++ b/website/components/DocContent.tsx
@@ -17,6 +17,7 @@ import {
   ClaudeSessionChoice,
 } from "@/components/ClaudeCodeStory";
 import { CodeBlock } from "@/components/CodeBlock";
+import { CedarComparisonFigure } from "@/components/figures/CedarComparisonFigure";
 import { BatteryRuleOrderFigure } from "@/components/figures/BatteriesFigures";
 import { ClaudeCodeHooksFigure } from "@/components/figures/ClaudeCodeHooksFigure";
 import { ConnectedAgentFigure } from "@/components/figures/ConnectedAgentFigure";
@@ -69,6 +70,7 @@ const appaTraceLanguage: LanguageFn = (hljs) => ({
 /* Block directives: a line of the form :::name::: in the markdown renders
    the mapped component in place. */
 const DIRECTIVES: Record<string, () => ReactNode> = {
+  "fig-comparison-cedar": () => <CedarComparisonFigure />,
   "advisory-signup": () => <AdvisorySignup />,
   "battery-catalog": () => <BatteryCatalog />,
   "battery-review-checklist": () => (

--- a/website/components/figures/CedarComparisonFigure.module.css
+++ b/website/components/figures/CedarComparisonFigure.module.css
@@ -1,0 +1,36 @@
+.figure {
+  container-type: inline-size;
+  margin: 1.75rem 0;
+  padding: clamp(12px, 3vw, 24px);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  --work: #b63535;
+}
+
+.figure *, .figure *::before, .figure *::after { box-sizing: border-box; }
+.toolbar { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; justify-content: space-between; font-size: 12px; }
+.toolbar > span { display: flex; align-items: center; gap: 8px; }
+.redKey { width: 10px; height: 10px; background: var(--work); border-radius: 2px; }
+.greenKey { width: 10px; height: 10px; background: var(--accent); border-radius: 2px; }
+.columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); column-gap: 20px; margin-top: 20px; }
+.column { min-width: 0; display: grid; grid-template-rows: subgrid; grid-row: span 13; }
+.figure .column h3 { margin: 0 0 16px; font-size: 17px; line-height: 1.4; }
+.node { min-width: 0; padding: 12px; border: 1px solid var(--border); border-radius: 5px; background: var(--bg-weak); overflow-wrap: anywhere; }
+.node strong, .node span { display: block; }
+.node strong { font-size: 14px; line-height: 1.4; color: var(--text-strong); }
+.node span { margin-top: 5px; font-size: 12px; line-height: 1.6; }
+.application { display: grid; grid-template-rows: subgrid; grid-row: span 6; min-width: 0; padding: 12px; border: 1px dashed var(--border); border-radius: 6px; }
+.platform { border: 1px solid var(--accent); background: color-mix(in srgb, var(--accent) 3%, var(--bg)); }
+.platform .groupTitle { color: var(--accent); }
+.groupTitle { margin-bottom: 12px; font-size: 12px; font-weight: 600; color: var(--text-strong); }
+.custom { border-color: var(--work); background: color-mix(in srgb, var(--work) 5%, var(--bg)); }
+.builtin { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 5%, var(--bg)); }
+.policy { border-style: dashed; }
+.connector { position: relative; flex: none; width: 18px; height: 30px; margin: 0 auto; text-align: center; line-height: 30px; color: var(--text-weak); }
+.figure figcaption { margin-top: 18px; font-size: 13px; line-height: 1.7; }
+@container (max-width: 480px) {
+  .columns { grid-template-columns: minmax(0, 1fr); gap: 28px; }
+  .column, .application { grid-template-rows: none; grid-row: auto; }
+}
+:global(.dark) .figure { --work: #ef8c8c; }

--- a/website/components/figures/CedarComparisonFigure.tsx
+++ b/website/components/figures/CedarComparisonFigure.tsx
@@ -1,0 +1,77 @@
+import styles from "./CedarComparisonFigure.module.css";
+
+function Connector() {
+  return <div className={styles.connector} aria-hidden="true">↓</div>;
+}
+
+export function CedarComparisonFigure() {
+  return (
+    <figure className={styles.figure} aria-label="Cedar and OpenAPPA: what you build and what is included">
+      <div className={styles.toolbar}>
+        <span><i className={styles.redKey} />Red: you implement</span>
+        <span><i className={styles.greenKey} />Green: included</span>
+      </div>
+      <div className={styles.columns}>
+        <section className={styles.column} aria-label="With Cedar">
+          <h3>With Cedar</h3>
+          <div className={styles.node}><strong>Agent</strong><span>Proposes a tool call</span></div>
+          <Connector />
+          <div className={`${styles.node} ${styles.policy}`}>
+            <strong>Cedar policies</strong><span>Access rules in the Cedar language</span>
+          </div>
+          <Connector />
+          <div className={styles.application}>
+            <div className={styles.groupTitle}>Your application</div>
+            <div className={`${styles.node} ${styles.custom}`}>
+              <strong>Agent history</strong>
+              <span>Keep track of what the agent reads and does.</span>
+            </div>
+            <Connector />
+            <div className={`${styles.node} ${styles.builtin}`}>
+              <strong>Cedar engine</strong>
+              <span>Checks whether an action is allowed using the facts you provide.</span>
+            </div>
+            <Connector />
+            <div className={`${styles.node} ${styles.custom}`}>
+              <strong>Recovery</strong>
+              <span>Build ways to remove private details or ask for approval.</span>
+            </div>
+          </div>
+          <Connector />
+          <div className={styles.node}><strong>Tool</strong><span>Your integration releases only allowed calls.</span></div>
+        </section>
+        <section className={styles.column} aria-label="With OpenAPPA">
+          <h3>With OpenAPPA</h3>
+          <div className={styles.node}><strong>Agent</strong><span>Proposes a tool call</span></div>
+          <Connector />
+          <div className={`${styles.node} ${styles.policy}`}>
+            <strong>OpenAPPA policy</strong><span>Tool restrictions, requirements, and permitted remedies</span>
+          </div>
+          <Connector />
+          <div className={`${styles.application} ${styles.platform}`}>
+            <div className={styles.groupTitle}>OpenAPPA</div>
+            <div className={`${styles.node} ${styles.builtin}`}>
+              <strong>Agent history</strong>
+              <span>Keeps track of what the agent reads and does.</span>
+            </div>
+            <Connector />
+            <div className={`${styles.node} ${styles.builtin}`}>
+              <strong>Policy engine</strong>
+              <span>Checks whether an action is allowed based on what happened earlier.</span>
+            </div>
+            <Connector />
+            <div className={`${styles.node} ${styles.builtin}`}>
+              <strong>Recovery</strong>
+              <span>Can arrange cleaning or approval when your rules allow it.</span>
+            </div>
+          </div>
+          <Connector />
+          <div className={styles.node}><strong>Tool</strong><span>Your integration releases only allowed calls.</span></div>
+        </section>
+      </div>
+      <figcaption>
+        Cedar checks the context you supply. OpenAPPA also carries data restrictions forward between actions.
+      </figcaption>
+    </figure>
+  );
+}

--- a/website/content/docs/comparison.md
+++ b/website/content/docs/comparison.md
@@ -1,0 +1,20 @@
+---
+title: Comparison
+category: Get started
+order: 1.5
+description: How OpenAPPA compares with Cedar for securing AI agents.
+---
+
+## OpenAPPA vs Cedar
+
+[Cedar](https://docs.cedarpolicy.com/) is a policy language and engine for application authorization. Your application supplies facts about a proposed action, asks Cedar whether it is allowed, and enforces the answer. You can embed the engine or call a service that runs it.
+
+OpenAPPA is a security framework built for AI agents. It tracks what an agent reads and carries the resulting restrictions forward as the agent uses tools and shares information.
+
+The main difference is how much of the agent's security behavior you need to build yourself. Cedar checks the context you supply. Your application must track what the agent has read, decide how restrictions combine, and supply that state to Cedar. OpenAPPA includes that behavior out of the box.
+
+:::fig-comparison-cedar:::
+
+For example, an agent may be allowed to read private tickets and create public issues. Once it reads a private ticket, OpenAPPA blocks public posting unless the policy permits a way to share that information. Cedar can check the same restriction, but your application must track the private read and tell Cedar about it.
+
+OpenAPPA suits teams enforcing agent security at scale. It includes restriction tracking, tool policy checks, and remedy plans for blocked actions. You connect the agent, declare how its tools handle data, and configure any services needed for cleaning or approval.


### PR DESCRIPTION
Adds a Comparison docs page explaining that Cedar evaluates the context an application supplies, while OpenAPPA tracks data restrictions across agent actions.

Includes a static, responsive diagram showing which responsibilities are provided by Cedar and OpenAPPA and which require application code. The diagram aligns corresponding boxes and distinguishes included functionality from custom implementation.

Validation: website TypeScript check and whitespace checks passed. The diagram was checked in-browser for aligned rows and no overflow at desktop and 320px/390px phone widths.
