### PR TITLE
ci(appa-yell): deploy on every push to main that touches the receiver

### DIFF
--- a/.github/workflows/appa-yell.yml
+++ b/.github/workflows/appa-yell.yml
@@ -1,7 +1,8 @@
 name: Deploy appa-yell
 
 # The receiver behind `appa yell`. Its tests and lint run in ci.yml; this
-# workflow only deploys, on a manual dispatch from main, like appa-demo's.
+# workflow only deploys: on every push to main that touches the receiver or
+# this file, and on a manual dispatch from main.
 #
 # This workflow owns the function's *code* and nothing else. Scaling, ingress,
 # IAM, the runtime service account, the bucket and its retention belong to the
@@ -24,6 +25,11 @@ name: Deploy appa-yell
 # the infra repository, not here.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - receiver/appa-yell/**
+      - .github/workflows/appa-yell.yml
   workflow_dispatch:
 
 permissions: {}

--- a/receiver/appa-yell/README.md
+++ b/receiver/appa-yell/README.md
@@ -86,7 +86,8 @@ configuration: region, ingress, scaling, environment. `APPA_YELL_BUCKET` is
 set there.
 
 `.github/workflows/appa-yell.yml` owns the code, and only the code. It runs on
-a manual dispatch from `main` and passes `gcloud functions deploy` no flag
+every push to `main` that touches this directory or the workflow itself, or on
+a manual dispatch from `main`, and passes `gcloud functions deploy` no flag
 that Terraform owns, so a deploy cannot roll configuration backward. For the
 same reason in the other direction, the Terraform resource must ignore changes
 to its `build_config` source — otherwise the next apply would roll the


### PR DESCRIPTION
Adds a `push` trigger on `main`, filtered to `receiver/appa-yell/**` and the workflow file itself. Manual dispatch stays. The README line describing when the deploy runs is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjJkEr3AunQQ5bDSXT8tL8