### PR TITLE
refactor(release): the plugin archive is the batteries archive

### DIFF
--- a/.github/actions/check-release-versions/action.yml
+++ b/.github/actions/check-release-versions/action.yml
@@ -1,8 +1,8 @@
 name: Check release versions
 description: >-
-  Assert the workspace, the plugin manifest and every release-please annotated line
+  Assert the workspace and every release-please annotated line
   carry the version release-please holds. The tag and the compiled CARGO_PKG_VERSION
-  are concatenated into the plugin artifact URL every shipped binary fetches, so a
+  are concatenated into the batteries artifact URL every shipped binary fetches, so a
   disagreement between them ships binaries that request a URL which does not exist.
   The charts resolve image tags to v<appVersion>, and the operator guides spell an
   image tag a reader pastes, so a disagreement names images no release published.

--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -15,8 +15,8 @@ on:
         description: Version the built binary must report
         required: true
         type: string
-      plugin_sha256:
-        description: SHA-256 of the plugin artifact these binaries must accept
+      batteries_sha256:
+        description: SHA-256 of the batteries artifact these binaries must accept
         required: true
         type: string
 permissions: {}
@@ -84,12 +84,12 @@ jobs:
           release_ref: ${{ inputs.release_ref }}
           source_commit: ${{ inputs.source_commit }}
 
-      # The binary accepts only the plugin artifact whose digest it is built
+      # The binary accepts only the batteries artifact whose digest it is built
       # with. Baking it in at compile time is what makes a shipped binary
-      # unable to install any other release's plugin.
+      # unable to install any other release's batteries archive.
       - name: Build binary
         env:
-          APPA_PLUGIN_SHA256: ${{ inputs.plugin_sha256 }}
+          APPA_BATTERIES_SHA256: ${{ inputs.batteries_sha256 }}
           # The tag/ref is compiled in beside the digest. Runtime init never
           # guesses it from the Cargo version, which may also describe later
           # development commits before the next release.
@@ -136,8 +136,8 @@ jobs:
           EXECUTABLE: ${{ matrix.executable }}
           TARGET: ${{ matrix.target }}
         run: |
-          # Binary only. The plugin ships once, platform-independently, as
-          # appa-plugin-<version>.tar.gz, and init fetches exactly the artifact
+          # Binary only. The batteries archive ships once, platform-independently, as
+          # appa-batteries-<version>.tar.gz, and init fetches exactly the artifact
           # whose digest this binary was built with.
           mkdir -p "dist/${ASSET}"
           cp "target/${TARGET}/release/${EXECUTABLE}" "dist/${ASSET}/${EXECUTABLE}"
@@ -175,7 +175,7 @@ jobs:
           # Every debug-only seam is read through one gate that
           # [profile.release] pins shut, so a released binary must ignore a
           # malformed APPA_ENDPOINT and carry on; one that refuses the value
-          # read it, and could be pointed at another release's plugin.
+          # read it, and could be pointed at another release's batteries archive.
           #
           # Activation settles the endpoint before it reads anything, so the
           # config it is pointed at is what fails next, and that failure is
@@ -297,7 +297,7 @@ jobs:
             # Every debug-only seam is read through one gate that
             # [profile.release] pins shut, so a released binary must ignore a
             # malformed APPA_ENDPOINT and carry on; one that refuses the value
-            # read it, and could be pointed at another release's plugin.
+            # read it, and could be pointed at another release's batteries archive.
             #
             # Activation settles the endpoint before it reads anything, so the
             # config it is pointed at is what fails next, and that failure is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
               - 'website/content/docs/contracts.md'
               # The published image compiles the appa-guide skill into
               # the binary and digests the batteries tree
-              # appa-runtime/src/plugin_layout.rs maps.
+              # appa-runtime/src/batteries_layout.rs maps.
               - 'marketplace/**'
               - 'integrations/appa-guide/**'
               - 'scripts/appa-refresh-batteries.py'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,8 @@ jobs:
             -c 'credential.helper=!f() { test "$1" = get && printf "%s\n" "username=x-access-token" "password=$RELEASE_PUSH_TOKEN"; }; f' \
             push origin "HEAD:${release_branch}"
 
-  plugin-artifact:
-    name: Build the plugin artifact
+  batteries-artifact:
+    name: Build the batteries artifact
     if: >-
       needs.release-please.outputs.should_publish == 'true' &&
       needs.release-please.outputs.registry_only != 'true'
@@ -189,28 +189,28 @@ jobs:
           release_ref: ${{ needs.release-please.outputs.tag_name }}
           source_commit: ${{ needs.release-please.outputs.source_commit }}
 
-      - name: Package the plugin
+      - name: Package the batteries
         id: package
         env:
           VERSION: ${{ needs.release-please.outputs.version }}
           COPYFILE_DISABLE: "1"
         run: |
           mkdir -p dist staged
-          # The archive's tree, as appa-runtime/src/plugin_layout.rs maps it.
+          # The archive's tree, as appa-runtime/src/batteries_layout.rs maps it.
           cp -R marketplace/batteries staged/batteries
           find staged -type d -name __pycache__ -prune -exec rm -rf -- {} +
           find staged -type f \( -name '*.pyc' -o -name '*.pyo' -o -name appa-package.toml \) -delete
-          tar -C staged -czf "dist/appa-plugin-${VERSION}.tar.gz" .
+          tar -C staged -czf "dist/appa-batteries-${VERSION}.tar.gz" .
           bash scripts/appa-marketplace.sh --check
           tar -C marketplace -czf "dist/appa-marketplace-${VERSION}.tar.gz" .
-          digest=$(sha256sum "dist/appa-plugin-${VERSION}.tar.gz" | cut -d' ' -f1)
+          digest=$(sha256sum "dist/appa-batteries-${VERSION}.tar.gz" | cut -d' ' -f1)
           echo "sha256=${digest}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload the plugin artifact
+      - name: Upload the batteries artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: appa-plugin
-          path: dist/appa-plugin-${{ needs.release-please.outputs.version }}.tar.gz
+          name: appa-batteries
+          path: dist/appa-batteries-${{ needs.release-please.outputs.version }}.tar.gz
           archive: false
           overwrite: true
           if-no-files-found: error
@@ -233,7 +233,7 @@ jobs:
       needs.release-please.outputs.registry_only != 'true'
     needs:
       - release-please
-      - plugin-artifact
+      - batteries-artifact
     permissions:
       contents: read # Required to verify and check out the release tag.
     uses: ./.github/workflows/build-appa-runtime-binaries.yml
@@ -241,7 +241,7 @@ jobs:
       release_ref: ${{ needs.release-please.outputs.tag_name }}
       source_commit: ${{ needs.release-please.outputs.source_commit }}
       expected_version: ${{ needs.release-please.outputs.version }}
-      plugin_sha256: ${{ needs.plugin-artifact.outputs.sha256 }}
+      batteries_sha256: ${{ needs.batteries-artifact.outputs.sha256 }}
 
   oci-tags:
     name: Resolve release image tags
@@ -385,7 +385,7 @@ jobs:
       needs.release-please.outputs.registry_only != 'true'
     needs:
       - release-please
-      - plugin-artifact
+      - batteries-artifact
       - build-binaries
       - publish-oci-images
       - publish-chart
@@ -441,11 +441,11 @@ jobs:
         working-directory: dist
         env:
           EXPECTED_VERSION: ${{ needs.release-please.outputs.version }}
-          PLUGIN_SHA256: ${{ needs.plugin-artifact.outputs.sha256 }}
+          BATTERIES_SHA256: ${{ needs.batteries-artifact.outputs.sha256 }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           test "$TAG_NAME" = "v${EXPECTED_VERSION}"
-          # Six binaries, the native plugin, the package catalog/trees and both charts.
+          # Six binaries, the batteries archive, the package catalog/trees and both charts.
           expected_archives=(
             appa-x86_64-unknown-linux-gnu.tar.gz
             appa-aarch64-unknown-linux-gnu.tar.gz
@@ -453,7 +453,7 @@ jobs:
             appa-aarch64-apple-darwin.tar.gz
             appa-x86_64-pc-windows-msvc.zip
             appa-aarch64-pc-windows-msvc.zip
-            "appa-plugin-${EXPECTED_VERSION}.tar.gz"
+            "appa-batteries-${EXPECTED_VERSION}.tar.gz"
             "appa-marketplace-${EXPECTED_VERSION}.tar.gz"
             "appa-runtime-${EXPECTED_VERSION}.tgz"
             "appa-kagent-demo-${EXPECTED_VERSION}.tgz"
@@ -471,10 +471,10 @@ jobs:
             exit 1
           fi
           # The binaries were built with this digest compiled in; a mismatch
-          # here would ship a release whose binaries refuse their own plugin.
-          published=$(sha256sum "appa-plugin-${EXPECTED_VERSION}.tar.gz" | cut -d' ' -f1)
-          if [ "$published" != "$PLUGIN_SHA256" ]; then
-            echo "::error::the published plugin artifact is not the one the binaries accept"
+          # here would ship a release whose binaries refuse their own batteries archive.
+          published=$(sha256sum "appa-batteries-${EXPECTED_VERSION}.tar.gz" | cut -d' ' -f1)
+          if [ "$published" != "$BATTERIES_SHA256" ]; then
+            echo "::error::the published batteries artifact is not the one the binaries accept"
             exit 1
           fi
           sh -n appa-install.sh

--- a/appa-package/examples/generation.rs
+++ b/appa-package/examples/generation.rs
@@ -65,7 +65,7 @@ fn render(dist: &Path, marketplace: &Path, images: &Path, commit: &str, release:
         "schema": 1, "repository": REPOSITORY, "commit": commit, "release": release,
         "protocol": appa_package::PROTOCOL, "catalog": digest(&catalog)?,
         "marketplace": digest(&dist.join(format!("appa-marketplace-{version}.tar.gz")))?,
-        "claude_plugin": digest(&dist.join(format!("appa-plugin-{version}.tar.gz")))?,
+        "batteries": digest(&dist.join(format!("appa-batteries-{version}.tar.gz")))?,
         "runtime_chart": digest(&dist.join(format!("appa-runtime-{version}.tgz")))?,
         "binaries": binaries, "images": image_digests,
     });
@@ -114,7 +114,7 @@ mod tests {
         }
         for artifact in [
             "appa-marketplace-1.0.0.tar.gz",
-            "appa-plugin-1.0.0.tar.gz",
+            "appa-batteries-1.0.0.tar.gz",
             "appa-runtime-1.0.0.tgz",
         ] {
             fs::write(dist.join(artifact), b"archive").unwrap();

--- a/appa-package/src/generation.rs
+++ b/appa-package/src/generation.rs
@@ -248,10 +248,10 @@ pub struct Generation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Artifacts {
     /// The release workflow's assets for one version tag: every platform's
-    /// executable, the plugin and marketplace archives, the chart, the images.
+    /// executable, the batteries and marketplace archives, the chart, the images.
     Published(Published),
     /// One development build installing itself on the machine that built it:
-    /// its own executable and the plugin tree stamped into it at compilation.
+    /// its own executable and the batteries tree stamped into it at compilation.
     Build(Build),
 }
 
@@ -259,7 +259,7 @@ pub enum Artifacts {
 pub struct Published {
     release: String,
     marketplace: ArtifactDigest,
-    claude_plugin: ArtifactDigest,
+    batteries: ArtifactDigest,
     runtime_chart: ArtifactDigest,
     binaries: BTreeMap<Platform, ArtifactDigest>,
     images: BTreeMap<Image, ImageDigests>,
@@ -278,8 +278,8 @@ impl Published {
     fn version(&self) -> &str {
         &self.release[1..]
     }
-    fn plugin_archive(&self) -> String {
-        format!("appa-plugin-{}.tar.gz", self.version())
+    fn batteries_archive(&self) -> String {
+        format!("appa-batteries-{}.tar.gz", self.version())
     }
     fn marketplace_archive(&self) -> String {
         format!("appa-marketplace-{}.tar.gz", self.version())
@@ -292,22 +292,22 @@ impl Published {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Build {
     platform: Platform,
-    plugin_tree: String,
+    batteries_tree: String,
     binary: ArtifactDigest,
-    claude_plugin: ArtifactDigest,
+    batteries: ArtifactDigest,
 }
 
 impl Build {
     pub fn platform(&self) -> Platform {
         self.platform
     }
-    /// The canonical digest of the staged plugin tree, as the build stamps it.
-    pub fn plugin_tree(&self) -> &str {
-        &self.plugin_tree
+    /// The canonical digest of the staged batteries tree, as the build stamps it.
+    pub fn batteries_tree(&self) -> &str {
+        &self.batteries_tree
     }
 }
 
-pub const BUILD_PLUGIN_ARCHIVE: &str = "appa-plugin-build.tar.gz";
+pub const BUILD_BATTERIES_ARCHIVE: &str = "appa-batteries-build.tar.gz";
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -319,7 +319,7 @@ struct RawPublished {
     protocol: u32,
     catalog: ArtifactDigest,
     marketplace: ArtifactDigest,
-    claude_plugin: ArtifactDigest,
+    batteries: ArtifactDigest,
     runtime_chart: ArtifactDigest,
     binaries: BTreeMap<Platform, ArtifactDigest>,
     images: BTreeMap<Image, ImageDigests>,
@@ -341,9 +341,9 @@ struct RawBuild {
     catalog: ArtifactDigest,
     source: BuildMarker,
     platform: Platform,
-    plugin_tree: String,
+    batteries_tree: String,
     binary: ArtifactDigest,
-    claude_plugin: ArtifactDigest,
+    batteries: ArtifactDigest,
 }
 
 /// The published shape is the release workflow's, unchanged. A build
@@ -396,9 +396,12 @@ fn validate_release(release: &str) -> Result<(), GenerationError> {
     Ok(())
 }
 
-fn validate_plugin_tree(digest: &str) -> Result<(), GenerationError> {
+fn validate_batteries_tree(digest: &str) -> Result<(), GenerationError> {
     if digest.len() != 64 || !digest.bytes().all(lower_hex) {
-        return Err(invalid("plugin_tree", "expected 64 lowercase hexadecimal characters"));
+        return Err(invalid(
+            "batteries_tree",
+            "expected 64 lowercase hexadecimal characters",
+        ));
     }
     Ok(())
 }
@@ -428,7 +431,7 @@ impl TryFrom<RawGeneration> for Generation {
                     artifacts: Artifacts::Published(Published {
                         release: raw.release,
                         marketplace: raw.marketplace,
-                        claude_plugin: raw.claude_plugin,
+                        batteries: raw.batteries,
                         runtime_chart: raw.runtime_chart,
                         binaries: raw.binaries,
                         images: raw.images,
@@ -437,15 +440,15 @@ impl TryFrom<RawGeneration> for Generation {
             }
             RawGeneration::Build(raw) => {
                 validate_identity(raw.schema, &raw.repository, raw.protocol)?;
-                validate_plugin_tree(&raw.plugin_tree)?;
+                validate_batteries_tree(&raw.batteries_tree)?;
                 Ok(Self {
                     commit: raw.commit,
                     catalog: raw.catalog,
                     artifacts: Artifacts::Build(Build {
                         platform: raw.platform,
-                        plugin_tree: raw.plugin_tree,
+                        batteries_tree: raw.batteries_tree,
                         binary: raw.binary,
-                        claude_plugin: raw.claude_plugin,
+                        batteries: raw.batteries,
                     }),
                 })
             }
@@ -464,7 +467,7 @@ impl From<Generation> for RawGeneration {
                 protocol: crate::PROTOCOL,
                 catalog: generation.catalog,
                 marketplace: published.marketplace,
-                claude_plugin: published.claude_plugin,
+                batteries: published.batteries,
                 runtime_chart: published.runtime_chart,
                 binaries: published.binaries,
                 images: published.images,
@@ -477,9 +480,9 @@ impl From<Generation> for RawGeneration {
                 catalog: generation.catalog,
                 source: BuildMarker::Build,
                 platform: build.platform,
-                plugin_tree: build.plugin_tree,
+                batteries_tree: build.batteries_tree,
                 binary: build.binary,
-                claude_plugin: build.claude_plugin,
+                batteries: build.batteries,
             }),
         }
     }
@@ -498,19 +501,19 @@ impl Generation {
         commit: Commit,
         catalog: ArtifactDigest,
         platform: Platform,
-        plugin_tree: &str,
+        batteries_tree: &str,
         binary: ArtifactDigest,
-        claude_plugin: ArtifactDigest,
+        batteries: ArtifactDigest,
     ) -> Result<Self, GenerationError> {
-        validate_plugin_tree(plugin_tree)?;
+        validate_batteries_tree(batteries_tree)?;
         Ok(Self {
             commit,
             catalog,
             artifacts: Artifacts::Build(Build {
                 platform,
-                plugin_tree: plugin_tree.to_owned(),
+                batteries_tree: batteries_tree.to_owned(),
                 binary,
-                claude_plugin,
+                batteries,
             }),
         })
     }
@@ -545,11 +548,11 @@ impl Generation {
         }
     }
 
-    /// The archive that carries the Claude Code plugin tree.
-    pub fn plugin_archive(&self) -> String {
+    /// The archive that carries the batteries tree.
+    pub fn batteries_archive(&self) -> String {
         match &self.artifacts {
-            Artifacts::Published(published) => published.plugin_archive(),
-            Artifacts::Build(_) => BUILD_PLUGIN_ARCHIVE.to_owned(),
+            Artifacts::Published(published) => published.batteries_archive(),
+            Artifacts::Build(_) => BUILD_BATTERIES_ARCHIVE.to_owned(),
         }
     }
 
@@ -573,13 +576,13 @@ impl Generation {
                     .map(|(platform, digest)| (platform.archive().to_owned(), digest.clone()))
                     .collect();
                 files.insert(published.marketplace_archive(), published.marketplace.clone());
-                files.insert(published.plugin_archive(), published.claude_plugin.clone());
+                files.insert(published.batteries_archive(), published.batteries.clone());
                 files.insert(published.runtime_chart_archive(), published.runtime_chart.clone());
                 files
             }
             Artifacts::Build(build) => BTreeMap::from([
                 (build.platform.archive().to_owned(), build.binary.clone()),
-                (BUILD_PLUGIN_ARCHIVE.to_owned(), build.claude_plugin.clone()),
+                (BUILD_BATTERIES_ARCHIVE.to_owned(), build.batteries.clone()),
             ]),
         }
     }
@@ -594,7 +597,7 @@ mod tests {
         let digest = ArtifactDigest::of_bytes(b"fixture");
         json!({"schema": 1, "repository": REPOSITORY, "commit": "a".repeat(40),
             "release": "v0.14.1", "protocol": crate::PROTOCOL, "catalog": digest,
-            "marketplace": digest, "claude_plugin": digest, "runtime_chart": digest,
+            "marketplace": digest, "batteries": digest, "runtime_chart": digest,
             "binaries": Platform::ALL.into_iter().map(|p| (p, digest.clone())).collect::<BTreeMap<_, _>>(),
             "images": Image::ALL.into_iter().map(|i| (i, json!({"digest": digest,
                 "platforms": {"linux/amd64": digest}}))).collect::<BTreeMap<_, _>>()})
@@ -609,7 +612,7 @@ mod tests {
             generation
         );
         assert_eq!(generation.archives().len(), 9);
-        assert!(generation.archives().contains_key("appa-plugin-0.14.1.tar.gz"));
+        assert!(generation.archives().contains_key("appa-batteries-0.14.1.tar.gz"));
         assert_eq!(generation.commit().as_str(), "a".repeat(40));
         assert_eq!(generation.published().unwrap().release(), "v0.14.1");
         assert!(generation.build_artifacts().is_none());
@@ -637,7 +640,7 @@ mod tests {
         assert!(parsed.published().is_none());
         assert_eq!(parsed.build_artifacts().unwrap().platform(), Platform::MacArm64);
         assert_eq!(parsed.archives().len(), 2);
-        assert_eq!(parsed.plugin_archive(), BUILD_PLUGIN_ARCHIVE);
+        assert_eq!(parsed.batteries_archive(), BUILD_BATTERIES_ARCHIVE);
         assert!(parsed.marketplace_archive().is_none());
         assert!(parsed.runtime_chart_archive().is_none());
         assert!(

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -13,9 +13,10 @@ fn main() {
 
     let crate_root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Cargo sets CARGO_MANIFEST_DIR"));
     let repository = crate_root.parent().expect("appa-runtime is inside the repository");
-    for (source, _) in batteries_layout::REPOSITORY_MAPPINGS {
-        println!("cargo:rerun-if-changed={}", repository.join(source).display());
-    }
+    println!(
+        "cargo:rerun-if-changed={}",
+        repository.join(batteries_layout::SOURCE).display()
+    );
     watch_git_identity(repository);
 
     let release = env::var("APPA_RELEASE_REF").ok();
@@ -39,7 +40,7 @@ fn main() {
     }
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"));
-    let staged = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR")).join("batteries-build-source");
+    let staged = out_dir.join("batteries-build-source");
     if staged.exists() {
         fs::remove_dir_all(&staged).expect("remove the previous staged batteries identity");
     }
@@ -140,8 +141,13 @@ fn release_yell_endpoint() -> String {
 }
 
 fn batteries_are_dirty(repository: &Path) -> bool {
-    let mut arguments = vec!["status", "--porcelain=v1", "--untracked-files=all", "--"];
-    arguments.extend(batteries_layout::REPOSITORY_MAPPINGS.iter().map(|(source, _)| *source));
+    let arguments = [
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--",
+        batteries_layout::SOURCE,
+    ];
     git(repository, &arguments).is_none_or(|output| !output.trim().is_empty())
 }
 
@@ -150,10 +156,7 @@ fn export_committed_repository(repository: &Path, destination: &Path) -> std::io
     command
         .arg("-C")
         .arg(repository)
-        .args(["archive", "--format=tar", "HEAD", "--"]);
-    for (source, _) in batteries_layout::REPOSITORY_MAPPINGS {
-        command.arg(source);
-    }
+        .args(["archive", "--format=tar", "HEAD", "--", batteries_layout::SOURCE]);
     let output = command.output()?;
     if !output.status.success() {
         return Err(std::io::Error::other(

--- a/appa-runtime/build.rs
+++ b/appa-runtime/build.rs
@@ -1,5 +1,5 @@
-#[path = "src/plugin_layout.rs"]
-mod plugin_layout;
+#[path = "src/batteries_layout.rs"]
+mod batteries_layout;
 
 use std::env;
 use std::fs;
@@ -7,22 +7,22 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=APPA_PLUGIN_SHA256");
+    println!("cargo:rerun-if-env-changed=APPA_BATTERIES_SHA256");
     println!("cargo:rerun-if-env-changed=APPA_RELEASE_REF");
     println!("cargo:rerun-if-env-changed=APPA_YELL_ENDPOINT");
 
     let crate_root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Cargo sets CARGO_MANIFEST_DIR"));
     let repository = crate_root.parent().expect("appa-runtime is inside the repository");
-    for (source, _) in plugin_layout::REPOSITORY_MAPPINGS {
+    for (source, _) in batteries_layout::REPOSITORY_MAPPINGS {
         println!("cargo:rerun-if-changed={}", repository.join(source).display());
     }
     watch_git_identity(repository);
 
     let release = env::var("APPA_RELEASE_REF").ok();
     let commit = git(repository, &["rev-parse", "HEAD"]);
-    let dirty = plugin_is_dirty(repository);
+    let dirty = batteries_are_dirty(repository);
     if release.is_some() {
-        // Release identity covers runtime code as well as plugin mappings.
+        // Release identity covers runtime code as well as batteries mappings.
         // Recheck on incremental release builds too, including newly added files.
         println!("cargo:rerun-if-changed={}", repository.display());
         assert!(
@@ -39,30 +39,31 @@ fn main() {
     }
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"));
-    let staged = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR")).join("plugin-build-source");
+    let staged = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR")).join("batteries-build-source");
     if staged.exists() {
-        fs::remove_dir_all(&staged).expect("remove the previous staged plugin identity");
+        fs::remove_dir_all(&staged).expect("remove the previous staged batteries identity");
     }
-    let committed = out_dir.join("plugin-build-repository");
+    let committed = out_dir.join("batteries-build-repository");
     if committed.exists() {
-        fs::remove_dir_all(&committed).expect("remove the previous committed plugin source");
+        fs::remove_dir_all(&committed).expect("remove the previous committed batteries source");
     }
     let identity_source = if commit.is_some() && !dirty {
-        export_committed_repository(repository, &committed).expect("export the committed plugin source");
+        export_committed_repository(repository, &committed).expect("export the committed batteries source");
         committed.as_path()
     } else {
         repository
     };
-    plugin_layout::stage_repository(identity_source, &staged).expect("stage the plugin source for build identity");
-    let digest = appa_package::tree::canonical_tree_digest(&staged).expect("digest the staged plugin source");
-    println!("cargo:rustc-env=APPA_PLUGIN_TREE_SHA256={}", hex(&digest));
+    batteries_layout::stage_repository(identity_source, &staged)
+        .expect("stage the batteries source for build identity");
+    let digest = appa_package::tree::canonical_tree_digest(&staged).expect("digest the staged batteries source");
+    println!("cargo:rustc-env=APPA_BATTERIES_TREE_SHA256={}", hex(&digest));
 
     if let Some(reference) = release {
         assert!(!reference.trim().is_empty(), "APPA_RELEASE_REF must not be empty");
-        let digest = release_plugin_digest();
+        let digest = release_batteries_digest();
         let endpoint = release_yell_endpoint();
         println!("cargo:rustc-env=APPA_RELEASE_REF={reference}");
-        println!("cargo:rustc-env=APPA_PLUGIN_SHA256={digest}");
+        println!("cargo:rustc-env=APPA_BATTERIES_SHA256={digest}");
         println!("cargo:rustc-env=APPA_YELL_COMPILED_ENDPOINT={endpoint}");
         return;
     }
@@ -80,20 +81,20 @@ fn main() {
     println!("cargo:rustc-env=APPA_BUILD_REPOSITORY={}", repository.display());
 }
 
-/// The SHA-256 of the release plugin archive this build accepts, as 64 hex
-/// characters. A release binary resolves its plugin from nothing else, so a
+/// The SHA-256 of the release batteries archive this build accepts, as 64 hex
+/// characters. A release binary resolves its batteries from nothing else, so a
 /// release build without it is refused here rather than at someone's install.
-fn release_plugin_digest() -> String {
-    let Some(digest) = env::var("APPA_PLUGIN_SHA256").ok() else {
+fn release_batteries_digest() -> String {
+    let Some(digest) = env::var("APPA_BATTERIES_SHA256").ok() else {
         panic!(
-            "a release build (APPA_RELEASE_REF is set) requires APPA_PLUGIN_SHA256, \
-             the SHA-256 of the release plugin archive"
+            "a release build (APPA_RELEASE_REF is set) requires APPA_BATTERIES_SHA256, \
+             the SHA-256 of the release batteries archive"
         );
     };
     let digest = digest.trim().to_owned();
     assert!(
         digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()),
-        "APPA_PLUGIN_SHA256 must be 64 hexadecimal characters, got {digest:?}"
+        "APPA_BATTERIES_SHA256 must be 64 hexadecimal characters, got {digest:?}"
     );
     digest
 }
@@ -138,9 +139,9 @@ fn release_yell_endpoint() -> String {
     endpoint
 }
 
-fn plugin_is_dirty(repository: &Path) -> bool {
+fn batteries_are_dirty(repository: &Path) -> bool {
     let mut arguments = vec!["status", "--porcelain=v1", "--untracked-files=all", "--"];
-    arguments.extend(plugin_layout::REPOSITORY_MAPPINGS.iter().map(|(source, _)| *source));
+    arguments.extend(batteries_layout::REPOSITORY_MAPPINGS.iter().map(|(source, _)| *source));
     git(repository, &arguments).is_none_or(|output| !output.trim().is_empty())
 }
 
@@ -150,7 +151,7 @@ fn export_committed_repository(repository: &Path, destination: &Path) -> std::io
         .arg("-C")
         .arg(repository)
         .args(["archive", "--format=tar", "HEAD", "--"]);
-    for (source, _) in plugin_layout::REPOSITORY_MAPPINGS {
+    for (source, _) in batteries_layout::REPOSITORY_MAPPINGS {
         command.arg(source);
     }
     let output = command.output()?;

--- a/appa-runtime/examples/installation_fixture.rs
+++ b/appa-runtime/examples/installation_fixture.rs
@@ -15,11 +15,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<_> = std::env::args_os().skip(1).collect();
     if args.len() != 3 {
         return Err(
-            "usage: installation_fixture <release-identity-binary> <native-plugin-archive> <new-bundle-path>".into(),
+            "usage: installation_fixture <release-identity-binary> <batteries-archive> <new-bundle-path>".into(),
         );
     }
     let binary = Path::new(&args[0]);
-    let plugin = Path::new(&args[1]);
+    let batteries = Path::new(&args[1]);
     let output = Path::new(&args[2]);
     let identity = std::process::Command::new(binary).arg("build-info").output()?;
     if !identity.status.success() {
@@ -29,9 +29,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let release = identity["release"]
         .as_str()
         .ok_or("fixture binary has no release identity")?;
-    let plugin_digest = digest(plugin)?;
-    if identity["plugin_sha256"].as_str() != Some(plugin_digest.hex()) {
-        return Err("fixture native plugin is not this binary's compiled twin".into());
+    let batteries_digest = digest(batteries)?;
+    if identity["batteries_sha256"].as_str() != Some(batteries_digest.hex()) {
+        return Err("fixture batteries archive is not this binary's compiled twin".into());
     }
     let repository = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
     let marketplace = repository.join("marketplace");
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let marketplace_digest = digest(marketplace_archive.path())?;
     let placeholder = ArtifactDigest::of_bytes(b"unused fixture artifact");
     let descriptor = serde_json::json!({"schema":1,"repository":REPOSITORY,"commit":identity["commit"],"release":release,"protocol":appa_package::PROTOCOL,
-        "catalog":digest(&marketplace.join("marketplace.toml"))?,"marketplace":marketplace_digest,"claude_plugin":plugin_digest,"runtime_chart":placeholder,
+        "catalog":digest(&marketplace.join("marketplace.toml"))?,"marketplace":marketplace_digest,"batteries":batteries_digest,"runtime_chart":placeholder,
         "binaries":Platform::ALL.into_iter().map(|p|(p,if p == platform { binary_digest.clone() } else { placeholder.clone() })).collect::<BTreeMap<_,_>>(),
         "images":Image::ALL.into_iter().map(|image|(image,serde_json::json!({"digest":placeholder,"platforms":{"linux/amd64":placeholder}}))).collect::<BTreeMap<_,_>>()});
     let generation = Generation::parse(&serde_json::to_vec(&descriptor)?)?;
@@ -78,7 +78,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     tar.append_dir_all("marketplace", &marketplace)?;
     tar.append_path_with_name(binary_archive.path(), format!("artifacts/{}", platform.archive()))?;
-    tar.append_path_with_name(plugin, format!("artifacts/appa-plugin-{}.tar.gz", &release[1..]))?;
+    tar.append_path_with_name(batteries, format!("artifacts/appa-batteries-{}.tar.gz", &release[1..]))?;
     tar.append_path_with_name(
         marketplace_archive.path(),
         format!("artifacts/appa-marketplace-{}.tar.gz", &release[1..]),

--- a/appa-runtime/src/batteries_layout.rs
+++ b/appa-runtime/src/batteries_layout.rs
@@ -1,27 +1,24 @@
 //! The repository paths that make up the batteries archive a generation
 //! carries, and the tree the build digests for its identity.
 //!
-//! This module is also compiled by `build.rs`, which reads only the mappings,
-//! so keep its dependencies to `std`. One mapping drives build-time identity
-//! and the staging of a development build's own archive.
+//! This module is also compiled by `build.rs`, which reads only the paths, so
+//! keep its dependencies to `std`. One source drives build-time identity and
+//! the staging of a development build's own archive.
 
 use std::fs;
 use std::io;
 use std::path::Path;
 
 /// The host-side code of a protected session is the deployed binary, so the
-/// archive carries only the batteries a policy may include.
-pub const REPOSITORY_MAPPINGS: [(&str, &str); 1] = [("marketplace/batteries", "batteries")];
+/// archive carries only the batteries a policy may include: the repository's
+/// batteries tree, at the archive's `batteries/`.
+pub const SOURCE: &str = "marketplace/batteries";
+const TARGET: &str = "batteries";
 
 /// Stage the batteries archive's tree from an OpenAPPA repository checkout.
 pub fn stage_repository(repository: &Path, destination: &Path) -> io::Result<()> {
     fs::create_dir_all(destination)?;
-    for (source, target) in REPOSITORY_MAPPINGS {
-        let source = repository.join(source);
-        let target = destination.join(target);
-        copy_entry(&source, &target)?;
-    }
-    Ok(())
+    copy_entry(&repository.join(SOURCE), &destination.join(TARGET))
 }
 
 fn copy_entry(source: &Path, destination: &Path) -> io::Result<()> {

--- a/appa-runtime/src/batteries_layout.rs
+++ b/appa-runtime/src/batteries_layout.rs
@@ -1,5 +1,5 @@
-//! The repository paths that make up the plugin archive a generation carries,
-//! and the tree the build digests for its identity.
+//! The repository paths that make up the batteries archive a generation
+//! carries, and the tree the build digests for its identity.
 //!
 //! This module is also compiled by `build.rs`, which reads only the mappings,
 //! so keep its dependencies to `std`. One mapping drives build-time identity
@@ -13,7 +13,7 @@ use std::path::Path;
 /// archive carries only the batteries a policy may include.
 pub const REPOSITORY_MAPPINGS: [(&str, &str); 1] = [("marketplace/batteries", "batteries")];
 
-/// Stage the plugin archive's tree from an OpenAPPA repository checkout.
+/// Stage the batteries archive's tree from an OpenAPPA repository checkout.
 pub fn stage_repository(repository: &Path, destination: &Path) -> io::Result<()> {
     fs::create_dir_all(destination)?;
     for (source, target) in REPOSITORY_MAPPINGS {

--- a/appa-runtime/src/batteries_layout.rs
+++ b/appa-runtime/src/batteries_layout.rs
@@ -1,9 +1,8 @@
 //! The repository paths that make up the batteries archive a generation
 //! carries, and the tree the build digests for its identity.
 //!
-//! This module is also compiled by `build.rs`, which reads only the paths, so
-//! keep its dependencies to `std`. One source drives build-time identity and
-//! the staging of a development build's own archive.
+//! This module is also compiled by `build.rs`. One source drives build-time
+//! identity and the staging of a development build's own archive.
 
 use std::fs;
 use std::io;

--- a/appa-runtime/src/bin/appa.rs
+++ b/appa-runtime/src/bin/appa.rs
@@ -23,8 +23,6 @@ enum Command {
         #[arg(long)]
         config: PathBuf,
         #[arg(long)]
-        archive: PathBuf,
-        #[arg(long)]
         previous_binary: Option<PathBuf>,
     },
     /// Internal journalled removal using the selected release executable.
@@ -32,8 +30,6 @@ enum Command {
     RemoveClaude {
         #[arg(long)]
         config: PathBuf,
-        #[arg(long)]
-        archive: PathBuf,
     },
     /// Inspect host plugin packages for a deployment.
     Plugin {
@@ -193,9 +189,8 @@ fn main() -> ExitCode {
         Command::BuildInfo => appa_runtime::installation::native::build_info(),
         Command::ActivateClaude {
             config,
-            archive,
             previous_binary,
-        } => match appa_runtime::init::activate_claude_code(&config, &archive, previous_binary.as_deref()) {
+        } => match appa_runtime::init::activate_claude_code(&config, previous_binary.as_deref()) {
             Ok(_) => ExitCode::SUCCESS,
             Err(error) => {
                 eprintln!("appa: {error}");
@@ -215,7 +210,7 @@ fn main() -> ExitCode {
         Command::Plugin {
             command: PluginCommand::Remove(args),
         } => appa_runtime::installation::cli::remove_plugin(args),
-        Command::RemoveClaude { config, archive } => match appa_runtime::init::claude_code_remove(&config, &archive) {
+        Command::RemoveClaude { config } => match appa_runtime::init::claude_code_remove(&config) {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
                 eprintln!("appa: {error}");

--- a/appa-runtime/src/bin/appa.rs
+++ b/appa-runtime/src/bin/appa.rs
@@ -93,7 +93,7 @@ enum Command {
                             either way.")]
     Yell {
         /// The runtime that builds the report. Loopback only.
-        #[arg(long, env = "APPA_RUNTIME_URL", default_value = "http://127.0.0.1:8787")]
+        #[arg(long, env = "APPA_RUNTIME_URL", default_value = appa_runtime::runtime_url::DEFAULT_RUNTIME_URL)]
         url: String,
 
         /// Answer both questions with yes: pseudonymize the report, and send it.
@@ -210,7 +210,7 @@ fn main() -> ExitCode {
         Command::Plugin {
             command: PluginCommand::Remove(args),
         } => appa_runtime::installation::cli::remove_plugin(args),
-        Command::RemoveClaude { config } => match appa_runtime::init::claude_code_remove(&config) {
+        Command::RemoveClaude { config: _ } => match appa_runtime::init::claude_code_remove() {
             Ok(()) => ExitCode::SUCCESS,
             Err(error) => {
                 eprintln!("appa: {error}");

--- a/appa-runtime/src/init/mod.rs
+++ b/appa-runtime/src/init/mod.rs
@@ -7,7 +7,7 @@
 //! the appa-guide skill is written from bytes compiled into the binary.
 
 use crate::config::ConfigError;
-use crate::installation::archive::{self, ArchiveError, VerifiedArchive};
+use crate::installation::archive;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -84,8 +84,6 @@ pub enum InitError {
         path: PathBuf,
         message: String,
     },
-    #[error(transparent)]
-    Archive(#[from] ArchiveError),
     #[error("{operation}; restoring the previous installation also failed: {recovery}")]
     Recovery {
         operation: Box<InitError>,
@@ -103,11 +101,7 @@ pub enum InitError {
 /// before the profile is switched over. Directories and the deployed binary's
 /// parent are written before that settling; both are additive and neither is
 /// what Claude reads.
-pub fn activate_claude_code(
-    config: &Path,
-    archive: &Path,
-    previous_binary: Option<&Path>,
-) -> Result<String, InitError> {
+pub fn activate_claude_code(config: &Path, previous_binary: Option<&Path>) -> Result<String, InitError> {
     // The endpoint is settled before anything is read: a release build ignores
     // the environment here, and the release check proves it on this refusal.
     let endpoint = Endpoint::resolve()?;
@@ -119,8 +113,21 @@ pub fn activate_claude_code(
         path: config.clone(),
         source: Box::new(source),
     })?;
-    let source = VerifiedArchive::of(archive)?;
-    install_claude(&source.label(), endpoint, config, previous_binary)
+    install_claude(&build_label(), endpoint, config, previous_binary)
+}
+
+/// The origin as a receipt names it: this binary's release tag, or the commit
+/// it was built from.
+fn build_label() -> String {
+    match option_env!("APPA_RELEASE_REF") {
+        Some(release) => format!("appa {release}"),
+        None => format!(
+            "appa build {}",
+            option_env!("APPA_BUILD_COMMIT")
+                .map(|commit| &commit[..commit.len().min(12)])
+                .unwrap_or("unknown")
+        ),
+    }
 }
 
 fn install_claude(

--- a/appa-runtime/src/init/removal.rs
+++ b/appa-runtime/src/init/removal.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::path::Path;
 
 use super::{CLAPPA, InitError, appa_filename, deployment_paths, file_before, mcp, settings, skill, write_state};
-use crate::installation::archive::VerifiedArchive;
 
 #[cfg(unix)]
 pub(super) const REMOVING: &str = "#!/bin/sh\nprintf 'APPA plugin removal is incomplete; rerun appa plugin remove claude-code with the same config.\\n' >&2\nexit 1\n";
@@ -16,10 +15,9 @@ pub(super) const REMOVING: &str = "@echo off\r\necho APPA plugin removal is inco
 /// removed. The runtime, configuration, retained artifacts and trajectory data
 /// stay put. The `--config` flag of the bridge stays because the installed
 /// binary invokes it; the profile carries everything removal needs.
-pub fn claude_code_remove(_config: &Path, archive: &Path) -> Result<(), InitError> {
+pub fn claude_code_remove(_config: &Path) -> Result<(), InitError> {
     let paths = deployment_paths()?;
     let _profile_lock = super::lock_claude_profile(&paths.claude_dir)?;
-    VerifiedArchive::of(archive)?;
     let deployed = paths.data_dir.join("bin").join(appa_filename());
     let launcher = paths.install_dir.join(CLAPPA.0);
     let launcher_before = file_before(&launcher)?;

--- a/appa-runtime/src/init/removal.rs
+++ b/appa-runtime/src/init/removal.rs
@@ -15,7 +15,7 @@ pub(super) const REMOVING: &str = "@echo off\r\necho APPA plugin removal is inco
 /// removed. The runtime, configuration, retained artifacts and trajectory data
 /// stay put. The `--config` flag of the bridge stays because the installed
 /// binary invokes it; the profile carries everything removal needs.
-pub fn claude_code_remove(_config: &Path) -> Result<(), InitError> {
+pub fn claude_code_remove() -> Result<(), InitError> {
     let paths = deployment_paths()?;
     let _profile_lock = super::lock_claude_profile(&paths.claude_dir)?;
     let deployed = paths.data_dir.join("bin").join(appa_filename());

--- a/appa-runtime/src/installation.rs
+++ b/appa-runtime/src/installation.rs
@@ -1355,7 +1355,7 @@ mod tests {
         let document = serde_json::json!({"schema": 1, "repository": REPOSITORY,
             "commit": "a".repeat(40), "release": "v1.0.0", "protocol": appa_package::PROTOCOL,
             "catalog": ArtifactDigest::of_bytes(catalog), "marketplace": digest,
-            "claude_plugin": digest, "runtime_chart": digest,
+            "batteries": digest, "runtime_chart": digest,
             "binaries": Platform::ALL.into_iter().map(|p| (p, digest.clone())).collect::<BTreeMap<_, _>>(),
             "images": Image::ALL.into_iter().map(|i| (i, serde_json::json!({"digest": digest,
                 "platforms": {"linux/amd64": digest}}))).collect::<BTreeMap<_, _>>()});

--- a/appa-runtime/src/installation/acquisition.rs
+++ b/appa-runtime/src/installation/acquisition.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use appa_package::generation::{
-    ArtifactDigest, BUILD_PLUGIN_ARCHIVE, Commit, DESCRIPTOR_FILE, Generation, Platform, REPOSITORY,
+    ArtifactDigest, BUILD_BATTERIES_ARCHIVE, Commit, DESCRIPTOR_FILE, Generation, Platform, REPOSITORY,
 };
 use serde::Deserialize;
 
@@ -192,7 +192,7 @@ impl Acquired {
     pub fn is_own_build(generation: &Generation) -> bool {
         generation.build_artifacts().is_some_and(|build| {
             Some(generation.commit().as_str()) == option_env!("APPA_BUILD_COMMIT")
-                && Some(build.plugin_tree()) == option_env!("APPA_PLUGIN_TREE_SHA256")
+                && Some(build.batteries_tree()) == option_env!("APPA_BATTERIES_TREE_SHA256")
         })
     }
 
@@ -220,7 +220,7 @@ impl Acquired {
         }
     }
 
-    /// A development build installs itself: the plugin tree staged from its
+    /// A development build installs itself: the batteries tree staged from its
     /// commit, which must digest to what the build stamped, the marketplace
     /// tree at that commit, and this process's own executable. Kagent needs
     /// published images and a chart, which a build cannot supply.
@@ -232,8 +232,8 @@ impl Acquired {
             )
         })?;
         let commit = Commit::parse(commit).map_err(|error| InstallError::Invalid(error.to_string()))?;
-        let plugin_tree = option_env!("APPA_PLUGIN_TREE_SHA256")
-            .ok_or_else(|| InstallError::Invalid("this build carries no plugin identity".into()))?;
+        let batteries_tree = option_env!("APPA_BATTERIES_TREE_SHA256")
+            .ok_or_else(|| InstallError::Invalid("this build carries no batteries identity".into()))?;
         let platform = Platform::current()
             .ok_or_else(|| InstallError::Invalid("this platform has no published runtime binary".into()))?;
         if matches!(requirements, Requirements::Kagent | Requirements::Both(_)) {
@@ -245,22 +245,22 @@ impl Acquired {
             tempfile::tempdir().map_err(|error| io("stage acquisition", Path::new("temporary directory"), error))?;
         let repository = source_at_commit(&commit, stage.path())?;
         let staged = stage.path().join("plugin");
-        crate::plugin_layout::stage_repository(&repository, &staged)
-            .map_err(|error| InstallError::Invalid(format!("cannot stage the plugin tree: {error}")))?;
+        crate::batteries_layout::stage_repository(&repository, &staged)
+            .map_err(|error| InstallError::Invalid(format!("cannot stage the batteries tree: {error}")))?;
         let actual = appa_package::canonical_tree_digest(&staged)
             .map_err(|error| InstallError::Invalid(error.to_string()))?
             .iter()
             .map(|byte| format!("{byte:02x}"))
             .collect::<String>();
-        if actual != plugin_tree {
+        if actual != batteries_tree {
             return Err(InstallError::Invalid(format!(
-                "the plugin tree at commit {commit} does not match this build; rebuild from that commit"
+                "the batteries tree at commit {commit} does not match this build; rebuild from that commit"
             )));
         }
         let marketplace = repository.join("marketplace");
         let catalog = ArtifactDigest::of_bytes(&super::required_bytes(&marketplace.join("marketplace.toml"))?);
-        let plugin_archive = stage.path().join(BUILD_PLUGIN_ARCHIVE);
-        pack_tree(&staged, &plugin_archive)?;
+        let batteries_archive = stage.path().join(BUILD_BATTERIES_ARCHIVE);
+        pack_tree(&staged, &batteries_archive)?;
         let binary_archive = stage.path().join(platform.archive());
         let executable =
             std::env::current_exe().map_err(|error| io("locate this executable", Path::new("appa"), error))?;
@@ -269,9 +269,9 @@ impl Acquired {
             commit.clone(),
             catalog,
             platform,
-            plugin_tree,
+            batteries_tree,
             digest_of(&binary_archive)?,
-            digest_of(&plugin_archive)?,
+            digest_of(&batteries_archive)?,
         )
         .map_err(|error| InstallError::Invalid(error.to_string()))?;
         verify_packages(&marketplace, &generation).map_err(|error| {
@@ -407,7 +407,7 @@ pub(super) fn required_archives(
             ));
         }
         names.push(platform.archive().to_owned());
-        names.push(generation.plugin_archive());
+        names.push(generation.batteries_archive());
     }
     if matches!(requirements, Requirements::Kagent | Requirements::Both(_)) {
         names.push(generation.runtime_chart_archive().ok_or_else(|| {
@@ -463,7 +463,7 @@ fn git_head(root: &Path) -> Option<String> {
 }
 
 /// Committed content only, so a dirty checkout exports exactly its HEAD. The
-/// marketplace tree holds every source `plugin_layout` maps.
+/// marketplace tree holds every source `batteries_layout` maps.
 fn export_commit(root: &Path, destination: &Path) -> Result<(), InstallError> {
     let output = Command::new("git")
         .arg("-C")
@@ -714,7 +714,10 @@ mod tests {
         );
         assert_eq!(
             required_archives(&generation, Requirements::Claude(Platform::MacArm64)).unwrap(),
-            vec![Platform::MacArm64.archive().to_owned(), BUILD_PLUGIN_ARCHIVE.to_owned()]
+            vec![
+                Platform::MacArm64.archive().to_owned(),
+                BUILD_BATTERIES_ARCHIVE.to_owned()
+            ]
         );
         assert!(required_archives(&generation, Requirements::Claude(Platform::LinuxAmd64)).is_err());
         assert!(required_archives(&generation, Requirements::Kagent).is_err());
@@ -767,7 +770,7 @@ mod tests {
         let descriptor = serde_json::to_vec(&serde_json::json!({"schema": 1, "repository": REPOSITORY,
             "commit": "a".repeat(40), "release": "v1.0.0", "protocol": appa_package::PROTOCOL,
             "catalog": ArtifactDigest::of_bytes(catalog), "marketplace": ArtifactDigest::of_bytes(&archive),
-            "claude_plugin": digest, "runtime_chart": digest,
+            "batteries": digest, "runtime_chart": digest,
             "binaries": Platform::ALL.into_iter().map(|p| (p, digest.clone())).collect::<BTreeMap<_, _>>(),
             "images": Image::ALL.into_iter().map(|i| (i, serde_json::json!({"digest": digest,
                 "platforms": {"linux/amd64": digest}}))).collect::<BTreeMap<_, _>>() }))

--- a/appa-runtime/src/installation/archive.rs
+++ b/appa-runtime/src/installation/archive.rs
@@ -1,20 +1,12 @@
-//! Archives an install reads bytes through: the plugin archive a build accepts
-//! as its own, the bounded fetch of a release asset or source archive, and the
-//! bounded extraction of either.
-//!
-//! A release binary is built knowing its release tag and the SHA-256 of that
-//! tag's plugin artifact. A source build knows its Git commit and the canonical
-//! digest of the tree staged beside it. Neither identity can be redirected by
-//! the environment, the working directory or a mutable ref.
+//! Archives an install reads bytes through: the bounded fetch of a release
+//! asset or source archive, and the bounded extraction of either.
 
 use std::env;
-use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use appa_package::tree::{MAX_ENTRIES, MAX_UNCOMPRESSED_BYTES};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 /// The one place a debug-only seam reads the environment.
@@ -35,12 +27,6 @@ pub(crate) fn debug_override(name: &str) -> Option<String> {
 
 #[derive(Debug, Error)]
 pub enum ArchiveError {
-    #[error("this appa build carries a release plugin digest but no release tag")]
-    MissingReleaseRef,
-    #[error("this appa build carries an invalid plugin digest: {value}")]
-    MalformedBuildDigest { value: String },
-    #[error("{value} is not a SHA-256 digest")]
-    MalformedDigest { value: String },
     #[error("cannot read {path}: {source}")]
     Read { path: PathBuf, source: std::io::Error },
     #[error("cannot write {path}: {source}")]
@@ -49,132 +35,6 @@ pub enum ArchiveError {
     Malformed { path: PathBuf, reason: String },
     #[error("cannot fetch {url}: {reason}")]
     Fetch { url: String, reason: String },
-    #[error("the plugin archive at {path} is not the one this build accepts: expected {expected}, got {actual}")]
-    DigestMismatch {
-        path: PathBuf,
-        expected: PluginDigest,
-        actual: PluginDigest,
-    },
-}
-
-/// The SHA-256 of a plugin artifact: what a binary was built with, and what a
-/// fetched or cached archive must hash to.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct PluginDigest([u8; 32]);
-
-impl PluginDigest {
-    fn parse(value: &str) -> Result<Self, ArchiveError> {
-        let trimmed = value.trim();
-        let malformed = || ArchiveError::MalformedDigest {
-            value: trimmed.to_owned(),
-        };
-        if trimmed.len() != 64 {
-            return Err(malformed());
-        }
-        let mut bytes = [0u8; 32];
-        // The length is already 64, so the remainder is empty by construction.
-        let (pairs, _) = trimmed.as_bytes().as_chunks::<2>();
-        for (slot, pair) in bytes.iter_mut().zip(pairs) {
-            let hex = std::str::from_utf8(pair).map_err(|_| malformed())?;
-            *slot = u8::from_str_radix(hex, 16).map_err(|_| malformed())?;
-        }
-        Ok(Self(bytes))
-    }
-
-    #[cfg(test)]
-    fn of(bytes: &[u8]) -> Self {
-        let mut digest = Sha256::new();
-        digest.update(bytes);
-        Self(digest.finalize().into())
-    }
-
-    fn from_hasher(hasher: Sha256) -> Self {
-        Self(hasher.finalize().into())
-    }
-}
-
-impl fmt::Display for PluginDigest {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.0 {
-            write!(formatter, "{byte:02x}")?;
-        }
-        Ok(())
-    }
-}
-
-impl fmt::Debug for PluginDigest {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "PluginDigest({self})")
-    }
-}
-
-/// What `build.rs` stamped into this binary about the plugin archive it
-/// belongs with.
-#[derive(Debug, Clone, Copy)]
-struct BuildIdentity<'a> {
-    release_digest: Option<PluginDigest>,
-    release_ref: Option<&'a str>,
-    commit: Option<&'a str>,
-}
-
-impl BuildIdentity<'static> {
-    fn compiled() -> Result<Self, ArchiveError> {
-        // The digest is a compile-time constant. Runtime environment changes
-        // cannot redirect a shipped binary to different plugin bytes.
-        let release_digest = option_env!("APPA_PLUGIN_SHA256")
-            .map(PluginDigest::parse)
-            .transpose()
-            .map_err(|_| ArchiveError::MalformedBuildDigest {
-                value: option_env!("APPA_PLUGIN_SHA256").unwrap_or_default().to_owned(),
-            })?;
-        Ok(Self {
-            release_digest,
-            release_ref: option_env!("APPA_RELEASE_REF"),
-            commit: option_env!("APPA_BUILD_COMMIT"),
-        })
-    }
-}
-
-/// A local plugin archive this binary accepts as its own.
-///
-/// A release build accepts only its release archive, by file digest. A
-/// development build accepts the archive its own generation packed, which the
-/// install already verified against the generation descriptor.
-#[derive(Debug, Clone)]
-pub(crate) struct VerifiedArchive {
-    reference: String,
-}
-
-impl VerifiedArchive {
-    pub(crate) fn of(path: &Path) -> Result<Self, ArchiveError> {
-        let identity = BuildIdentity::compiled()?;
-        let reference = match identity.release_digest {
-            Some(expected) => {
-                let actual = digest_of_file(path)?;
-                if actual != expected {
-                    return Err(ArchiveError::DigestMismatch {
-                        path: path.to_path_buf(),
-                        expected,
-                        actual,
-                    });
-                }
-                identity.release_ref.ok_or(ArchiveError::MissingReleaseRef)?.to_owned()
-            }
-            None => format!(
-                "build {}",
-                identity
-                    .commit
-                    .map(|commit| &commit[..commit.len().min(12)])
-                    .unwrap_or("unknown")
-            ),
-        };
-        Ok(Self { reference })
-    }
-
-    /// The origin as a receipt names it: the release tag, or the build's commit.
-    pub(crate) fn label(&self) -> String {
-        format!("appa {} plugin", self.reference)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -224,26 +84,6 @@ pub(crate) fn single_directory(container: &Path) -> Result<PathBuf, ArchiveError
         });
     }
     Ok(first.path())
-}
-
-fn digest_of_file(path: &Path) -> Result<PluginDigest, ArchiveError> {
-    let mut file = fs::File::open(path).map_err(|source| ArchiveError::Read {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 64 * 1024];
-    loop {
-        let read = std::io::Read::read(&mut file, &mut buffer).map_err(|source| ArchiveError::Read {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(PluginDigest::from_hasher(hasher))
 }
 
 /// Stream the artifact to `destination`, enforcing the size cap as it goes.
@@ -461,21 +301,6 @@ fn safe_relative(path: &Path) -> EntryPath {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn digest_round_trips_through_hex() {
-        let digest = PluginDigest::of(b"appa");
-        let text = digest.to_string();
-        assert_eq!(text.len(), 64);
-        assert_eq!(PluginDigest::parse(&text).unwrap(), digest);
-    }
-
-    #[test]
-    fn digest_rejects_malformed_hex() {
-        for value in ["", "abc", &"z".repeat(64), &"a".repeat(63), &"a".repeat(65)] {
-            assert!(PluginDigest::parse(value).is_err(), "accepted {value:?}");
-        }
-    }
 
     #[test]
     fn deployment_bundles_have_room_for_metadata_beyond_the_package_entry_limit() {

--- a/appa-runtime/src/installation/native.rs
+++ b/appa-runtime/src/installation/native.rs
@@ -1,4 +1,4 @@
-//! Executables are selected with their native plugin, never independently.
+//! Executables are selected with their batteries archive, never independently.
 
 use std::fs::{self, File};
 use std::io::{Read, Write};
@@ -29,9 +29,9 @@ struct BinaryIdentity {
     protocol: u32,
     commit: Option<String>,
     release: Option<String>,
-    plugin_sha256: Option<String>,
+    batteries_sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    plugin_tree_sha256: Option<String>,
+    batteries_tree_sha256: Option<String>,
 }
 
 pub fn build_info() -> ExitCode {
@@ -40,8 +40,8 @@ pub fn build_info() -> ExitCode {
         protocol: appa_package::PROTOCOL,
         commit: option_env!("APPA_BUILD_COMMIT").map(str::to_owned),
         release: option_env!("APPA_RELEASE_REF").map(str::to_owned),
-        plugin_sha256: option_env!("APPA_PLUGIN_SHA256").map(str::to_owned),
-        plugin_tree_sha256: option_env!("APPA_PLUGIN_TREE_SHA256").map(str::to_owned),
+        batteries_sha256: option_env!("APPA_BATTERIES_SHA256").map(str::to_owned),
+        batteries_tree_sha256: option_env!("APPA_BATTERIES_TREE_SHA256").map(str::to_owned),
     };
     let mut output = std::io::stdout().lock();
     match serde_json::to_writer(&mut output, &identity)
@@ -56,12 +56,11 @@ pub fn build_info() -> ExitCode {
 
 pub struct ClaudeArtifacts {
     binary: PathBuf,
-    archive: PathBuf,
 }
 
 impl ClaudeArtifacts {
-    /// Uses only retained, rehashed archives. It does not register a plugin,
-    /// start a runtime, or change the active config.
+    /// Uses only retained, rehashed archives. It does not write the Claude
+    /// profile, start a runtime, or change the active config.
     pub fn prepare(
         installation: &Installation,
         generation: &Generation,
@@ -76,11 +75,11 @@ impl ClaudeArtifacts {
         let binary_digest = archives
             .get(platform.archive())
             .ok_or_else(|| InstallError::Invalid("the installed version has no executable for this platform".into()))?;
-        let plugin_digest = &archives[&generation.plugin_archive()];
+        let batteries_digest = &archives[&generation.batteries_archive()];
         let binary_archive = installation.state.join("artifacts").join(binary_digest.hex());
-        let archive = installation.state.join("artifacts").join(plugin_digest.hex());
+        let batteries_archive = installation.state.join("artifacts").join(batteries_digest.hex());
         acquisition::verify_artifact(&binary_archive, binary_digest)?;
-        acquisition::verify_artifact(&archive, plugin_digest)?;
+        acquisition::verify_artifact(&batteries_archive, batteries_digest)?;
         let directory = installation.state.join("native");
         require_directory_or_absent(&directory)?;
         fs::create_dir_all(&directory).map_err(|error| io("create native cache", &directory, error))?;
@@ -121,12 +120,12 @@ impl ClaudeArtifacts {
         let same_artifacts = match generation.artifacts() {
             Artifacts::Published(published) => {
                 identity.release.as_deref() == Some(published.release())
-                    && identity.plugin_sha256.as_deref() == Some(plugin_digest.hex())
+                    && identity.batteries_sha256.as_deref() == Some(batteries_digest.hex())
             }
             Artifacts::Build(build) => {
                 identity.release.is_none()
-                    && identity.plugin_sha256.is_none()
-                    && identity.plugin_tree_sha256.as_deref() == Some(build.plugin_tree())
+                    && identity.batteries_sha256.is_none()
+                    && identity.batteries_tree_sha256.as_deref() == Some(build.batteries_tree())
             }
         };
         if identity.schema != 1
@@ -135,7 +134,7 @@ impl ClaudeArtifacts {
             || !same_artifacts
         {
             return Err(InstallError::Invalid(
-                "the selected runtime and native plugin do not belong to the same version".into(),
+                "the selected runtime and batteries archive do not belong to the same version".into(),
             ));
         }
         let destination = directory.join(binary_digest.hex());
@@ -153,19 +152,12 @@ impl ClaudeArtifacts {
         }
         Ok(Self {
             binary: destination.join(binary_name),
-            archive,
         })
     }
 
     /// Caller holds the installation lock and durable activation journal.
     pub fn activate(&self, config: &Path, previous: Option<&Self>) -> Result<(), InstallError> {
-        let mut arguments = vec![
-            "activate-claude".as_ref(),
-            "--config".as_ref(),
-            config.as_os_str(),
-            "--archive".as_ref(),
-            self.archive.as_os_str(),
-        ];
+        let mut arguments = vec!["activate-claude".as_ref(), "--config".as_ref(), config.as_os_str()];
         if let Some(previous) = previous {
             arguments.extend(["--previous-binary".as_ref(), previous.binary.as_os_str()]);
         }
@@ -176,13 +168,7 @@ impl ClaudeArtifacts {
     pub fn remove(&self, config: &Path) -> Result<(), InstallError> {
         invoke(
             &self.binary,
-            &[
-                "remove-claude".as_ref(),
-                "--config".as_ref(),
-                config.as_os_str(),
-                "--archive".as_ref(),
-                self.archive.as_os_str(),
-            ],
+            &["remove-claude".as_ref(), "--config".as_ref(), config.as_os_str()],
             Duration::from_secs(120),
         )?;
         Ok(())

--- a/appa-runtime/src/lib.rs
+++ b/appa-runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod statusline;
 pub mod tls;
 pub mod tool_validation;
 
+mod batteries_layout;
 mod builtins;
 mod consult;
 mod elicit;
@@ -30,5 +31,4 @@ mod engine;
 mod events;
 mod external;
 mod llm;
-pub mod plugin_layout;
 pub mod yell;

--- a/appa-runtime/tests/common/init_fixture.rs
+++ b/appa-runtime/tests/common/init_fixture.rs
@@ -14,7 +14,7 @@ use appa_engine::profile::PolicyFileKey;
 use appa_runtime::config::Config;
 use sha2::{Digest, Sha256};
 
-use crate::common::{repo_root, stage_bundle};
+use crate::common::repo_root;
 
 /// The key of the policy the fixture's config carries: the shipped default,
 /// which composes to the same bytes wherever it is loaded from.
@@ -39,21 +39,6 @@ pub fn executable(path: &Path) {
     fs::set_permissions(path, permissions).expect("fixture is executable");
 }
 
-/// The staged plugin tree of this checkout, packed as the archive a development
-/// build's generation carries and its activation verifies.
-fn pack_bundle(root: &Path) -> PathBuf {
-    let staged = stage_bundle(root);
-    let archive = root.join("plugin-source.tar.gz");
-    let file = fs::File::create(&archive).expect("the archive is created");
-    let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(file, flate2::Compression::fast()));
-    builder.append_dir_all(".", &staged).expect("the staged tree packs");
-    builder
-        .into_inner()
-        .and_then(flate2::write::GzEncoder::finish)
-        .expect("the archive is finished");
-    archive
-}
-
 pub fn runtime_fingerprint(deployed: &Path) -> String {
     let digest = Sha256::digest(fs::read(deployed).expect("runtime bytes"));
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
@@ -67,7 +52,6 @@ pub struct Fixture {
     pub data: PathBuf,
     pub claude: PathBuf,
     pub appa: PathBuf,
-    pub archive: PathBuf,
 }
 
 impl Fixture {
@@ -93,7 +77,6 @@ impl Fixture {
         let config = root.join("config");
         fs::create_dir_all(&config).expect("config directory");
         fs::write(config.join("appa.toml"), shipped_default_config()).expect("the config is written");
-        let archive = pack_bundle(&root);
         Self {
             _directory: directory,
             config,
@@ -102,7 +85,6 @@ impl Fixture {
             bin,
             claude,
             appa,
-            archive,
         }
     }
 
@@ -116,9 +98,7 @@ impl Fixture {
             .current_dir(&self.root)
             .arg("activate-claude")
             .arg("--config")
-            .arg(self.config.join("appa.toml"))
-            .arg("--archive")
-            .arg(&self.archive);
+            .arg(self.config.join("appa.toml"));
         self.environment(&mut command);
         command
     }
@@ -131,9 +111,7 @@ impl Fixture {
             .current_dir(&self.root)
             .arg("remove-claude")
             .arg("--config")
-            .arg(self.config.join("appa.toml"))
-            .arg("--archive")
-            .arg(&self.archive);
+            .arg(self.config.join("appa.toml"));
         self.environment(&mut command);
         command
     }

--- a/appa-runtime/tests/common/init_fixture.rs
+++ b/appa-runtime/tests/common/init_fixture.rs
@@ -93,23 +93,20 @@ impl Fixture {
     /// answering as this deployment's own healthy runtime serving the fixture's
     /// policy. A test overrides the `FAKE_*` variables for the case it reproduces.
     pub fn activate(&self) -> Command {
-        let mut command = Command::new(&self.appa);
-        command
-            .current_dir(&self.root)
-            .arg("activate-claude")
-            .arg("--config")
-            .arg(self.config.join("appa.toml"));
-        self.environment(&mut command);
-        command
+        self.bridge("activate-claude")
     }
 
     /// `appa remove-claude` against this fixture, as `appa plugin remove
     /// claude-code` runs it.
     pub fn remove(&self) -> Command {
+        self.bridge("remove-claude")
+    }
+
+    fn bridge(&self, subcommand: &str) -> Command {
         let mut command = Command::new(&self.appa);
         command
             .current_dir(&self.root)
-            .arg("remove-claude")
+            .arg(subcommand)
             .arg("--config")
             .arg(self.config.join("appa.toml"));
         self.environment(&mut command);

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -145,14 +145,6 @@ pub fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-/// This checkout's plugin archive tree, staged into `into` by the same mapping
-/// the build and the install use.
-pub fn stage_bundle(into: &Path) -> PathBuf {
-    let staged = into.join("plugin-source");
-    appa_runtime::plugin_layout::stage_repository(&repo_root(), &staged).expect("the checkout stages");
-    staged
-}
-
 /// Every offer a feedback body names, in the order the feedback lists
 /// them. Which end a suite takes is its own assertion: a remedy plan
 /// that stages several offers surfaces one line each.

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -24,9 +24,7 @@ fn release_override_probe_reaches_endpoint_before_deployment_paths() {
             .current_dir(&fixture.root)
             .arg("activate-claude")
             .arg("--config")
-            .arg("./no-such-dir/appa.toml")
-            .arg("--archive")
-            .arg("./no-such-archive.tar.gz");
+            .arg("./no-such-dir/appa.toml");
         for variable in [
             "HOME",
             "USERPROFILE",

--- a/appa-runtime/tests/marketplace_cli.rs
+++ b/appa-runtime/tests/marketplace_cli.rs
@@ -327,7 +327,7 @@ fn deployment_for(root: &Path, kagent: Option<&[&str]>) -> std::path::PathBuf {
     let archive = archive.into_inner().unwrap().finish().unwrap();
     let digest = ArtifactDigest::of_bytes(&archive);
     let descriptor = serde_json::json!({"schema":1,"repository":REPOSITORY,"commit":"a".repeat(40),"release":"v1.0.0","protocol":appa_package::PROTOCOL,
-        "catalog":ArtifactDigest::of_bytes(catalog.as_bytes()),"marketplace":digest,"claude_plugin":digest,"runtime_chart":digest,
+        "catalog":ArtifactDigest::of_bytes(catalog.as_bytes()),"marketplace":digest,"batteries":digest,"runtime_chart":digest,
         "binaries":Platform::ALL.into_iter().map(|platform|(platform,digest.clone())).collect::<BTreeMap<_,_>>(),
         "images":Image::ALL.into_iter().map(|image|(image,serde_json::json!({"digest":digest,"platforms":{"linux/amd64":digest}}))).collect::<BTreeMap<_,_>>()});
     let generation = Generation::parse(&serde_json::to_vec(&descriptor).unwrap()).unwrap();

--- a/charts/appa-runtime/README.md
+++ b/charts/appa-runtime/README.md
@@ -92,7 +92,7 @@ With persistence on, the runtime uses this lookup order:
 3. `/opt/appa/batteries` for the batteries built into the running image.
 
 The appa-guide skill can refresh the second directory from the latest
-published semver release after approval. It verifies the plugin archive
+published semver release after approval. It verifies the batteries archive
 against that release's `SHA256SUMS` and validates the serving root
 config. It retains the previous layer until policy reload succeeds, then
 commits the refresh. A refused reload rolls the layer back. The operator

--- a/integrations/kagent/e2e/marketplace/run.py
+++ b/integrations/kagent/e2e/marketplace/run.py
@@ -158,7 +158,7 @@ class Acceptance:
         platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"]
         descriptor = {"schema": 1, "repository": "archestra-ai/OpenAPPA", "commit": commit,
                       "release": release, "protocol": 1, "catalog": placeholder, "marketplace": placeholder,
-                      "claude_plugin": placeholder, "runtime_chart": "sha256:" + hashlib.sha256(chart.read_bytes()).hexdigest(),
+                      "batteries": placeholder, "runtime_chart": "sha256:" + hashlib.sha256(chart.read_bytes()).hexdigest(),
                       "binaries": {p: placeholder for p in platforms}, "images": images}
         source = self.work / "descriptor.json"
         source.write_text(json.dumps(descriptor))

--- a/scripts/appa-refresh-batteries.py
+++ b/scripts/appa-refresh-batteries.py
@@ -85,7 +85,7 @@ def release_assets(repository: str, tag: str | None = None, opener: Callable = u
         for asset in assets
         if isinstance(asset, dict)
     }
-    archive_name = f"appa-plugin-{version}.tar.gz"
+    archive_name = f"appa-batteries-{version}.tar.gz"
     checksums_url = names.get("SHA256SUMS")
     archive_url = names.get(archive_name)
     if not isinstance(checksums_url, str) or not isinstance(archive_url, str):
@@ -126,13 +126,13 @@ def extract_batteries(archive: bytes, destination: Path) -> None:
     try:
         package = tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz")
     except tarfile.TarError as error:
-        raise RefreshError(f"plugin archive is not a readable tarball: {error}") from error
+        raise RefreshError(f"batteries archive is not a readable tarball: {error}") from error
     with package:
         for member in package:
             path = PurePosixPath(member.name)
             parts = tuple(part for part in path.parts if part != ".")
             if path.is_absolute() or ".." in parts:
-                raise RefreshError(f"plugin archive has an unsafe path: {member.name}")
+                raise RefreshError(f"batteries archive has an unsafe path: {member.name}")
             if not parts or parts[0] != "batteries":
                 continue
             relative = parts[1:]
@@ -140,22 +140,22 @@ def extract_batteries(archive: bytes, destination: Path) -> None:
                 continue
             count += 1
             if count > MAX_FILES:
-                raise RefreshError(f"plugin archive has more than {MAX_FILES} battery entries")
+                raise RefreshError(f"batteries archive has more than {MAX_FILES} battery entries")
             if relative in seen:
-                raise RefreshError(f"plugin archive repeats batteries/{'/'.join(relative)}")
+                raise RefreshError(f"batteries archive repeats batteries/{'/'.join(relative)}")
             seen.add(relative)
             target = destination.joinpath(*relative)
             if member.isdir():
                 target.mkdir(parents=True, exist_ok=True)
                 continue
             if not member.isfile():
-                raise RefreshError(f"plugin archive battery entry is not a regular file: {member.name}")
+                raise RefreshError(f"batteries archive battery entry is not a regular file: {member.name}")
             extracted_bytes += member.size
             if extracted_bytes > MAX_EXTRACTED_BYTES:
                 raise RefreshError(f"battery files exceed {MAX_EXTRACTED_BYTES} extracted bytes")
             source = package.extractfile(member)
             if source is None:
-                raise RefreshError(f"plugin archive cannot read {member.name}")
+                raise RefreshError(f"batteries archive cannot read {member.name}")
             target.parent.mkdir(parents=True, exist_ok=True)
             with source, target.open("xb") as output:
                 shutil.copyfileobj(source, output, length=1024 * 1024)
@@ -163,7 +163,7 @@ def extract_batteries(archive: bytes, destination: Path) -> None:
             if len(relative) == 2 and relative[1] == "appa.toml":
                 battery_configs += 1
     if battery_configs == 0:
-        raise RefreshError("plugin archive carries no battery appa.toml files")
+        raise RefreshError("batteries archive carries no battery appa.toml files")
 
 
 def previous_path(target: Path) -> Path:
@@ -279,7 +279,7 @@ def refresh(
     opener: Callable = urlopen,
 ) -> str:
     tag, checksums_url, archive_url = release_assets(repository, tag, opener)
-    archive_name = f"appa-plugin-{tag.removeprefix('v')}.tar.gz"
+    archive_name = f"appa-batteries-{tag.removeprefix('v')}.tar.gz"
     checksums = download(checksums_url, MAX_CHECKSUM_BYTES, opener)
     archive = download(archive_url, MAX_ARCHIVE_BYTES, opener)
     verify_archive(archive, checksums, archive_name)

--- a/scripts/test_appa_refresh_batteries.py
+++ b/scripts/test_appa_refresh_batteries.py
@@ -53,16 +53,16 @@ class RefreshBatteriesTests(unittest.TestCase):
                 "assets": [
                     {"name": "SHA256SUMS", "browser_download_url": f"{release_root}/SHA256SUMS"},
                     {
-                        "name": "appa-plugin-1.2.3.tar.gz",
-                        "browser_download_url": f"{release_root}/appa-plugin-1.2.3.tar.gz",
+                        "name": "appa-batteries-1.2.3.tar.gz",
+                        "browser_download_url": f"{release_root}/appa-batteries-1.2.3.tar.gz",
                     },
                 ],
             }
         ).encode()
         responses = {
             "https://api.github.com/repos/archestra-ai/OpenAPPA/releases/latest": release,
-            f"{release_root}/SHA256SUMS": f"{digest}  appa-plugin-1.2.3.tar.gz\n".encode(),
-            f"{release_root}/appa-plugin-1.2.3.tar.gz": package,
+            f"{release_root}/SHA256SUMS": f"{digest}  appa-batteries-1.2.3.tar.gz\n".encode(),
+            f"{release_root}/appa-batteries-1.2.3.tar.gz": package,
         }
 
         def opener(request, timeout):
@@ -144,8 +144,8 @@ class RefreshBatteriesTests(unittest.TestCase):
         with self.assertRaisesRegex(refresh_batteries.RefreshError, "checksum mismatch"):
             refresh_batteries.verify_archive(
                 b"archive",
-                f"{'0' * 64}  appa-plugin-1.2.3.tar.gz\n".encode(),
-                "appa-plugin-1.2.3.tar.gz",
+                f"{'0' * 64}  appa-batteries-1.2.3.tar.gz\n".encode(),
+                "appa-batteries-1.2.3.tar.gz",
             )
 
     def test_staged_validation_substitutes_the_target_and_clears_its_env(self):


### PR DESCRIPTION
Stacked on #293. The archive a version carries holds the batteries tree and nothing else, so everything is named for that.

## What changes

- Release asset `appa-plugin-<v>.tar.gz` → `appa-batteries-<v>.tar.gz`; the build's own `appa-batteries-build.tar.gz`. The `release.yml` job is `batteries-artifact`, and the binaries workflow takes `batteries_sha256`.
- Generation descriptor fields `claude_plugin` → `batteries` and `plugin_tree` → `batteries_tree`. No compatibility shim: a descriptor with the old names is refused.
- `appa build-info` reports `batteries_sha256` and `batteries_tree_sha256`; the build reads `APPA_BATTERIES_SHA256` and stamps `APPA_BATTERIES_TREE_SHA256`.
- `plugin_layout.rs` → `batteries_layout.rs`, private to the crate.
- `activate-claude` and `remove-claude` take no `--archive`. The install verifies the retained batteries archive before it selects a binary, and the receipt names the build from the release tag or commit the binary carries, so `VerifiedArchive` and the archive digest type are gone.
- `scripts/appa-refresh-batteries.py` fetches the renamed asset; the kagent e2e fixture and the chart README follow.

## Validation

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast` (67 suites), the refresh script's unittest, actionlint on the three workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLi2evLA3suGN8ko4frXwu
