### PR TITLE
feat(claude-code): show APPA token cost

### DIFF
--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -858,6 +858,16 @@ impl Runtime {
     pub(crate) fn record(&self, root: Option<&TrajectoryId>, event: crate::events::RuntimeEvent) {
         self.inner.record(root, event);
     }
+
+    /// Count direct APPA-authored input shown to a root agent. The count is diagnostic only
+    /// and resets when Claude Code starts or compacts that session.
+    pub(crate) fn count_appa_tokens(&self, root: &TrajectoryId, tokens: u64, reset: bool) {
+        self.inner
+            .events
+            .lock()
+            .expect("the event mutex is never poisoned: no panic runs while it is held")
+            .count_appa_tokens(root, tokens, reset);
+    }
 }
 
 impl Inner {
@@ -1392,7 +1402,14 @@ impl Runtime {
                 return None;
             }
         };
-        policy.engine().trajectory_status(&view, id)
+        let mut status = policy.engine().trajectory_status(&view, id)?;
+        status.appa_tokens = self
+            .inner
+            .events
+            .lock()
+            .expect("the event mutex is never poisoned: no panic runs while it is held")
+            .appa_tokens(id);
+        Some(status)
     }
 
     /// Every decision this family's log recorded, in log order.

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -561,6 +561,8 @@ pub struct TrajectoryStatus {
     pub trajectory: String,
     pub trust: String,
     pub audience: String,
+    /// Estimated Claude tokens in direct APPA-authored input since the latest session start.
+    pub appa_tokens: u64,
 }
 
 /// One label rendered for a display surface: each dimension as chain
@@ -989,6 +991,7 @@ impl RuntimeEngine {
             trajectory: terminal_safe(&trajectory.0),
             trust: label.trust,
             audience: label.audience,
+            appa_tokens: 0,
         })
     }
 

--- a/appa-runtime/src/events.rs
+++ b/appa-runtime/src/events.rs
@@ -302,6 +302,9 @@ struct RootEvents {
     dropped: u64,
     dropped_through_seq: Option<u64>,
     bytes: usize,
+    /// Direct APPA-authored input shown to the root agent since its latest session start.
+    /// This is a display metric, not part of the trajectory or a policy decision.
+    appa_tokens: u64,
 }
 
 impl RootEvents {
@@ -346,6 +349,22 @@ pub(crate) struct EventLog {
 }
 
 impl EventLog {
+    /// Reset or add to one root agent's direct APPA input count. Like the diagnostic events,
+    /// this projection is bounded by `MAX_ROOTS` and disappears on process restart.
+    pub(crate) fn count_appa_tokens(&mut self, root: &TrajectoryId, tokens: u64, reset: bool) {
+        let events = self.roots.entry(root.0.clone()).or_default();
+        events.appa_tokens = if reset {
+            tokens
+        } else {
+            events.appa_tokens.saturating_add(tokens)
+        };
+        self.evict_coldest_roots();
+    }
+
+    pub(crate) fn appa_tokens(&self, root: &TrajectoryId) -> u64 {
+        self.roots.get(&root.0).map_or(0, |events| events.appa_tokens)
+    }
+
     pub(crate) fn record(&mut self, root: Option<&TrajectoryId>, event: RuntimeEvent) {
         let seq = self.next_seq;
         self.next_seq += 1;
@@ -644,6 +663,18 @@ mod tests {
             panic!("a hook event was recorded");
         };
         assert_eq!(offers.len(), MAX_OFFERS);
+    }
+
+    #[test]
+    fn appa_tokens_accumulate_and_a_session_start_resets_them() {
+        let mut log = EventLog::default();
+        log.count_appa_tokens(&root("a"), 11, true);
+        log.count_appa_tokens(&root("a"), 7, false);
+        assert_eq!(log.appa_tokens(&root("a")), 18);
+
+        log.count_appa_tokens(&root("a"), 5, true);
+        assert_eq!(log.appa_tokens(&root("a")), 5);
+        assert_eq!(log.appa_tokens(&root("unknown")), 0);
     }
 
     /// An `Option` that is `None` and an empty `Vec` must not reach the wire: a reader of a

--- a/appa-runtime/src/hooks.rs
+++ b/appa-runtime/src/hooks.rs
@@ -12,6 +12,9 @@ use crate::api::{
     ToolResultDecision, is_control_tool,
 };
 
+/// The APPA-authored context the plugin adds independently after its SessionStart post.
+const SESSION_CONTEXT: &str = include_str!("../../marketplace/plugins/claude-code/plugin/hooks/session-context.md");
+
 fn wire(decision: &HookDecision) -> serde_json::Value {
     serde_json::to_value(WireDecision::of(decision)).expect("a wire decision serializes")
 }
@@ -110,6 +113,9 @@ pub async fn answer(runtime: &Runtime, adapter: &Adapter, body: &[u8]) -> (u16, 
         };
         if let Some((status, decision)) = early {
             let (outcome, offers) = hook_result(&decision);
+            if root_agent_event(&event) {
+                runtime.count_appa_tokens(&root, decision_tokens(&decision), false);
+            }
             runtime.record(
                 Some(&root),
                 crate::events::RuntimeEvent::Hook {
@@ -123,13 +129,60 @@ pub async fn answer(runtime: &Runtime, adapter: &Adapter, body: &[u8]) -> (u16, 
             return (status, wire(&decision));
         }
     }
+    let reset_appa_tokens = matches!(event, HookEvent::SessionStart { .. });
+    let count_for_root = root_agent_event(&event);
     let handled = handle_internal(runtime, event).await;
+    let mut appa_tokens = if reset_appa_tokens {
+        estimated_tokens(SESSION_CONTEXT)
+    } else {
+        0
+    };
+    if count_for_root {
+        appa_tokens = appa_tokens.saturating_add(decision_tokens(&handled.decision));
+    }
+    runtime.count_appa_tokens(&root, appa_tokens, reset_appa_tokens);
     runtime.record(Some(&root), handled.event);
     let status = match handled.decision {
         HookDecision::Refuse { .. } => 409,
         _ => 200,
     };
     (status, wire(&handled.decision))
+}
+
+/// Whether the decision text reaches the root model whose context total its statusline reports.
+/// Child-start and child-stop text belongs to the child's separate model context.
+fn root_agent_event(event: &HookEvent) -> bool {
+    match event {
+        HookEvent::SessionStart { .. } => true,
+        HookEvent::Prompt { actor, .. }
+        | HookEvent::TurnEnd { actor }
+        | HookEvent::ToolCall { actor, .. }
+        | HookEvent::SpawnResume { actor, .. }
+        | HookEvent::ToolResult { actor, .. }
+        | HookEvent::SpawnResult { actor, .. } => actor.child.is_none(),
+        HookEvent::ChildStart { .. } | HookEvent::ChildEnd { .. } => false,
+    }
+}
+
+/// Claude does not publish its tokenizer for local use. This deliberately narrow estimate
+/// counts only APPA-authored text, at the conventional four UTF-8 bytes per model token.
+fn estimated_tokens(text: &str) -> u64 {
+    u64::try_from(text.len()).unwrap_or(u64::MAX).div_ceil(4)
+}
+
+fn decision_tokens(decision: &HookDecision) -> u64 {
+    match decision {
+        HookDecision::DenyCall { feedback, .. } => estimated_tokens(feedback),
+        HookDecision::Block { reason } => estimated_tokens(reason),
+        HookDecision::ReplaceOutput { output } => estimated_tokens(output),
+        HookDecision::Refuse { detail } => estimated_tokens(detail),
+        HookDecision::Ack
+        | HookDecision::AllowCall { .. }
+        | HookDecision::PassControl
+        | HookDecision::DeliverValue { .. }
+        | HookDecision::ChildReturn { .. }
+        | HookDecision::Context { .. } => 0,
+    }
 }
 
 /// A hook that ended before an actor existed, so there is nothing to attribute it to.
@@ -584,6 +637,25 @@ mod tests {
     use crate::api::Runtime;
     use crate::config::Config;
 
+    #[test]
+    fn direct_appa_input_counts_only_appa_authored_decision_text() {
+        assert_eq!(estimated_tokens("12345"), 2);
+        assert_eq!(
+            decision_tokens(&HookDecision::DenyCall {
+                feedback: "12345678".to_string(),
+                offers: Vec::new(),
+                review: Vec::new(),
+            }),
+            2
+        );
+        assert_eq!(
+            decision_tokens(&HookDecision::DeliverValue {
+                value: "a sanitizer's derived value is not APPA prompt text".to_string(),
+            }),
+            0
+        );
+    }
+
     /// The client side of the wire, as `appa hook` runs it: the
     /// Claude Code hook JSON these tests are written in is translated onto the wire,
     /// and the wire decision is rendered back into Claude Code's hook answer.
@@ -642,6 +714,19 @@ mod tests {
 
     fn open_runtime(dir: &tempfile::TempDir) -> Runtime {
         Runtime::open(config(), dir.path().join("appa.db"), None).expect("the fixture deployment opens")
+    }
+
+    #[tokio::test]
+    async fn session_start_counts_the_appa_context_the_root_model_receives() {
+        let dir = tempfile::tempdir().expect("a temp dir is creatable");
+        let runtime = open_runtime(&dir);
+        let started = br#"{"hook_event_name":"SessionStart","session_id":"token-count"}"#;
+        assert_eq!(through_the_wire(&runtime, started).await.0, 200);
+
+        let status = runtime
+            .status(&TrajectoryId("cc:token-count".to_string()))
+            .expect("the started trajectory has status");
+        assert_eq!(status.appa_tokens, estimated_tokens(SESSION_CONTEXT));
     }
 
     async fn call_hook(runtime: &Runtime, body: &[u8]) -> (u16, serde_json::Value) {

--- a/appa-runtime/tests/api_shape.rs
+++ b/appa-runtime/tests/api_shape.rs
@@ -160,7 +160,7 @@ fn the_declared_vocabulary(event: HookEvent, decision: HookDecision, refusal: Pa
 fn the_declared_status(runtime: &Runtime, id: &TrajectoryId) {
     let status: Option<TrajectoryStatus> = runtime.status(id);
     if let Some(status) = status {
-        let _: (String, String, String) = (status.trajectory, status.trust, status.audience);
+        let _: (String, String, String, u64) = (status.trajectory, status.trust, status.audience, status.appa_tokens);
     }
 }
 

--- a/appa-runtime/tests/plugin_hooks.rs
+++ b/appa-runtime/tests/plugin_hooks.rs
@@ -59,6 +59,48 @@ fn an_ungated_session_has_no_appa_statusline() {
     assert_eq!(output.stdout, b"", "plain Claude must have no APPA statusline");
 }
 
+#[cfg(unix)]
+#[test]
+fn the_statusline_shows_raw_appa_tokens_and_their_input_share() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let curl = dir.path().join("curl");
+    std::fs::write(
+        &curl,
+        "#!/bin/sh\nprintf '%s' '{\"trajectory\":\"cc:widget\",\"trust\":\"trusted\",\"audience\":\"self\",\"appa_tokens\":125}'\n",
+    )
+    .expect("the curl fixture writes");
+    std::fs::set_permissions(&curl, std::fs::Permissions::from_mode(0o755)).expect("the curl fixture is executable");
+    let path = format!(
+        "{}:{}",
+        dir.path().display(),
+        std::env::var("PATH").expect("the test process has PATH")
+    );
+    let mut child = Command::new("sh")
+        .arg(plugin_file("statusline.sh"))
+        .env("APPA_GATE", "1")
+        .env("PATH", path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("the POSIX statusline starts");
+    child
+        .stdin
+        .take()
+        .expect("the statusline has stdin")
+        .write_all(br#"{"session_id":"widget","context_window":{"total_input_tokens":1000}}"#)
+        .expect("the status input writes");
+    let output = child.wait_with_output().expect("the statusline exits");
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("~125 APPA tokens (12.5%)"),
+        "the statusline did not render the narrow APPA token share: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
 /// The two shipped hook maps gate the same events. Nothing else compares
 /// them, so a hook added to one and not the other leaves that platform
 /// on the behaviour the other one fixed.

--- a/marketplace/plugins/claude-code/README.md
+++ b/marketplace/plugins/claude-code/README.md
@@ -285,8 +285,12 @@ Claude Code reads `statusLine` only from your own global settings — a plugin
 cannot set it. The install adds the platform script there unless you already
 have a custom statusline. In a protected session the script shows the APPA pixel
 mascot plus the session's current Trust and Audience, read from the
-process's `GET /status`. In an unprotected session it prints nothing and never
-queries the runtime, so regular `claude` has no APPA statusline. Both platform
+process's `GET /status`. It also shows the estimated raw token count and
+percentage of Claude's current input context spent on direct APPA-authored
+instructions and block or remedy feedback. It does not estimate extra model
+work against a hypothetical session without APPA. In an unprotected session,
+it prints nothing and never queries the runtime. Regular `claude` has no APPA
+statusline. Both platform
 scripts fail open inside a protected session: runtime down, unknown
 trajectory, or malformed input prints the mascot alone, never a blocked
 action. The POSIX script also needs `jq` and `curl`.

--- a/marketplace/plugins/claude-code/plugin/README.md
+++ b/marketplace/plugins/claude-code/plugin/README.md
@@ -21,6 +21,9 @@ successful tool-result admission; WSL runs the POSIX hooks as-is.
 for protected sessions. The install registers the platform script in Claude's
 global statusline setting, so each script exits without printing anything when
 `APPA_GATE=1` is absent. Plain `claude` therefore keeps its normal status area.
+Alongside Trust and Audience, the display shows the estimated raw tokens and
+percentage of Claude's input context occupied by direct APPA-authored
+instructions and block or remedy feedback.
 
 Initialization and every protected session share one starter,
 `hooks/ensure-runtime.sh` (on Windows, `hook.ps1 -EnsureRuntime`): it

--- a/marketplace/plugins/claude-code/plugin/statusline.ps1
+++ b/marketplace/plugins/claude-code/plugin/statusline.ps1
@@ -25,7 +25,16 @@ try {
         throw "Runtime returned an invalid status"
     }
 
-    Write-Output "$mascotTop  trust:$($status.trust)  audience:$($status.audience)"
+    $escape = [char]0x1b
+    $appa = "~$($status.appa_tokens) APPA tokens"
+    $total = $statusInput.context_window.total_input_tokens
+    if ($total -is [ValueType] -and $total -gt 0) {
+        $percentage = (100 * [double]$status.appa_tokens / [double]$total).ToString(
+            "0.0", [Globalization.CultureInfo]::InvariantCulture
+        )
+        $appa = "$appa ($percentage%)"
+    }
+    Write-Output "$mascotTop  trust:$($status.trust) $([char]0xb7) audience:$($status.audience) $([char]0xb7) $escape[2m$appa$escape[0m"
     Write-Output $mascotBottom
 } catch {
     Write-Output $mascotTop

--- a/marketplace/plugins/claude-code/plugin/statusline.sh
+++ b/marketplace/plugins/claude-code/plugin/statusline.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# The APPA statusline: the pixel mascot, plus the root trajectory's
-# current Trust and Audience from the runtime's /status read.
+# The APPA statusline: the pixel mascot, plus the root trajectory's current
+# Trust, Audience, and direct APPA-authored share of Claude's input context.
 #
 # The mark is the website mascot as half blocks — solid pixels, eyes
 # as terminal-background gaps, like the SVG. The chips render the
@@ -24,8 +24,13 @@ if command -v jq >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then
       --data-urlencode "trajectory=cc:${sid}" \
       "${APPA_RUNTIME_URL:-http://127.0.0.1:8787}/status" 2>/dev/null) &&
     chips=$(printf '%s' "$body" |
-      jq -er 'select((.trust | type) == "string" and (.audience | type) == "string")
-        | "trust:\(.trust)  audience:\(.audience)"' 2>/dev/null) ||
+      jq -er --argjson total "$(printf '%s' "$input" | jq '.context_window.total_input_tokens // 0')" '
+        select((.trust | type) == "string" and (.audience | type) == "string" and (.appa_tokens | type) == "number")
+        | if $total > 0 then
+            "trust:\(.trust) · audience:\(.audience) · \u001b[2m~\(.appa_tokens) APPA tokens (\((.appa_tokens * 1000 / $total | round) / 10)%)\u001b[0m"
+          else
+            "trust:\(.trust) · audience:\(.audience) · \u001b[2m~\(.appa_tokens) APPA tokens\u001b[0m"
+          end' 2>/dev/null) ||
     chips=''
 fi
 if [ -n "$chips" ]; then


### PR DESCRIPTION
## Summary

- count direct APPA-authored context and block/remedy feedback per root trajectory
- expose the estimated count through the runtime status projection
- display the raw count and input-context share in both Claude Code statuslines, using Claude's native dim token-counter styling
- exclude admitted values, sanitizer output, subagent context, and hypothetical counterfactual model work

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p appa --lib --tests --locked -- -D warnings`
- `cargo test -p appa --lib hooks::tests`
- `cargo test -p appa --lib events::tests`
- `cargo test -p appa --test plugin_hooks`
- `cargo test -p appa --test api_shape`
- `cargo test -p appa --lib plugin_bundle::`
- `cargo test -p appa --test rendered_hooks`

The counter is marked with `~` because Claude's current tokenizer is not available for local component-level counting.