### PR TITLE
fix(appa-yell): label the Slack object link "gzip" instead of the full path

### DIFF
--- a/receiver/appa-yell/main.py
+++ b/receiver/appa-yell/main.py
@@ -292,7 +292,7 @@ def format_slack_payload(document: dict[str, Any], digest: str, kind: str, bucke
                 "elements": [
                     {
                         "type": "mrkdwn",
-                        "text": f"*Trajectory*: {has_trajectory} | *Gzip*: <{gcs_link}|{object_path}>",
+                        "text": f"*Trajectory*: {has_trajectory} | <{gcs_link}|gzip>",
                     }
                 ],
             },

--- a/receiver/appa-yell/test_main.py
+++ b/receiver/appa-yell/test_main.py
@@ -258,7 +258,7 @@ def test_format_slack_payload_structure(trajectory, expected_status):
     expected_url = (
         "https://console.cloud.google.com/storage/browser/_details/test-bucket/reports/release/abcd1234abcd.json.gz"
     )
-    assert f"<{expected_url}|reports/release/abcd1234abcd.json.gz>" in context
+    assert f"<{expected_url}|gzip>" in context
 
 
 def test_sanitize_message_for_slack_breaks_mentions_and_truncates():


### PR DESCRIPTION
The context footer of a Slack alert now reads `<link|gzip>` rather than spelling out the 64-hex object path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjJkEr3AunQQ5bDSXT8tL8