### PR TITLE
feat(audience): declared selector templates and selector placeholders

### DIFF
--- a/appa-engine/src/admit.rs
+++ b/appa-engine/src/admit.rs
@@ -807,7 +807,7 @@ mod tests {
             audience: crate::audience::AudienceConfig {
                 sources: vec![crate::audience::SourceRegistration {
                     provider: "slack".to_string(),
-                    templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                    templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
                 }],
                 groups: vec![crate::audience::NamedAudience {
                     name: crate::names::GroupName::new("team"),

--- a/appa-engine/src/admit.rs
+++ b/appa-engine/src/admit.rs
@@ -295,7 +295,7 @@ mod tests {
 
     use super::*;
     use crate::authority::{DeclaredTransition, Sanitizer, SanitizerPoints, Scope};
-    use crate::contract::{Delta, ToolAnnotation, ToolDeclaration};
+    use crate::contract::{Delta, DeltaAudience, ToolAnnotation, ToolDeclaration};
     use crate::fact::EffectKind;
     use crate::label::DeclaredAudience;
     use crate::label::{Audience, ReaderId, Trust};
@@ -344,7 +344,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: Some(SUSPICIOUS),
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::new([EffectKind::new("read")]).unwrap(),
@@ -382,7 +382,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: Some(SUSPICIOUS),
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::new([EffectKind::new("read")]).unwrap(),
@@ -394,7 +394,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: Some(SUSPICIOUS),
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::new([EffectKind::new("read")]).unwrap(),
@@ -778,7 +778,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: Some(SUSPICIOUS),
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::new([EffectKind::new("read")]).unwrap(),

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -256,23 +256,6 @@ impl DeclaredTemplate {
     pub fn named(template: impl Into<String>) -> DeclaredTemplate {
         DeclaredTemplate::new(template, None)
     }
-
-    pub fn role(&self) -> TemplateRole {
-        match self.feeds {
-            Some(ChainAudience::Self_) => TemplateRole::Viewer,
-            Some(ChainAudience::Internal) => TemplateRole::Members,
-            None => TemplateRole::Named,
-        }
-    }
-}
-
-/// What one declared collection may feed: `self` (the requesting principal), `internal`
-/// (a full membership), or only named audiences and direct mentions.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TemplateRole {
-    Viewer,
-    Members,
-    Named,
 }
 
 /// One registered audience source: a provider name and the selector templates it declares
@@ -281,23 +264,6 @@ pub enum TemplateRole {
 pub struct SourceRegistration {
     pub provider: String,
     pub templates: Vec<DeclaredTemplate>,
-}
-
-impl SourceRegistration {
-    /// The template a selector of this source matches, if any.
-    pub fn template_of(&self, selector: &str) -> Option<&DeclaredTemplate> {
-        self.templates
-            .iter()
-            .find(|declared| declared.template.matches(selector))
-    }
-
-    /// The declared template spellings, as a consult's declaration carries them.
-    pub fn template_spellings(&self) -> Vec<String> {
-        self.templates
-            .iter()
-            .map(|declared| declared.template.as_str().to_string())
-            .collect()
-    }
 }
 
 /// One configured named audience: `[audience.group.<name>] within / from`.

--- a/appa-engine/src/audience.rs
+++ b/appa-engine/src/audience.rs
@@ -234,12 +234,70 @@ impl SelectorTemplate {
     }
 }
 
-/// One registered audience source: a provider name and the selector templates it serves.
-/// Batteries register sources; one provider is registered exactly once per deployment.
+/// One template a source declares, with what its collections may feed beyond named
+/// audiences and direct mentions: `Some(Self_)` names the requesting principal and feeds
+/// `self`; `Some(Internal)` is a full membership and feeds `internal`; `None` feeds neither.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeclaredTemplate {
+    pub template: SelectorTemplate,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feeds: Option<ChainAudience>,
+}
+
+impl DeclaredTemplate {
+    pub fn new(template: impl Into<String>, feeds: Option<ChainAudience>) -> DeclaredTemplate {
+        DeclaredTemplate {
+            template: SelectorTemplate::new(template),
+            feeds,
+        }
+    }
+
+    /// A template feeding neither built-in audience: named groups and direct mentions only.
+    pub fn named(template: impl Into<String>) -> DeclaredTemplate {
+        DeclaredTemplate::new(template, None)
+    }
+
+    pub fn role(&self) -> TemplateRole {
+        match self.feeds {
+            Some(ChainAudience::Self_) => TemplateRole::Viewer,
+            Some(ChainAudience::Internal) => TemplateRole::Members,
+            None => TemplateRole::Named,
+        }
+    }
+}
+
+/// What one declared collection may feed: `self` (the requesting principal), `internal`
+/// (a full membership), or only named audiences and direct mentions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TemplateRole {
+    Viewer,
+    Members,
+    Named,
+}
+
+/// One registered audience source: a provider name and the selector templates it declares
+/// beside its binding. One provider is registered exactly once per deployment.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceRegistration {
     pub provider: String,
-    pub templates: Vec<SelectorTemplate>,
+    pub templates: Vec<DeclaredTemplate>,
+}
+
+impl SourceRegistration {
+    /// The template a selector of this source matches, if any.
+    pub fn template_of(&self, selector: &str) -> Option<&DeclaredTemplate> {
+        self.templates
+            .iter()
+            .find(|declared| declared.template.matches(selector))
+    }
+
+    /// The declared template spellings, as a consult's declaration carries them.
+    pub fn template_spellings(&self) -> Vec<String> {
+        self.templates
+            .iter()
+            .map(|declared| declared.template.as_str().to_string())
+            .collect()
+    }
 }
 
 /// One configured named audience: `[audience.group.<name>] within / from`.
@@ -277,7 +335,7 @@ pub struct AudienceConfig {
 /// indexed. Built once at load behind the registry's structural lints.
 #[derive(Clone, Debug, Default)]
 pub struct AudienceRegistry {
-    providers: BTreeMap<String, Vec<SelectorTemplate>>,
+    providers: BTreeMap<String, Vec<DeclaredTemplate>>,
     self_from: BTreeSet<SelectorSpec>,
     internal_from: BTreeSet<SelectorSpec>,
     groups: BTreeMap<GroupName, NamedAudience>,
@@ -369,7 +427,7 @@ impl AudienceRegistry {
         &self.provider_names
     }
 
-    pub fn templates(&self, provider: &str) -> Option<&[SelectorTemplate]> {
+    pub fn templates(&self, provider: &str) -> Option<&[DeclaredTemplate]> {
         self.providers.get(provider).map(Vec::as_slice)
     }
 
@@ -416,7 +474,7 @@ impl AudienceRegistry {
             .providers
             .get(provider)
             .ok_or_else(|| Unroutable::UnknownProvider(provider.to_string()))?;
-        if templates.iter().any(|template| template.matches(selector)) {
+        if templates.iter().any(|declared| declared.template.matches(selector)) {
             Ok(SelectorSpec {
                 provider: provider.to_string(),
                 selector: selector.to_string(),
@@ -787,17 +845,17 @@ mod tests {
                 SourceRegistration {
                     provider: "google-workspace".into(),
                     templates: vec![
-                        SelectorTemplate::new("viewer"),
-                        SelectorTemplate::new("full-members"),
-                        SelectorTemplate::new("group/<group-address>"),
+                        DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+                        DeclaredTemplate::new("full-members", Some(ChainAudience::Internal)),
+                        DeclaredTemplate::named("group/<group-address>"),
                     ],
                 },
                 SourceRegistration {
                     provider: "slack".into(),
                     templates: vec![
-                        SelectorTemplate::new("viewer"),
-                        SelectorTemplate::new("full-members"),
-                        SelectorTemplate::new("user-group/<handle>"),
+                        DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+                        DeclaredTemplate::new("full-members", Some(ChainAudience::Internal)),
+                        DeclaredTemplate::named("user-group/<handle>"),
                     ],
                 },
             ],

--- a/appa-engine/src/check.rs
+++ b/appa-engine/src/check.rs
@@ -479,7 +479,7 @@ mod tests {
             audience: crate::audience::AudienceConfig {
                 sources: vec![crate::audience::SourceRegistration {
                     provider: "slack".to_string(),
-                    templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                    templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
                 }],
                 groups: vec![crate::audience::NamedAudience {
                     name: GroupName::new("team"),

--- a/appa-engine/src/check.rs
+++ b/appa-engine/src/check.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::candidate::CallStage;
 use crate::contract::{
-    AudienceRequirement, HistoryRequirement, RecipientSpec, StaticAnnotation, ToolAnnotation, ToolDeclaration,
+    AudienceRequirement, DeltaAudience, HistoryRequirement, RecipientSpec, StaticAnnotation, ToolAnnotation,
+    ToolDeclaration,
 };
 use crate::fact::EffectKind;
 use crate::label::{
@@ -224,6 +225,11 @@ fn label_gaps(
                             recipients: unresolved_recipient(key),
                         });
                     }
+                    RecipientSpec::Selector(placeholder) => {
+                        gaps.push(Gap::Includes {
+                            recipients: unresolved_recipient(&placeholder.to_string()),
+                        });
+                    }
                     RecipientSpec::Static(_) => {
                         unreachable!("a static includes spec always resolves to its declared audience")
                     }
@@ -267,19 +273,26 @@ fn history_gaps(
 fn resolve_recipients(spec: &RecipientSpec, reads: CallReads<'_>) -> Option<DeclaredAudience> {
     match (spec, reads) {
         (RecipientSpec::Static(declared), _) => Some(declared.clone()),
-        (RecipientSpec::Placeholder(_), CallReads::Static) => {
+        (RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_), CallReads::Static) => {
             unreachable!("`StaticAnnotation::of` refuses a placeholder, so a static read never meets one")
         }
         (RecipientSpec::Placeholder(key), CallReads::Resolved(call)) => {
-            placeholder_argument(key, call).map(|argument| match argument {
-                AudienceArgument::Public => DeclaredAudience::Public,
-                AudienceArgument::Chain(chain) => {
-                    DeclaredAudience::Union(Clause::new([chain], [], []).expect("a chain clause names no reader"))
-                }
-                AudienceArgument::Group(group) => {
-                    DeclaredAudience::Union(Clause::new([], [group], []).expect("a group clause names no reader"))
-                }
-                AudienceArgument::Reader(reader) => DeclaredAudience::restricted([reader]),
+            placeholder_argument(key, call).and_then(|argument| match argument {
+                AudienceArgument::Public => Some(DeclaredAudience::Public),
+                AudienceArgument::Chain(chain) => Some(DeclaredAudience::Union(
+                    Clause::new([chain], [], []).expect("a chain clause names no reader"),
+                )),
+                AudienceArgument::Group(group) => Some(DeclaredAudience::Union(
+                    Clause::new([], [group], []).expect("a group clause names no reader"),
+                )),
+                // An actual that spells a placeholder names no collection.
+                AudienceArgument::Placeholder(_) => None,
+                AudienceArgument::Reader(reader) => Some(DeclaredAudience::restricted([reader])),
+            })
+        }
+        (RecipientSpec::Selector(placeholder), CallReads::Resolved(call)) => {
+            placeholder.instantiate(call.arguments()).ok().map(|group| {
+                DeclaredAudience::Union(Clause::new([], [group], []).expect("a group clause names no reader"))
             })
         }
     }
@@ -331,9 +344,13 @@ pub(crate) fn validate_annotation(
     }
     let annotation = pinned.produced();
     let outside = |what: &str| AnnotationRefusal::OutsidePolicy(what.to_string());
+    // The mandate is read per call: a selector placeholder in it admits exactly the collection
+    // this call's arguments spell.
     let mandate = registry
         .annotator_mandate(annotator)
-        .expect("declarations name only registered annotators");
+        .expect("declarations name only registered annotators")
+        .instantiate(call.arguments())
+        .map_err(|unfilled| outside(&format!("the call does not fill the mandate's placeholder: {unfilled}")))?;
     let permits_declared = |declared: &DeclaredAudience| match declared {
         DeclaredAudience::Public => true,
         DeclaredAudience::Union(clause) => mandate.permits_clause(clause),
@@ -343,13 +360,12 @@ pub(crate) fn validate_annotation(
     {
         return Err(outside("the produced delta trust is outside the mandate"));
     }
-    if annotation
-        .delta
-        .audience
-        .as_ref()
-        .is_some_and(|audience| !permits_declared(audience))
-    {
-        return Err(outside("the produced delta audience is outside the mandate"));
+    match annotation.delta.audience.as_ref() {
+        Some(DeltaAudience::Static(audience)) if !permits_declared(audience) => {
+            return Err(outside("the produced delta audience is outside the mandate"));
+        }
+        Some(DeltaAudience::Selector(_)) => return Err(outside("a produced annotation reads a placeholder")),
+        Some(DeltaAudience::Static(_)) | None => {}
     }
     if annotation
         .requires
@@ -365,7 +381,7 @@ pub(crate) fn validate_annotation(
             // A produced annotation never reads a call argument: a placeholder belongs to a
             // static declaration, which resolves it per call; an annotation already is the
             // judgment of one exact call.
-            AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => {
+            AudienceRequirement::Includes(RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_)) => {
                 return Err(outside("a produced annotation reads a placeholder"));
             }
         };
@@ -456,7 +472,9 @@ mod tests {
                     description: Some("Reads one file.".to_string()),
                     delta: Delta {
                         trust: Some(Trust::new(1)),
-                        audience: Some(DeclaredAudience::restricted([ReaderId::new("support")])),
+                        audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                            "support",
+                        )]))),
                     },
                     emits: EffectSet::new([EffectKind::new("mail.sent")]).unwrap(),
                     requires: Requires {
@@ -619,7 +637,7 @@ mod tests {
         let with_delta = |audience: DeclaredAudience| ToolAnnotation {
             delta: Delta {
                 trust: None,
-                audience: Some(audience),
+                audience: Some(DeltaAudience::Static(audience)),
             },
             ..annotation("lookup")
         };
@@ -714,7 +732,9 @@ mod tests {
         let within = ToolAnnotation {
             delta: Delta {
                 trust: Some(Trust::new(0)),
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("support")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "support",
+                )]))),
             },
             emits: EffectSet::new([EffectKind::new("mail.sent")]).unwrap(),
             requires: Requires {
@@ -745,7 +765,9 @@ mod tests {
             ToolAnnotation {
                 delta: Delta {
                     trust: None,
-                    audience: Some(DeclaredAudience::restricted([ReaderId::new("stranger")])),
+                    audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                        "stranger",
+                    )]))),
                 },
                 ..annotation("lookup")
             },
@@ -811,7 +833,7 @@ mod tests {
         let produced = ToolAnnotation {
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::Public),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::Public)),
             },
             ..annotation("lookup")
         };
@@ -822,7 +844,9 @@ mod tests {
         let restricted = ToolAnnotation {
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("support")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "support",
+                )]))),
             },
             ..annotation("lookup")
         };

--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::fact::{EffectKind, EffectSet};
-use crate::label::{Audience, DeclaredAudience, Label, SymbolicAtom, Trust};
+use crate::label::{Audience, Clause, DeclaredAudience, GroupRef, Label, SymbolicAtom, Trust};
 use crate::names::{AnnotatorName, MarkName, TagName};
 use crate::value::ToolName;
 
@@ -20,7 +20,7 @@ use crate::value::ToolName;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Delta {
     pub trust: Option<Trust>,
-    pub audience: Option<DeclaredAudience>,
+    pub audience: Option<DeltaAudience>,
 }
 
 impl Delta {
@@ -32,29 +32,42 @@ impl Delta {
     /// The delta as a label — the output label a raw result carries, and the meet operand a
     /// successful call narrows the trajectory by. Absent dimensions fill with the fold identity,
     /// so they neither narrow the trajectory nor lower the value's own label. A symbolic
-    /// audience enters the label as its clause, unresolved.
+    /// audience enters the label as its clause, unresolved. A selector placeholder names no
+    /// label until a call binds it — see [`ToolAnnotation::bound_to`].
     pub fn output_label(&self) -> Label {
-        Label::new(
-            self.trust.unwrap_or(Trust::new(u8::MAX)),
-            match &self.audience {
-                Some(audience) => Audience::of_declared(audience),
-                None => Audience::public(),
-            },
-        )
+        let audience = match &self.audience {
+            Some(DeltaAudience::Static(audience)) => Audience::of_declared(audience),
+            Some(DeltaAudience::Selector(placeholder)) => {
+                unreachable!("delta placeholder {placeholder} is bound to its call before a label is read from it")
+            }
+            None => Audience::public(),
+        };
+        Label::new(self.trust.unwrap_or(Trust::new(u8::MAX)), audience)
     }
 
     pub fn is_none(&self) -> bool {
         self.trust.is_none() && self.audience.is_none()
     }
 
-    /// The symbolic atoms this delta writes into the label.
+    /// The symbolic atoms this delta writes into the label as written; a placeholder writes
+    /// the call's, unknown here.
     pub(crate) fn symbolic_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
-        self.audience.iter().flat_map(DeclaredAudience::symbolic_atoms)
+        self.audience
+            .iter()
+            .filter_map(DeltaAudience::declared)
+            .flat_map(DeclaredAudience::symbolic_atoms)
+    }
+
+    pub(crate) fn selector_placeholder(&self) -> Option<&SelectorPlaceholder> {
+        match &self.audience {
+            Some(DeltaAudience::Selector(placeholder)) => Some(placeholder),
+            Some(DeltaAudience::Static(_)) | None => None,
+        }
     }
 }
 
 /// An annotation the check can evaluate with no call at hand: nothing it reads comes from a
-/// call — no placeholder recipients. This is the only shape a recovery route plans a
+/// call — no placeholder recipients, no placeholder delta. This is the only shape a recovery route plans a
 /// preceding tool over (RMD-20): its check and its successor state are argument-independent
 /// facts of the registry (symbolic audiences included — they ride the label and resolve at
 /// the check, not before it). An Annotator-produced annotation never qualifies: it exists
@@ -73,10 +86,10 @@ impl<'a> StaticAnnotation<'a> {
         let placeholder = annotation.requires.audience_requirements().iter().any(|requirement| {
             matches!(
                 requirement,
-                AudienceRequirement::Includes(RecipientSpec::Placeholder(_))
+                AudienceRequirement::Includes(RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_))
             )
         });
-        if placeholder {
+        if placeholder || annotation.delta.selector_placeholder().is_some() {
             return Err(NotStatic);
         }
         Ok(StaticAnnotation(annotation))
@@ -87,12 +100,14 @@ impl<'a> StaticAnnotation<'a> {
     }
 }
 
-/// The recipients of an audience `includes` requirement — a static set, or a placeholder resolved
-/// from the call's arguments (`$recipient` → the value of argument `recipient`).
+/// The recipients of an audience `includes` requirement — a static set, a placeholder resolved
+/// from the call's arguments (`$recipient` → the value of argument `recipient`), or a source
+/// collection the arguments key (`@slack:channel/$channel_id`).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RecipientSpec {
     Static(DeclaredAudience),
     Placeholder(String),
+    Selector(SelectorPlaceholder),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -108,7 +123,170 @@ impl AudienceRequirement {
         match self {
             AudienceRequirement::Includes(RecipientSpec::Static(recipients)) => Some(recipients),
             AudienceRequirement::Cap(cap) => Some(cap),
-            AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => None,
+            AudienceRequirement::Includes(RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_)) => None,
+        }
+    }
+}
+
+/// One segment of a selector placeholder: text written as is, or the name of the call argument
+/// whose value fills it.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Segment {
+    Literal(String),
+    Argument(String),
+}
+
+/// A source collection keyed by the call: `@provider:selector` where at least one `/`-separated
+/// segment is `$argument`. Instantiated per call into the ordinary `@provider:selector` mention
+/// the arguments spell, whose members are then read exactly as for a static mention.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SelectorPlaceholder {
+    provider: String,
+    segments: Vec<Segment>,
+}
+
+/// Why a call's arguments do not fill a selector placeholder: a value must be one non-empty
+/// selector segment a policy could write — no `/`, which would change the collection's shape,
+/// and no leading `$`, which spells a placeholder.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "argument {argument:?} does not fill a selector segment: a non-empty string without `/` and not starting with `$`"
+)]
+pub struct UnfilledPlaceholder {
+    pub argument: String,
+}
+
+impl SelectorPlaceholder {
+    /// The text after the `@` mark, `provider:segment/segment/…`, when some segment starts with
+    /// `$`. A bare `$`, an empty provider, selector, or segment reads as nothing; a spelling
+    /// with no `$` segment is a static mention, not a placeholder.
+    pub fn parse(after_at: &str) -> Option<SelectorPlaceholder> {
+        let (provider, selector) = after_at.split_once(':')?;
+        if provider.is_empty() || selector.is_empty() {
+            return None;
+        }
+        let mut segments = Vec::new();
+        for segment in selector.split('/') {
+            let parsed = match segment.strip_prefix('$') {
+                Some("") => return None,
+                Some(argument) => Segment::Argument(argument.to_string()),
+                None if segment.is_empty() => return None,
+                None => Segment::Literal(segment.to_string()),
+            };
+            segments.push(parsed);
+        }
+        if !segments.iter().any(|segment| matches!(segment, Segment::Argument(_))) {
+            return None;
+        }
+        Some(SelectorPlaceholder {
+            provider: provider.to_string(),
+            segments,
+        })
+    }
+
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// The call arguments this placeholder reads, in written order.
+    pub fn arguments(&self) -> impl Iterator<Item = &str> {
+        self.segments.iter().filter_map(|segment| match segment {
+            Segment::Argument(argument) => Some(argument.as_str()),
+            Segment::Literal(_) => None,
+        })
+    }
+
+    /// Whether every instantiation of this placeholder matches the template: the same number
+    /// of segments, a literal equal to the template's literal or filling a `<variable>`, and
+    /// an argument only on a `<variable>`, since its value is unknown until the call.
+    pub fn fits(&self, template: &crate::audience::SelectorTemplate) -> bool {
+        let pattern: Vec<&str> = template.as_str().split('/').collect();
+        pattern.len() == self.segments.len()
+            && pattern.iter().zip(&self.segments).all(|(pattern, segment)| {
+                let variable = pattern.starts_with('<') && pattern.ends_with('>');
+                match segment {
+                    Segment::Literal(literal) => variable || pattern == literal,
+                    Segment::Argument(_) => variable,
+                }
+            })
+    }
+
+    /// The collection one call's arguments name: each argument segment replaced by the
+    /// argument's value. Every argument is a required string of the tool's schema (checked at
+    /// load) and every value one writable segment (checked when the call is minted), so a
+    /// minted call always instantiates into a mention the log can carry; anything else is
+    /// refused rather than read as another collection.
+    pub fn instantiate(&self, arguments: &serde_json::Value) -> Result<GroupRef, UnfilledPlaceholder> {
+        let mut selector = Vec::with_capacity(self.segments.len());
+        for segment in &self.segments {
+            match segment {
+                Segment::Literal(literal) => selector.push(literal.as_str()),
+                Segment::Argument(argument) => match arguments.get(argument).and_then(serde_json::Value::as_str) {
+                    Some(value) if !value.is_empty() && !value.contains('/') && !value.starts_with('$') => {
+                        selector.push(value)
+                    }
+                    _ => {
+                        return Err(UnfilledPlaceholder {
+                            argument: argument.clone(),
+                        });
+                    }
+                },
+            }
+        }
+        Ok(GroupRef::Source {
+            provider: self.provider.clone(),
+            selector: selector.join("/"),
+        })
+    }
+}
+
+impl std::fmt::Display for SelectorPlaceholder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "@{}:", self.provider)?;
+        for (index, segment) in self.segments.iter().enumerate() {
+            if index > 0 {
+                f.write_str("/")?;
+            }
+            match segment {
+                Segment::Literal(literal) => f.write_str(literal)?,
+                Segment::Argument(argument) => write!(f, "${argument}")?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for SelectorPlaceholder {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for SelectorPlaceholder {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let spelled = String::deserialize(deserializer)?;
+        spelled
+            .strip_prefix('@')
+            .and_then(SelectorPlaceholder::parse)
+            .ok_or_else(|| serde::de::Error::custom(format!("{spelled:?} is not a selector placeholder")))
+    }
+}
+
+/// What a delta writes into the audience: an audience as written, or a selector placeholder
+/// the call's arguments fill.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeltaAudience {
+    Static(DeclaredAudience),
+    Selector(SelectorPlaceholder),
+}
+
+impl DeltaAudience {
+    /// The audience as written, when the delta does not read the call.
+    pub fn declared(&self) -> Option<&DeclaredAudience> {
+        match self {
+            DeltaAudience::Static(audience) => Some(audience),
+            DeltaAudience::Selector(_) => None,
         }
     }
 }
@@ -180,6 +358,69 @@ impl ToolAnnotation {
         self.delta.output_label()
     }
 
+    /// This annotation read for one call: a delta placeholder becomes the collection the
+    /// call's arguments spell, so every label read from it downstream is static. `None` when
+    /// the delta reads no placeholder — the annotation is already bound. A `contains`
+    /// placeholder stays: it is a requirement, resolved against the call where the check reads
+    /// recipients, as an argument placeholder is.
+    pub(crate) fn bound_to(
+        &self,
+        arguments: &serde_json::Value,
+    ) -> Result<Option<ToolAnnotation>, UnfilledPlaceholder> {
+        let Some(DeltaAudience::Selector(placeholder)) = &self.delta.audience else {
+            return Ok(None);
+        };
+        let group = placeholder.instantiate(arguments)?;
+        let mut bound = self.clone();
+        bound.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::Union(
+            Clause::new([], [group], []).expect("a group clause names no reader"),
+        )));
+        Ok(Some(bound))
+    }
+
+    /// Every audience-source provider this annotation names: by a `@provider:selector` mention
+    /// in its delta or requirements, or by a selector placeholder.
+    pub fn referenced_providers(&self) -> std::collections::BTreeSet<String> {
+        let mentioned = self
+            .delta
+            .symbolic_atoms()
+            .chain(self.requires.audience_requirements().iter().flat_map(|requirement| {
+                let declared = match requirement {
+                    AudienceRequirement::Includes(RecipientSpec::Static(declared))
+                    | AudienceRequirement::Cap(declared) => Some(declared),
+                    AudienceRequirement::Includes(RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_)) => None,
+                };
+                declared.into_iter().flat_map(DeclaredAudience::symbolic_atoms)
+            }))
+            .filter_map(|atom| match atom {
+                SymbolicAtom::Group(GroupRef::Source { provider, .. }) => Some(provider),
+                SymbolicAtom::Group(GroupRef::Named(_)) | SymbolicAtom::Chain(_) | SymbolicAtom::Reader(_) => None,
+            });
+        mentioned
+            .chain(
+                self.selector_placeholders()
+                    .map(|placeholder| placeholder.provider().to_string()),
+            )
+            .collect()
+    }
+
+    /// Every selector placeholder this annotation reads: its delta's and its `contains`'.
+    pub fn selector_placeholders(&self) -> impl Iterator<Item = &SelectorPlaceholder> {
+        self.delta
+            .selector_placeholder()
+            .into_iter()
+            .chain(
+                self.requires
+                    .audience_requirements()
+                    .iter()
+                    .filter_map(|requirement| match requirement {
+                        AudienceRequirement::Includes(RecipientSpec::Selector(placeholder)) => Some(placeholder),
+                        AudienceRequirement::Includes(RecipientSpec::Static(_) | RecipientSpec::Placeholder(_))
+                        | AudienceRequirement::Cap(_) => None,
+                    }),
+            )
+    }
+
     /// Every atom evaluating this annotation may ask for beyond a placeholder's: the atoms of
     /// its audience requirements, and — only where a requirement compares the committed label
     /// extensionally — its delta's, plus each written reader whose provider prefix names a
@@ -196,6 +437,7 @@ impl ToolAnnotation {
                 self.delta
                     .audience
                     .iter()
+                    .filter_map(DeltaAudience::declared)
                     .flat_map(move |audience| audience.needed_atoms(providers))
             })
             .into_iter()
@@ -387,6 +629,61 @@ mod tests {
         assert_eq!(annotated.name().as_str(), "Bash");
     }
 
+    /// A placeholder is spelled as the policy writes it, so the identity document and the log
+    /// carry it as that one string, distinct from every static audience.
+    #[test]
+    fn a_delta_placeholder_serializes_as_its_spelling() {
+        let placeholder = SelectorPlaceholder::parse("slack:channel/$channel_id").expect("a placeholder spelling");
+        let delta = Delta {
+            trust: None,
+            audience: Some(DeltaAudience::Selector(placeholder.clone())),
+        };
+        let rendered = serde_json::to_value(&delta).expect("a delta serializes");
+        assert_eq!(rendered["audience"], serde_json::json!("@slack:channel/$channel_id"));
+        assert_eq!(
+            serde_json::from_value::<Delta>(rendered).expect("the spelling reads back"),
+            delta
+        );
+        let public = Delta {
+            trust: None,
+            audience: Some(DeltaAudience::Static(DeclaredAudience::Public)),
+        };
+        let rendered = serde_json::to_value(&public).expect("a delta serializes");
+        assert_eq!(
+            serde_json::from_value::<Delta>(rendered).expect("a static audience reads back"),
+            public
+        );
+        assert!(serde_json::from_value::<Delta>(serde_json::json!({ "audience": "@slack:user-group/eng" })).is_err());
+    }
+
+    /// Every instantiation is a mention the policy could have written and the log can carry:
+    /// one non-empty segment per argument, never a `/` or a placeholder mark.
+    #[test]
+    fn a_placeholder_instantiates_only_into_a_writable_mention() {
+        let placeholder = SelectorPlaceholder::parse("slack:channel/$channel").expect("a placeholder spelling");
+        assert_eq!(
+            placeholder.instantiate(&serde_json::json!({ "channel": "C1" })),
+            Ok(GroupRef::Source {
+                provider: "slack".to_string(),
+                selector: "channel/C1".to_string(),
+            })
+        );
+        for value in [
+            serde_json::json!(""),
+            serde_json::json!("a/b"),
+            serde_json::json!("$x"),
+            serde_json::json!(7),
+        ] {
+            assert!(
+                placeholder
+                    .instantiate(&serde_json::json!({ "channel": value }))
+                    .is_err(),
+                "{value} fills no segment"
+            );
+        }
+        assert!(placeholder.instantiate(&serde_json::json!({})).is_err());
+    }
+
     #[test]
     fn a_pin_materializes_the_declarations_metadata_and_its_own_semantics() {
         let declaration = ToolDeclaration::Annotated {
@@ -434,7 +731,7 @@ mod tests {
             ProducedAnnotation {
                 delta: Delta {
                     trust: Some(Trust::new(1)),
-                    audience: Some(DeclaredAudience::Public),
+                    audience: Some(DeltaAudience::Static(DeclaredAudience::Public)),
                 },
                 emits: EffectSet::default(),
                 requires: Requires::default(),

--- a/appa-engine/src/contract.rs
+++ b/appa-engine/src/contract.rs
@@ -131,7 +131,7 @@ impl AudienceRequirement {
 /// One segment of a selector placeholder: text written as is, or the name of the call argument
 /// whose value fills it.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Segment {
+enum Segment {
     Literal(String),
     Argument(String),
 }
@@ -184,12 +184,12 @@ impl SelectorPlaceholder {
         })
     }
 
-    pub fn provider(&self) -> &str {
+    pub(crate) fn provider(&self) -> &str {
         &self.provider
     }
 
     /// The call arguments this placeholder reads, in written order.
-    pub fn arguments(&self) -> impl Iterator<Item = &str> {
+    pub(crate) fn arguments(&self) -> impl Iterator<Item = &str> {
         self.segments.iter().filter_map(|segment| match segment {
             Segment::Argument(argument) => Some(argument.as_str()),
             Segment::Literal(_) => None,
@@ -199,7 +199,7 @@ impl SelectorPlaceholder {
     /// Whether every instantiation of this placeholder matches the template: the same number
     /// of segments, a literal equal to the template's literal or filling a `<variable>`, and
     /// an argument only on a `<variable>`, since its value is unknown until the call.
-    pub fn fits(&self, template: &crate::audience::SelectorTemplate) -> bool {
+    pub(crate) fn fits(&self, template: &crate::audience::SelectorTemplate) -> bool {
         let pattern: Vec<&str> = template.as_str().split('/').collect();
         pattern.len() == self.segments.len()
             && pattern.iter().zip(&self.segments).all(|(pattern, segment)| {
@@ -212,10 +212,10 @@ impl SelectorPlaceholder {
     }
 
     /// The collection one call's arguments name: each argument segment replaced by the
-    /// argument's value. Every argument is a required string of the tool's schema (checked at
-    /// load) and every value one writable segment (checked when the call is minted), so a
-    /// minted call always instantiates into a mention the log can carry; anything else is
-    /// refused rather than read as another collection.
+    /// argument's value. Every argument is a required string of the tool's schema (the
+    /// registry makes it one) and every value one writable segment (checked when the call is
+    /// minted), so a minted call always instantiates into a mention the log can carry;
+    /// anything else is refused rather than read as another collection.
     pub fn instantiate(&self, arguments: &serde_json::Value) -> Result<GroupRef, UnfilledPlaceholder> {
         let mut selector = Vec::with_capacity(self.segments.len());
         for segment in &self.segments {

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -2583,6 +2583,9 @@ fn select_call<'a>(
         .parameters()
         .validate(parsed.value())
         .map_err(EngineError::InvalidCall)?;
+    registry
+        .placeholders_filled(declaration, parsed.value())
+        .map_err(EngineError::InvalidCall)?;
     Ok((ResolvedCall::new_keyed(tool, id, parsed), declaration))
 }
 
@@ -3126,7 +3129,8 @@ mod tests {
     use super::*;
     use crate::check::Gap;
     use crate::contract::{
-        AudienceRequirement, Delta, HistoryRequirement, LabelRequirements, RecipientSpec, Requires, ToolAnnotation,
+        AudienceRequirement, Delta, DeltaAudience, HistoryRequirement, LabelRequirements, RecipientSpec, Requires,
+        ToolAnnotation,
     };
     use crate::fact::{EffectKind, EffectSet, Fact};
     use crate::label::{Audience, Label, ReaderId, Trust};
@@ -3272,7 +3276,9 @@ mod tests {
             "read_internal",
             Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "insider",
+                )]))),
             },
         )
     }
@@ -3292,7 +3298,9 @@ mod tests {
             "read_suspicious_internal",
             Delta {
                 trust: Some(SUSPICIOUS),
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "insider",
+                )]))),
             },
         )
     }
@@ -3592,7 +3600,9 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "insider",
+                )]))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::default(),
@@ -3979,7 +3989,9 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("a")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "a",
+                )]))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::default(),
@@ -4062,7 +4074,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(a_reader.clone())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(a_reader.clone()))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::default(),
@@ -6982,7 +6994,7 @@ mod tests {
                 let mut produced = classified.clone();
                 produced.delta = Delta {
                     trust: None,
-                    audience: Some(DeclaredAudience::literal(Audience::public())),
+                    audience: Some(DeltaAudience::Static(DeclaredAudience::literal(Audience::public()))),
                 };
                 produced
             },
@@ -10099,7 +10111,9 @@ mod tests {
                     let mut narrowing = plain_tool("insider");
                     narrowing.delta = Delta {
                         trust: None,
-                        audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+                        audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                            "insider",
+                        )]))),
                     };
                     narrowing
                 },
@@ -10156,7 +10170,9 @@ mod tests {
                 },
                 "insider" => Delta {
                     trust: None,
-                    audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+                    audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                        "insider",
+                    )]))),
                 },
                 other => panic!("no labeled tool named {other}"),
             };
@@ -11150,7 +11166,7 @@ mod tests {
         );
         let narrowing = {
             let mut produced = notify.clone();
-            produced.delta.audience = Some(internal.clone());
+            produced.delta.audience = Some(DeltaAudience::Static(internal.clone()));
             let unpinned = call("notify", json!({}));
             raw(&unpinned
                 .clone()
@@ -12862,7 +12878,7 @@ mod tests {
             let mut tool = plain_tool(name);
             tool.delta = Delta {
                 trust: None,
-                audience: Some(grouped(&[], &["team"])),
+                audience: Some(DeltaAudience::Static(grouped(&[], &["team"]))),
             };
             tool
         }
@@ -12944,7 +12960,7 @@ mod tests {
             backup.emits = EffectSet::new([EffectKind::new("backup")]).unwrap();
             backup.delta = Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(readers(&["insider"]))),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(readers(&["insider"])))),
             };
             let mut wire = plain_tool("wire");
             wire.requires = Requires {
@@ -13028,7 +13044,7 @@ mod tests {
             let mut seen = plain_tool("seen");
             seen.delta = Delta {
                 trust: None,
-                audience: Some(grouped(&[], &["board"])),
+                audience: Some(DeltaAudience::Static(grouped(&[], &["board"]))),
             };
             let e = grouped_engine(
                 config(vec![capped_send(), seen], vec![]),
@@ -13614,7 +13630,9 @@ mod tests {
                 "read_member",
                 Delta {
                     trust: None,
-                    audience: Some(DeclaredAudience::restricted([ReaderId::new("slack:U1")])),
+                    audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                        "slack:U1",
+                    )]))),
                 },
             )));
             // Confine no result, so the child's own read never asks the
@@ -13696,5 +13714,245 @@ mod tests {
             let log = [log, facts].concat();
             assert_eq!(e.validate_replay(&log), Ok(()));
         }
+    }
+
+    fn channel_source() -> crate::audience::AudienceConfig {
+        crate::audience::AudienceConfig {
+            sources: vec![crate::audience::SourceRegistration {
+                provider: "slack".to_string(),
+                templates: vec![crate::audience::DeclaredTemplate::named("channel/<id>")],
+            }],
+            ..crate::audience::AudienceConfig::default()
+        }
+    }
+
+    fn channel_placeholder() -> crate::contract::SelectorPlaceholder {
+        crate::contract::SelectorPlaceholder::parse("slack:channel/$channel").expect("a placeholder spelling")
+    }
+
+    fn channel_group(id: &str) -> DeclaredAudience {
+        DeclaredAudience::Union(
+            crate::label::Clause::new(
+                [],
+                [crate::label::GroupRef::Source {
+                    provider: "slack".to_string(),
+                    selector: format!("channel/{id}"),
+                }],
+                [],
+            )
+            .expect("a group clause names no reader"),
+        )
+    }
+
+    /// A delta placeholder labels the result with the one collection the call spells — folded
+    /// symbolically, so no membership is read: on a trajectory already at that collection the
+    /// call releases under it, on any other it narrows to it. Minting refuses a call whose
+    /// argument cannot spell a selector segment.
+    #[test]
+    fn a_delta_placeholder_labels_the_result_with_the_collection_the_call_spells() {
+        let mut read = plain_tool("read");
+        read.parameters = crate::params::test_string_argument_schema("channel");
+        read.delta = Delta {
+            trust: None,
+            audience: Some(DeltaAudience::Selector(channel_placeholder())),
+        };
+        let mut cfg = test_config(vec![read]);
+        cfg.audience = channel_source();
+        let at_channel = |id: &str| known(TRUSTED, Audience::of_declared(&channel_group(id)));
+        let e = open_engine_at(cfg, at_channel("C1"));
+        let log = vec![opened(&e)];
+        let to_channel = |id: &str| {
+            e.resolve_call(ToolName::new("read"), format!(r#"{{"channel":"{id}"}}"#).as_bytes())
+                .expect("the call fills the placeholder")
+        };
+
+        let facts = appended_facts(proposed(&e, &log, "b1", nonce(), to_channel("C1")).expect("the batch decides"));
+        let label = facts
+            .iter()
+            .find_map(|fact| match fact {
+                Fact::DispatchOpened { proposed_label, .. } => Some(proposed_label.clone()),
+                _ => None,
+            })
+            .expect("a call to the channel the trajectory is at releases");
+        assert_eq!(label, at_channel("C1"));
+        assert_eq!(e.validate_replay(&[log.clone(), facts.clone()].concat()), Ok(()));
+
+        // A recorded opening whose arguments fill no placeholder was never minted here.
+        let forged: Vec<Fact> = facts
+            .iter()
+            .cloned()
+            .map(|fact| match fact {
+                Fact::DispatchOpened {
+                    trajectory,
+                    dispatch,
+                    tool,
+                    declaration,
+                    arguments: _,
+                    proposed_label,
+                    receiving,
+                    proposed_effects,
+                    annotation,
+                    subject,
+                    evidence,
+                } => Fact::DispatchOpened {
+                    trajectory,
+                    dispatch,
+                    tool,
+                    declaration,
+                    arguments: crate::params::test_arguments(&json!({ "channel": "a/b" })),
+                    proposed_label,
+                    receiving,
+                    proposed_effects,
+                    annotation,
+                    subject,
+                    evidence,
+                },
+                other => other,
+            })
+            .collect();
+        assert!(e.validate_replay(&[log.clone(), forged].concat()).is_err());
+
+        match check(&e, &log, &to_channel("C2")) {
+            CheckOutcome::Block(block) => {
+                assert!(block.requirement_gaps.is_empty());
+                assert_eq!(
+                    block.narrowing.map(|narrowing| narrowing.to),
+                    Some(at_channel("C1").combine(&at_channel("C2"))),
+                    "another channel is another collection"
+                );
+            }
+            other => panic!("a call to another channel narrows, got {other:?}"),
+        }
+
+        for unwritable in [br#"{"channel":"a/b"}"#.as_slice(), br#"{"channel":"$x"}"#.as_slice()] {
+            assert!(matches!(
+                e.resolve_call(ToolName::new("read"), unwritable),
+                Err(EngineError::InvalidCall(ArgumentError::UnfilledPlaceholder(unfilled))) if unfilled.argument == "channel"
+            ));
+        }
+    }
+
+    /// A `contains` placeholder asks for the collection the call spells and requires every
+    /// member of it among the current readers.
+    #[test]
+    fn a_contains_placeholder_requires_the_collection_the_call_spells() {
+        let mut send = plain_tool("send");
+        send.parameters = crate::params::test_string_argument_schema("channel");
+        send.requires = Requires {
+            label: LabelRequirements {
+                trust_floor: None,
+                audience: vec![AudienceRequirement::Includes(RecipientSpec::Selector(
+                    channel_placeholder(),
+                ))],
+            },
+            ..Requires::default()
+        };
+        let mut cfg = test_config(vec![send]);
+        cfg.audience = channel_source();
+        let e = open_engine_at(cfg, known(TRUSTED, Audience::restricted([corp_reader("alice")])));
+        let log = vec![opened(&e)];
+        let to_channel = |id: &str| raw(&call("send", json!({ "channel": id })));
+        let atom = SymbolicAtom::Group(crate::label::GroupRef::Source {
+            provider: "slack".to_string(),
+            selector: "channel/C1".to_string(),
+        });
+        assert_eq!(
+            e.handle(&viewing(&e, &log), batch("b1", Vec::new(), vec![to_channel("C1")])),
+            Err(TransitionError::MembershipNeeded { needed: vec![atom] })
+        );
+        let members = |readers: Vec<ReaderId>| {
+            source_evidence(vec![crate::audience::SourceClaims {
+                provider: "slack".to_string(),
+                selector: "channel/C1".to_string(),
+                members: readers,
+            }])
+        };
+        let decision = e
+            .handle(
+                &viewing(&e, &log),
+                evidenced_batch("b2", vec![to_channel("C1")], members(vec![corp_reader("alice")])),
+            )
+            .expect("the batch decides");
+        assert_eq!(
+            answered(&decision).0.len(),
+            1,
+            "every member of the channel already reads"
+        );
+        let decision = e
+            .handle(
+                &viewing(&e, &log),
+                evidenced_batch(
+                    "b3",
+                    vec![to_channel("C1")],
+                    members(vec![corp_reader("alice"), corp_reader("bob")]),
+                ),
+            )
+            .expect("the batch decides");
+        let (released, blocked) = answered(&decision);
+        assert!(released.is_empty());
+        assert_eq!(
+            blocked[0].block.raw.requirement_gaps,
+            vec![Gap::Includes {
+                recipients: channel_group("C1")
+            }]
+        );
+    }
+
+    /// A mandate placeholder admits, per call, exactly the collection the call's arguments
+    /// spell. The policy refuses to route a tool without the argument, or the wildcard, through
+    /// such a mandate.
+    #[test]
+    fn a_mandate_placeholder_admits_the_collection_each_call_spells() {
+        let acl = crate::registry::AnnotatorDeclaration {
+            name: crate::names::AnnotatorName::new("acl"),
+            trust: None,
+            audiences: Some(
+                crate::registry::AudienceVocabulary::parse_entries(&["@slack:channel/$channel".to_string()])
+                    .expect("a placeholder mandate parses"),
+            ),
+            marks: None,
+            effects: None,
+        };
+        let mut lookup = plain_tool("lookup");
+        lookup.parameters = crate::params::test_string_argument_schema("channel");
+        let mut cfg = test_config(vec![]);
+        cfg.annotators = vec![acl];
+        cfg.tools = vec![annotated(lookup, "acl")];
+        cfg.audience = channel_source();
+        let e = open_engine_at(cfg.clone(), known(TRUSTED, Audience::public()));
+        let declaration = e.registry().tool(&ToolName::new("lookup")).expect("lookup registers");
+        let unpinned = call("lookup", json!({ "channel": "C1" }));
+        let pinned = |id: &str| {
+            let mut produced = plain_tool("lookup");
+            produced.delta = Delta {
+                trust: None,
+                audience: Some(DeltaAudience::Static(channel_group(id))),
+            };
+            unpinned
+                .clone()
+                .with_annotation(Some(pinned_for(produced, "acl", &unpinned)))
+        };
+        assert_eq!(
+            crate::check::validate_annotation(e.registry(), declaration, &pinned("C1")),
+            Ok(())
+        );
+        assert!(matches!(
+            crate::check::validate_annotation(e.registry(), declaration, &pinned("C2")),
+            Err(crate::check::AnnotationRefusal::OutsidePolicy(_))
+        ));
+
+        let mut through_wildcard = cfg.clone();
+        through_wildcard.tools = vec![wildcard("acl")];
+        assert!(matches!(
+            crate::registry::Registry::build_covered(through_wildcard),
+            Err(crate::registry::LoadError::WildcardPlaceholderMandate(name)) if name == "acl"
+        ));
+        let mut unbound = cfg;
+        unbound.tools = vec![annotated(plain_tool("lookup"), "acl")];
+        assert!(matches!(
+            crate::registry::Registry::build_covered(unbound),
+            Err(crate::registry::LoadError::AudienceBindingSchema { context, argument, .. })
+                if context == "tool lookup annotator acl mandate" && argument == "channel"
+        ));
     }
 }

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -10634,7 +10634,7 @@ mod tests {
         crate::audience::AudienceConfig {
             sources: vec![crate::audience::SourceRegistration {
                 provider: "slack".to_string(),
-                templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
             }],
             groups: handles
                 .iter()

--- a/appa-engine/src/engine.rs
+++ b/appa-engine/src/engine.rs
@@ -13947,12 +13947,18 @@ mod tests {
             crate::registry::Registry::build_covered(through_wildcard),
             Err(crate::registry::LoadError::WildcardPlaceholderMandate(name)) if name == "acl"
         ));
+        // A tool that declares no `parameters` still binds the mandate's argument: the
+        // registry makes `channel` a required string of its schema.
         let mut unbound = cfg;
         unbound.tools = vec![annotated(plain_tool("lookup"), "acl")];
-        assert!(matches!(
-            crate::registry::Registry::build_covered(unbound),
-            Err(crate::registry::LoadError::AudienceBindingSchema { context, argument, .. })
-                if context == "tool lookup annotator acl mandate" && argument == "channel"
-        ));
+        let registry = crate::registry::Registry::build_covered(unbound).expect("the argument implies its schema");
+        let Some(crate::contract::ToolDeclaration::Annotated { parameters, .. }) =
+            registry.tool(&ToolName::new("lookup"))
+        else {
+            panic!("lookup is Annotator-routed");
+        };
+        assert!(parameters.validate(&serde_json::json!({ "channel": "C1" })).is_ok());
+        assert!(parameters.validate(&serde_json::json!({})).is_err());
+        assert!(parameters.validate(&serde_json::json!({ "channel": 1 })).is_err());
     }
 }

--- a/appa-engine/src/label.rs
+++ b/appa-engine/src/label.rs
@@ -182,14 +182,19 @@ pub enum GroupRef {
 
 impl GroupRef {
     /// Parse the text after the `@` mark. Empty, a bare provider (`slack:`), or a bare
-    /// selector (`:x`) are malformed and read as nothing.
+    /// selector (`:x`) are malformed and read as nothing. So is a selector with a segment
+    /// starting with `$`: that spelling is a selector placeholder, never a static mention, and
+    /// a collection whose selector begins with `$` cannot be written in a policy.
     pub fn parse(after_at: &str) -> Option<GroupRef> {
         if after_at.is_empty() {
             return None;
         }
         match after_at.split_once(':') {
             Some((provider, selector)) => {
-                if provider.is_empty() || selector.is_empty() {
+                if provider.is_empty()
+                    || selector.is_empty()
+                    || selector.split('/').any(|segment| segment.starts_with('$'))
+                {
                     None
                 } else {
                     Some(GroupRef::Source {
@@ -460,7 +465,9 @@ pub enum DeclaredAudience {
 pub enum AudienceSpelling {
     #[error("empty reader set")]
     Empty,
-    #[error("argument placeholder {0:?} is only valid in a `contains`")]
+    #[error(
+        "placeholder {0:?} is valid only as the sole entry of `contains` or `delta`, or in an annotator's `audiences`"
+    )]
     Placeholder(String),
     #[error("`public` is the whole universe and cannot be combined with other entries")]
     PublicCombined,
@@ -507,6 +514,9 @@ impl DeclaredAudience {
                     None => true,
                 },
                 Some(crate::names::AudienceArgument::Group(group)) => groups.insert(group),
+                Some(crate::names::AudienceArgument::Placeholder(_)) => {
+                    return Err(AudienceSpelling::Placeholder(entry.clone()));
+                }
                 Some(crate::names::AudienceArgument::Reader(reader)) => readers.insert(reader),
                 None => return Err(AudienceSpelling::Unknown(entry.clone())),
             };

--- a/appa-engine/src/names.rs
+++ b/appa-engine/src/names.rs
@@ -47,14 +47,16 @@ impl std::fmt::Display for GroupName {
 /// One audience entry as policy and tool arguments spell it: the reserved word `public` is
 /// the Public audience itself, `self` and `internal` are the built-in chain audiences, an
 /// `@`-marked spelling is a group reference — a configured named audience or a
-/// source-qualified selector — and any other string is one literal reader ID. `@` with no
-/// name after it, and a malformed selector form, read as nothing. The one grammar: a
-/// declared audience list and an `includes($arg)` placeholder's actual both read through it.
+/// source-qualified selector — or, with a `$argument` segment in its selector, a selector
+/// placeholder, and any other string is one literal reader ID. `@` with no name after it, and
+/// a malformed selector form, read as nothing. The one grammar: a declared audience list and
+/// an `includes($arg)` placeholder's actual both read through it; each admits what it may.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AudienceArgument {
     Public,
     Chain(crate::label::ChainAudience),
     Group(crate::label::GroupRef),
+    Placeholder(crate::contract::SelectorPlaceholder),
     Reader(crate::label::ReaderId),
 }
 
@@ -67,7 +69,10 @@ impl AudienceArgument {
             return Some(AudienceArgument::Chain(chain));
         }
         match value.strip_prefix('@') {
-            Some(reference) => crate::label::GroupRef::parse(reference).map(AudienceArgument::Group),
+            Some(reference) => match crate::contract::SelectorPlaceholder::parse(reference) {
+                Some(placeholder) => Some(AudienceArgument::Placeholder(placeholder)),
+                None => crate::label::GroupRef::parse(reference).map(AudienceArgument::Group),
+            },
             None => {
                 let reader = crate::label::ReaderId::new(value);
                 reader.is_literal().then_some(AudienceArgument::Reader(reader))

--- a/appa-engine/src/params.rs
+++ b/appa-engine/src/params.rs
@@ -217,16 +217,33 @@ impl ToolParameters {
         validate_object(&self.root, arguments, "$")
     }
 
-    /// Whether `name` is a required top-level string property — the shape an audience argument
-    /// binding must point at: a placeholder or dynamic binding reads that
-    /// argument, so the schema has to guarantee it is present and a string before any check.
-    pub(crate) fn required_string_property(&self, name: &str) -> Result<(), PropertyFault> {
-        match self.root.properties.get(name) {
-            None => Err(PropertyFault::Undeclared),
-            Some(SchemaNode::String { .. }) if self.root.required.iter().any(|required| required == name) => Ok(()),
-            Some(SchemaNode::String { .. }) => Err(PropertyFault::Optional),
-            Some(_) => Err(PropertyFault::NotString),
+    /// This schema with `name` a required top-level string: what an audience argument binding
+    /// implies, since a placeholder reads that argument and the schema has to guarantee it is
+    /// present and a string before any check. An undeclared property is added as a free
+    /// string, an optional string becomes required, and a property of another type is refused.
+    /// The result is compiled again, so the implied property is held to the budgets an
+    /// authored one is.
+    pub(crate) fn require_string(&self, name: &str) -> Result<ToolParameters, PropertyFault> {
+        let mut root = (*self.root).clone();
+        match root.properties.get(name) {
+            None => {
+                root.properties.insert(
+                    name.to_string(),
+                    SchemaNode::String {
+                        description: None,
+                        constraint: ScalarConstraint::Free,
+                        min_length: None,
+                        max_length: None,
+                    },
+                );
+            }
+            Some(SchemaNode::String { .. }) => {}
+            Some(_) => return Err(PropertyFault::NotString),
         }
+        if !root.required.iter().any(|required| required == name) {
+            root.required.push(name.to_string());
+        }
+        Self::compile(&render_object(&root)).map_err(PropertyFault::Budget)
     }
 
     /// Whether `name` is a required top-level property of any type — the shape an Annotator
@@ -244,9 +261,10 @@ impl ToolParameters {
     }
 }
 
-/// Why a top-level property is not the required string an audience argument binding needs.
-/// Nesting does not count: only the root object's own properties are read.
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+/// Why a top-level property is not what a binding needs: the required string an audience
+/// argument implies, or the required property an Annotator input reads. Nesting does not
+/// count: only the root object's own properties are read.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum PropertyFault {
     #[error("is not a top-level property of the tool's `parameters`")]
     Undeclared,
@@ -254,6 +272,8 @@ pub enum PropertyFault {
     NotString,
     #[error("is declared but not listed in `required`")]
     Optional,
+    #[error("cannot be added to the tool's `parameters`: {0}")]
+    Budget(ParamsError),
 }
 
 impl Serialize for ToolParameters {
@@ -1592,13 +1612,11 @@ mod tests {
     // --- the audience-binding read ------------------------------------------
 
     #[test]
-    fn a_binding_target_is_a_required_top_level_string_and_nothing_else() {
+    fn requiring_a_string_adds_or_promotes_a_top_level_property_and_refuses_another_type() {
         let schema = compile(json!({
             "type": "object",
             "properties": {
-                "to": { "type": "string" },
                 "channel": { "type": "string", "enum": ["ops", "dev"] },
-                "kind": { "type": "string", "const": "email" },
                 "cc": { "type": "string" },
                 "count": { "type": "integer" },
                 "meta": {
@@ -1607,24 +1625,49 @@ mod tests {
                     "required": ["owner"]
                 }
             },
-            "required": ["to", "channel", "kind", "count", "meta"],
+            "required": ["channel", "count", "meta"],
             "additionalProperties": true,
         }))
         .unwrap();
-        assert_eq!(schema.required_string_property("to"), Ok(()));
-        assert_eq!(schema.required_string_property("channel"), Ok(()));
-        assert_eq!(schema.required_string_property("kind"), Ok(()));
-        assert_eq!(schema.required_string_property("cc"), Err(PropertyFault::Optional));
-        assert_eq!(schema.required_string_property("count"), Err(PropertyFault::NotString));
-        assert_eq!(schema.required_string_property("meta"), Err(PropertyFault::NotString));
-        // Nesting does not count: `owner` is required inside `meta`, not at the top level.
-        assert_eq!(schema.required_string_property("owner"), Err(PropertyFault::Undeclared));
-        assert_eq!(schema.required_string_property("bcc"), Err(PropertyFault::Undeclared));
-        // The omitted-`parameters` default declares nothing, so it can host no binding.
+        // A required string keeps its constraints; an optional one becomes required.
+        assert_eq!(schema.require_string("channel").unwrap(), schema);
+        let promoted = schema.require_string("cc").unwrap();
+        assert_eq!(promoted.root.required, vec!["cc", "channel", "count", "meta"]);
+        assert_eq!(promoted.root.properties, schema.root.properties);
+        // An undeclared name is added as a free string; nesting does not count, so `owner`
+        // inside `meta` is undeclared at the top level.
+        let added = schema.require_string("owner").unwrap();
         assert_eq!(
-            ToolParameters::open().required_string_property("to"),
-            Err(PropertyFault::Undeclared)
+            added.root.properties["owner"],
+            SchemaNode::String {
+                description: None,
+                constraint: ScalarConstraint::Free,
+                min_length: None,
+                max_length: None,
+            }
         );
+        assert!(added.root.required.iter().any(|name| name == "owner"));
+        assert_eq!(schema.require_string("count"), Err(PropertyFault::NotString));
+        assert_eq!(schema.require_string("meta"), Err(PropertyFault::NotString));
+        // The implied property is held to the compiled budgets.
+        let members: serde_json::Map<String, Value> = (0..MAX_OBJECT_PROPERTIES)
+            .map(|i| (format!("p{i:03}"), json!({ "type": "string" })))
+            .collect();
+        let full = compile(json!({ "type": "object", "properties": members })).unwrap();
+        assert_eq!(
+            full.require_string("one-more"),
+            Err(PropertyFault::Budget(ParamsError::TooManyProperties))
+        );
+        let long = "a".repeat(MAX_PROPERTY_NAME_BYTES + 1);
+        assert_eq!(
+            schema.require_string(&long),
+            Err(PropertyFault::Budget(ParamsError::PropertyNameTooLong(long)))
+        );
+        // The omitted-`parameters` default declares nothing, so every argument is added.
+        let open = ToolParameters::open().require_string("to").unwrap();
+        assert!(open.validate(&json!({ "to": "ops", "extra": 1 })).is_ok());
+        assert!(open.validate(&json!({ "extra": 1 })).is_err());
+        assert!(open.validate(&json!({ "to": 1 })).is_err());
     }
 
     // --- the strict argument path ----------------------------------------------------------

--- a/appa-engine/src/params.rs
+++ b/appa-engine/src/params.rs
@@ -103,6 +103,8 @@ pub enum ArgumentError {
     UnsafeInteger,
     #[error("arguments do not satisfy the tool's registered schema: {0}")]
     Schema(String),
+    #[error("arguments do not fill the contract's selector placeholder: {0}")]
+    UnfilledPlaceholder(#[from] crate::contract::UnfilledPlaceholder),
     #[error("arguments match no registered contract")]
     NoMatchingContract,
     #[error("persisted argument payload is not in canonical form")]

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -2319,7 +2319,7 @@ mod tests {
             audience: crate::audience::AudienceConfig {
                 sources: vec![crate::audience::SourceRegistration {
                     provider: "slack".to_string(),
-                    templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                    templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
                 }],
                 groups: vec![crate::audience::NamedAudience {
                     name: crate::names::GroupName::new("team"),
@@ -2454,7 +2454,7 @@ mod tests {
                 audience: crate::audience::AudienceConfig {
                     sources: vec![crate::audience::SourceRegistration {
                         provider: "slack".to_string(),
-                        templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                        templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
                     }],
                     groups: vec![named("team"), named("legal"), named("press")],
                     ..crate::audience::AudienceConfig::default()
@@ -2661,7 +2661,7 @@ mod tests {
             audience: crate::audience::AudienceConfig {
                 sources: vec![crate::audience::SourceRegistration {
                     provider: "slack".to_string(),
-                    templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                    templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
                 }],
                 groups: vec![crate::audience::NamedAudience {
                     name: crate::names::GroupName::new("team"),

--- a/appa-engine/src/plan.rs
+++ b/appa-engine/src/plan.rs
@@ -1216,7 +1216,9 @@ pub(crate) fn block_atoms(
     }
     if has(|gap| matches!(gap, Gap::Cap { .. })) {
         for tool in registry.tools().filter_map(crate::contract::ToolDeclaration::declared) {
-            if let Some(audience) = &tool.delta.audience {
+            // A placeholder delta names its collection only per call; a cap comparison against
+            // it waits for that call.
+            if let Some(crate::contract::DeltaAudience::Static(audience)) = &tool.delta.audience {
                 atoms.extend(audience.needed_atoms(providers));
             }
         }
@@ -1313,7 +1315,9 @@ pub(crate) fn direct_clears(
     needs: &mut NeededAtoms,
 ) -> Vec<Gap> {
     let has_cap = gaps.iter().any(|gap| matches!(gap, Gap::Cap { .. }));
-    let committed = has_cap.then(|| check::committed_label(tool, current));
+    // No call is at hand here, so a placeholder delta commits no label and clears no cap.
+    let committed =
+        (has_cap && tool.delta.selector_placeholder().is_none()).then(|| check::committed_label(tool, current));
     gaps.iter()
         .filter(|gap| match (gap, &committed) {
             (Gap::Prior(kind), _) => tool.emits.contains(kind),
@@ -1339,8 +1343,8 @@ mod tests {
     use crate::authority::{Hint, Mandate, Sanitizer, SanitizerPoints, Scope};
     use crate::check::CheckOutcome;
     use crate::contract::{
-        AudienceRequirement, Delta, HistoryRequirement, LabelRequirements, PinnedAnnotation, ProducedAnnotation,
-        RecipientSpec, Requires, ToolAnnotation, ToolDeclaration,
+        AudienceRequirement, Delta, DeltaAudience, HistoryRequirement, LabelRequirements, PinnedAnnotation,
+        ProducedAnnotation, RecipientSpec, Requires, ToolAnnotation, ToolDeclaration,
     };
     use crate::fact::{EffectSet, Fact};
     use crate::label::DeclaredAudience;
@@ -1621,14 +1625,14 @@ mod tests {
             "crm",
             Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
         );
         let tracker = reader(
             "tracker",
             Delta {
                 trust: Some(SUSPICIOUS),
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
         );
         let registry = build(RegistryConfig {
@@ -1682,7 +1686,7 @@ mod tests {
             "lookup",
             Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
         );
         pinned.parameters = crate::params::test_string_argument_schema("room");
@@ -1748,7 +1752,7 @@ mod tests {
             "publish",
             Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(internal())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(internal()))),
             },
         );
         publish.requires.attention = vec![MarkName::new("signoff")];
@@ -1890,7 +1894,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(to)),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(to))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::default(),
@@ -2023,7 +2027,7 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::literal(a.clone())),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::literal(a.clone()))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::new([EffectKind::new("backup.done"), EffectKind::new("receipt")]).unwrap(),
@@ -2438,7 +2442,7 @@ mod tests {
                         &[],
                         Delta {
                             trust: None,
-                            audience: Some(group("press")),
+                            audience: Some(DeltaAudience::Static(group("press"))),
                         },
                     ),
                 ]),
@@ -3403,7 +3407,9 @@ mod tests {
             tags: vec![],
             delta: Delta {
                 trust: None,
-                audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+                audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                    "insider",
+                )]))),
             },
             parameters: crate::params::ToolParameters::open(),
             emits: EffectSet::default(),
@@ -3816,7 +3822,8 @@ mod tests {
             for tool in registry.tools().filter_map(crate::contract::ToolDeclaration::declared) {
                 let narrowed = match &tool.delta {
                     Delta {
-                        audience: Some(delta), ..
+                        audience: Some(DeltaAudience::Static(delta)),
+                        ..
                     } => Some(intersect(&current.audience, &Audience::of_declared(delta))),
                     _ => None,
                 };
@@ -3889,7 +3896,10 @@ mod tests {
             prop::option::of((0u8..2).prop_map(Trust::new)),
             prop::option::of(small_audience().prop_map(DeclaredAudience::literal)),
         )
-            .prop_map(|(trust, audience)| Delta { trust, audience })
+            .prop_map(|(trust, audience)| Delta {
+                trust,
+                audience: audience.map(DeltaAudience::Static),
+            })
     }
 
     fn an_includes() -> impl Strategy<Value = Option<AudienceRequirement>> {
@@ -4252,7 +4262,10 @@ mod tests {
                 .filter(|candidate| {
                     candidate.emits.iter().any(|kind| priors.contains(kind))
                         || (has_cap
-                            && matches!(candidate.delta.audience.as_ref(), Some(DeclaredAudience::Union(_))))
+                            && matches!(
+                                candidate.delta.audience.as_ref(),
+                                Some(DeltaAudience::Static(DeclaredAudience::Union(_)) | DeltaAudience::Selector(_))
+                            ))
                 })
                 .count() as u128;
             bound = bound.saturating_add(redispatches);

--- a/appa-engine/src/profile.rs
+++ b/appa-engine/src/profile.rs
@@ -634,7 +634,7 @@ pub(crate) fn covering_declaration(config: &RegistryConfig) -> ProfileDeclaratio
 mod tests {
     use super::*;
     use crate::authority::{Authority, DeclaredTransition, Hint, Mandate, Sanitizer, SanitizerPoints, Scope};
-    use crate::contract::{Delta, LabelRequirements, Requires};
+    use crate::contract::{Delta, DeltaAudience, LabelRequirements, Requires};
     use crate::engine::Engine;
     use crate::fact::EffectSet;
     use crate::label::DeclaredAudience;
@@ -1041,7 +1041,9 @@ mod tests {
         let mut leak = tool("leak");
         leak.delta = Delta {
             trust: None,
-            audience: Some(DeclaredAudience::restricted([ReaderId::new("insider")])),
+            audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                "insider",
+            )]))),
         };
         let mut cfg = config(vec![leak]);
         cfg.sanitizers = vec![Sanitizer {
@@ -1332,7 +1334,9 @@ mod tests {
         let mut with_reader = omitted.clone();
         with_reader.tools.push(ToolDeclaration::Declared({
             let mut t = tool("read");
-            t.delta.audience = Some(DeclaredAudience::restricted([ReaderId::new("alice")]));
+            t.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                "alice",
+            )])));
             t
         }));
         assert_eq!(rendered(&with_reader), ["self", "internal", "alice"]);

--- a/appa-engine/src/profile.rs
+++ b/appa-engine/src/profile.rs
@@ -1341,7 +1341,7 @@ mod tests {
         with_group.audience = crate::audience::AudienceConfig {
             sources: vec![crate::audience::SourceRegistration {
                 provider: "slack".to_string(),
-                templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
             }],
             groups: vec![crate::audience::NamedAudience {
                 name: crate::names::GroupName::new("team"),
@@ -1408,5 +1408,49 @@ mod tests {
             .insert(ToolName::new("fetch"), ExecutorClass::Assumed);
         let weaker = DeploymentProfile::declare(weaker).unwrap();
         assert_ne!(identity(&cfg, &weaker), base);
+    }
+
+    /// Which collections a source declares, and what each may feed, is part of what the
+    /// policy means: the identity document renders every declared template with its role,
+    /// and a declaration edit moves the identity as a delta edit does.
+    #[test]
+    fn a_sources_declared_templates_render_in_the_identity_and_move_it() {
+        use crate::audience::{AudienceConfig, DeclaredTemplate, SelectorSpec, SourceRegistration};
+        use crate::label::ChainAudience;
+
+        let with_templates = |templates: Vec<DeclaredTemplate>| {
+            let mut cfg = config(vec![tool("fetch")]);
+            cfg.audience = AudienceConfig {
+                sources: vec![SourceRegistration {
+                    provider: "slack".to_string(),
+                    templates,
+                }],
+                self_from: vec![SelectorSpec {
+                    provider: "slack".to_string(),
+                    selector: "viewer".to_string(),
+                }],
+                ..AudienceConfig::default()
+            };
+            cfg
+        };
+        let viewer_only = with_templates(vec![DeclaredTemplate::new("viewer", Some(ChainAudience::Self_))]);
+        let profile = covering_profile(&viewer_only);
+        let base = identity(&viewer_only, &profile);
+
+        let engine = open(viewer_only.clone(), covering_declaration(&viewer_only)).expect("the fixture opens");
+        let document = identity_document_from_registry(engine.registry());
+        assert_eq!(
+            document["audience"]["sources"],
+            serde_json::json!([{ "provider": "slack", "templates": [{ "template": "viewer", "feeds": "self" }] }])
+        );
+
+        let with_group = with_templates(vec![
+            DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+            DeclaredTemplate::named("user-group/<handle>"),
+        ]);
+        assert_ne!(identity(&with_group, &profile), base, "a declared template is policy");
+
+        let refed = with_templates(vec![DeclaredTemplate::new("viewer", Some(ChainAudience::Internal))]);
+        assert_ne!(identity(&refed, &profile), base, "what a template feeds is policy");
     }
 }

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -7,7 +7,10 @@ use thiserror::Error;
 
 use crate::audience::{AudienceConfig, AudienceRegistry, SelectorSpec, Unroutable};
 use crate::authority::{Authority, DeclaredTransition, Hint, Sanitizer};
-use crate::contract::{AudienceRequirement, HistoryRequirement, RecipientSpec, ToolAnnotation, ToolDeclaration};
+use crate::contract::{
+    AudienceRequirement, DeltaAudience, HistoryRequirement, RecipientSpec, SelectorPlaceholder, ToolAnnotation,
+    ToolDeclaration,
+};
 use crate::fact::EffectKind;
 use crate::label::{
     Audience, AudienceSpelling, ChainAudience, Clause, DeclaredAudience, Evaluation, Expansions, GroupRef,
@@ -279,6 +282,9 @@ pub struct AudienceVocabulary {
     chain: BTreeSet<ChainAudience>,
     groups: BTreeSet<GroupRef>,
     readers: BTreeSet<ReaderId>,
+    /// Collections keyed by the call: each is instantiated into a group per call, so the
+    /// mandate admits the one collection the call's arguments spell and no other.
+    placeholders: BTreeSet<SelectorPlaceholder>,
 }
 
 impl TryFrom<Vec<String>> for AudienceVocabulary {
@@ -297,8 +303,9 @@ impl From<AudienceVocabulary> for Vec<String> {
 
 impl AudienceVocabulary {
     /// One written vocabulary list, entry by entry. `public` is refused — always admissible,
-    /// never listed — and so are a placeholder, which belongs to a call argument, and a
-    /// repeated entry. An empty list is the vocabulary that admits `public` alone.
+    /// never listed — and so are an argument placeholder, which belongs to a call argument, and
+    /// a repeated entry. A selector placeholder is admitted: it names, per call, the collection
+    /// the call's arguments spell. An empty list is the vocabulary that admits `public` alone.
     pub fn parse_entries(list: &[String]) -> Result<AudienceVocabulary, AudienceSpelling> {
         let mut vocabulary = AudienceVocabulary::default();
         for entry in list {
@@ -314,6 +321,11 @@ impl AudienceVocabulary {
                 }
                 Some(crate::names::AudienceArgument::Group(group)) => {
                     if !vocabulary.groups.insert(group) {
+                        return Err(AudienceSpelling::Duplicate(entry.clone()));
+                    }
+                }
+                Some(crate::names::AudienceArgument::Placeholder(placeholder)) => {
+                    if !vocabulary.placeholders.insert(placeholder) {
                         return Err(AudienceSpelling::Duplicate(entry.clone()));
                     }
                 }
@@ -337,18 +349,58 @@ impl AudienceVocabulary {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.chain.is_empty() && self.groups.is_empty() && self.readers.is_empty()
+        self.chain.is_empty() && self.groups.is_empty() && self.readers.is_empty() && self.placeholders.is_empty()
     }
 
     /// The canonical spellings, as a policy writes them: the chain words in chain order, then
-    /// the group references (named, then source-qualified), then the readers. The one
-    /// rendering the consult declaration, the policy identity, and a description all use.
+    /// the group references (named, then source-qualified), then the selector placeholders,
+    /// then the readers. The one rendering the consult declaration, the policy identity, and a
+    /// description all use.
     pub fn entries(&self) -> impl Iterator<Item = String> + '_ {
         self.chain
             .iter()
             .map(|level| level.as_str().to_string())
             .chain(self.groups.iter().map(ToString::to_string))
+            .chain(self.placeholders.iter().map(ToString::to_string))
             .chain(self.readers.iter().map(|reader| reader.as_str().to_string()))
+    }
+
+    pub fn placeholders(&self) -> impl Iterator<Item = &SelectorPlaceholder> {
+        self.placeholders.iter()
+    }
+
+    /// Every audience-source provider this vocabulary names, by a `@provider:selector` mention
+    /// or a selector placeholder.
+    pub fn referenced_providers(&self) -> BTreeSet<String> {
+        self.groups
+            .iter()
+            .filter_map(|group| match group {
+                GroupRef::Source { provider, .. } => Some(provider.clone()),
+                GroupRef::Named(_) => None,
+            })
+            .chain(
+                self.placeholders
+                    .iter()
+                    .map(|placeholder| placeholder.provider().to_string()),
+            )
+            .collect()
+    }
+
+    /// The vocabulary for one call: each selector placeholder becomes the group the call's
+    /// arguments spell. A vocabulary without placeholders is its own instantiation; a call
+    /// that fills no placeholder — never a minted one — has no vocabulary.
+    pub fn instantiate(
+        &self,
+        arguments: &serde_json::Value,
+    ) -> Result<AudienceVocabulary, crate::contract::UnfilledPlaceholder> {
+        let mut instantiated = AudienceVocabulary {
+            placeholders: BTreeSet::new(),
+            ..self.clone()
+        };
+        for placeholder in &self.placeholders {
+            instantiated.groups.insert(placeholder.instantiate(arguments)?);
+        }
+        Ok(instantiated)
     }
 
     pub(crate) fn group_atoms(&self) -> impl Iterator<Item = SymbolicAtom> + '_ {
@@ -385,6 +437,7 @@ impl AudienceVocabulary {
         self.chain.extend(other.chain.iter().copied());
         self.groups.extend(other.groups.iter().cloned());
         self.readers.extend(other.readers.iter().cloned());
+        self.placeholders.extend(other.placeholders.iter().cloned());
     }
 }
 
@@ -434,6 +487,18 @@ impl AnnotatorMandate {
 
     pub fn effects(&self) -> impl Iterator<Item = &EffectKind> {
         self.effects.iter()
+    }
+
+    /// The mandate for one call: its audience vocabulary with every selector placeholder
+    /// instantiated from the call's arguments.
+    pub fn instantiate(
+        &self,
+        arguments: &serde_json::Value,
+    ) -> Result<AnnotatorMandate, crate::contract::UnfilledPlaceholder> {
+        Ok(AnnotatorMandate {
+            audiences: self.audiences.instantiate(arguments)?,
+            ..self.clone()
+        })
     }
 
     pub(crate) fn permits_trust(&self, trust: Trust) -> bool {
@@ -488,6 +553,10 @@ pub enum LoadError {
     WildcardMetadata,
     #[error("the policy writes more than one wildcard tool \"*\"")]
     DuplicateWildcard,
+    #[error(
+        "the wildcard tool \"*\" routes through annotator {0}, whose mandate reads call arguments through a selector placeholder — a wildcard covers calls whose arguments the policy does not describe"
+    )]
+    WildcardPlaceholderMandate(String),
     #[error("duplicate tool contract: {0}")]
     DuplicateTool(String),
     #[error("malformed tool selector {0:?}")]
@@ -551,6 +620,10 @@ pub enum LoadError {
         "tool {tool} is provider-run and cannot be a confined result point: its result reaches the model inside the inference call, before any host could withhold it"
     )]
     ConfinedProviderRun { tool: String },
+    #[error(
+        "tool {tool} is provider-run and its delta reads a selector placeholder: a provider-run result arrives with no call to read the placeholder from"
+    )]
+    ProviderRunPlaceholder { tool: String },
     #[error(
         "sanitizer {sanitizer} registers on tool_output but the deployment confines no application point — neither a result point nor, under context control, a child's return"
     )]
@@ -710,7 +783,9 @@ fn worst_case_plan_alternatives(
                             RecipientSpec::Static(recipients) => multiply(includes_competent(recipients)),
                             // A placeholder's recipients come from the call, so nothing about
                             // the gap is known here.
-                            RecipientSpec::Placeholder(_) => multiply(reader_cap_competent()),
+                            RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_) => {
+                                multiply(reader_cap_competent())
+                            }
                         }
                     }
                     AudienceRequirement::Includes(_) | AudienceRequirement::Cap(_) => {}
@@ -758,11 +833,15 @@ fn worst_case_plan_alternatives(
             .filter(|sanitizer| !sanitizer.name.is_attest_schema())
             .filter(|sanitizer| sanitizer.on.output && sanitizer.applies_to(tags))
             .count(),
-        ToolDeclaration::Declared(tool) if tool.delta.symbolic_atoms().next().is_some() => sanitizers
-            .iter()
-            .filter(|sanitizer| !sanitizer.name.is_attest_schema())
-            .filter(|sanitizer| sanitizer.on.output && sanitizer.applies_to(tags))
-            .count(),
+        ToolDeclaration::Declared(tool)
+            if tool.delta.symbolic_atoms().next().is_some() || tool.delta.selector_placeholder().is_some() =>
+        {
+            sanitizers
+                .iter()
+                .filter(|sanitizer| !sanitizer.name.is_attest_schema())
+                .filter(|sanitizer| sanitizer.on.output && sanitizer.applies_to(tags))
+                .count()
+        }
         ToolDeclaration::Declared(tool) => {
             let output = tool.output_label();
             sanitizers
@@ -809,7 +888,11 @@ fn worst_case_plan_alternatives(
             ToolDeclaration::Declared(tool) => {
                 tool.emits.iter().any(|kind| priors.contains(&kind))
                     || (any_prior && !tool.emits.is_empty())
-                    || (has_cap && matches!(tool.delta.audience.as_ref(), Some(DeclaredAudience::Union(_))))
+                    || (has_cap
+                        && matches!(
+                            tool.delta.audience.as_ref(),
+                            Some(DeltaAudience::Static(DeclaredAudience::Union(_)) | DeltaAudience::Selector(_))
+                        ))
             }
             // An Annotated candidate's emits and delta are unknown at load; the cap is the only
             // bound, so it stays counted wherever a prior or a cap could match it.
@@ -977,6 +1060,9 @@ impl Registry {
             }
             if let Some(audiences) = &annotator.audiences {
                 direct.extend(check_routable(&audience, audiences.group_atoms(), context)?);
+                for placeholder in audiences.placeholders() {
+                    check_placeholder(&audience, placeholder, context)?;
+                }
             }
             let name = annotator.name.clone();
             if annotator_declarations.insert(name.clone(), annotator).is_some() {
@@ -1009,10 +1095,16 @@ impl Registry {
                     check_rank(&config.trust_chain, tool.requires.trust_floor(), || {
                         format!("tool {} trust floor", tool.name.as_str())
                     })?;
-                    if let Some(declared) = tool.delta.audience.as_ref() {
-                        direct.extend(check_declared(&audience, declared, || {
-                            format!("tool {} delta", tool.name.as_str())
-                        })?);
+                    match tool.delta.audience.as_ref() {
+                        Some(DeltaAudience::Static(declared)) => {
+                            direct.extend(check_declared(&audience, declared, || {
+                                format!("tool {} delta", tool.name.as_str())
+                            })?);
+                        }
+                        Some(DeltaAudience::Selector(placeholder)) => {
+                            check_placeholder(&audience, placeholder, || format!("tool {} delta", tool.name.as_str()))?;
+                        }
+                        None => {}
                     }
                     for requirement in tool.requires.audience_requirements() {
                         match requirement {
@@ -1026,16 +1118,39 @@ impl Registry {
                                     format!("tool {} within", tool.name.as_str())
                                 })?);
                             }
+                            AudienceRequirement::Includes(RecipientSpec::Selector(placeholder)) => {
+                                check_placeholder(&audience, placeholder, || {
+                                    format!("tool {} contains", tool.name.as_str())
+                                })?;
+                            }
                             AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => {}
                         }
                     }
                 }
-                ToolDeclaration::Annotated { name, annotator, .. } => {
-                    if !annotator_declarations.contains_key(annotator) {
+                ToolDeclaration::Annotated {
+                    name,
+                    annotator,
+                    parameters,
+                    ..
+                } => {
+                    let Some(declared) = annotator_declarations.get(annotator) else {
                         return Err(LoadError::UnknownAnnotator {
                             tool: name.as_str().to_string(),
                             annotator: annotator.as_str().to_string(),
                         });
+                    };
+                    // The mandate's placeholders are instantiated from this tool's arguments,
+                    // so each argument they read is a required string of its schema.
+                    for placeholder in declared.audiences.iter().flat_map(AudienceVocabulary::placeholders) {
+                        for argument in placeholder.arguments() {
+                            parameters.required_string_property(argument).map_err(|fault| {
+                                LoadError::AudienceBindingSchema {
+                                    context: format!("tool {} annotator {} mandate", name.as_str(), annotator.as_str()),
+                                    argument: argument.to_string(),
+                                    fault,
+                                }
+                            })?;
+                        }
                     }
                 }
             }
@@ -1046,6 +1161,11 @@ impl Registry {
                 let ToolDeclaration::Declared(tool) = declaration else {
                     return Err(LoadError::ProviderRunAnnotated(declaration.name().as_str().to_string()));
                 };
+                if tool.delta.selector_placeholder().is_some() {
+                    return Err(LoadError::ProviderRunPlaceholder {
+                        tool: tool.name.as_str().to_string(),
+                    });
+                }
                 let name = tool.name.clone();
                 if provider_run
                     .keys()
@@ -1245,11 +1365,18 @@ impl Registry {
         else {
             return Err(LoadError::WildcardStatic);
         };
-        if !annotators.contains_key(annotator) {
+        let Some(declared) = annotators.get(annotator) else {
             return Err(LoadError::UnknownAnnotator {
                 tool: WILDCARD_SPELLING.to_string(),
                 annotator: annotator.as_str().to_string(),
             });
+        };
+        if declared
+            .audiences
+            .as_ref()
+            .is_some_and(|audiences| audiences.placeholders().next().is_some())
+        {
+            return Err(LoadError::WildcardPlaceholderMandate(annotator.as_str().to_string()));
         }
         if *matcher != ToolMatcher::Bare
             || !tags.is_empty()
@@ -1352,11 +1479,10 @@ impl Registry {
         call: &'a crate::value::ResolvedCall,
     ) -> Option<std::borrow::Cow<'a, ToolAnnotation>> {
         let declaration = self.declaration(call)?;
-        match call.annotation() {
-            Some(pinned) => Some(std::borrow::Cow::Owned(
-                pinned.tool_annotation(declaration, call.tool()),
-            )),
-            None => declaration.declared().map(|annotation| {
+        let annotation = match call.annotation() {
+            Some(pinned) => std::borrow::Cow::Owned(pinned.tool_annotation(declaration, call.tool())),
+            None => {
+                let annotation = declaration.declared()?;
                 if annotation.name == *call.tool() {
                     std::borrow::Cow::Borrowed(annotation)
                 } else {
@@ -1364,7 +1490,14 @@ impl Registry {
                     annotation.name = call.tool().clone();
                     std::borrow::Cow::Owned(annotation)
                 }
-            }),
+            }
+        };
+        // The one place a call meets its contract: a delta placeholder is bound here, so every
+        // label read from the annotation downstream is static. A minted call fills it; a
+        // recorded call that does not was never minted here and has no annotation.
+        match annotation.bound_to(call.arguments()).ok()? {
+            Some(bound) => Some(std::borrow::Cow::Owned(bound)),
+            None => Some(annotation),
         }
     }
 
@@ -1459,6 +1592,29 @@ impl Registry {
 
     /// One registered Annotator's compiled mandate, with every omitted bound already resolved
     /// to the policy vocabulary.
+    /// Whether a call's arguments fill every selector placeholder its declaration reads: a
+    /// static contract's own, or the mandate's of the Annotator an annotated tool routes
+    /// through. Part of minting a call, so the check and the annotation consult only ever meet
+    /// a filled placeholder.
+    pub(crate) fn placeholders_filled(
+        &self,
+        declaration: &ToolDeclaration,
+        arguments: &serde_json::Value,
+    ) -> Result<(), crate::params::ArgumentError> {
+        let placeholders: Vec<&SelectorPlaceholder> = match declaration {
+            ToolDeclaration::Declared(tool) => tool.selector_placeholders().collect(),
+            ToolDeclaration::Annotated { annotator, .. } => self
+                .annotator_mandate(annotator)
+                .into_iter()
+                .flat_map(|mandate| mandate.audiences().placeholders())
+                .collect(),
+        };
+        for placeholder in placeholders {
+            placeholder.instantiate(arguments)?;
+        }
+        Ok(())
+    }
+
     pub fn annotator_mandate(&self, name: &AnnotatorName) -> Option<&AnnotatorMandate> {
         self.annotators.get(name)
     }
@@ -1520,10 +1676,44 @@ fn check_audience_bindings(tool: &ToolAnnotation) -> Result<(), LoadError> {
     for requirement in tool.requires.audience_requirements() {
         match requirement {
             AudienceRequirement::Includes(RecipientSpec::Placeholder(argument)) => check(argument, "contains")?,
+            AudienceRequirement::Includes(RecipientSpec::Selector(placeholder)) => {
+                for argument in placeholder.arguments() {
+                    check(argument, "contains")?;
+                }
+            }
             AudienceRequirement::Includes(RecipientSpec::Static(_)) | AudienceRequirement::Cap(_) => {}
         }
     }
+    for argument in tool
+        .delta
+        .selector_placeholder()
+        .into_iter()
+        .flat_map(SelectorPlaceholder::arguments)
+    {
+        check(argument, "delta")?;
+    }
     Ok(())
+}
+
+/// A selector placeholder resolves at load as far as it can: its provider is registered and
+/// some declared template fits every collection it may instantiate into.
+fn check_placeholder(
+    registry: &AudienceRegistry,
+    placeholder: &SelectorPlaceholder,
+    context: impl Fn() -> String,
+) -> Result<(), LoadError> {
+    let fault = match registry.templates(placeholder.provider()) {
+        None => Unroutable::UnknownProvider(placeholder.provider().to_string()),
+        Some(templates) if templates.iter().any(|declared| placeholder.fits(&declared.template)) => return Ok(()),
+        Some(_) => Unroutable::UnknownSelector {
+            provider: placeholder.provider().to_string(),
+            selector: placeholder.to_string(),
+        },
+    };
+    Err(LoadError::UnroutableAudience {
+        context: context(),
+        fault,
+    })
 }
 
 pub(crate) fn check_rank(
@@ -1698,7 +1888,8 @@ fn configured_audience_vocabulary(
         let Some(tool) = declaration.declared() else {
             continue;
         };
-        if let Some(audience) = &tool.delta.audience {
+        // A placeholder names no audience until a call does; the omitted bound stays static.
+        if let Some(DeltaAudience::Static(audience)) = &tool.delta.audience {
             vocabulary.add_declared(audience);
         }
         for requirement in &tool.requires.label.audience {
@@ -1706,7 +1897,7 @@ fn configured_audience_vocabulary(
                 AudienceRequirement::Includes(RecipientSpec::Static(audience)) | AudienceRequirement::Cap(audience) => {
                     vocabulary.add_declared(audience)
                 }
-                AudienceRequirement::Includes(RecipientSpec::Placeholder(_)) => {}
+                AudienceRequirement::Includes(RecipientSpec::Placeholder(_) | RecipientSpec::Selector(_)) => {}
             }
         }
     }
@@ -1851,7 +2042,9 @@ mod tests {
         let mut classified = tool("classified");
         classified.delta = Delta {
             trust: None,
-            audience: Some(DeclaredAudience::restricted([ReaderId::new("private")])),
+            audience: Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+                "private",
+            )]))),
         };
         classified.requires.label.audience =
             vec![AudienceRequirement::Cap(DeclaredAudience::restricted([ReaderId::new(
@@ -1876,7 +2069,7 @@ mod tests {
         let mut delta_tool = tool("emit");
         delta_tool.delta = Delta {
             trust: None,
-            audience: Some(DeclaredAudience::literal(named.clone())),
+            audience: Some(DeltaAudience::Static(DeclaredAudience::literal(named.clone()))),
         };
         delta.tools = declared(vec![delta_tool]);
 
@@ -2207,7 +2400,9 @@ mod tests {
     #[test]
     fn an_omitted_audience_bound_admits_every_surface_the_policy_writes() {
         let mut reads = tool("read");
-        reads.delta.audience = Some(DeclaredAudience::restricted([ReaderId::new("insider")]));
+        reads.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+            "insider",
+        )])));
         let mut sends = tool("send");
         sends.requires.label.audience = vec![
             AudienceRequirement::Includes(RecipientSpec::Static(DeclaredAudience::Union(
@@ -2303,7 +2498,9 @@ mod tests {
     #[test]
     fn an_omitted_mandate_bound_resolves_to_the_whole_policy_vocabulary() {
         let mut catalogued = tool("send");
-        catalogued.delta.audience = Some(DeclaredAudience::restricted([ReaderId::new("insider")]));
+        catalogued.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+            "insider",
+        )])));
         catalogued.emits = EffectSet::new([EffectKind::new("mail.sent")]).unwrap();
         catalogued.requires.attention = vec![MarkName::new("signoff")];
         let mut cfg = base();
@@ -3151,11 +3348,14 @@ mod tests {
         let mut tools = vec![target];
         for i in 0..narrowers {
             let mut narrower = tool(&format!("narrow{i}"));
-            narrower.delta.audience = Some(DeclaredAudience::restricted([ReaderId::new("a"), ReaderId::new("c")]));
+            narrower.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::restricted([
+                ReaderId::new("a"),
+                ReaderId::new("c"),
+            ])));
             tools.push(narrower);
         }
         let mut public = tool("public-delta");
-        public.delta.audience = Some(DeclaredAudience::literal(Audience::public()));
+        public.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::literal(Audience::public())));
         let neutral = tool("neutral");
         let mut unannotated = tool("unannotated");
         unannotated.delta = Delta::NONE;
@@ -3223,7 +3423,9 @@ mod tests {
         };
         let mut fixer = tool("fixer");
         fixer.emits = EffectSet::new([EffectKind::new("k")]).unwrap();
-        fixer.delta.audience = Some(DeclaredAudience::restricted([ReaderId::new("a")]));
+        fixer.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+            "a",
+        )])));
         let mut cfg = base();
         cfg.tools = declared(vec![target, fixer]);
         assert!(Registry::build_covered_with_cap(cfg, PlannerCap::new(2).expect("nonzero")).is_ok());
@@ -3448,7 +3650,9 @@ mod tests {
     #[test]
     fn sanitizer_chains_do_not_multiply_either_stage_bound() {
         let mut narrowing = tool("fetch");
-        narrowing.delta.audience = Some(DeclaredAudience::restricted([ReaderId::new("a")]));
+        narrowing.delta.audience = Some(DeltaAudience::Static(DeclaredAudience::restricted([ReaderId::new(
+            "a",
+        )])));
         let mut cfg = base();
         cfg.tools = declared(vec![narrowing]);
         cfg.sanitizers = (0..5).map(output_sanitizer).collect();

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -1792,7 +1792,7 @@ mod tests {
         crate::audience::AudienceConfig {
             sources: vec![crate::audience::SourceRegistration {
                 provider: "slack".to_string(),
-                templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
             }],
             groups: handles
                 .iter()
@@ -1939,7 +1939,10 @@ mod tests {
         use crate::audience::{NamedAudience, SourceRegistration};
         let source = |provider: &str| SourceRegistration {
             provider: provider.to_string(),
-            templates: vec![crate::audience::SelectorTemplate::new("viewer")],
+            templates: vec![crate::audience::DeclaredTemplate::new(
+                "viewer",
+                Some(ChainAudience::Self_),
+            )],
         };
         // A `:` makes one member id qualified under two providers, `@` makes members
         // non-literal, and an empty name owns no namespace.
@@ -3001,7 +3004,7 @@ mod tests {
         grouped.audience = crate::audience::AudienceConfig {
             sources: vec![crate::audience::SourceRegistration {
                 provider: "slack".to_string(),
-                templates: vec![crate::audience::SelectorTemplate::new("user-group/<handle>")],
+                templates: vec![crate::audience::DeclaredTemplate::named("user-group/<handle>")],
             }],
             groups: vec![crate::audience::NamedAudience {
                 name: crate::names::GroupName::new("desk"),

--- a/appa-engine/src/registry.rs
+++ b/appa-engine/src/registry.rs
@@ -650,7 +650,7 @@ pub enum LoadError {
         construct: crate::profile::ProviderRunConstruct,
     },
     #[error(
-        "{context} binds audience argument {argument:?}, which {fault}: a placeholder names a required top-level string property of the tool's `parameters`"
+        "{context} binds audience argument {argument:?}, which {fault}: an audience argument is a required top-level string, so `parameters` may not declare it as another type"
     )]
     AudienceBindingSchema {
         context: String,
@@ -1076,6 +1076,26 @@ impl Registry {
         let mut wildcard: Option<ToolDeclaration> = None;
         for mut declaration in config.tools {
             let (contract, matcher) = parse_tool_selector(declaration.name().as_str())?;
+            // An audience argument binding implies its schema: the argument is a required
+            // top-level string, so a minted call always carries a value the binding can read.
+            let bound_arguments = audience_arguments(&declaration, &annotator_declarations);
+            if !bound_arguments.is_empty() {
+                let tool_name = declaration.name().as_str().to_string();
+                let parameters = match &mut declaration {
+                    ToolDeclaration::Declared(tool) => &mut tool.parameters,
+                    ToolDeclaration::Annotated { parameters, .. } => parameters,
+                };
+                for argument in bound_arguments {
+                    *parameters =
+                        parameters
+                            .require_string(&argument)
+                            .map_err(|fault| LoadError::AudienceBindingSchema {
+                                context: format!("tool {tool_name}"),
+                                argument,
+                                fault,
+                            })?;
+                }
+            }
             let base_name = match contract {
                 ContractName::Named(name) => name,
                 ContractName::Wildcard => {
@@ -1127,30 +1147,12 @@ impl Registry {
                         }
                     }
                 }
-                ToolDeclaration::Annotated {
-                    name,
-                    annotator,
-                    parameters,
-                    ..
-                } => {
-                    let Some(declared) = annotator_declarations.get(annotator) else {
+                ToolDeclaration::Annotated { name, annotator, .. } => {
+                    if !annotator_declarations.contains_key(annotator) {
                         return Err(LoadError::UnknownAnnotator {
                             tool: name.as_str().to_string(),
                             annotator: annotator.as_str().to_string(),
                         });
-                    };
-                    // The mandate's placeholders are instantiated from this tool's arguments,
-                    // so each argument they read is a required string of its schema.
-                    for placeholder in declared.audiences.iter().flat_map(AudienceVocabulary::placeholders) {
-                        for argument in placeholder.arguments() {
-                            parameters.required_string_property(argument).map_err(|fault| {
-                                LoadError::AudienceBindingSchema {
-                                    context: format!("tool {} annotator {} mandate", name.as_str(), annotator.as_str()),
-                                    argument: argument.to_string(),
-                                    fault,
-                                }
-                            })?;
-                        }
                     }
                 }
             }
@@ -1205,10 +1207,6 @@ impl Registry {
             if seen_authorities.insert(authority.name.clone(), ()).is_some() {
                 return Err(LoadError::DuplicateAuthority(authority.name.as_str().to_string()));
             }
-        }
-
-        for tool in tools.values().flatten().filter_map(|(_, d)| d.declared()) {
-            check_audience_bindings(tool)?;
         }
 
         // The planner-cap lint runs the same cover evaluation planning runs, against the
@@ -1663,36 +1661,37 @@ impl Registry {
     }
 }
 
-fn check_audience_bindings(tool: &ToolAnnotation) -> Result<(), LoadError> {
-    let check = |argument: &str, site: &str| {
-        tool.parameters
-            .required_string_property(argument)
-            .map_err(|fault| LoadError::AudienceBindingSchema {
-                context: format!("tool {} {site}", tool.name.as_str()),
-                argument: argument.to_string(),
-                fault,
-            })
-    };
-    for requirement in tool.requires.audience_requirements() {
-        match requirement {
-            AudienceRequirement::Includes(RecipientSpec::Placeholder(argument)) => check(argument, "contains")?,
-            AudienceRequirement::Includes(RecipientSpec::Selector(placeholder)) => {
-                for argument in placeholder.arguments() {
-                    check(argument, "contains")?;
-                }
-            }
-            AudienceRequirement::Includes(RecipientSpec::Static(_)) | AudienceRequirement::Cap(_) => {}
+/// The call arguments a tool's audience bindings read: each `$argument` recipient and each
+/// argument of a selector placeholder in its delta, its `contains`, or — for an
+/// Annotator-routed tool — its annotator's mandate.
+fn audience_arguments(
+    declaration: &ToolDeclaration,
+    annotators: &BTreeMap<AnnotatorName, AnnotatorDeclaration>,
+) -> Vec<String> {
+    match declaration {
+        ToolDeclaration::Declared(tool) => {
+            let recipients = tool
+                .requires
+                .audience_requirements()
+                .iter()
+                .filter_map(|requirement| match requirement {
+                    AudienceRequirement::Includes(RecipientSpec::Placeholder(argument)) => Some(argument.clone()),
+                    AudienceRequirement::Includes(_) | AudienceRequirement::Cap(_) => None,
+                });
+            recipients
+                .chain(
+                    tool.selector_placeholders()
+                        .flat_map(|placeholder| placeholder.arguments().map(str::to_string)),
+                )
+                .collect()
         }
+        ToolDeclaration::Annotated { annotator, .. } => annotators
+            .get(annotator)
+            .into_iter()
+            .flat_map(|declared| declared.audiences.iter().flat_map(AudienceVocabulary::placeholders))
+            .flat_map(|placeholder| placeholder.arguments().map(str::to_string))
+            .collect(),
     }
-    for argument in tool
-        .delta
-        .selector_placeholder()
-        .into_iter()
-        .flat_map(SelectorPlaceholder::arguments)
-    {
-        check(argument, "delta")?;
-    }
-    Ok(())
 }
 
 /// A selector placeholder resolves at load as far as it can: its provider is registered and
@@ -2953,87 +2952,84 @@ mod tests {
     }
 
     #[test]
-    fn every_audience_argument_binding_names_a_required_top_level_string() {
+    fn an_audience_argument_binding_implies_a_required_top_level_string() {
         use crate::params::{PropertyFault, ToolParameters};
         let schema = |value: serde_json::Value| ToolParameters::compile(&value).unwrap();
-        let refused = [
-            (ToolParameters::open(), PropertyFault::Undeclared),
+        let required_string = |extra: serde_json::Value| {
+            let mut object = serde_json::json!({
+                "type": "object",
+                "properties": { "to": { "type": "string" } },
+                "required": ["to"],
+            });
+            object
+                .as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone());
+            schema(object)
+        };
+        let implied = [
             (
-                schema(serde_json::json!({
-                    "type": "object",
-                    "properties": { "cc": { "type": "string" } },
-                    "required": ["cc"],
-                })),
-                PropertyFault::Undeclared,
-            ),
-            (
-                schema(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "envelope": {
-                            "type": "object",
-                            "properties": { "to": { "type": "string" } },
-                            "required": ["to"],
-                        }
-                    },
-                    "required": ["envelope"],
-                })),
-                PropertyFault::Undeclared,
+                ToolParameters::open(),
+                required_string(serde_json::json!({"additionalProperties": true})),
             ),
             (
                 schema(serde_json::json!({
                     "type": "object",
                     "properties": { "to": { "type": "string" } },
                 })),
-                PropertyFault::Optional,
+                required_string(serde_json::json!({})),
             ),
             (
                 schema(serde_json::json!({
                     "type": "object",
-                    "properties": { "to": { "type": "array", "items": { "type": "string" } } },
+                    "properties": { "body": { "type": "string" } },
+                    "required": ["body"],
+                })),
+                schema(serde_json::json!({
+                    "type": "object",
+                    "properties": { "body": { "type": "string" }, "to": { "type": "string" } },
+                    "required": ["body", "to"],
+                })),
+            ),
+            (
+                schema(serde_json::json!({
+                    "type": "object",
+                    "properties": { "to": { "type": "string", "enum": ["ops", "dev"] } },
                     "required": ["to"],
                 })),
-                PropertyFault::NotString,
+                schema(serde_json::json!({
+                    "type": "object",
+                    "properties": { "to": { "type": "string", "enum": ["ops", "dev"] } },
+                    "required": ["to"],
+                })),
             ),
         ];
-        for (parameters, expected) in refused {
-            for (expected_context, cfg) in binding_sites(&parameters) {
-                match Registry::build_covered(cfg) {
-                    Err(LoadError::AudienceBindingSchema {
-                        context,
-                        argument,
-                        fault,
-                    }) => {
-                        assert_eq!(context, expected_context);
-                        assert_eq!(argument, "to");
-                        assert_eq!(fault, expected, "at {expected_context}");
-                    }
-                    other => {
-                        panic!("{expected_context} under {parameters:?} must refuse with {expected:?}, got {other:?}")
-                    }
-                }
+        for (parameters, expected) in implied {
+            for (context, cfg) in binding_sites(&parameters) {
+                let registry = Registry::build_covered(cfg)
+                    .unwrap_or_else(|error| panic!("{context} under {parameters:?} must load: {error}"));
+                let loaded = registry.tool(&ToolName::new("emit")).unwrap().declared().unwrap();
+                assert_eq!(loaded.parameters.normalized(), expected.normalized(), "{context}");
             }
         }
 
-        let accepted = [
-            schema(serde_json::json!({
-                "type": "object",
-                "properties": { "to": { "type": "string" }, "body": { "type": "string" } },
-                "required": ["to"],
-                "additionalProperties": true,
-            })),
-            schema(serde_json::json!({
-                "type": "object",
-                "properties": { "to": { "type": "string", "enum": ["ops", "dev"] } },
-                "required": ["to"],
-            })),
-        ];
-        for parameters in accepted {
-            for (context, cfg) in binding_sites(&parameters) {
-                assert!(
-                    Registry::build_covered(cfg).is_ok(),
-                    "{context} under {parameters:?} must load"
-                );
+        let array = schema(serde_json::json!({
+            "type": "object",
+            "properties": { "to": { "type": "array", "items": { "type": "string" } } },
+            "required": ["to"],
+        }));
+        for (context, cfg) in binding_sites(&array) {
+            match Registry::build_covered(cfg) {
+                Err(LoadError::AudienceBindingSchema {
+                    context: found,
+                    argument,
+                    fault,
+                }) => {
+                    assert_eq!(found, "tool emit");
+                    assert_eq!(argument, "to");
+                    assert_eq!(fault, PropertyFault::NotString, "at {context}");
+                }
+                other => panic!("{context} must refuse a non-string argument, got {other:?}"),
             }
         }
 

--- a/appa-engine/src/route.rs
+++ b/appa-engine/src/route.rs
@@ -885,7 +885,9 @@ fn disclosure_cmp(a: &[Audience], b: &[Audience], within: &WithinAssertions) -> 
 mod tests {
     use super::*;
     use crate::authority::{Authority, Mandate, Sanitizer, SanitizerPoints, Scope};
-    use crate::contract::{AudienceRequirement, Delta, HistoryRequirement, RecipientSpec, Requires, ToolAnnotation};
+    use crate::contract::{
+        AudienceRequirement, Delta, DeltaAudience, HistoryRequirement, RecipientSpec, Requires, ToolAnnotation,
+    };
     use crate::fact::{CloseOutcome, EffectSet, Fact};
     use crate::label::DeclaredAudience;
     use crate::label::{Label, ReaderId, Trust};
@@ -972,7 +974,7 @@ mod tests {
     fn narrowing_to(mut contract: ToolAnnotation, trust: Option<Trust>, audience: Option<Audience>) -> ToolAnnotation {
         contract.delta = Delta {
             trust,
-            audience: audience.map(DeclaredAudience::literal),
+            audience: audience.map(|audience| DeltaAudience::Static(DeclaredAudience::literal(audience))),
         };
         contract
     }

--- a/appa-engine/src/transition.rs
+++ b/appa-engine/src/transition.rs
@@ -1138,6 +1138,11 @@ impl<'a> Sequence<'a> {
                 if crate::check::validate_annotation(self.engine.registry(), entry, &call).is_err() {
                     return Err(TransitionRefusal::ForgedEvidence);
                 }
+                let checked = match checked.bound_to(call.arguments()) {
+                    Ok(Some(bound)) => std::borrow::Cow::Owned(bound),
+                    Ok(None) => checked,
+                    Err(_) => return Err(TransitionRefusal::ForgedLabel),
+                };
                 let views = self.projection.view(trajectory);
                 if proposed_effects != &checked.emits {
                     return Err(TransitionRefusal::EffectsMismatch);

--- a/appa-package/src/manifest.rs
+++ b/appa-package/src/manifest.rs
@@ -28,10 +28,6 @@ pub enum ManifestError {
     },
     #[error("{path} declares the namespace `{namespace}` twice")]
     RepeatedNamespace { path: PathBuf, namespace: String },
-    #[error(
-        "{path} declares the audience source `{provider}` badly: a provider name is non-empty, has no whitespace, and appears once"
-    )]
-    Audience { path: PathBuf, provider: String },
     #[error("{path} includes the battery `{battery}` twice")]
     RepeatedBattery { path: PathBuf, battery: String },
     #[error("{path} is not valid TOML: {source}")]

--- a/appa-package/src/manifest.rs
+++ b/appa-package/src/manifest.rs
@@ -28,6 +28,10 @@ pub enum ManifestError {
     },
     #[error("{path} declares the namespace `{namespace}` twice")]
     RepeatedNamespace { path: PathBuf, namespace: String },
+    #[error(
+        "{path} declares the audience source `{provider}` badly: a provider name is non-empty, has no whitespace, and appears once"
+    )]
+    Audience { path: PathBuf, provider: String },
     #[error("{path} includes the battery `{battery}` twice")]
     RepeatedBattery { path: PathBuf, battery: String },
     #[error("{path} is not valid TOML: {source}")]

--- a/appa-package/src/marketplace.rs
+++ b/appa-package/src/marketplace.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::digest::TreeDigest;
 use crate::manifest::{ManifestError, SCHEMA};
 use crate::names::{CredentialPrefix, Host, Namespace, PackageKind, PackageName, RelativePath};
-use crate::package::{Package, Role};
+use crate::package::{Battery, Package, Role};
 
 /// One listed package: where it lives and what its tree must digest to.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,6 +117,12 @@ pub enum OwnershipError {
         second: PackageName,
         namespace: Namespace,
     },
+    #[error("`{first}` and `{second}` both bind the audience source `{provider}`")]
+    SharedAudienceProvider {
+        first: PackageName,
+        second: PackageName,
+        provider: String,
+    },
     #[error("`{first}` reads every credential `{second}` reads, under `{prefix}`")]
     NestedCredentials {
         first: PackageName,
@@ -148,10 +154,10 @@ pub enum OwnershipError {
 /// this marketplace written for the plugin's host, so a first install never
 /// selects a package the catalog cannot supply.
 pub fn check_ownership(packages: &[Package]) -> Result<(), OwnershipError> {
-    let batteries: Vec<(&PackageName, &[Namespace])> = packages
+    let batteries: Vec<(&PackageName, &Battery)> = packages
         .iter()
         .filter_map(|package| match &package.role {
-            Role::Battery(battery) => Some((&package.name, battery.namespaces.as_slice())),
+            Role::Battery(battery) => Some((&package.name, battery)),
             Role::Plugin(_) => None,
         })
         .collect();
@@ -167,13 +173,28 @@ pub fn check_ownership(packages: &[Package]) -> Result<(), OwnershipError> {
     }
 
     let mut owner: BTreeMap<&Namespace, &PackageName> = BTreeMap::new();
-    for (name, namespaces) in &batteries {
-        for namespace in *namespaces {
+    for (name, battery) in &batteries {
+        for namespace in &battery.namespaces {
             if let Some(first) = owner.insert(namespace, name) {
                 return Err(OwnershipError::SharedNamespace {
                     first: first.clone(),
                     second: (*name).clone(),
                     namespace: namespace.clone(),
+                });
+            }
+        }
+    }
+
+    // An audience source answers who may read what, so one provider name has
+    // one battery answering for it — flat and exact, as a namespace is owned.
+    let mut source_owner: BTreeMap<&str, &PackageName> = BTreeMap::new();
+    for (name, battery) in &batteries {
+        for provider in &battery.audiences {
+            if let Some(first) = source_owner.insert(provider.as_str(), name) {
+                return Err(OwnershipError::SharedAudienceProvider {
+                    first: first.clone(),
+                    second: (*name).clone(),
+                    provider: provider.clone(),
                 });
             }
         }
@@ -335,15 +356,23 @@ mod tests {
     }
 
     fn battery(name: &str, namespaces: &[&str]) -> Package {
-        let namespaces = namespaces
-            .iter()
-            .map(|namespace| format!("\"{namespace}\""))
-            .collect::<Vec<_>>()
-            .join(", ");
+        battery_with_audiences(name, namespaces, &[])
+    }
+
+    fn battery_with_audiences(name: &str, namespaces: &[&str], audiences: &[&str]) -> Package {
+        let quoted = |items: &[&str]| {
+            items
+                .iter()
+                .map(|item| format!("\"{item}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let (namespaces, audiences) = (quoted(namespaces), quoted(audiences));
         Package::parse(
             &format!(
                 "schema = 1\nname = \"{name}\"\ndescription = \"a battery\"\n\n\
-                 [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nnamespaces = [{namespaces}]\n"
+                 [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nnamespaces = [{namespaces}]\n\
+                 audiences = [{audiences}]\n"
             ),
             Path::new("appa-package.toml"),
         )
@@ -413,6 +442,25 @@ mod tests {
         assert!(matches!(
             check_ownership(&[slack, battery("other", &["slack"])]),
             Err(OwnershipError::SharedNamespace { .. })
+        ));
+    }
+
+    /// An audience source answers who may read what, so one provider name has
+    /// one battery behind it — a flat, exact match, as a namespace is owned.
+    #[test]
+    fn two_batteries_may_not_bind_one_audience_source() {
+        let slack = battery_with_audiences("slack", &["claude_ai_Slack"], &["slack"]);
+
+        assert!(
+            check_ownership(&[
+                slack.clone(),
+                battery_with_audiences("github", &["github"], &["github"])
+            ])
+            .is_ok()
+        );
+        assert!(matches!(
+            check_ownership(&[slack, battery_with_audiences("other", &["other"], &["slack"])]),
+            Err(OwnershipError::SharedAudienceProvider { .. })
         ));
     }
 

--- a/appa-package/src/marketplace.rs
+++ b/appa-package/src/marketplace.rs
@@ -187,6 +187,7 @@ pub fn check_ownership(packages: &[Package]) -> Result<(), OwnershipError> {
 
     // An audience source answers who may read what, so one provider name has
     // one battery answering for it — flat and exact, as a namespace is owned.
+    // The providers a battery binds are read from its validated policy.
     let mut source_owner: BTreeMap<&str, &PackageName> = BTreeMap::new();
     for (name, battery) in &batteries {
         for provider in &battery.audiences {
@@ -359,24 +360,26 @@ mod tests {
         battery_with_audiences(name, namespaces, &[])
     }
 
+    /// A battery as `validate_package` returns it: the audience providers its policy binds
+    /// are read from the policy, not the manifest.
     fn battery_with_audiences(name: &str, namespaces: &[&str], audiences: &[&str]) -> Package {
-        let quoted = |items: &[&str]| {
-            items
-                .iter()
-                .map(|item| format!("\"{item}\""))
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        let (namespaces, audiences) = (quoted(namespaces), quoted(audiences));
-        Package::parse(
+        let namespaces = namespaces
+            .iter()
+            .map(|item| format!("\"{item}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut package = Package::parse(
             &format!(
                 "schema = 1\nname = \"{name}\"\ndescription = \"a battery\"\n\n\
-                 [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nnamespaces = [{namespaces}]\n\
-                 audiences = [{audiences}]\n"
+                 [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nnamespaces = [{namespaces}]\n"
             ),
             Path::new("appa-package.toml"),
         )
-        .expect("the manifest parses")
+        .expect("the manifest parses");
+        if let Role::Battery(battery) = &mut package.role {
+            battery.audiences = audiences.iter().map(|item| item.to_string()).collect();
+        }
+        package
     }
 
     fn plugin(name: &str) -> Package {

--- a/appa-package/src/package.rs
+++ b/appa-package/src/package.rs
@@ -78,6 +78,10 @@ pub struct Battery {
     /// product names each of them.
     pub namespaces: Vec<Namespace>,
     pub helpers: Vec<RelativePath>,
+    /// The audience source providers this battery binds under
+    /// `[externals.audience.<provider>]`. A marketplace gives each provider one
+    /// owner, as it does each namespace.
+    pub audiences: Vec<String>,
 }
 
 /// A plugin package, with installation fields specific to its host.
@@ -222,6 +226,8 @@ struct RawBattery {
     namespaces: Vec<String>,
     #[serde(default)]
     helpers: Vec<String>,
+    #[serde(default)]
+    audiences: Vec<String>,
 }
 
 impl RawBattery {
@@ -260,11 +266,22 @@ impl RawBattery {
         for helper in &self.helpers {
             helpers.push(relative(helper, "battery.helpers", path)?);
         }
+        let mut audiences: Vec<String> = Vec::new();
+        for provider in &self.audiences {
+            if provider.is_empty() || provider.chars().any(char::is_whitespace) || audiences.contains(provider) {
+                return Err(ManifestError::Audience {
+                    path: path.to_path_buf(),
+                    provider: provider.clone(),
+                });
+            }
+            audiences.push(provider.clone());
+        }
         Ok(Battery {
             policy,
             hosts,
             namespaces,
             helpers,
+            audiences,
         })
     }
 }
@@ -394,6 +411,7 @@ mod tests {
                 policy: RelativePath::parse("appa.toml").unwrap(),
                 hosts: vec![Host::ClaudeCode],
                 namespaces: vec![Namespace::parse("github").unwrap()],
+                audiences: vec![],
                 helpers: vec![RelativePath::parse("audience-source.py").unwrap()],
             }
         );
@@ -436,6 +454,22 @@ mod tests {
         ));
 
         assert!(matches!(refused, Err(ManifestError::RepeatedNamespace { .. })));
+    }
+
+    /// An audience provider list is read the same way: one name each, and a
+    /// name is a bare provider token.
+    #[test]
+    fn a_battery_declares_each_audience_source_once_by_a_bare_name() {
+        for audiences in ["[\"github\", \"github\"]", "[\"\"]", "[\"git hub\"]"] {
+            let refused = manifest(&BATTERY.replace(
+                "helpers = [\"audience-source.py\"]",
+                &format!("audiences = {audiences}\nhelpers = [\"audience-source.py\"]"),
+            ));
+            assert!(
+                matches!(refused, Err(ManifestError::Audience { .. })),
+                "accepted {audiences}"
+            );
+        }
     }
 
     #[test]

--- a/appa-package/src/package.rs
+++ b/appa-package/src/package.rs
@@ -78,9 +78,10 @@ pub struct Battery {
     /// product names each of them.
     pub namespaces: Vec<Namespace>,
     pub helpers: Vec<RelativePath>,
-    /// The audience source providers this battery binds under
-    /// `[externals.audience.<provider>]`. A marketplace gives each provider one
-    /// owner, as it does each namespace.
+    /// The audience source providers the policy binds under
+    /// `[externals.audience.<provider>]`, read from the policy by
+    /// `validate_package` and empty from the manifest alone. A marketplace
+    /// gives each provider one owner, as it does each namespace.
     pub audiences: Vec<String>,
 }
 
@@ -226,8 +227,6 @@ struct RawBattery {
     namespaces: Vec<String>,
     #[serde(default)]
     helpers: Vec<String>,
-    #[serde(default)]
-    audiences: Vec<String>,
 }
 
 impl RawBattery {
@@ -266,22 +265,12 @@ impl RawBattery {
         for helper in &self.helpers {
             helpers.push(relative(helper, "battery.helpers", path)?);
         }
-        let mut audiences: Vec<String> = Vec::new();
-        for provider in &self.audiences {
-            if provider.is_empty() || provider.chars().any(char::is_whitespace) || audiences.contains(provider) {
-                return Err(ManifestError::Audience {
-                    path: path.to_path_buf(),
-                    provider: provider.clone(),
-                });
-            }
-            audiences.push(provider.clone());
-        }
         Ok(Battery {
             policy,
             hosts,
             namespaces,
             helpers,
-            audiences,
+            audiences: Vec::new(),
         })
     }
 }
@@ -454,22 +443,6 @@ mod tests {
         ));
 
         assert!(matches!(refused, Err(ManifestError::RepeatedNamespace { .. })));
-    }
-
-    /// An audience provider list is read the same way: one name each, and a
-    /// name is a bare provider token.
-    #[test]
-    fn a_battery_declares_each_audience_source_once_by_a_bare_name() {
-        for audiences in ["[\"github\", \"github\"]", "[\"\"]", "[\"git hub\"]"] {
-            let refused = manifest(&BATTERY.replace(
-                "helpers = [\"audience-source.py\"]",
-                &format!("audiences = {audiences}\nhelpers = [\"audience-source.py\"]"),
-            ));
-            assert!(
-                matches!(refused, Err(ManifestError::Audience { .. })),
-                "accepted {audiences}"
-            );
-        }
     }
 
     #[test]

--- a/appa-package/src/validate.rs
+++ b/appa-package/src/validate.rs
@@ -1,7 +1,6 @@
 //! The one coarse operation over a package directory: parse its manifest and
 //! refuse everything a marketplace package may not be.
 
-use std::collections::BTreeSet;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -86,12 +85,6 @@ pub enum PackageError {
         contract: String,
         namespaces: String,
     },
-    #[error("{policy} binds the audience sources [{bound}] but the manifest declares [{declared}]")]
-    PolicyAudienceMismatch {
-        policy: PathBuf,
-        bound: String,
-        declared: String,
-    },
 }
 
 /// Read `<dir>/appa-package.toml` and refuse a package that is not
@@ -100,7 +93,7 @@ pub enum PackageError {
 /// own package.
 pub fn validate_package(dir: &Path) -> Result<Package, PackageError> {
     let manifest_path = dir.join(MANIFEST_FILE);
-    let package = Package::read(&manifest_path)?;
+    let mut package = Package::read(&manifest_path)?;
 
     // Symlinks and the source caps are refused by the same walk the digest
     // uses, so a package that validates can be digested and shipped.
@@ -110,13 +103,13 @@ pub fn validate_package(dir: &Path) -> Result<Package, PackageError> {
     })?;
 
     let contained = Contained::new(dir, &manifest_path);
-    match &package.role {
+    match &mut package.role {
         Role::Battery(battery) => {
             let policy = contained.resolve(&battery.policy, "battery.policy", EntryKind::File)?;
             for helper in &battery.helpers {
                 contained.resolve(helper, "battery.helpers", EntryKind::File)?;
             }
-            check_policy(&policy, &package.name, battery)?;
+            battery.audiences = check_policy(&policy, &package.name, battery)?;
         }
         Role::Plugin(plugin) => {
             contained.resolve(plugin.default_policy(), "plugin.default_policy", EntryKind::File)?;
@@ -193,9 +186,10 @@ const DECLARATION_ARRAYS: [&str; 4] = ["tool", "annotator", "authority", "saniti
 
 /// A battery is a fragment a deployment includes, not a deployment: it neither
 /// includes further files nor sets the root-only externals, it runs only its own
-/// declared helpers, it names only contracts in the namespaces it declares, and
-/// it binds exactly the audience sources it declares.
-fn check_policy(policy: &Path, name: &PackageName, battery: &Battery) -> Result<(), PackageError> {
+/// declared helpers, and it names only contracts in the namespaces it declares.
+/// Returns the audience source providers it binds, which a marketplace gives one
+/// owner each.
+fn check_policy(policy: &Path, name: &PackageName, battery: &Battery) -> Result<Vec<String>, PackageError> {
     let namespaces = &battery.namespaces;
     let helpers = &battery.helpers;
     let text = std::fs::read_to_string(policy).map_err(|source| PackageError::PolicyRead {
@@ -261,22 +255,12 @@ fn check_policy(policy: &Path, name: &PackageName, battery: &Battery) -> Result<
     if let Some(externals) = document.get("externals") {
         check_externals(policy, externals, name, helpers)?;
     }
-    // A marketplace gives each audience provider one owner by the manifest
-    // alone, so the manifest lists exactly the providers the policy binds.
-    let bound: BTreeSet<&str> = document
+    let audiences: Vec<String> = document
         .get("externals")
         .and_then(|externals| externals.get("audience"))
         .and_then(Value::as_table)
-        .map(|bindings| bindings.keys().map(String::as_str).collect())
+        .map(|bindings| bindings.keys().cloned().collect())
         .unwrap_or_default();
-    let declared: BTreeSet<&str> = battery.audiences.iter().map(String::as_str).collect();
-    if bound != declared {
-        return Err(PackageError::PolicyAudienceMismatch {
-            policy: policy.to_path_buf(),
-            bound: bound.into_iter().collect::<Vec<_>>().join(", "),
-            declared: declared.into_iter().collect::<Vec<_>>().join(", "),
-        });
-    }
 
     // A contract may carry an argument filter — `mcp/ns/send(channel:C1)` — so
     // the check is on the family and namespace it opens with, not on the whole
@@ -299,7 +283,7 @@ fn check_policy(policy: &Path, name: &PackageName, battery: &Battery) -> Result<
             });
         }
     }
-    Ok(())
+    Ok(audiences)
 }
 
 fn check_externals(
@@ -502,8 +486,7 @@ mod tests {
     use crate::package::Plugin;
 
     const BATTERY_MANIFEST: &str = "schema = 1\nname = \"github\"\ndescription = \"GitHub MCP server\"\n\n\
-         [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n\
-         audiences = [\"github\"]\n";
+         [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n";
 
     const BATTERY_POLICY: &str = "[policy]\nversion = 2\n\n\
          [[policy.tool]]\nname = \"mcp/github/get_me\"\ndelta = {}\n\n\
@@ -583,6 +566,8 @@ mod tests {
 
         assert_eq!(package.name.as_str(), "github");
         assert_eq!(package.battery().unwrap().hosts, vec![Host::ClaudeCode]);
+        // The providers the policy binds are read from it, for the marketplace's ownership check.
+        assert_eq!(package.battery().unwrap().audiences, vec!["github"]);
     }
 
     #[test]
@@ -739,31 +724,6 @@ mod tests {
                     Err(PackageError::PolicyForeignCredential { .. })
                 ),
                 "accepted token_env {var:?}"
-            );
-        }
-    }
-
-    /// The manifest lists exactly the audience sources the policy binds: a
-    /// marketplace assigns each provider one owner by reading manifests alone.
-    #[test]
-    fn a_battery_binds_exactly_the_audience_sources_it_declares() {
-        let bound_but_undeclared = battery(BATTERY_POLICY);
-        fs::write(
-            bound_but_undeclared.path().join("appa-package.toml"),
-            BATTERY_MANIFEST.replace("audiences = [\"github\"]\n", ""),
-        )
-        .unwrap();
-        let declared_but_unbound = battery(&BATTERY_POLICY[..BATTERY_POLICY.find("[externals").unwrap()]);
-        for (directory, case) in [
-            (bound_but_undeclared, "bound but undeclared"),
-            (declared_but_unbound, "declared but unbound"),
-        ] {
-            assert!(
-                matches!(
-                    validate_package(directory.path()),
-                    Err(PackageError::PolicyAudienceMismatch { .. })
-                ),
-                "accepted a battery {case}"
             );
         }
     }

--- a/appa-package/src/validate.rs
+++ b/appa-package/src/validate.rs
@@ -1,6 +1,7 @@
 //! The one coarse operation over a package directory: parse its manifest and
 //! refuse everything a marketplace package may not be.
 
+use std::collections::BTreeSet;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -9,7 +10,7 @@ use toml::Value;
 
 use crate::manifest::ManifestError;
 use crate::names::{CredentialPrefix, Namespace, PackageName, RelativePath};
-use crate::package::{MANIFEST_FILE, Package, Role};
+use crate::package::{Battery, MANIFEST_FILE, Package, Role};
 use crate::tree::{self, EntryKind, TreeDigestError};
 
 /// Why a directory is not a package. Every variant names the file it read.
@@ -85,6 +86,12 @@ pub enum PackageError {
         contract: String,
         namespaces: String,
     },
+    #[error("{policy} binds the audience sources [{bound}] but the manifest declares [{declared}]")]
+    PolicyAudienceMismatch {
+        policy: PathBuf,
+        bound: String,
+        declared: String,
+    },
 }
 
 /// Read `<dir>/appa-package.toml` and refuse a package that is not
@@ -109,7 +116,7 @@ pub fn validate_package(dir: &Path) -> Result<Package, PackageError> {
             for helper in &battery.helpers {
                 contained.resolve(helper, "battery.helpers", EntryKind::File)?;
             }
-            check_policy(&policy, &package.name, &battery.namespaces, &battery.helpers)?;
+            check_policy(&policy, &package.name, battery)?;
         }
         Role::Plugin(plugin) => {
             contained.resolve(plugin.default_policy(), "plugin.default_policy", EntryKind::File)?;
@@ -186,13 +193,11 @@ const DECLARATION_ARRAYS: [&str; 4] = ["tool", "annotator", "authority", "saniti
 
 /// A battery is a fragment a deployment includes, not a deployment: it neither
 /// includes further files nor sets the root-only externals, it runs only its own
-/// declared helpers, and it names only contracts in the namespaces it declares.
-fn check_policy(
-    policy: &Path,
-    name: &PackageName,
-    namespaces: &[Namespace],
-    helpers: &[RelativePath],
-) -> Result<(), PackageError> {
+/// declared helpers, it names only contracts in the namespaces it declares, and
+/// it binds exactly the audience sources it declares.
+fn check_policy(policy: &Path, name: &PackageName, battery: &Battery) -> Result<(), PackageError> {
+    let namespaces = &battery.namespaces;
+    let helpers = &battery.helpers;
     let text = std::fs::read_to_string(policy).map_err(|source| PackageError::PolicyRead {
         policy: policy.to_path_buf(),
         source,
@@ -255,6 +260,22 @@ fn check_policy(
 
     if let Some(externals) = document.get("externals") {
         check_externals(policy, externals, name, helpers)?;
+    }
+    // A marketplace gives each audience provider one owner by the manifest
+    // alone, so the manifest lists exactly the providers the policy binds.
+    let bound: BTreeSet<&str> = document
+        .get("externals")
+        .and_then(|externals| externals.get("audience"))
+        .and_then(Value::as_table)
+        .map(|bindings| bindings.keys().map(String::as_str).collect())
+        .unwrap_or_default();
+    let declared: BTreeSet<&str> = battery.audiences.iter().map(String::as_str).collect();
+    if bound != declared {
+        return Err(PackageError::PolicyAudienceMismatch {
+            policy: policy.to_path_buf(),
+            bound: bound.into_iter().collect::<Vec<_>>().join(", "),
+            declared: declared.into_iter().collect::<Vec<_>>().join(", "),
+        });
     }
 
     // A contract may carry an argument filter — `mcp/ns/send(channel:C1)` — so
@@ -354,6 +375,9 @@ fn check_binding(
                     prefix,
                 });
             }
+            // An audience source declares the selector templates it serves
+            // beside its binding; the loader parses the templates themselves.
+            "selectors" if external.starts_with("audience.") && declares_selectors(value) => {}
             _ => return Err(refuse()),
         }
     }
@@ -361,6 +385,44 @@ fn check_binding(
         true => Ok(()),
         false => Err(refuse()),
     }
+}
+
+/// A `selectors` array as the config loader reads it: a non-empty list of
+/// tables, each a `template` string with an optional `feeds` of `self` or
+/// `internal`, no template twice. A template is `/`-separated non-empty
+/// segments, each a literal or a `<variable>`, none starting with `$`.
+fn declares_selectors(value: &Value) -> bool {
+    let Some(entries) = value.as_array() else {
+        return false;
+    };
+    let mut seen = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let Some(table) = entry.as_table() else {
+            return false;
+        };
+        if !table.keys().all(|key| key == "template" || key == "feeds") {
+            return false;
+        }
+        let Some(template) = table.get("template").and_then(Value::as_str) else {
+            return false;
+        };
+        let well_formed = |segment: &str| {
+            let bracketed = segment.starts_with('<') || segment.ends_with('>');
+            !segment.is_empty()
+                && !segment.starts_with('$')
+                && (!bracketed || (segment.starts_with('<') && segment.ends_with('>') && segment.len() > 2))
+        };
+        if template.is_empty() || !template.split('/').all(well_formed) || seen.contains(&template) {
+            return false;
+        }
+        seen.push(template);
+        match table.get("feeds") {
+            None => {}
+            Some(feeds) if matches!(feeds.as_str(), Some("self" | "internal")) => {}
+            Some(_) => return false,
+        }
+    }
+    !seen.is_empty()
 }
 
 /// A battery ships the programs it runs, so an argv is exactly `python3` and one
@@ -440,11 +502,13 @@ mod tests {
     use crate::package::Plugin;
 
     const BATTERY_MANIFEST: &str = "schema = 1\nname = \"github\"\ndescription = \"GitHub MCP server\"\n\n\
-         [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n";
+         [battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n\
+         audiences = [\"github\"]\n";
 
     const BATTERY_POLICY: &str = "[policy]\nversion = 2\n\n\
          [[policy.tool]]\nname = \"mcp/github/get_me\"\ndelta = {}\n\n\
-         [externals.audience.github]\ncommand = [\"python3\", \"audience-source.py\"]\n";
+         [externals.audience.github]\ncommand = [\"python3\", \"audience-source.py\"]\n\
+         selectors = [{ template = \"viewer\", feeds = \"self\" }, { template = \"repo/<owner>/<repo>/collaborators\" }]\n";
 
     /// A battery package on disk, with the policy body the caller wants.
     fn battery(policy: &str) -> tempfile::TempDir {
@@ -677,6 +741,71 @@ mod tests {
                 "accepted token_env {var:?}"
             );
         }
+    }
+
+    /// The manifest lists exactly the audience sources the policy binds: a
+    /// marketplace assigns each provider one owner by reading manifests alone.
+    #[test]
+    fn a_battery_binds_exactly_the_audience_sources_it_declares() {
+        let bound_but_undeclared = battery(BATTERY_POLICY);
+        fs::write(
+            bound_but_undeclared.path().join("appa-package.toml"),
+            BATTERY_MANIFEST.replace("audiences = [\"github\"]\n", ""),
+        )
+        .unwrap();
+        let declared_but_unbound = battery(&BATTERY_POLICY[..BATTERY_POLICY.find("[externals").unwrap()]);
+        for (directory, case) in [
+            (bound_but_undeclared, "bound but undeclared"),
+            (declared_but_unbound, "declared but unbound"),
+        ] {
+            assert!(
+                matches!(
+                    validate_package(directory.path()),
+                    Err(PackageError::PolicyAudienceMismatch { .. })
+                ),
+                "accepted a battery {case}"
+            );
+        }
+    }
+
+    /// A `selectors` array is the one extra key an audience binding carries,
+    /// and each entry is a `template` string with an optional `feeds` string.
+    #[test]
+    fn an_audience_binding_declares_selectors_in_the_loaders_shape() {
+        let declared = "selectors = [{ template = \"viewer\", feeds = \"self\" }, { template = \"repo/<owner>/<repo>/collaborators\" }]\n";
+        for replacement in [
+            "selectors = [\"viewer\"]\n",
+            "selectors = []\n",
+            "selectors = [{ feeds = \"self\" }]\n",
+            "selectors = [{ template = \"viewer\", feeds = 1 }]\n",
+            "selectors = [{ template = \"viewer\", feeds = \"public\" }]\n",
+            "selectors = [{ template = \"viewer\", roster = \"x\" }]\n",
+            "selectors = [{ template = \"viewer\" }, { template = \"viewer\" }]\n",
+            "selectors = [{ template = \"\" }]\n",
+            "selectors = [{ template = \"repo//collaborators\" }]\n",
+            "selectors = [{ template = \"channel/$id\" }]\n",
+            "selectors = [{ template = \"channel/<id\" }]\n",
+            "selectors = \"viewer\"\n",
+        ] {
+            let directory = battery(&BATTERY_POLICY.replace(declared, replacement));
+            assert!(
+                matches!(
+                    validate_package(directory.path()),
+                    Err(PackageError::PolicyExternalCommand { .. })
+                ),
+                "accepted {replacement}"
+            );
+        }
+        let annotator = battery(&format!(
+            "{BATTERY_POLICY}\n[externals.annotators.github]\ncommand = [\"python3\", \"audience-source.py\"]\n{declared}"
+        ));
+        assert!(
+            matches!(
+                validate_package(annotator.path()),
+                Err(PackageError::PolicyExternalCommand { .. })
+            ),
+            "accepted selectors on an annotator binding"
+        );
     }
 
     /// A declared path names one kind of thing. Containment alone accepts a

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -6,9 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::Deserialize;
 use thiserror::Error;
 
-use appa_engine::audience::{
-    AudienceConfig, DeclaredTemplate, NamedAudience, SelectorSpec, SourceRegistration, TemplateRole,
-};
+use appa_engine::audience::{AudienceConfig, DeclaredTemplate, NamedAudience, SelectorSpec, SourceRegistration};
 use appa_engine::authority::{Authority, DeclaredTransition, Hint, Mandate, Sanitizer, SanitizerPoints, Scope};
 use appa_engine::contract::{
     AudienceRequirement, Delta, DeltaAudience, HistoryRequirement, LabelRequirements, RecipientSpec, Requires,
@@ -131,52 +129,72 @@ pub enum ConfigError {
     Registry(#[from] LoadError),
 }
 
-/// One `selectors` entry of an `[externals.audience.<provider>]` binding: the template the
-/// source serves, and what its collections may feed (`self`, `internal`, or nothing beyond
-/// named audiences and direct mentions). A template is `/`-separated non-empty segments,
-/// each a literal or a `<variable>`; a segment may not start with `$`, which marks an
-/// argument placeholder in a policy's spelling of a selector.
-pub fn parse_declared_template(
+/// One `selectors` entry of an `[externals.audience.<provider>]` binding, as written: the
+/// template the source serves and what its collections may feed.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SelectorDeclaration {
+    pub template: String,
+    pub feeds: Option<String>,
+}
+
+/// The templates one source declares under `selectors`. A template is `/`-separated
+/// non-empty segments, each a literal or a `<variable>`; a segment may not start with `$`,
+/// which marks an argument placeholder in a policy's spelling of a selector. `feeds` names
+/// what the collections may feed beyond named audiences and direct mentions: `self` or
+/// `internal`. A source declares at least one template and none twice.
+pub fn declare_templates(
     provider: &str,
-    template: &str,
-    feeds: Option<&str>,
-) -> Result<DeclaredTemplate, ConfigError> {
-    let refused = |reason: &str| ConfigError::BadSelectorDeclaration {
+    selectors: &[SelectorDeclaration],
+) -> Result<Vec<DeclaredTemplate>, ConfigError> {
+    let refused = |template: &str, reason: &str| ConfigError::BadSelectorDeclaration {
         provider: provider.to_string(),
         template: template.to_string(),
         reason: reason.to_string(),
     };
-    if template.is_empty() {
-        return Err(refused("is empty"));
+    let mut templates: Vec<DeclaredTemplate> = Vec::new();
+    for selector in selectors {
+        let template = selector.template.as_str();
+        if template.is_empty() {
+            return Err(refused(template, "is empty"));
+        }
+        for segment in template.split('/') {
+            if segment.is_empty() {
+                return Err(refused(template, "has an empty segment"));
+            }
+            if segment.starts_with('$') {
+                return Err(refused(
+                    template,
+                    "has a segment starting with `$`, which marks an argument placeholder",
+                ));
+            }
+            let bracketed = segment.starts_with('<') || segment.ends_with('>');
+            if bracketed && !(segment.starts_with('<') && segment.ends_with('>') && segment.len() > 2) {
+                return Err(refused(template, "has a malformed `<variable>` segment"));
+            }
+        }
+        let feeds = match &selector.feeds {
+            None => None,
+            Some(level) => Some(
+                ChainAudience::parse(level)
+                    .ok_or_else(|| refused(template, "`feeds` names a built-in audience: `self` or `internal`"))?,
+            ),
+        };
+        if templates.iter().any(|known| known.template.as_str() == template) {
+            return Err(refused(template, "is declared twice"));
+        }
+        templates.push(DeclaredTemplate::new(template, feeds));
     }
-    for segment in template.split('/') {
-        if segment.is_empty() {
-            return Err(refused("has an empty segment"));
-        }
-        if segment.starts_with('$') {
-            return Err(refused(
-                "has a segment starting with `$`, which marks an argument placeholder",
-            ));
-        }
-        let bracketed = segment.starts_with('<') || segment.ends_with('>');
-        if bracketed && !(segment.starts_with('<') && segment.ends_with('>') && segment.len() > 2) {
-            return Err(refused("has a malformed `<variable>` segment"));
-        }
+    if templates.is_empty() {
+        return Err(refused("", "`selectors` declares no template"));
     }
-    let feeds = match feeds {
-        None => None,
-        Some(level) => Some(
-            ChainAudience::parse(level)
-                .ok_or_else(|| refused("`feeds` names a built-in audience: `self` or `internal`"))?,
-        ),
-    };
-    Ok(DeclaredTemplate::new(template, feeds))
+    Ok(templates)
 }
 
 /// The audience sources a configuration document declares: every `[externals.audience.<p>]`
 /// entry with a `selectors` list, as [`Config::from_toml_str_routed`] takes them. An entry
-/// without `selectors` — a roster, or a root entry that only routes lookups — declares no
-/// source. The list's shape is validated here; how the entry answers is the deployment's.
+/// without `selectors` — a roster — declares no source. The list's shape is validated here;
+/// how the entry answers is the deployment's.
 pub fn declared_sources(document: &toml::Value) -> Result<Vec<SourceRegistration>, ConfigError> {
     let Some(entries) = document
         .get("externals")
@@ -190,59 +208,21 @@ pub fn declared_sources(document: &toml::Value) -> Result<Vec<SourceRegistration
         let Some(selectors) = entry.get("selectors") else {
             continue;
         };
-        let refused = |reason: &str| ConfigError::BadSelectorDeclaration {
-            provider: provider.clone(),
-            template: String::new(),
-            reason: reason.to_string(),
-        };
-        let selectors = selectors
-            .as_array()
-            .ok_or_else(|| refused("`selectors` is a list of `{ template, feeds }` tables"))?;
-        let mut templates: Vec<DeclaredTemplate> = Vec::new();
-        for selector in selectors {
-            let table = selector
-                .as_table()
-                .ok_or_else(|| refused("`selectors` is a list of `{ template, feeds }` tables"))?;
-            if let Some(key) = table.keys().find(|key| !matches!(key.as_str(), "template" | "feeds")) {
-                return Err(refused(&format!("a selector entry has no field `{key}`")));
-            }
-            let template = table
-                .get("template")
-                .and_then(toml::Value::as_str)
-                .ok_or_else(|| refused("a selector entry names its `template` as a string"))?;
-            let feeds = match table.get("feeds") {
-                None => None,
-                Some(feeds) => Some(feeds.as_str().ok_or_else(|| refused("`feeds` is a string"))?),
-            };
-            let declared = parse_declared_template(provider, template, feeds)?;
-            if templates.iter().any(|known| known.template == declared.template) {
-                return Err(ConfigError::BadSelectorDeclaration {
+        let selectors: Vec<SelectorDeclaration> =
+            selectors
+                .clone()
+                .try_into()
+                .map_err(|error: toml::de::Error| ConfigError::BadSelectorDeclaration {
                     provider: provider.clone(),
-                    template: template.to_string(),
-                    reason: "is declared twice".to_string(),
-                });
-            }
-            templates.push(declared);
-        }
-        if templates.is_empty() {
-            return Err(refused("`selectors` declares no template"));
-        }
+                    template: String::new(),
+                    reason: format!("`selectors` is a list of `{{ template, feeds }}` tables: {error}"),
+                })?;
         sources.push(SourceRegistration {
             provider: provider.clone(),
-            templates,
+            templates: declare_templates(provider, &selectors)?,
         });
     }
     Ok(sources)
-}
-
-/// Why a selector names nothing its provider serves: the templates the source declares, spelled
-/// out so the writer need not guess them.
-fn undeclared_selector(source: &SourceRegistration) -> String {
-    format!(
-        "names no collection {} serves; it serves {}",
-        source.provider,
-        source.template_spellings().join(", ")
-    )
 }
 
 /// The stock model transports an `[[annotator]]` may name on its declaration with `builtin`.
@@ -821,7 +801,7 @@ fn convert_audience(
     let mut providers: BTreeSet<String> = BTreeSet::new();
     let mut selectors = |list: &[String],
                          context: &str,
-                         admits: &dyn Fn(TemplateRole) -> bool,
+                         admits: fn(Option<ChainAudience>) -> bool,
                          expected: &str|
      -> Result<Vec<SelectorSpec>, ConfigError> {
         let refused = |selector: &str, reason: String| ConfigError::BadAudienceSource {
@@ -840,11 +820,26 @@ fn convert_audience(
                     context: context.to_string(),
                     provider: spec.provider.clone(),
                 })?;
-            let role = source
-                .template_of(&spec.selector)
-                .ok_or_else(|| refused(entry, undeclared_selector(source)))?
-                .role();
-            if !admits(role) {
+            let declared = source
+                .templates
+                .iter()
+                .find(|declared| declared.template.matches(&spec.selector))
+                .ok_or_else(|| {
+                    let served: Vec<&str> = source
+                        .templates
+                        .iter()
+                        .map(|declared| declared.template.as_str())
+                        .collect();
+                    refused(
+                        entry,
+                        format!(
+                            "names no collection {} serves; it serves {}",
+                            source.provider,
+                            served.join(", ")
+                        ),
+                    )
+                })?;
+            if !admits(declared.feeds) {
                 return Err(refused(entry, format!("cannot feed this audience — {expected}")));
             }
             providers.insert(spec.provider.clone());
@@ -857,7 +852,7 @@ fn convert_audience(
             config.self_from = selectors(
                 &from,
                 "[audience] self",
-                &|role| role == TemplateRole::Viewer,
+                |feeds| feeds == Some(ChainAudience::Self_),
                 "`self` reads only collections declared to feed it",
             )?;
         }
@@ -865,7 +860,7 @@ fn convert_audience(
             config.internal_from = selectors(
                 &from,
                 "[audience] internal",
-                &|role| role == TemplateRole::Members,
+                |feeds| feeds == Some(ChainAudience::Internal),
                 "`internal` reads only collections declared to feed it",
             )?;
         }
@@ -893,7 +888,7 @@ fn convert_audience(
             let from = selectors(
                 &group.from,
                 &format!("[audience.group.{name}]"),
-                &|role| role != TemplateRole::Viewer,
+                |feeds| feeds != Some(ChainAudience::Self_),
                 "a named audience reads collections, and `viewer` names the requesting principal",
             )?;
             config.groups.push(NamedAudience {
@@ -2130,48 +2125,45 @@ annotator = "acl"
     }
 
     #[test]
-    fn every_audience_argument_binding_needs_a_required_top_level_string_in_parameters() {
+    fn an_audience_argument_binding_implies_a_required_string_in_parameters() {
         use appa_engine::params::PropertyFault;
-        let refused = |policy: &str, expected: PropertyFault| match load(policy) {
-            Err(ConfigError::Registry(LoadError::AudienceBindingSchema { argument, fault, .. })) => {
-                assert_eq!(argument, "to");
-                assert_eq!(fault, expected, "policy:\n{policy}");
-            }
-            other => panic!("expected an audience-binding refusal with {expected:?}, got {other:?} for:\n{policy}"),
+        let policy = |parameters: &str| {
+            format!(
+                "version = 2\n[[tool]]\nname = \"send\"\n{parameters}\nrequires = {{ audience = {{ contains = [\"$to\"] }} }}\ndelta = {{}}\n"
+            )
         };
-        let bindings = ["requires = { audience = { contains = [\"$to\"] } }\ndelta = {}"];
-        let parameters = [
-            ("", PropertyFault::Undeclared),
-            (
-                "parameters = { type = \"object\", properties = { cc = { type = \"string\" } }, required = [\"cc\"] }",
-                PropertyFault::Undeclared,
-            ),
-            (
-                "parameters = { type = \"object\", properties = { envelope = { type = \"object\", properties = { to = { type = \"string\" } }, required = [\"to\"] } }, required = [\"envelope\"] }",
-                PropertyFault::Undeclared,
-            ),
-            (
-                "parameters = { type = \"object\", properties = { to = { type = \"string\" } } }",
-                PropertyFault::Optional,
-            ),
-            (
-                "parameters = { type = \"object\", properties = { to = { type = \"integer\" } }, required = [\"to\"] }",
-                PropertyFault::NotString,
-            ),
-        ];
-        let policy = |binding: &str, parameters: &str| {
-            format!("version = 2\n[[tool]]\nname = \"send\"\n{parameters}\n{binding}\n")
-        };
-        for binding in bindings {
-            for (parameters, expected) in parameters {
-                refused(&policy(binding, parameters), expected);
-            }
-            let ok = policy(
-                binding,
-                "parameters = { type = \"object\", properties = { to = { type = \"string\" }, body = { type = \"string\" } }, required = [\"to\"] }",
+        for parameters in [
+            "",
+            "parameters = { type = \"object\", properties = { cc = { type = \"string\" } }, required = [\"cc\"] }",
+            "parameters = { type = \"object\", properties = { envelope = { type = \"object\", properties = { to = { type = \"string\" } }, required = [\"to\"] } }, required = [\"envelope\"] }",
+            "parameters = { type = \"object\", properties = { to = { type = \"string\" } } }",
+            "parameters = { type = \"object\", properties = { to = { type = \"string\", enum = [\"ops\"] }, body = { type = \"string\" } }, required = [\"to\"] }",
+        ] {
+            let config = load(&policy(parameters)).unwrap_or_else(|error| panic!("must load: {error}\n{parameters}"));
+            let schema = config
+                .registry()
+                .variants(&ToolName::new("send"))
+                .next()
+                .and_then(ToolDeclaration::declared)
+                .expect("send is declared")
+                .parameters
+                .normalized();
+            assert_eq!(schema["properties"]["to"]["type"], "string", "{parameters}");
+            assert!(
+                schema["required"]
+                    .as_array()
+                    .is_some_and(|required| required.contains(&serde_json::json!("to"))),
+                "{parameters}"
             );
-            assert!(load(&ok).is_ok(), "must load:\n{ok}");
         }
+        let integer = policy(
+            "parameters = { type = \"object\", properties = { to = { type = \"integer\" } }, required = [\"to\"] }",
+        );
+        assert!(matches!(
+            load(&integer),
+            Err(ConfigError::Registry(LoadError::AudienceBindingSchema { argument, fault, .. }))
+                if argument == "to" && fault == PropertyFault::NotString
+        ));
         let static_recipients = "version = 2\n[[tool]]\nname = \"send\"\nrequires = { audience = { contains = [\"finance\"] } }\ndelta = {}\n";
         assert!(load(static_recipients).is_ok());
     }
@@ -2536,7 +2528,8 @@ confined_results = ["read", "send"]
             [AudienceRequirement::Includes(RecipientSpec::Selector(placeholder))]
         );
 
-        let optional = r#"{ type = "object", properties = { channel_id = { type = "string" } } }"#;
+        let integer =
+            r#"{ type = "object", properties = { channel_id = { type = "integer" } }, required = ["channel_id"] }"#;
         for (case, policy, expected) in [
             (
                 "beside another entry",
@@ -2563,8 +2556,8 @@ confined_results = ["read", "send"]
                 "spelling",
             ),
             (
-                "an argument the schema does not require",
-                tool(optional, delta),
+                "an argument the schema declares as another type",
+                tool(integer, delta),
                 "schema",
             ),
             (
@@ -2616,7 +2609,7 @@ confined_results = ["read", "send"]
     }
 
     /// A mandate placeholder is read per call: it admits exactly the collection the routed
-    /// call's arguments spell, so every routed tool must carry the argument, and the wildcard —
+    /// call's arguments spell, so every routed tool carries the argument as a required string, and the wildcard —
     /// whose calls the policy does not describe — cannot route through it.
     #[test]
     fn an_annotator_mandate_placeholder_binds_to_each_routed_tools_arguments() {
@@ -2645,11 +2638,15 @@ confined_results = ["read", "send"]
         assert!(config.registry().audience().providers().contains("slack"));
 
         let unbound = "[[tool]]\nname = \"read_channel\"\nannotator = \"acl\"\n";
-        assert!(matches!(
-            load(&policy(unbound)),
-            Err(ConfigError::Registry(LoadError::AudienceBindingSchema { context, argument, .. }))
-                if context == "tool read_channel annotator acl mandate" && argument == "channel_id"
-        ));
+        let implied = load(&policy(unbound)).expect("the mandate's argument implies its schema");
+        let Some(ToolDeclaration::Annotated { parameters, .. }) =
+            implied.registry().variants(&ToolName::new("read_channel")).next()
+        else {
+            panic!("read_channel is Annotator-routed");
+        };
+        let schema = parameters.normalized();
+        assert_eq!(schema["properties"]["channel_id"]["type"], "string");
+        assert_eq!(schema["required"], serde_json::json!(["channel_id"]));
         let wildcard = "[[tool]]\nname = \"*\"\nannotator = \"acl\"\n";
         assert!(matches!(
             load(&policy(wildcard)),

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 use thiserror::Error;
 
-use appa_engine::audience::{AudienceConfig, NamedAudience, SelectorSpec, SelectorTemplate, SourceRegistration};
+use appa_engine::audience::{
+    AudienceConfig, DeclaredTemplate, NamedAudience, SelectorSpec, SourceRegistration, TemplateRole,
+};
 use appa_engine::authority::{Authority, DeclaredTransition, Hint, Mandate, Sanitizer, SanitizerPoints, Scope};
 use appa_engine::contract::{
     AudienceRequirement, Delta, HistoryRequirement, LabelRequirements, RecipientSpec, Requires, ToolAnnotation,
@@ -115,74 +117,132 @@ pub enum ConfigError {
     },
     #[error("bad named audience {name:?}: {reason}")]
     BadNamedAudience { name: String, reason: String },
+    #[error(
+        "audience source {provider:?} in {context} declares no selectors: bind it under [externals.audience.{provider}] with `selectors`"
+    )]
+    UndeclaredProvider { context: String, provider: String },
+    #[error("bad selector declaration for audience source {provider:?}: {template:?} {reason}")]
+    BadSelectorDeclaration {
+        provider: String,
+        template: String,
+        reason: String,
+    },
     #[error("registry rejected: {0}")]
     Registry(#[from] LoadError),
 }
 
-/// The audience-source catalog the stock batteries register: one provider per battery, its
-/// selector templates fixed by this build. A policy's `from` selectors pick collections out
-/// of it, and only providers the policy references enter its identity. `viewer` names the
-/// requesting principal and feeds `self`; the members collections can feed `internal`; the
-/// named collections (and members collections) can feed `[audience.group.<name>]`.
-pub fn stock_audience_sources() -> Vec<SourceRegistration> {
-    let source = |provider: &str, templates: &[&str]| SourceRegistration {
+/// One `selectors` entry of an `[externals.audience.<provider>]` binding: the template the
+/// source serves, and what its collections may feed (`self`, `internal`, or nothing beyond
+/// named audiences and direct mentions). A template is `/`-separated non-empty segments,
+/// each a literal or a `<variable>`; a segment may not start with `$`, which marks an
+/// argument placeholder in a policy's spelling of a selector.
+pub fn parse_declared_template(
+    provider: &str,
+    template: &str,
+    feeds: Option<&str>,
+) -> Result<DeclaredTemplate, ConfigError> {
+    let refused = |reason: &str| ConfigError::BadSelectorDeclaration {
         provider: provider.to_string(),
-        templates: templates
-            .iter()
-            .map(|template| SelectorTemplate::new(*template))
-            .collect(),
+        template: template.to_string(),
+        reason: reason.to_string(),
     };
-    vec![
-        source("google-workspace", &["viewer", "full-members", "group/<group-address>"]),
-        source("slack", &["viewer", "full-members", "user-group/<handle>"]),
-        source("github", &["viewer", "org/<org>/members", "org/<org>/team/<team>"]),
-    ]
-}
-
-/// What one catalog collection may feed: `self` (the requesting principal), `internal`
-/// (a provider's full membership, or one explicitly selected GitHub organization), or a
-/// named audience.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CollectionRole {
-    Viewer,
-    Members,
-    Named,
-}
-
-fn collection_role(catalog: &[SourceRegistration], spec: &SelectorSpec) -> Option<CollectionRole> {
-    let template = catalog
-        .iter()
-        .find(|source| source.provider == spec.provider)?
-        .templates
-        .iter()
-        .find(|template| template.matches(&spec.selector))?;
-    Some(match template.as_str() {
-        "viewer" => CollectionRole::Viewer,
-        "full-members" | "org/<org>/members" => CollectionRole::Members,
-        _ => CollectionRole::Named,
-    })
-}
-
-/// Why a selector names nothing: the provider is not stock, or the selector matches none of
-/// the provider's templates — each spelled out, so the writer need not guess the catalog.
-fn uncatalogued(catalog: &[SourceRegistration], spec: &SelectorSpec) -> String {
-    match catalog.iter().find(|source| source.provider == spec.provider) {
-        Some(source) => {
-            let templates: Vec<&str> = source.templates.iter().map(SelectorTemplate::as_str).collect();
-            format!(
-                "names no collection {} serves; it serves {}",
-                spec.provider,
-                templates.join(", ")
-            )
+    if template.is_empty() {
+        return Err(refused("is empty"));
+    }
+    for segment in template.split('/') {
+        if segment.is_empty() {
+            return Err(refused("has an empty segment"));
         }
-        None => {
-            let providers: Vec<&str> = catalog.iter().map(|source| source.provider.as_str()).collect();
-            format!(
-                "names no stock provider; the stock providers are {}",
-                providers.join(", ")
-            )
+        if segment.starts_with('$') {
+            return Err(refused(
+                "has a segment starting with `$`, which marks an argument placeholder",
+            ));
+        }
+        let bracketed = segment.starts_with('<') || segment.ends_with('>');
+        if bracketed && !(segment.starts_with('<') && segment.ends_with('>') && segment.len() > 2) {
+            return Err(refused("has a malformed `<variable>` segment"));
         }
     }
+    let feeds = match feeds {
+        None => None,
+        Some(level) => Some(
+            ChainAudience::parse(level)
+                .ok_or_else(|| refused("`feeds` names a built-in audience: `self` or `internal`"))?,
+        ),
+    };
+    Ok(DeclaredTemplate::new(template, feeds))
+}
+
+/// The audience sources a configuration document declares: every `[externals.audience.<p>]`
+/// entry with a `selectors` list, as [`Config::from_toml_str_routed`] takes them. An entry
+/// without `selectors` — a roster, or a root entry that only routes lookups — declares no
+/// source. The list's shape is validated here; how the entry answers is the deployment's.
+pub fn declared_sources(document: &toml::Value) -> Result<Vec<SourceRegistration>, ConfigError> {
+    let Some(entries) = document
+        .get("externals")
+        .and_then(|externals| externals.get("audience"))
+        .and_then(toml::Value::as_table)
+    else {
+        return Ok(Vec::new());
+    };
+    let mut sources = Vec::new();
+    for (provider, entry) in entries {
+        let Some(selectors) = entry.get("selectors") else {
+            continue;
+        };
+        let refused = |reason: &str| ConfigError::BadSelectorDeclaration {
+            provider: provider.clone(),
+            template: String::new(),
+            reason: reason.to_string(),
+        };
+        let selectors = selectors
+            .as_array()
+            .ok_or_else(|| refused("`selectors` is a list of `{ template, feeds }` tables"))?;
+        let mut templates: Vec<DeclaredTemplate> = Vec::new();
+        for selector in selectors {
+            let table = selector
+                .as_table()
+                .ok_or_else(|| refused("`selectors` is a list of `{ template, feeds }` tables"))?;
+            if let Some(key) = table.keys().find(|key| !matches!(key.as_str(), "template" | "feeds")) {
+                return Err(refused(&format!("a selector entry has no field `{key}`")));
+            }
+            let template = table
+                .get("template")
+                .and_then(toml::Value::as_str)
+                .ok_or_else(|| refused("a selector entry names its `template` as a string"))?;
+            let feeds = match table.get("feeds") {
+                None => None,
+                Some(feeds) => Some(feeds.as_str().ok_or_else(|| refused("`feeds` is a string"))?),
+            };
+            let declared = parse_declared_template(provider, template, feeds)?;
+            if templates.iter().any(|known| known.template == declared.template) {
+                return Err(ConfigError::BadSelectorDeclaration {
+                    provider: provider.clone(),
+                    template: template.to_string(),
+                    reason: "is declared twice".to_string(),
+                });
+            }
+            templates.push(declared);
+        }
+        if templates.is_empty() {
+            return Err(refused("`selectors` declares no template"));
+        }
+        sources.push(SourceRegistration {
+            provider: provider.clone(),
+            templates,
+        });
+    }
+    Ok(sources)
+}
+
+/// Why a selector names nothing its provider serves: the templates the source declares, spelled
+/// out so the writer need not guess them.
+fn undeclared_selector(source: &SourceRegistration) -> String {
+    format!(
+        "names no collection {} serves; it serves {}",
+        source.provider,
+        source.template_spellings().join(", ")
+    )
 }
 
 /// The stock model transports an `[[annotator]]` may name on its declaration with `builtin`.
@@ -286,15 +346,21 @@ impl Config {
     /// Parse the policy TOML. HTTP and command bindings remain deployment-owned; a stock
     /// annotator builtin is selected on the declaration that carries it.
     pub fn from_toml_str(s: &str) -> Result<Config, ConfigError> {
-        Config::from_toml_str_routed(s, BTreeMap::new())
+        Config::from_toml_str_routed(s, BTreeMap::new(), Vec::new())
     }
 
-    /// [`Config::from_toml_str`] under the deployment's lookup routing: `lookup_targets`
-    /// names, per audience provider whose member lookups the deployment redirects, the entry
-    /// that answers them, so every qualified member such a provider reports is looked up
-    /// there before it seats. Routing is the deployment's, not the policy's, and stays out
-    /// of the policy identity.
-    pub fn from_toml_str_routed(s: &str, lookup_targets: BTreeMap<String, String>) -> Result<Config, ConfigError> {
+    /// [`Config::from_toml_str`] under the deployment's audience bindings. `sources` are the
+    /// selector templates each bound provider declares; a `[audience]` selector must match
+    /// one, and only providers a selector references enter the policy identity.
+    /// `lookup_targets` names, per audience provider whose member lookups the deployment
+    /// redirects, the entry that answers them, so every qualified member such a provider
+    /// reports is looked up there before it seats. Routing is the deployment's, not the
+    /// policy's, and stays out of the policy identity.
+    pub fn from_toml_str_routed(
+        s: &str,
+        lookup_targets: BTreeMap<String, String>,
+        sources: Vec<SourceRegistration>,
+    ) -> Result<Config, ConfigError> {
         let raw: RawConfig = toml::from_str(s)?;
         if raw.version != SUPPORTED_VERSION {
             return Err(ConfigError::UnsupportedVersion { found: raw.version });
@@ -384,7 +450,7 @@ impl Config {
             });
             annotators.insert(name, AnnotatorBinding { hint, builtin, inputs });
         }
-        let mut audience = convert_audience(raw.audience)?;
+        let mut audience = convert_audience(raw.audience, sources)?;
         audience.lookup_targets = lookup_targets;
         let mut tools = Vec::new();
         let mut qualified: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
@@ -735,13 +801,15 @@ struct RawAudienceGroup {
 /// Compile `[audience]` into the engine's audience configuration. Each `from` selector must
 /// name a stock collection whose role fits its level; a provider enters the registered
 /// sources — and so the policy identity — exactly when some selector picks from it.
-fn convert_audience(audience: Option<RawAudience>) -> Result<AudienceConfig, ConfigError> {
+fn convert_audience(
+    audience: Option<RawAudience>,
+    sources: Vec<SourceRegistration>,
+) -> Result<AudienceConfig, ConfigError> {
     let mut config = AudienceConfig::default();
-    let catalog = stock_audience_sources();
     let mut providers: Vec<String> = Vec::new();
     let mut selectors = |list: &[String],
                          context: &str,
-                         admits: &dyn Fn(CollectionRole) -> bool,
+                         admits: &dyn Fn(TemplateRole) -> bool,
                          expected: &str|
      -> Result<Vec<SelectorSpec>, ConfigError> {
         let refused = |selector: &str, reason: String| ConfigError::BadAudienceSource {
@@ -753,7 +821,17 @@ fn convert_audience(audience: Option<RawAudience>) -> Result<AudienceConfig, Con
         for entry in list {
             let spec = SelectorSpec::parse(entry)
                 .ok_or_else(|| refused(entry, "is not a `<provider>:<selector>` source".to_string()))?;
-            let role = collection_role(&catalog, &spec).ok_or_else(|| refused(entry, uncatalogued(&catalog, &spec)))?;
+            let source = sources
+                .iter()
+                .find(|source| source.provider == spec.provider)
+                .ok_or_else(|| ConfigError::UndeclaredProvider {
+                    context: context.to_string(),
+                    provider: spec.provider.clone(),
+                })?;
+            let role = source
+                .template_of(&spec.selector)
+                .ok_or_else(|| refused(entry, undeclared_selector(source)))?
+                .role();
             if !admits(role) {
                 return Err(refused(entry, format!("cannot feed this audience — {expected}")));
             }
@@ -769,16 +847,16 @@ fn convert_audience(audience: Option<RawAudience>) -> Result<AudienceConfig, Con
             config.self_from = selectors(
                 &from,
                 "[audience] self",
-                &|role| role == CollectionRole::Viewer,
-                "`self` reads only each provider's `viewer`",
+                &|role| role == TemplateRole::Viewer,
+                "`self` reads only collections declared to feed it",
             )?;
         }
         if let Some(from) = audience.internal {
             config.internal_from = selectors(
                 &from,
                 "[audience] internal",
-                &|role| role == CollectionRole::Members,
-                "`internal` reads only full-membership collections and explicitly selected GitHub organizations",
+                &|role| role == TemplateRole::Members,
+                "`internal` reads only collections declared to feed it",
             )?;
         }
         for (name, group) in audience.group {
@@ -805,7 +883,7 @@ fn convert_audience(audience: Option<RawAudience>) -> Result<AudienceConfig, Con
             let from = selectors(
                 &group.from,
                 &format!("[audience.group.{name}]"),
-                &|role| role != CollectionRole::Viewer,
+                &|role| role != TemplateRole::Viewer,
                 "a named audience reads collections, and `viewer` names the requesting principal",
             )?;
             config.groups.push(NamedAudience {
@@ -815,7 +893,7 @@ fn convert_audience(audience: Option<RawAudience>) -> Result<AudienceConfig, Con
             });
         }
     }
-    config.sources = catalog
+    config.sources = sources
         .into_iter()
         .filter(|source| providers.contains(&source.provider))
         .collect();
@@ -1275,7 +1353,47 @@ fn parse_points(tokens: &[String], name: &str) -> Result<SanitizerPoints, Config
 #[cfg(test)]
 mod tests {
     use super::*;
-    use appa_engine::label::{Clause, GroupRef};
+    use appa_engine::audience::DeclaredTemplate;
+    use appa_engine::label::{ChainAudience, Clause, GroupRef};
+
+    /// The sources the shipped batteries declare, as a deployment's bindings would supply them.
+    fn declared_sources() -> Vec<SourceRegistration> {
+        let source = |provider: &str, templates: Vec<DeclaredTemplate>| SourceRegistration {
+            provider: provider.to_string(),
+            templates,
+        };
+        vec![
+            source(
+                "google-workspace",
+                vec![
+                    DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+                    DeclaredTemplate::new("full-members", Some(ChainAudience::Internal)),
+                    DeclaredTemplate::named("group/<group-address>"),
+                ],
+            ),
+            source(
+                "slack",
+                vec![
+                    DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+                    DeclaredTemplate::new("full-members", Some(ChainAudience::Internal)),
+                    DeclaredTemplate::named("user-group/<handle>"),
+                ],
+            ),
+            source(
+                "github",
+                vec![
+                    DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+                    DeclaredTemplate::new("org/<org>/members", Some(ChainAudience::Internal)),
+                    DeclaredTemplate::named("org/<org>/team/<team>"),
+                ],
+            ),
+        ]
+    }
+
+    /// A policy loaded under the shipped batteries' declared sources.
+    fn load(policy: &str) -> Result<Config, ConfigError> {
+        Config::from_toml_str_routed(policy, BTreeMap::new(), declared_sources())
+    }
 
     const DECLARATIONS: &str = r#"
 version = 2
@@ -1313,7 +1431,7 @@ confined_results = ["lookup"]
 
     #[test]
     fn declaration_only_policy_builds_the_engine_registry() {
-        let config = Config::from_toml_str(DECLARATIONS).expect("the policy compiles");
+        let config = load(DECLARATIONS).expect("the policy compiles");
         assert!(config.registry().variants(&ToolName::new("lookup")).next().is_some());
         assert!(config.registry().variants(&ToolName::new("send")).next().is_some());
         assert!(config.registry().authority(&AuthorityName::new("approver")).is_some());
@@ -1325,8 +1443,8 @@ confined_results = ["lookup"]
     fn server_qualification_preserves_the_contract_and_deployment_references() {
         let qualified = DECLARATIONS.replace("name = \"lookup\"", "name = \"lookup\"\nserver = \"demo\"");
         let canonical = DECLARATIONS.replace("\"lookup\"", "\"mcp/demo/lookup\"");
-        let qualified = Config::from_toml_str(&qualified).unwrap();
-        let canonical = Config::from_toml_str(&canonical).unwrap();
+        let qualified = load(&qualified).unwrap();
+        let canonical = load(&canonical).unwrap();
         assert_eq!(qualified.engine().identity(), canonical.engine().identity());
         assert!(
             qualified
@@ -1349,8 +1467,8 @@ confined_results = ["lookup"]
             .replace("read(path:private*)", "mcp/demo/read(path:private*)")
             .replace("server = 'demo'\n", "");
         assert_eq!(
-            Config::from_toml_str(native).unwrap().engine().identity(),
-            Config::from_toml_str(&canonical).unwrap().engine().identity()
+            load(native).unwrap().engine().identity(),
+            load(&canonical).unwrap().engine().identity()
         );
     }
 
@@ -1365,7 +1483,7 @@ confined_results = ["lookup"]
         ] {
             let policy = format!("version = 2\n[[tool]]\nname = '{name}'\nserver = '{server}'\n");
             assert!(
-                matches!(Config::from_toml_str(&policy), Err(ConfigError::ToolServer { .. })),
+                matches!(load(&policy), Err(ConfigError::ToolServer { .. })),
                 "{name:?} / {server:?}"
             );
         }
@@ -1394,7 +1512,7 @@ confined_results = ["lookup"]
         for (kind, policy) in cases {
             assert!(
                 matches!(
-                    Config::from_toml_str(policy),
+                    load(policy),
                     Err(ConfigError::ForbiddenInlineBinding { kind: found, .. }) if found == kind
                 ),
                 "{kind} inline binding was accepted"
@@ -1409,7 +1527,7 @@ confined_results = ["lookup"]
              implementation = { url = \"https://attest.invalid\" }\n\
              [sanitizer.permits]\ntrust = { from = \"suspicious\", to = \"trusted\" }\n";
         assert!(matches!(
-            Config::from_toml_str(policy),
+            load(policy),
             Err(ConfigError::ForbiddenInlineBinding { kind: "sanitizer", name }) if name == "attest-schema"
         ));
     }
@@ -1425,7 +1543,7 @@ confined_results = ["lookup"]
                  [sanitizer.permits]\n{mandate}\n"
             )
         };
-        let config = Config::from_toml_str(&policy("audience = { from = [\"insider\"], to = [\"partner\"] }"))
+        let config = load(&policy("audience = { from = [\"insider\"], to = [\"partner\"] }"))
             .expect("an input substitution compiles");
         let sanitizer = config
             .registry()
@@ -1436,11 +1554,11 @@ confined_results = ["lookup"]
         assert!(!sanitizer.scope.covers(&[TagName::new("inbound")]));
 
         assert!(matches!(
-            Config::from_toml_str(&policy("trust = { from = \"suspicious\", to = \"trusted\" }")),
+            load(&policy("trust = { from = \"suspicious\", to = \"trusted\" }")),
             Err(ConfigError::Registry(LoadError::InputSanitizerTrust(name))) if name == "redact"
         ));
         assert!(matches!(
-            Config::from_toml_str(
+            load(
                 &policy("audience = { from = [\"insider\"], to = [\"partner\"] }")
                     .replace("on = [\"tool_input\"]", "on = []")
             ),
@@ -1455,7 +1573,7 @@ confined_results = ["lookup"]
              internal = [\"slack:full-members\", \"github:org/corp/members\"]\n\
              [audience.group.finance]\nwithin = \"internal\"\n\
              from = [\"google-workspace:group/finance@corp.com\"]\n";
-        let config = Config::from_toml_str(policy).expect("the audience tables load");
+        let config = load(policy).expect("the audience tables load");
         let audience = &config.registry_config().audience;
         let spec = |spelled: &str| SelectorSpec::parse(spelled).expect("a stock selector parses");
         assert_eq!(
@@ -1476,7 +1594,7 @@ confined_results = ["lookup"]
                 from: vec![spec("google-workspace:group/finance@corp.com")],
             }]
         );
-        let bare = Config::from_toml_str("version = 2\n").unwrap();
+        let bare = load("version = 2\n").unwrap();
         assert_eq!(bare.registry_config().audience, AudienceConfig::default());
     }
 
@@ -1511,7 +1629,7 @@ confined_results = ["lookup"]
             (
                 "an unknown provider",
                 "[audience]\nself = [\"msft:viewer\"]\n",
-                "source",
+                "provider",
             ),
             (
                 "a bare word is no selector",
@@ -1534,9 +1652,10 @@ confined_results = ["lookup"]
                 "group",
             ),
         ] {
-            let refusal = Config::from_toml_str(&format!("version = 2\n{table}")).expect_err(case);
+            let refusal = load(&format!("version = 2\n{table}")).expect_err(case);
             let fits = match expected {
                 "source" => matches!(refusal, ConfigError::BadAudienceSource { .. }),
+                "provider" => matches!(refusal, ConfigError::UndeclaredProvider { .. }),
                 _ => matches!(refusal, ConfigError::BadNamedAudience { .. }),
             };
             assert!(fits, "{case}: got {refusal:?}");
@@ -1552,7 +1671,7 @@ confined_results = ["lookup"]
             )
         };
         for expected in AnnotatorBuiltin::ALL {
-            let config = Config::from_toml_str(&policy(expected.wire_name())).expect("the stock builtin loads");
+            let config = load(&policy(expected.wire_name())).expect("the stock builtin loads");
             let annotators: Vec<_> = config
                 .annotators()
                 .map(|(name, binding)| (name.as_str(), binding.builtin))
@@ -1565,7 +1684,7 @@ confined_results = ["lookup"]
         }
 
         assert!(matches!(
-            Config::from_toml_str(&policy("no-such")),
+            load(&policy("no-such")),
             Err(ConfigError::UnknownAnnotatorBuiltin { name, builtin }) if name == "classify" && builtin == "no-such"
         ));
     }
@@ -1573,7 +1692,7 @@ confined_results = ["lookup"]
     #[test]
     fn a_tool_requires_a_registered_annotator() {
         assert!(matches!(
-            Config::from_toml_str("version = 2\n[[tool]]\nname = \"lookup\"\nannotator = \"classifier\"\n"),
+            load("version = 2\n[[tool]]\nname = \"lookup\"\nannotator = \"classifier\"\n"),
             Err(ConfigError::Registry(LoadError::UnknownAnnotator { tool, annotator }))
                 if tool == "lookup" && annotator == "classifier"
         ));
@@ -1582,7 +1701,7 @@ confined_results = ["lookup"]
     #[test]
     fn a_duplicate_annotator_is_refused() {
         assert!(matches!(
-            Config::from_toml_str("version = 2\n[[annotator]]\nname = \"a\"\n[[annotator]]\nname = \"a\"\n"),
+            load("version = 2\n[[annotator]]\nname = \"a\"\n[[annotator]]\nname = \"a\"\n"),
             Err(ConfigError::Registry(LoadError::DuplicateAnnotator(name))) if name == "a"
         ));
     }
@@ -1595,9 +1714,9 @@ confined_results = ["lookup"]
                  [[tool]]\nname = \"send\"\nannotator = \"acl\"\n{statics}\n"
             )
         };
-        assert!(Config::from_toml_str(&with("")).is_ok());
+        assert!(load(&with("")).is_ok());
         // Metadata is not a recipe: it stays legal beside `annotator`.
-        assert!(Config::from_toml_str(&with("description = \"Sends one message.\"\ntags = [\"outbound\"]")).is_ok());
+        assert!(load(&with("description = \"Sends one message.\"\ntags = [\"outbound\"]")).is_ok());
         for (field, statics) in [
             ("delta", "delta = {}"),
             ("requires", "requires = { trust = \"trusted\" }"),
@@ -1605,7 +1724,7 @@ confined_results = ["lookup"]
         ] {
             assert!(
                 matches!(
-                    Config::from_toml_str(&with(statics)),
+                    load(&with(statics)),
                     Err(ConfigError::AnnotatorWithStatics { tool, annotator, field: found })
                         if tool == "send" && annotator == "acl" && found == field
                 ),
@@ -1618,7 +1737,7 @@ confined_results = ["lookup"]
     fn the_wildcard_tool_loads_with_an_annotator_and_nothing_else() {
         let policy = "version = 2\n[[annotator]]\nname = \"any\"\n\
                       [[tool]]\nname = \"*\"\nannotator = \"any\"\n";
-        let config = Config::from_toml_str(policy).expect("the wildcard loads");
+        let config = load(policy).expect("the wildcard loads");
         assert_eq!(
             config.registry().classify(&appa_engine::value::ToolName::new("ghost")),
             Some(appa_engine::registry::ToolKind::Wildcard)
@@ -1637,7 +1756,7 @@ confined_results = ["lookup"]
                       [[tool]]\nname = \"*\"\nannotator = \"any\"\n\
                       [[tool]]\nname = \"*\"\nannotator = \"any\"\n";
         assert!(matches!(
-            Config::from_toml_str(policy),
+            load(policy),
             Err(ConfigError::Registry(LoadError::DuplicateWildcard))
         ));
     }
@@ -1647,10 +1766,7 @@ confined_results = ["lookup"]
         for statics in ["", "delta = {}"] {
             let policy = format!("version = 2\n[[tool]]\nname = \"*\"\n{statics}\n");
             assert!(
-                matches!(
-                    Config::from_toml_str(&policy),
-                    Err(ConfigError::Registry(LoadError::WildcardStatic))
-                ),
+                matches!(load(&policy), Err(ConfigError::Registry(LoadError::WildcardStatic))),
                 "a wildcard without an annotator (statics: {statics:?}) must be refused"
             );
         }
@@ -1668,20 +1784,14 @@ confined_results = ["lookup"]
                  [[tool]]\nname = \"*\"\nannotator = \"any\"\n{metadata}\n"
             );
             assert!(
-                matches!(
-                    Config::from_toml_str(&policy),
-                    Err(ConfigError::Registry(LoadError::WildcardMetadata))
-                ),
+                matches!(load(&policy), Err(ConfigError::Registry(LoadError::WildcardMetadata))),
                 "wildcard metadata {metadata:?} must be refused"
             );
         }
         let selected = "version = 2\n[[annotator]]\nname = \"any\"\n\
                         [[tool]]\nname = \"*(path:*)\"\nannotator = \"any\"\n";
         assert!(
-            matches!(
-                Config::from_toml_str(selected),
-                Err(ConfigError::Registry(LoadError::WildcardMetadata))
-            ),
+            matches!(load(selected), Err(ConfigError::Registry(LoadError::WildcardMetadata))),
             "a wildcard with an argument selector must be refused"
         );
     }
@@ -1719,7 +1829,7 @@ name = "reviewer"
 [authority.permits]
 attention = ["operator-signoff", "legal-review"]
 "#;
-        let config = Config::from_toml_str(policy).expect("annotator bounds load");
+        let config = load(policy).expect("annotator bounds load");
         let registry = config.registry();
 
         let open = registry
@@ -1757,7 +1867,7 @@ attention = ["operator-signoff", "legal-review"]
         );
 
         assert!(matches!(
-            Config::from_toml_str("version = 2\n[[annotator]]\nname = \"a\"\nranks = [\"nope\"]\n"),
+            load("version = 2\n[[annotator]]\nname = \"a\"\nranks = [\"nope\"]\n"),
             Err(ConfigError::UnknownTrustRank { .. })
         ));
     }
@@ -1765,15 +1875,15 @@ attention = ["operator-signoff", "legal-review"]
     #[test]
     fn an_annotator_hint_is_runtime_owned_and_bounded() {
         let source = "version = 2\n[[annotator]]\nname = \"classifier\"\nhint = \"Suspicious means unvetted data.\"\n";
-        let config = Config::from_toml_str(source).expect("the Annotator hint loads");
+        let config = load(source).expect("the Annotator hint loads");
         let (_, binding) = config.annotators().next().expect("the Annotator is registered");
         assert_eq!(
             binding.hint.as_ref().map(Hint::as_str),
             Some("Suspicious means unvetted data.")
         );
 
-        let without_hint = Config::from_toml_str("version = 2\n[[annotator]]\nname = \"classifier\"\n")
-            .expect("the unhinted Annotator loads");
+        let without_hint =
+            load("version = 2\n[[annotator]]\nname = \"classifier\"\n").expect("the unhinted Annotator loads");
         assert_eq!(
             config.engine().identity(),
             without_hint.engine().identity(),
@@ -1783,7 +1893,7 @@ attention = ["operator-signoff", "legal-review"]
         let overlong = "x".repeat(MAX_HINT_CHARS + 1);
         let refused = format!("version = 2\n[[annotator]]\nname = \"classifier\"\nhint = \"{overlong}\"\n");
         assert!(matches!(
-            Config::from_toml_str(&refused),
+            load(&refused),
             Err(ConfigError::Registry(LoadError::HintTooLong { context, len, max }))
                 if context == "annotator classifier" && len == MAX_HINT_CHARS + 1 && max == MAX_HINT_CHARS
         ));
@@ -1806,7 +1916,7 @@ delta = { audience = ["alice"] }
 name = "fetch"
 annotator = "acl"
 "#;
-        let config = Config::from_toml_str(policy).expect("the public-only mandate loads");
+        let config = load(policy).expect("the public-only mandate loads");
         let mandate = config
             .registry()
             .annotator_mandate(&AnnotatorName::new("acl"))
@@ -1830,7 +1940,7 @@ name = "acl"
 name = "*"
 annotator = "acl"
 "#;
-        Config::from_toml_str(policy).expect("the wildcard covers the confined tool");
+        load(policy).expect("the wildcard covers the confined tool");
     }
 
     #[test]
@@ -1840,7 +1950,7 @@ annotator = "acl"
                 "version = 2\n[audience.group.team]\nfrom = [\"slack:user-group/team\"]\n[[annotator]]\nname = \"acl\"\naudiences = {audiences}\n"
             )
         };
-        let config = Config::from_toml_str(&with(
+        let config = load(&with(
             "[\"alice\", \"@team\", \"internal\", \"self\", \"@slack:user-group/eng\", \"bob\"]",
         ))
         .expect("a symbolic bound loads");
@@ -1861,15 +1971,12 @@ annotator = "acl"
             ("a repeated entry", "[\"@team\", \"@team\"]"),
         ] {
             assert!(
-                matches!(
-                    Config::from_toml_str(&with(audiences)),
-                    Err(ConfigError::BadAudience { .. })
-                ),
+                matches!(load(&with(audiences)), Err(ConfigError::BadAudience { .. })),
                 "{case} must be refused in an annotator's `audiences`"
             );
         }
         assert!(
-            Config::from_toml_str(&with("[\"@nobody\"]")).is_err(),
+            load(&with("[\"@nobody\"]")).is_err(),
             "a group no configuration serves does not route"
         );
     }
@@ -1878,13 +1985,10 @@ annotator = "acl"
     fn a_written_audience_list_refuses_a_repeated_entry() {
         let with =
             |audience: &str| format!("version = 2\n[[tool]]\nname = \"post\"\ndelta = {{ audience = {audience} }}\n");
-        assert!(Config::from_toml_str(&with("[\"alice\", \"bob\"]")).is_ok());
+        assert!(load(&with("[\"alice\", \"bob\"]")).is_ok());
         for repeated in ["[\"alice\", \"alice\"]", "[\"a@CORP.example\", \"a@corp.example\"]"] {
             assert!(
-                matches!(
-                    Config::from_toml_str(&with(repeated)),
-                    Err(ConfigError::BadAudience { .. })
-                ),
+                matches!(load(&with(repeated)), Err(ConfigError::BadAudience { .. })),
                 "{repeated} names one reader twice"
             );
         }
@@ -1907,10 +2011,7 @@ annotator = "acl"
             "$tool_call.arguments",
             "$tool_call.arguments.id",
         ] {
-            assert!(
-                Config::from_toml_str(&policy(supported)).is_ok(),
-                "{supported} is a tool-call value"
-            );
+            assert!(load(&policy(supported)).is_ok(), "{supported} is a tool-call value");
         }
         for unsupported in [
             "$tool",
@@ -1921,7 +2022,7 @@ annotator = "acl"
         ] {
             assert!(
                 matches!(
-                    Config::from_toml_str(&policy(unsupported)),
+                    load(&policy(unsupported)),
                     Err(ConfigError::UnknownCallSource { annotator, input, spelling })
                         if annotator == "r" && input == "subject" && spelling == unsupported
                 ),
@@ -1939,7 +2040,7 @@ annotator = "acl"
             )
         };
         assert!(
-            Config::from_toml_str(&policy(
+            load(&policy(
                 "parameters = { type = \"object\", properties = { id = { type = \"string\" } }, required = [\"id\"] }"
             ))
             .is_ok()
@@ -1957,7 +2058,7 @@ annotator = "acl"
         ] {
             assert!(
                 matches!(
-                    Config::from_toml_str(&policy(parameters)),
+                    load(&policy(parameters)),
                     Err(ConfigError::AnnotatorInput { tool, annotator, input, .. })
                         if tool == "lookup" && annotator == "acl" && input == "subject"
                 ),
@@ -1974,9 +2075,9 @@ annotator = "acl"
                  [[tool]]\nname = \"lookup\"\nannotator = \"acl\"\n{description}\n"
             )
         };
-        assert!(Config::from_toml_str(&policy("description = \"Looks one customer up.\"")).is_ok());
+        assert!(load(&policy("description = \"Looks one customer up.\"")).is_ok());
         assert!(matches!(
-            Config::from_toml_str(&policy("")),
+            load(&policy("")),
             Err(ConfigError::AnnotatorInput { tool, input, .. }) if tool == "lookup" && input == "what"
         ));
     }
@@ -1985,9 +2086,9 @@ annotator = "acl"
     fn an_annotator_name_is_an_opaque_non_empty_string() {
         let policy = "version = 2\n[[annotator]]\nname = \"a.b\"\n\
             [[tool]]\nname = \"lookup\"\ndescription = \"Looks up a value.\"\nannotator = \"a.b\"\n";
-        assert!(Config::from_toml_str(policy).is_ok());
+        assert!(load(policy).is_ok());
         assert!(matches!(
-            Config::from_toml_str("version = 2\n[[annotator]]\nname = \"\"\n"),
+            load("version = 2\n[[annotator]]\nname = \"\"\n"),
             Err(ConfigError::BadAnnotatorName(name)) if name.is_empty()
         ));
     }
@@ -1995,7 +2096,7 @@ annotator = "acl"
     #[test]
     fn every_audience_argument_binding_needs_a_required_top_level_string_in_parameters() {
         use appa_engine::params::PropertyFault;
-        let refused = |policy: &str, expected: PropertyFault| match Config::from_toml_str(policy) {
+        let refused = |policy: &str, expected: PropertyFault| match load(policy) {
             Err(ConfigError::Registry(LoadError::AudienceBindingSchema { argument, fault, .. })) => {
                 assert_eq!(argument, "to");
                 assert_eq!(fault, expected, "policy:\n{policy}");
@@ -2033,15 +2134,15 @@ annotator = "acl"
                 binding,
                 "parameters = { type = \"object\", properties = { to = { type = \"string\" }, body = { type = \"string\" } }, required = [\"to\"] }",
             );
-            assert!(Config::from_toml_str(&ok).is_ok(), "must load:\n{ok}");
+            assert!(load(&ok).is_ok(), "must load:\n{ok}");
         }
         let static_recipients = "version = 2\n[[tool]]\nname = \"send\"\nrequires = { audience = { contains = [\"finance\"] } }\ndelta = {}\n";
-        assert!(Config::from_toml_str(static_recipients).is_ok());
+        assert!(load(static_recipients).is_ok());
     }
 
     #[test]
     fn the_deployment_table_compiles_into_the_validated_profile() {
-        let config = Config::from_toml_str(DECLARATIONS).expect("the policy compiles");
+        let config = load(DECLARATIONS).expect("the policy compiles");
         let profile = config.engine().profile();
         assert_eq!(
             profile.executor_class(&ToolName::new("lookup")),
@@ -2059,7 +2160,7 @@ annotator = "acl"
 
     #[test]
     fn an_absent_deployment_table_is_the_no_coverage_default_and_refuses_covered_constructs() {
-        let plain = Config::from_toml_str("version = 2\n[[tool]]\nname = \"t\"\ndelta = {}\n").expect("loads");
+        let plain = load("version = 2\n[[tool]]\nname = \"t\"\ndelta = {}\n").expect("loads");
         assert_eq!(
             plain.engine().profile().executor_class(&ToolName::new("t")),
             ExecutorClass::Assumed
@@ -2070,7 +2171,7 @@ annotator = "acl"
             "",
         );
         assert!(matches!(
-            Config::from_toml_str(&uncovered),
+            load(&uncovered),
             Err(ConfigError::Registry(LoadError::OutputSanitizerUncovered { .. }))
         ));
     }
@@ -2084,31 +2185,28 @@ annotator = "acl"
             "binding = \"content\"",
             "provider_surfaces = { web_search = \"proxied\" }",
         ] {
-            assert!(matches!(
-                Config::from_toml_str(&with(bad_token)),
-                Err(ConfigError::Parse(_))
-            ));
+            assert!(matches!(load(&with(bad_token)), Err(ConfigError::Parse(_))));
         }
         assert!(matches!(
-            Config::from_toml_str(&with("starting_label = { audience = \"everyone\" }")),
+            load(&with("starting_label = { audience = \"everyone\" }")),
             Err(ConfigError::BadDeploymentToken {
                 field: "starting_label audience",
                 ..
             })
         ));
         assert!(matches!(
-            Config::from_toml_str(&with("assumed_tools = [\"t\"]\nprovider_run_tools = [\"t\"]")),
+            load(&with("assumed_tools = [\"t\"]\nprovider_run_tools = [\"t\"]")),
             Err(ConfigError::ConflictingExecutorException { tool }) if tool == "t"
         ));
         assert!(matches!(
-            Config::from_toml_str(&with("confined_results = [\"ghost\"]")),
+            load(&with("confined_results = [\"ghost\"]")),
             Err(ConfigError::Registry(LoadError::UnknownDeploymentTool { .. }))
         ));
     }
 
     #[test]
     fn the_wildcard_is_part_of_the_policy_identity() {
-        let identity = |source: &str| Config::from_toml_str(source).expect("loads").engine().identity();
+        let identity = |source: &str| load(source).expect("loads").engine().identity();
         let base = "version = 2\n\n[[annotator]]\nname = \"acl\"\n\n[[annotator]]\nname = \"other\"\n\n[[tool]]\nname = \"post\"\ndelta = {}\n";
         let with_wildcard = format!("{base}\n[[tool]]\nname = \"*\"\nannotator = \"acl\"\n");
         let with_other = format!("{base}\n[[tool]]\nname = \"*\"\nannotator = \"other\"\n");
@@ -2126,7 +2224,7 @@ annotator = "acl"
 
     #[test]
     fn hints_and_limits_never_move_the_policy_identity() {
-        let identity = |source: &str| Config::from_toml_str(source).expect("loads").engine().identity();
+        let identity = |source: &str| load(source).expect("loads").engine().identity();
         let base = identity(DECLARATIONS);
         let hinted = DECLARATIONS.replace(
             "name = \"approver\"",
@@ -2141,7 +2239,7 @@ annotator = "acl"
 
     #[test]
     fn compiled_tool_parameters_are_normalized_in_policy_identity() {
-        let config = Config::from_toml_str(
+        let config = load(
             "version = 2\n[[tool]]\nname = \"t\"\nparameters = { type = \"object\", properties = { value = { type = \"string\" } } }\n",
         )
         .expect("the schema compiles");
@@ -2213,7 +2311,7 @@ confined_results = ["read", "send"]
                 .expect("the fixture readers are literal"),
             )
         };
-        let config = Config::from_toml_str(policy).expect("routed group mentions load");
+        let config = load(policy).expect("routed group mentions load");
         let registry = config.registry();
         assert_eq!(
             registry
@@ -2251,7 +2349,7 @@ confined_results = ["read", "send"]
 
         let unrouted = policy.replace("[audience.group.board]\nfrom = [\"slack:user-group/board\"]\n", "");
         assert!(matches!(
-            Config::from_toml_str(&unrouted),
+            load(&unrouted),
             Err(ConfigError::Registry(LoadError::UnroutableAudience { .. }))
         ));
 
@@ -2261,7 +2359,7 @@ confined_results = ["read", "send"]
         ] {
             let malformed = policy.replace("within = [\"@team\"]", replacement);
             assert!(
-                matches!(Config::from_toml_str(&malformed), Err(ConfigError::BadAudience { .. })),
+                matches!(load(&malformed), Err(ConfigError::BadAudience { .. })),
                 "{case} loads"
             );
         }
@@ -2270,7 +2368,7 @@ confined_results = ["read", "send"]
              [audience.group.team]\nfrom = [\"slack:user-group/team\"]\n\
              [[tool]]\nname = \"t\"\ndelta = {}\n";
         let bare = "version = 2\n[[tool]]\nname = \"t\"\ndelta = {}\n";
-        let symbolic = Config::from_toml_str(&format!(
+        let symbolic = load(&format!(
             "{routed}[deployment]\nstarting_label = {{ audience = [\"@team\"] }}\n"
         ))
         .expect("a routed symbolic starting label loads");
@@ -2278,16 +2376,15 @@ confined_results = ["read", "send"]
             symbolic.engine().profile().starting_label().audience,
             Audience::of_declared(&mention("team", &[]))
         );
-        Config::from_toml_str(&format!("{routed}[boundary]\naudience = [\"@team\"]\n"))
-            .expect("a routed symbolic boundary label loads");
+        load(&format!("{routed}[boundary]\naudience = [\"@team\"]\n")).expect("a routed symbolic boundary label loads");
         assert!(matches!(
-            Config::from_toml_str(&format!(
+            load(&format!(
                 "{bare}[deployment]\nstarting_label = {{ audience = [\"@team\"] }}\n"
             )),
             Err(ConfigError::Registry(LoadError::UnroutableAudience { .. }))
         ));
         assert!(matches!(
-            Config::from_toml_str(&format!("{bare}[boundary]\naudience = [\"@team\"]\n")),
+            load(&format!("{bare}[boundary]\naudience = [\"@team\"]\n")),
             Err(ConfigError::BadAudience { .. })
         ));
     }
@@ -2296,7 +2393,7 @@ confined_results = ["read", "send"]
         let base = "version = 2\n[[tool]]\nname = \"t\"\ndelta = {}\n";
         let starting = |audience: &str| {
             let policy = format!("{base}[deployment]\nstarting_label = {{ audience = {audience} }}\n");
-            Config::from_toml_str(&policy)
+            load(&policy)
                 .expect("a public starting label loads")
                 .engine()
                 .profile()
@@ -2310,7 +2407,7 @@ confined_results = ["read", "send"]
                 "version = 2\n[[tool]]\nname = \"t\"\ndelta = {{ audience = {audience} }}\n\
                  [deployment]\ndispatch = \"enforced\"\nconfined_results = [\"t\"]\n"
             );
-            Config::from_toml_str(&policy)
+            load(&policy)
         };
         assert!(
             delta("\"public\"").is_err(),
@@ -2330,7 +2427,7 @@ confined_results = ["read", "send"]
              [[authority]]\nname = \"officer\"\ntags = [\"hr\", \"crm\"]\n\
              [authority.permits]\naudience_missing = [\"alice\", \"bob\"]\n\
              [deployment]\ndispatch = \"enforced\"\nconfined_results = [\"read\"]\n";
-        let config = Config::from_toml_str(policy).expect("lists of more than one member load");
+        let config = load(policy).expect("lists of more than one member load");
         let registry = config.registry();
         let redact = registry
             .sanitizer(&SanitizerName::new("redact"))

--- a/appa-policy/src/lib.rs
+++ b/appa-policy/src/lib.rs
@@ -1,7 +1,7 @@
 //! The spec's policy-dialect compiler: the configuration dialect (TOML) → the engine's
 //! [`RegistryConfig`] for the runtime.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Deserialize;
 use thiserror::Error;
@@ -11,8 +11,8 @@ use appa_engine::audience::{
 };
 use appa_engine::authority::{Authority, DeclaredTransition, Hint, Mandate, Sanitizer, SanitizerPoints, Scope};
 use appa_engine::contract::{
-    AudienceRequirement, Delta, HistoryRequirement, LabelRequirements, RecipientSpec, Requires, ToolAnnotation,
-    ToolDeclaration,
+    AudienceRequirement, Delta, DeltaAudience, HistoryRequirement, LabelRequirements, RecipientSpec, Requires,
+    SelectorPlaceholder, ToolAnnotation, ToolDeclaration,
 };
 use appa_engine::engine::Engine;
 use appa_engine::fact::{EffectKind, EffectSet};
@@ -450,8 +450,14 @@ impl Config {
             });
             annotators.insert(name, AnnotatorBinding { hint, builtin, inputs });
         }
-        let mut audience = convert_audience(raw.audience, sources)?;
+        let (mut audience, mut referenced) = convert_audience(raw.audience, sources)?;
         audience.lookup_targets = lookup_targets;
+        referenced.extend(
+            annotator_declarations
+                .iter()
+                .filter_map(|annotator| annotator.audiences.as_ref())
+                .flat_map(AudienceVocabulary::referenced_providers),
+        );
         let mut tools = Vec::new();
         let mut qualified: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
         for t in raw.tool {
@@ -470,8 +476,12 @@ impl Config {
                     .expect("split always yields one entry")
                     .to_string(),
             );
+            if let Some(annotation) = tool.declared() {
+                referenced.extend(annotation.referenced_providers());
+            }
             tools.push(tool);
         }
+        audience.sources.retain(|source| referenced.contains(&source.provider));
         // An input mapping is validated against every tool that routes through its Annotator:
         // a mapped argument must be a required top-level property of that tool's schema, and a
         // description read needs a declared description. A tool naming an unregistered
@@ -799,14 +809,16 @@ struct RawAudienceGroup {
 }
 
 /// Compile `[audience]` into the engine's audience configuration. Each `from` selector must
-/// name a stock collection whose role fits its level; a provider enters the registered
-/// sources — and so the policy identity — exactly when some selector picks from it.
+/// name a stock collection whose role fits its level. Every declared source is carried; the
+/// caller keeps the ones the policy references — here, or by a mention or placeholder in a
+/// tool contract or an annotator mandate — since a provider enters the registered sources,
+/// and so the policy identity, exactly when the policy names it.
 fn convert_audience(
     audience: Option<RawAudience>,
     sources: Vec<SourceRegistration>,
-) -> Result<AudienceConfig, ConfigError> {
+) -> Result<(AudienceConfig, BTreeSet<String>), ConfigError> {
     let mut config = AudienceConfig::default();
-    let mut providers: Vec<String> = Vec::new();
+    let mut providers: BTreeSet<String> = BTreeSet::new();
     let mut selectors = |list: &[String],
                          context: &str,
                          admits: &dyn Fn(TemplateRole) -> bool,
@@ -835,9 +847,7 @@ fn convert_audience(
             if !admits(role) {
                 return Err(refused(entry, format!("cannot feed this audience — {expected}")));
             }
-            if !providers.contains(&spec.provider) {
-                providers.push(spec.provider.clone());
-            }
+            providers.insert(spec.provider.clone());
             specs.push(spec);
         }
         Ok(specs)
@@ -893,11 +903,8 @@ fn convert_audience(
             });
         }
     }
-    config.sources = sources
-        .into_iter()
-        .filter(|source| providers.contains(&source.provider))
-        .collect();
-    Ok(config)
+    config.sources = sources;
+    Ok((config, providers))
 }
 
 #[derive(Deserialize)]
@@ -1043,7 +1050,7 @@ impl RawDelta {
             None => None,
         };
         let audience = match self.audience {
-            Some(a) => Some(parse_declared_audience(&a, &format!("{ctx} delta audience"))?),
+            Some(a) => Some(parse_delta_audience(&a, &format!("{ctx} delta audience"))?),
             None => None,
         };
         Ok(Delta { trust, audience })
@@ -1326,7 +1333,35 @@ fn parse_recipient_spec(list: &[String], context: &str) -> Result<RecipientSpec,
             reason: format!("placeholder {ph:?} must be the sole recipient"),
         });
     }
+    if let Some(placeholder) = selector_placeholder(list, context)? {
+        return Ok(RecipientSpec::Selector(placeholder));
+    }
     Ok(RecipientSpec::Static(parse_declared_audience(list, context)?))
+}
+
+/// A `delta.audience` list: a static declared audience, or one selector placeholder alone.
+fn parse_delta_audience(list: &[String], context: &str) -> Result<DeltaAudience, ConfigError> {
+    match selector_placeholder(list, context)? {
+        Some(placeholder) => Ok(DeltaAudience::Selector(placeholder)),
+        None => Ok(DeltaAudience::Static(parse_declared_audience(list, context)?)),
+    }
+}
+
+/// The selector placeholder a written list spells, which must be its sole entry: a
+/// placeholder names one collection per call, and a union around it would have no single
+/// spelling the check could instantiate. `None` when no entry spells one.
+fn selector_placeholder(list: &[String], context: &str) -> Result<Option<SelectorPlaceholder>, ConfigError> {
+    let placeholder = list
+        .iter()
+        .find_map(|entry| entry.strip_prefix('@').and_then(SelectorPlaceholder::parse));
+    match placeholder {
+        None => Ok(None),
+        Some(placeholder) if list.len() == 1 => Ok(Some(placeholder)),
+        Some(placeholder) => Err(ConfigError::BadAudience {
+            context: context.to_string(),
+            reason: format!("selector placeholder \"@{placeholder}\" must be the sole entry"),
+        }),
+    }
 }
 
 fn parse_points(tokens: &[String], name: &str) -> Result<SanitizerPoints, ConfigError> {
@@ -1377,6 +1412,7 @@ mod tests {
                     DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
                     DeclaredTemplate::new("full-members", Some(ChainAudience::Internal)),
                     DeclaredTemplate::named("user-group/<handle>"),
+                    DeclaredTemplate::named("channel/<id>"),
                 ],
             ),
             source(
@@ -2327,7 +2363,10 @@ confined_results = ["read", "send"]
             .expect("read registers")
             .declared()
             .expect("read is declared");
-        assert_eq!(read.delta.audience.as_ref(), Some(&mention("team", &["auditor"])));
+        assert_eq!(
+            read.delta.audience.as_ref(),
+            Some(&DeltaAudience::Static(mention("team", &["auditor"])))
+        );
         let officer = registry
             .authority(&AuthorityName::new("officer"))
             .expect("officer registers");
@@ -2455,6 +2494,198 @@ confined_results = ["read", "send"]
                 ReaderId::new("alice"),
                 ReaderId::new("bob")
             ]))
+        );
+    }
+
+    /// A selector placeholder is a contract over the call: it stands alone in its list, each
+    /// argument it reads is a required string of the tool's schema, and its spelling fits a
+    /// template some declared provider serves. Naming the provider is what registers it.
+    #[test]
+    fn a_selector_placeholder_reads_one_declared_collection_per_call() {
+        let channel =
+            r#"{ type = "object", properties = { channel_id = { type = "string" } }, required = ["channel_id"] }"#;
+        let tool = |parameters: &str, contract: &str| {
+            format!("version = 2\n[[tool]]\nname = \"read_channel\"\nparameters = {parameters}\n{contract}\n")
+        };
+        let delta = "delta = { audience = [\"@slack:channel/$channel_id\"] }";
+        let placeholder = SelectorPlaceholder::parse("slack:channel/$channel_id").expect("a placeholder spelling");
+
+        let config = load(&tool(channel, delta)).expect("a placeholder delta loads");
+        let read = config
+            .registry()
+            .variants(&ToolName::new("read_channel"))
+            .next()
+            .and_then(ToolDeclaration::declared)
+            .expect("read_channel is declared");
+        assert_eq!(read.delta.audience, Some(DeltaAudience::Selector(placeholder.clone())));
+        assert_eq!(
+            config.registry().audience().providers().iter().collect::<Vec<_>>(),
+            ["slack"],
+            "a placeholder names its provider into the policy"
+        );
+        let floor = "requires = { audience = { contains = [\"@slack:channel/$channel_id\"] } }";
+        let send = load(&tool(channel, floor)).expect("a placeholder floor loads");
+        let send = send
+            .registry()
+            .variants(&ToolName::new("read_channel"))
+            .next()
+            .and_then(ToolDeclaration::declared)
+            .expect("read_channel is declared");
+        assert_eq!(
+            send.requires.audience_requirements(),
+            [AudienceRequirement::Includes(RecipientSpec::Selector(placeholder))]
+        );
+
+        let optional = r#"{ type = "object", properties = { channel_id = { type = "string" } } }"#;
+        for (case, policy, expected) in [
+            (
+                "beside another entry",
+                tool(
+                    channel,
+                    "delta = { audience = [\"@slack:channel/$channel_id\", \"alice\"] }",
+                ),
+                "spelling",
+            ),
+            (
+                "beside another entry in a floor",
+                tool(
+                    channel,
+                    "requires = { audience = { contains = [\"alice\", \"@slack:channel/$channel_id\"] } }",
+                ),
+                "spelling",
+            ),
+            (
+                "under within",
+                tool(
+                    channel,
+                    "requires = { audience = { within = [\"@slack:channel/$channel_id\"] } }",
+                ),
+                "spelling",
+            ),
+            (
+                "an argument the schema does not require",
+                tool(optional, delta),
+                "schema",
+            ),
+            (
+                "a template the provider does not declare",
+                tool(channel, "delta = { audience = [\"@slack:room/$channel_id\"] }"),
+                "selector",
+            ),
+            (
+                "a variable where the template is literal",
+                tool(channel, "delta = { audience = [\"@slack:$channel_id\"] }"),
+                "selector",
+            ),
+            (
+                "a provider no source declares",
+                tool(channel, "delta = { audience = [\"@msft:channel/$channel_id\"] }"),
+                "provider",
+            ),
+            (
+                "a provider-run tool",
+                tool(channel, delta) + "[deployment]\nprovider_run_tools = [\"read_channel\"]\n",
+                "provider-run",
+            ),
+        ] {
+            let refusal = load(&policy).expect_err(case);
+            let fits = match expected {
+                "spelling" => matches!(refusal, ConfigError::BadAudience { .. }),
+                "schema" => matches!(
+                    &refusal,
+                    ConfigError::Registry(LoadError::AudienceBindingSchema { argument, .. }) if argument == "channel_id"
+                ),
+                "selector" => matches!(
+                    refusal,
+                    ConfigError::Registry(LoadError::UnroutableAudience {
+                        fault: appa_engine::audience::Unroutable::UnknownSelector { .. },
+                        ..
+                    })
+                ),
+                "provider" => matches!(
+                    refusal,
+                    ConfigError::Registry(LoadError::UnroutableAudience {
+                        fault: appa_engine::audience::Unroutable::UnknownProvider(_),
+                        ..
+                    })
+                ),
+                _ => matches!(refusal, ConfigError::Registry(LoadError::ProviderRunPlaceholder { .. })),
+            };
+            assert!(fits, "{case}: got {refusal:?}");
+        }
+    }
+
+    /// A mandate placeholder is read per call: it admits exactly the collection the routed
+    /// call's arguments spell, so every routed tool must carry the argument, and the wildcard —
+    /// whose calls the policy does not describe — cannot route through it.
+    #[test]
+    fn an_annotator_mandate_placeholder_binds_to_each_routed_tools_arguments() {
+        let policy = |tool: &str| {
+            format!("version = 2\n[[annotator]]\nname = \"acl\"\naudiences = [\"@slack:channel/$channel_id\"]\n{tool}")
+        };
+        let routed = "[[tool]]\nname = \"read_channel\"\nparameters = { type = \"object\", properties = { channel_id = { type = \"string\" } }, required = [\"channel_id\"] }\nannotator = \"acl\"\n";
+        let config = load(&policy(routed)).expect("a mandate placeholder loads");
+        let mandate = config
+            .registry()
+            .annotator_mandate(&AnnotatorName::new("acl"))
+            .expect("acl registers");
+        assert_eq!(
+            mandate.audiences().entries().collect::<Vec<_>>(),
+            ["@slack:channel/$channel_id"]
+        );
+        assert_eq!(
+            mandate
+                .instantiate(&serde_json::json!({ "channel_id": "C1" }))
+                .expect("C1 fills the placeholder")
+                .audiences()
+                .entries()
+                .collect::<Vec<_>>(),
+            ["@slack:channel/C1"]
+        );
+        assert!(config.registry().audience().providers().contains("slack"));
+
+        let unbound = "[[tool]]\nname = \"read_channel\"\nannotator = \"acl\"\n";
+        assert!(matches!(
+            load(&policy(unbound)),
+            Err(ConfigError::Registry(LoadError::AudienceBindingSchema { context, argument, .. }))
+                if context == "tool read_channel annotator acl mandate" && argument == "channel_id"
+        ));
+        let wildcard = "[[tool]]\nname = \"*\"\nannotator = \"acl\"\n";
+        assert!(matches!(
+            load(&policy(wildcard)),
+            Err(ConfigError::Registry(LoadError::WildcardPlaceholderMandate(name))) if name == "acl"
+        ));
+    }
+
+    /// A provider is part of the policy exactly when the policy names it — by an `[audience]`
+    /// selector, a mention in a contract or a mandate, or a placeholder — and no other
+    /// declared source enters the registry or the identity.
+    #[test]
+    fn a_provider_enters_the_policy_when_a_contract_or_mandate_names_it() {
+        let providers = |policy: &str| {
+            load(policy)
+                .expect("the policy loads")
+                .registry()
+                .audience()
+                .providers()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        assert!(providers("version = 2\n[[tool]]\nname = \"t\"\n").is_empty());
+        assert_eq!(
+            providers("version = 2\n[[tool]]\nname = \"t\"\ndelta = { audience = [\"@github:org/corp/team/x\"] }\n"),
+            ["github"]
+        );
+        assert_eq!(
+            providers(
+                "version = 2\n[[tool]]\nname = \"t\"\nrequires = { audience = { within = [\"@google-workspace:group/eng@corp.com\"] } }\n"
+            ),
+            ["google-workspace"]
+        );
+        assert_eq!(
+            providers("version = 2\n[[annotator]]\nname = \"acl\"\naudiences = [\"@slack:user-group/eng\"]\n"),
+            ["slack"]
         );
     }
 }

--- a/appa-policy/tests/docs_examples.rs
+++ b/appa-policy/tests/docs_examples.rs
@@ -93,8 +93,10 @@ fn every_toml_fence_in_the_policy_reference_loads() {
         let table: toml::Table = fence
             .parse()
             .unwrap_or_else(|error| panic!("a fence is not valid TOML: {error}\n{fence}"));
+        let sources = appa_policy::declared_sources(&toml::Value::Table(table.clone()))
+            .unwrap_or_else(|error| panic!("a fence declares its audience sources badly: {error}\n{fence}"));
         let Some(policy) = as_policy(table) else { continue };
-        if let Err(error) = Config::from_toml_str(&policy) {
+        if let Err(error) = Config::from_toml_str_routed(&policy, std::collections::BTreeMap::new(), sources) {
             panic!("a policy example does not load: {error}\n{policy}");
         }
     }

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -1988,8 +1988,10 @@ fn validate_deployment(policy: &appa_policy::Config, externals: &crate::config::
     }
     bound_exactly("annotator", bound_by_deployment.into_iter(), &externals.annotators)?;
     // Every provider the policy references is bound, and so is every entry a provider's
-    // `lookup` names. A roster answers member lookups only, so a provider whose selectors
-    // the policy reads never binds one.
+    // `lookup` names. A bound provider the policy never references stays idle rather than
+    // refused: a battery binds its own source, and a deployment may include the battery
+    // for its tool rules alone. A roster answers member lookups only, so a provider whose
+    // selectors the policy reads never binds one.
     let providers: std::collections::BTreeSet<&str> = rc
         .audience
         .sources
@@ -2001,7 +2003,7 @@ fn validate_deployment(policy: &appa_policy::Config, externals: &crate::config::
         .filter_map(|provider| externals.audience.get(*provider))
         .filter_map(|binding| binding.lookup.as_deref())
         .collect();
-    bound_exactly(
+    no_unbound(
         "audience source",
         providers.iter().chain(targets.iter()).copied(),
         &externals.audience,
@@ -2025,13 +2027,23 @@ fn bound_exactly<'a, Implementation>(
     bound: &std::collections::BTreeMap<String, Implementation>,
 ) -> Result<(), OpenError> {
     let registered: std::collections::BTreeSet<&str> = registered.collect();
-    if let Some(name) = registered.iter().find(|name| !bound.contains_key(**name)) {
-        return Err(OpenError::UnboundExternal {
-            kind,
-            name: (*name).to_string(),
-        });
-    }
+    no_unbound(kind, registered.iter().copied(), bound)?;
     no_undeclared(kind, registered.into_iter(), bound)
+}
+
+fn no_unbound<'a, Implementation>(
+    kind: &'static str,
+    registered: impl Iterator<Item = &'a str>,
+    bound: &std::collections::BTreeMap<String, Implementation>,
+) -> Result<(), OpenError> {
+    let mut registered = registered;
+    match registered.find(|name| !bound.contains_key(*name)) {
+        Some(name) => Err(OpenError::UnboundExternal {
+            kind,
+            name: name.to_string(),
+        }),
+        None => Ok(()),
+    }
 }
 
 fn no_undeclared<'a, Implementation>(
@@ -2064,8 +2076,12 @@ fn compile_policy(config: &Config, naming: ToolNaming) -> Result<appa_policy::Co
     .map_err(OpenError::UnsupportedPolicy)?;
     let text = toml::to_string(&policy)
         .map_err(|error| OpenError::UnsupportedPolicy(format!("the policy table does not serialize: {error}")))?;
-    appa_policy::Config::from_toml_str_routed(&text, config.externals.lookup_targets())
-        .map_err(|error| OpenError::Policy(Box::new(error)))
+    appa_policy::Config::from_toml_str_routed(
+        &text,
+        config.externals.lookup_targets(),
+        config.externals.source_registrations(),
+    )
+    .map_err(|error| OpenError::Policy(Box::new(error)))
 }
 
 /// The `[policy]` table of a stored policy file, with the key of the bytes it came from.
@@ -2133,7 +2149,9 @@ fn compile_stored_for_host(bytes: &[u8], naming: ToolNaming) -> Result<appa_poli
     let policy = resolve_served_policy(policy, naming, &inventory, &aliases)?;
     let text =
         toml::to_string(&policy).map_err(|error| format!("the stored policy table does not serialize: {error}"))?;
-    appa_policy::Config::from_toml_str_routed(&text, crate::config::lookup_targets_of(&value))
+    let sources = crate::config::source_registrations_of(&value)
+        .map_err(|error| format!("the stored policy declares its audience sources badly: {error}"))?;
+    appa_policy::Config::from_toml_str_routed(&text, crate::config::lookup_targets_of(&value), sources)
         .map_err(|error| format!("the stored policy does not load: {error}"))
 }
 

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -2053,7 +2053,7 @@ delta = {}
 starting_label = { audience = ["alice@corp.example"] }
 "#;
         let text = format!(
-            "[policy]\n{policy}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.audience.slack]\nurl = \"{source}\"\n"
+            "[policy]\n{policy}\n[externals]\ntimeout_ms = 2000\nmax_body_bytes = 65536\n[externals.audience.slack]\nurl = \"{source}\"\nselectors = [{{ template = \"user-group/<handle>\" }}]\n"
         );
         let dir = tempfile::tempdir().expect("a temp dir is creatable");
         let path = dir.path().join("appa.toml");

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -748,15 +748,7 @@ struct RawAudienceBinding {
     readers: Option<BTreeMap<String, String>>,
     lookup: Option<String>,
     /// The selector templates this source serves, with what each may feed.
-    #[serde(default)]
-    selectors: Vec<RawSelector>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawSelector {
-    template: String,
-    feeds: Option<String>,
+    selectors: Option<Vec<appa_policy::SelectorDeclaration>>,
 }
 
 fn default_review_timeout_ms() -> u64 {
@@ -1373,29 +1365,14 @@ fn compose_include(
             .as_table_mut()
             .expect("RawExternals requires named external tables");
         for (name, entry) in entries {
-            // A root entry whose only key is `lookup` routes the member lookups of a
-            // provider a battery binds; the routing rides on the battery's entry. Any
-            // other same-named pair is two bindings of one provider.
-            let routed_lookup = match (section, destination.get(name), entry.as_table()) {
-                (Section::Audience, Some(toml::Value::Table(root)), Some(_))
-                    if root.len() == 1 && root.contains_key("lookup") =>
-                {
-                    root.get("lookup").cloned()
-                }
-                (_, Some(_), _) => {
-                    return Err(ConfigError::DuplicateExternal {
-                        path: include_path.display().to_string(),
-                        section: section_name.clone(),
-                        name: name.clone(),
-                    });
-                }
-                (_, None, _) => None,
-            };
-            let mut entry = entry.clone();
-            if let (Some(lookup), Some(table)) = (routed_lookup, entry.as_table_mut()) {
-                table.insert("lookup".to_string(), lookup);
+            if destination.contains_key(name) {
+                return Err(ConfigError::DuplicateExternal {
+                    path: include_path.display().to_string(),
+                    section: section_name.clone(),
+                    name: name.clone(),
+                });
             }
-            destination.insert(name.clone(), entry);
+            destination.insert(name.clone(), entry.clone());
             origins.insert(
                 section.origin_key(name),
                 include_path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf(),
@@ -1491,21 +1468,11 @@ fn resolve_audience_bindings(
             lookup: redirect,
             selectors,
         } = entry;
-        let mut templates: Vec<DeclaredTemplate> = Vec::new();
-        for selector in &selectors {
-            let declared = appa_policy::parse_declared_template(&name, &selector.template, selector.feeds.as_deref())
-                .map_err(|error| ConfigError::SelectorDeclaration(Box::new(error)))?;
-            if templates.iter().any(|known| known.template == declared.template) {
-                return Err(ConfigError::SelectorDeclaration(Box::new(
-                    appa_policy::ConfigError::BadSelectorDeclaration {
-                        provider: name.clone(),
-                        template: selector.template.clone(),
-                        reason: "is declared twice".to_string(),
-                    },
-                )));
-            }
-            templates.push(declared);
-        }
+        let templates = match &selectors {
+            None => Vec::new(),
+            Some(selectors) => appa_policy::declare_templates(&name, selectors)
+                .map_err(|error| ConfigError::SelectorDeclaration(Box::new(error)))?,
+        };
         // A roster answers lookups only and a source declares what it serves, so a roster
         // with `selectors` is neither.
         let implementation = match (url, command, readers) {

--- a/appa-runtime/src/config.rs
+++ b/appa-runtime/src/config.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use appa_engine::audience::well_formed_reader;
+use appa_engine::audience::{DeclaredTemplate, SourceRegistration, well_formed_reader};
 use appa_engine::label::ReaderId;
 use serde::Deserialize;
 
@@ -204,11 +204,31 @@ impl Externals {
             .collect()
     }
 
+    /// The audience sources these bindings declare: each entry with selector templates,
+    /// as the policy compiles under them.
+    pub(crate) fn source_registrations(&self) -> Vec<SourceRegistration> {
+        self.audience
+            .iter()
+            .filter(|(_, binding)| !binding.templates.is_empty())
+            .map(|(name, binding)| SourceRegistration {
+                provider: name.clone(),
+                templates: binding.templates.clone(),
+            })
+            .collect()
+    }
+
     /// How many `llm` consults this deployment lets run at once: `max_concurrent` of its
     /// profile, none without one.
     pub(crate) fn llm_bound(&self) -> usize {
         self.llm.as_ref().map_or(0, |profile| profile.max_concurrent)
     }
+}
+
+/// The audience sources a composed document declares, read from its `[externals.audience]`
+/// table: what a stored policy file compiles under at replay, and what a file that does not
+/// load is described with.
+pub(crate) fn source_registrations_of(document: &toml::Value) -> Result<Vec<SourceRegistration>, ConfigError> {
+    appa_policy::declared_sources(document).map_err(|error| ConfigError::SelectorDeclaration(Box::new(error)))
 }
 
 /// The lookup routing a composed document declares, read from its `[externals.audience]`
@@ -298,6 +318,9 @@ pub struct AudienceBinding {
     pub implementation: AudienceImplementation,
     /// The entry that answers this provider's member lookups. `None`: the provider's own.
     pub lookup: Option<String>,
+    /// The selector templates this source declares it serves. Empty for a roster and for
+    /// an entry that only answers another provider's lookups: neither is a policy source.
+    pub templates: Vec<DeclaredTemplate>,
 }
 
 /// How one audience entry answers: an HTTP endpoint, a local command, or an inline roster
@@ -404,6 +427,8 @@ pub enum ConfigError {
     IncludedPolicyField { path: String, field: String },
     #[error("included config {path} cannot set externals field {field:?}")]
     IncludedExternalsField { path: String, field: String },
+    #[error("[externals.audience] {0}")]
+    SelectorDeclaration(Box<appa_policy::ConfigError>),
     #[error("included config {path} uses policy version {found}, but the root uses {root}")]
     IncludedVersion { path: String, root: i64, found: i64 },
     #[error("included config {path} repeats [externals.{section}] entry {name:?}")]
@@ -722,6 +747,16 @@ struct RawAudienceBinding {
     command: Option<Vec<String>>,
     readers: Option<BTreeMap<String, String>>,
     lookup: Option<String>,
+    /// The selector templates this source serves, with what each may feed.
+    #[serde(default)]
+    selectors: Vec<RawSelector>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSelector {
+    template: String,
+    feeds: Option<String>,
 }
 
 fn default_review_timeout_ms() -> u64 {
@@ -1338,14 +1373,29 @@ fn compose_include(
             .as_table_mut()
             .expect("RawExternals requires named external tables");
         for (name, entry) in entries {
-            if destination.contains_key(name) {
-                return Err(ConfigError::DuplicateExternal {
-                    path: include_path.display().to_string(),
-                    section: section_name.clone(),
-                    name: name.clone(),
-                });
+            // A root entry whose only key is `lookup` routes the member lookups of a
+            // provider a battery binds; the routing rides on the battery's entry. Any
+            // other same-named pair is two bindings of one provider.
+            let routed_lookup = match (section, destination.get(name), entry.as_table()) {
+                (Section::Audience, Some(toml::Value::Table(root)), Some(_))
+                    if root.len() == 1 && root.contains_key("lookup") =>
+                {
+                    root.get("lookup").cloned()
+                }
+                (_, Some(_), _) => {
+                    return Err(ConfigError::DuplicateExternal {
+                        path: include_path.display().to_string(),
+                        section: section_name.clone(),
+                        name: name.clone(),
+                    });
+                }
+                (_, None, _) => None,
+            };
+            let mut entry = entry.clone();
+            if let (Some(lookup), Some(table)) = (routed_lookup, entry.as_table_mut()) {
+                table.insert("lookup".to_string(), lookup);
             }
-            destination.insert(name.clone(), entry.clone());
+            destination.insert(name.clone(), entry);
             origins.insert(
                 section.origin_key(name),
                 include_path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf(),
@@ -1439,7 +1489,25 @@ fn resolve_audience_bindings(
             command,
             readers,
             lookup: redirect,
+            selectors,
         } = entry;
+        let mut templates: Vec<DeclaredTemplate> = Vec::new();
+        for selector in &selectors {
+            let declared = appa_policy::parse_declared_template(&name, &selector.template, selector.feeds.as_deref())
+                .map_err(|error| ConfigError::SelectorDeclaration(Box::new(error)))?;
+            if templates.iter().any(|known| known.template == declared.template) {
+                return Err(ConfigError::SelectorDeclaration(Box::new(
+                    appa_policy::ConfigError::BadSelectorDeclaration {
+                        provider: name.clone(),
+                        template: selector.template.clone(),
+                        reason: "is declared twice".to_string(),
+                    },
+                )));
+            }
+            templates.push(declared);
+        }
+        // A roster answers lookups only and a source declares what it serves, so a roster
+        // with `selectors` is neither.
         let implementation = match (url, command, readers) {
             (Some(url), None, None) => {
                 let url = validated_url(section.name(), &name, url)?;
@@ -1449,7 +1517,7 @@ fn resolve_audience_bindings(
             (None, Some(argv), None) => {
                 AudienceImplementation::Command(resolve_command(section, &name, argv, token_env, origins)?)
             }
-            (None, None, Some(readers)) if token_env.is_none() => {
+            (None, None, Some(readers)) if token_env.is_none() && templates.is_empty() => {
                 AudienceImplementation::Readers(resolve_readers(&name, readers)?)
             }
             _ => {
@@ -1464,6 +1532,7 @@ fn resolve_audience_bindings(
             AudienceBinding {
                 implementation,
                 lookup: redirect,
+                templates,
             },
         );
     }

--- a/appa-runtime/src/describe.rs
+++ b/appa-runtime/src/describe.rs
@@ -228,6 +228,14 @@ impl Bindings<'_> {
             Bindings::Raw(root) => crate::config::lookup_targets_of(root),
         }
     }
+
+    /// The audience sources the bindings declare, from the loaded configuration or the raw table.
+    fn source_registrations(self) -> Result<Vec<appa_engine::audience::SourceRegistration>, String> {
+        match self {
+            Bindings::Loaded(externals) => Ok(externals.source_registrations()),
+            Bindings::Raw(root) => crate::config::source_registrations_of(root).map_err(|error| error.to_string()),
+        }
+    }
 }
 
 /// The declared audience configuration, with each source's binding status.
@@ -344,7 +352,8 @@ fn describe_policy_value(policy_value: &toml::Value, bindings: Bindings<'_>, out
     let compiled = toml::to_string(policy_value)
         .map_err(|error| error.to_string())
         .and_then(|source| {
-            appa_policy::Config::from_toml_str_routed(&source, bindings.lookup_targets())
+            let sources = bindings.source_registrations()?;
+            appa_policy::Config::from_toml_str_routed(&source, bindings.lookup_targets(), sources)
                 .map_err(|error| error.to_string())
         });
     out.audience = match compiled {
@@ -602,7 +611,7 @@ mod tests {
         let root = directory.path().join("appa.toml");
         std::fs::write(
             &root,
-            "include = [\"batteries/mail/appa.toml\"]\n[policy]\nversion = 2\n[policy.audience]\nself = [\"slack:viewer\"]\n[policy.audience.group.finance]\nwithin = \"internal\"\nfrom = [\"slack:user-group/finance\"]\n[[policy.authority]]\nname = \"operator\"\n[policy.authority.permits]\ntrust_below = \"trusted\"\naudience_missing = [\"public\"]\neffects_containing = [\"mail.sent\"]\nattention = [\"hitl\"]\n[externals]\ntimeout_ms = 1000\nmax_body_bytes = 65536\n[externals.authorities.operator]\nbuiltin = \"hitl\"\n[externals.audience.slack]\ncommand = [\"true\"]\nlookup = \"people\"\n[externals.audience.people]\nreaders = { \"slack:U1\" = \"alice@corp.example\" }\n",
+            "include = [\"batteries/mail/appa.toml\"]\n[policy]\nversion = 2\n[policy.audience]\nself = [\"slack:viewer\"]\n[policy.audience.group.finance]\nwithin = \"internal\"\nfrom = [\"slack:user-group/finance\"]\n[[policy.authority]]\nname = \"operator\"\n[policy.authority.permits]\ntrust_below = \"trusted\"\naudience_missing = [\"public\"]\neffects_containing = [\"mail.sent\"]\nattention = [\"hitl\"]\n[externals]\ntimeout_ms = 1000\nmax_body_bytes = 65536\n[externals.authorities.operator]\nbuiltin = \"hitl\"\n[externals.audience.slack]\ncommand = [\"true\"]\nlookup = \"people\"\nselectors = [{ template = \"viewer\", feeds = \"self\" }, { template = \"full-members\", feeds = \"internal\" }, { template = \"user-group/<handle>\" }]\n[externals.audience.people]\nreaders = { \"slack:U1\" = \"alice@corp.example\" }\n",
         )
         .expect("root config");
 

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -2199,7 +2199,7 @@ impl RuntimeEngine {
                 } => {
                     let routable = audience
                         .templates(provider)
-                        .is_some_and(|templates| templates.iter().any(|template| template.matches(selector)));
+                        .is_some_and(|templates| templates.iter().any(|declared| declared.template.matches(selector)));
                     if !routable {
                         continue;
                     }
@@ -2522,9 +2522,12 @@ pub(crate) fn selector_templates(
     audience: &appa_engine::audience::AudienceRegistry,
     provider: &str,
 ) -> Option<Vec<String>> {
-    audience
-        .templates(provider)
-        .map(|templates| templates.iter().map(|template| template.as_str().to_string()).collect())
+    audience.templates(provider).map(|templates| {
+        templates
+            .iter()
+            .map(|declared| declared.template.as_str().to_string())
+            .collect()
+    })
 }
 
 #[derive(Debug, Default)]

--- a/appa-runtime/src/engine.rs
+++ b/appa-runtime/src/engine.rs
@@ -38,8 +38,8 @@
 
 use appa_engine::audience::{AudienceEvidence, MemberLookup, SelectorSpec, SourceClaims};
 use appa_engine::contract::{
-    AudienceRequirement, Delta, HistoryRequirement, LabelRequirements, PinnedAnnotation, ProducedAnnotation,
-    RecipientSpec, Requires, ToolDeclaration,
+    AudienceRequirement, Delta, DeltaAudience, HistoryRequirement, LabelRequirements, PinnedAnnotation,
+    ProducedAnnotation, RecipientSpec, Requires, ToolDeclaration,
 };
 pub(crate) use appa_engine::engine::ForkStatus;
 use appa_engine::engine::{Engine, EngineError};
@@ -1689,10 +1689,17 @@ impl RuntimeEngine {
         .map_err(|error| format!("`label` is not a label this policy spells: {error}"))?;
         let floor = Label {
             trust: delta.trust.unwrap_or(current.trust),
-            audience: delta
-                .audience
-                .map(|declared| Audience::of_declared(&declared))
-                .unwrap_or(current.audience),
+            audience: match delta.audience {
+                Some(DeltaAudience::Static(declared)) => Audience::of_declared(&declared),
+                // A floor is a label, not a contract: there is no call whose argument a
+                // placeholder could read.
+                Some(DeltaAudience::Selector(placeholder)) => {
+                    return Err(format!(
+                        "`label` spells the selector placeholder \"@{placeholder}\", which reads a call argument; a return floor names its audience outright"
+                    ));
+                }
+                None => current.audience,
+            },
         };
         let sanitizer = match step {
             Some(name) if name.is_attest_schema() => {
@@ -1948,7 +1955,7 @@ impl RuntimeEngine {
             return Err(Resolution(vec![ExternalRequest::Annotation {
                 annotator: annotator.as_str().to_string(),
                 call: digest,
-                declaration: self.annotation_declaration(annotator, binding),
+                declaration: self.annotation_declaration(annotator, binding, resolved),
                 args: annotation_args(&binding.inputs, declaration, resolved),
             }]));
         };
@@ -1959,18 +1966,22 @@ impl RuntimeEngine {
         ))
     }
 
-    /// What one annotation consult declares: the Annotator's trusted hint, resolved mandate
-    /// vocabulary, and the input names its artifact carries.
+    /// What one annotation consult declares: the Annotator's trusted hint, the mandate
+    /// vocabulary bound to this call — a selector placeholder in it names the collection the
+    /// call's arguments spell — and the input names its artifact carries.
     fn annotation_declaration(
         &self,
         annotator: &appa_engine::names::AnnotatorName,
         binding: &appa_policy::AnnotatorBinding,
+        resolved: &ResolvedCall,
     ) -> AnnotationDeclaration {
         let registry = self.engine.registry();
         let chain = registry.trust_chain();
         let mandate = registry
             .annotator_mandate(annotator)
-            .expect("declarations name only registered annotators");
+            .expect("declarations name only registered annotators")
+            .instantiate(resolved.arguments())
+            .expect("a minted call fills every selector placeholder of its annotator's mandate");
         AnnotationDeclaration {
             hint: binding.hint.as_ref().map(|hint| hint.as_str().to_string()),
             inputs: binding.inputs.keys().cloned().collect(),
@@ -2007,7 +2018,7 @@ impl RuntimeEngine {
         ProducedAnnotation {
             delta: Delta {
                 trust: answer.delta_trust.as_deref().map(rank),
-                audience: answer.delta_audience.clone(),
+                audience: answer.delta_audience.clone().map(DeltaAudience::Static),
             },
             emits: EffectSet::new(answer.emits.iter().map(|kind| EffectKind::new(kind.as_str())))
                 .expect("a decoded annotation answer holds no duplicate effect"),
@@ -3342,7 +3353,7 @@ mod tests {
     use crate::api::ToolNaming;
     use crate::consult::{AnnotationAnswer, HistoryEntry, RequiredAudienceAnswer, SanitizerPoint};
     use appa_engine::check::{Gap, RawBlock};
-    use appa_engine::contract::{AudienceRequirement, HistoryRequirement, RecipientSpec};
+    use appa_engine::contract::{AudienceRequirement, DeltaAudience, HistoryRequirement, RecipientSpec};
     use appa_engine::fact::{EffectKind, EffectSet};
     use appa_engine::label::{Audience, DeclaredAudience, ReaderId, Trust};
     use appa_engine::names::{AnnotatorName, MarkName};
@@ -3649,7 +3660,10 @@ mod tests {
         assert_eq!(pin.call(), &call.digest(), "the pin binds the exact call it answered");
         let produced = pin.produced();
         assert_eq!(produced.delta.trust, Some(Trust::new(0)));
-        assert_eq!(produced.delta.audience, Some(DeclaredAudience::Public));
+        assert_eq!(
+            produced.delta.audience,
+            Some(DeltaAudience::Static(DeclaredAudience::Public))
+        );
         assert_eq!(produced.requires.label.trust_floor, Some(Trust::new(1)));
         assert_eq!(
             produced.requires.label.audience,

--- a/appa-runtime/src/external.rs
+++ b/appa-runtime/src/external.rs
@@ -913,6 +913,8 @@ mod tests {
         AuthorityArtifact, AuthorityDeclaration, DeclaredPermits, DeclaredSanitizerTransition, MembersAnswer,
         SanitizerArtifact, SanitizerDeclaration, SanitizerPoint, WireAudience,
     };
+    use appa_engine::audience::DeclaredTemplate;
+    use appa_engine::label::ChainAudience;
 
     #[cfg(unix)]
     fn process_environment() -> &'static tokio::sync::Mutex<()> {
@@ -971,6 +973,10 @@ mod tests {
                 let binding = AudienceBinding {
                     implementation: AudienceImplementation::Resolver(Endpoint::new(url.to_string(), None)),
                     lookup: None,
+                    templates: vec![
+                        DeclaredTemplate::new("viewer", Some(ChainAudience::Self_)),
+                        DeclaredTemplate::new("full-members", Some(ChainAudience::Internal)),
+                    ],
                 };
                 ("slack".to_string(), binding)
             })
@@ -1802,6 +1808,7 @@ printf '%s' '{"version":1,"answer":{"delta.trust":"trusted"}}'"#,
                         .collect(),
                 ),
                 lookup: None,
+                templates: vec![],
             },
         );
         let services = services_over(config);

--- a/appa-runtime/src/yell/policy.rs
+++ b/appa-runtime/src/yell/policy.rs
@@ -280,6 +280,8 @@ fn declared_tools(document: &Value) -> std::collections::BTreeSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use appa_engine::audience::{DeclaredTemplate, SourceRegistration};
+    use appa_engine::label::ChainAudience;
 
     /// Strip a fixture that the policy compiler accepts.
     ///
@@ -289,7 +291,35 @@ mod tests {
     /// fixture a policy a deployment could actually run, so "every section is classified"
     /// means what it says.
     fn stripped(text: &str, mode: Mode) -> Stripped {
-        appa_policy::Config::from_toml_str(text).expect("the fixture is a policy the loader accepts");
+        // The fixtures read the selectors the shipped slack and google-workspace batteries
+        // declare; a bare policy carries no bindings, so the declarations come from here.
+        let declared = |provider: &str, templates: &[(&str, Option<ChainAudience>)]| SourceRegistration {
+            provider: provider.to_string(),
+            templates: templates
+                .iter()
+                .map(|(template, feeds)| DeclaredTemplate::new(*template, *feeds))
+                .collect(),
+        };
+        let sources = vec![
+            declared(
+                "slack",
+                &[
+                    ("viewer", Some(ChainAudience::Self_)),
+                    ("full-members", Some(ChainAudience::Internal)),
+                    ("user-group/<handle>", None),
+                ],
+            ),
+            declared(
+                "google-workspace",
+                &[
+                    ("viewer", Some(ChainAudience::Self_)),
+                    ("full-members", Some(ChainAudience::Internal)),
+                    ("group/<group-address>", None),
+                ],
+            ),
+        ];
+        appa_policy::Config::from_toml_str_routed(text, std::collections::BTreeMap::new(), sources)
+            .expect("the fixture is a policy the loader accepts");
         let document: toml::Value = toml::from_str(text).expect("the fixture parses");
         let mut tokens = Tokens::default();
         strip_policy(&document, &mut tokens, mode)

--- a/appa-runtime/src/yell/strip.rs
+++ b/appa-runtime/src/yell/strip.rs
@@ -381,11 +381,29 @@ impl Walk<'_> {
             // An empty half either side is malformed: the rule cannot know what it holds.
             Some((provider, selector)) if !provider.is_empty() && !selector.is_empty() => {
                 let provider = self.tokens.token(self.mode, Class::Source, provider);
-                let selector = self.tokens.token(self.mode, Class::Selector, selector);
+                let selector = self.selector(selector);
                 Value::String(format!("{provider}:{selector}"))
             }
             _ => self.unclassify(path),
         }
+    }
+
+    /// A selector is one token — unless a segment spells a `$argument`, which makes it a
+    /// selector placeholder: then each literal segment is a selector token of its own and each
+    /// argument keeps its `$` mark over an argument token, so the report shows a placeholder
+    /// as a placeholder, reading a named argument, without spelling the collection.
+    fn selector(&mut self, selector: &str) -> String {
+        if !selector.split('/').any(|segment| segment.starts_with('$')) {
+            return self.tokens.token(self.mode, Class::Selector, selector);
+        }
+        selector
+            .split('/')
+            .map(|segment| match segment.strip_prefix('$') {
+                Some(argument) => format!("${}", self.tokens.token(self.mode, Class::Argument, argument)),
+                None => self.tokens.token(self.mode, Class::Selector, segment),
+            })
+            .collect::<Vec<_>>()
+            .join("/")
     }
 
     /// One authored literal from a return contract, as a token of its own spelling.
@@ -963,5 +981,30 @@ mod tests {
         );
         assert_eq!(first.value["tool"], "tool-2");
         assert_eq!(first.value, second.value, "insertion order does not matter");
+    }
+
+    /// A selector placeholder reads a tool argument: its argument segment keeps the `$` mark
+    /// and correlates with the argument's own key token, while the provider and the literal
+    /// segments are tokens like any selector's.
+    #[test]
+    fn a_selector_placeholder_keeps_its_argument_mark_and_correlates_with_the_argument() {
+        let stripped = run(serde_json::json!({
+            "group": "@slack:channel/$channel_id",
+            "arguments": { "channel_id": "C1" }
+        }));
+        let group = stripped.value["group"].as_str().expect("a placeholder stays a string");
+        let (mention, argument) = group
+            .split_once("/$")
+            .unwrap_or_else(|| panic!("the argument lost its `$` mark: {group}"));
+        assert!(mention.starts_with('@') && mention.contains(':'), "{group}");
+        assert_eq!(
+            stripped.value["argument_keys"],
+            serde_json::json!([argument]),
+            "the placeholder reads the argument the call spells"
+        );
+        assert!(
+            !group.contains("channel"),
+            "the collection's spelling survived: {group}"
+        );
     }
 }

--- a/appa-runtime/tests/annotators.rs
+++ b/appa-runtime/tests/annotators.rs
@@ -945,6 +945,7 @@ url = "{annotator_url}"
 
 [externals.audience.slack]
 url = "{audience_url}"
+selectors = [{{ template = "user-group/<handle>" }}]
 "#
     )
 }

--- a/appa-runtime/tests/annotators.rs
+++ b/appa-runtime/tests/annotators.rs
@@ -1117,3 +1117,92 @@ async fn a_produced_chain_word_narrows_the_trajectory_without_a_directory_read()
     );
     assert!(source.reads().is_empty());
 }
+
+/// An annotator whose mandate reads the call's channel: bound to a tool that carries the
+/// argument, served by `url`; the slack source is declared so the placeholder routes.
+fn placeholder_mandate_policy(url: &str) -> String {
+    format!(
+        r#"
+[policy]
+version = 2
+
+[[policy.annotator]]
+name = "acl"
+audiences = ["@slack:channel/$channel_id"]
+
+[[policy.tool]]
+name = "read_channel"
+parameters = {{ type = "object", properties = {{ channel_id = {{ type = "string" }} }}, required = ["channel_id"] }}
+annotator = "acl"
+
+[externals]
+timeout_ms = 2000
+max_body_bytes = 65536
+
+[externals.annotators.acl]
+url = "{url}"
+
+[externals.audience.slack]
+url = "{url}"
+selectors = [{{ template = "viewer", feeds = "self" }}, {{ template = "channel/<id>" }}]
+"#
+    )
+}
+
+fn read_channel(channel_id: &str) -> ProposedCall {
+    ProposedCall {
+        tool: "read_channel".to_string(),
+        arguments: raw(serde_json::json!({ "channel_id": channel_id })),
+    }
+}
+
+/// A mandate placeholder is instantiated per call: the consult declares the one collection
+/// the call's argument spells, and an answer naming any other collection is outside the
+/// mandate.
+#[tokio::test]
+async fn a_mandate_placeholder_declares_the_collection_each_call_spells() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, annotator) = serve_annotator().await;
+    annotator.set(
+        "acl",
+        Answer::Wire(serde_json::json!({
+            "version": 1,
+            "answer": {
+                "delta": { "audience": ["@slack:channel/C1"] },
+                "requires": { "history": [], "attention": [] },
+                "emits": [],
+            }
+        })),
+    );
+    let runtime = open_runtime(&dir, &placeholder_mandate_policy(&url)).await;
+
+    // The answer names the channel the call reads: the produced delta narrows to it, which
+    // is offered for acceptance like any narrowing.
+    assert!(matches!(
+        propose(&runtime, read_channel("C1")).await,
+        HookDecision::DenyCall { .. }
+    ));
+    let requests = annotator.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]["declaration"]["audiences"],
+        serde_json::json!(["@slack:channel/C1"])
+    );
+
+    // The same answer for another channel names a collection the call did not spell: no
+    // answer at all, which refuses the hook.
+    let baseline = audit_len(&runtime);
+    let second = propose(&runtime, read_channel("C2")).await;
+    assert!(matches!(second, HookDecision::Refuse { .. }), "got {second:?}");
+    let requests = annotator.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        requests[1]["declaration"]["audiences"],
+        serde_json::json!(["@slack:channel/C2"])
+    );
+    assert_eq!(
+        audit_len(&runtime),
+        baseline,
+        "an answer outside the mandate appends nothing"
+    );
+}

--- a/appa-runtime/tests/audience.rs
+++ b/appa-runtime/tests/audience.rs
@@ -49,15 +49,17 @@ max_body_bytes = 4096
 
 [externals.audience.slack]
 url = "AUDIENCE_URL"
+selectors = [{ template = "viewer", feeds = "self" }, { template = "full-members", feeds = "internal" }, { template = "user-group/<handle>" }]
 "#;
 
 /// The `[externals.audience]` block of `POLICY`, for the variants that replace it.
-const SLACK_BINDING: &str = "[externals.audience.slack]\nurl = \"AUDIENCE_URL\"\n";
+const SLACK_BINDING: &str = "[externals.audience.slack]\nurl = \"AUDIENCE_URL\"\nselectors = [{ template = \"viewer\", feeds = \"self\" }, { template = \"full-members\", feeds = \"internal\" }, { template = \"user-group/<handle>\" }]\n";
 
 /// Slack's member lookups answered in process from a roster.
 const ROSTER_BINDINGS: &str = r#"
 [externals.audience.slack]
 url = "AUDIENCE_URL"
+selectors = [{ template = "viewer", feeds = "self" }, { template = "full-members", feeds = "internal" }, { template = "user-group/<handle>" }]
 lookup = "people"
 
 [externals.audience.people]
@@ -69,6 +71,7 @@ readers = { "slack:U-bob" = "bob@corp.example" }
 const LOOKUP_URL_BINDINGS: &str = r#"
 [externals.audience.slack]
 url = "AUDIENCE_URL"
+selectors = [{ template = "viewer", feeds = "self" }, { template = "full-members", feeds = "internal" }, { template = "user-group/<handle>" }]
 lookup = "people"
 
 [externals.audience.people]
@@ -435,7 +438,7 @@ async fn a_retired_trajectory_keeps_the_lookup_routing_it_opened_under() {
 
     // Slack's lookups move to `directory`; a new GitHub group keeps `people` bound.
     let retargeted = format!(
-        "{}\n[externals.audience.directory]\nurl = \"{url}\"\n\n[externals.audience.github]\nurl = \"{url}\"\nlookup = \"people\"\n",
+        "{}\n[externals.audience.directory]\nurl = \"{url}\"\n\n[externals.audience.github]\nurl = \"{url}\"\nlookup = \"people\"\nselectors = [{{ template = \"org/<org>/members\", feeds = \"internal\" }}]\n",
         policy
             .replace("AUDIENCE_URL", &url)
             .replace("lookup = \"people\"", "lookup = \"directory\"")
@@ -472,12 +475,15 @@ async fn a_retired_trajectory_keeps_the_lookup_routing_it_opened_under() {
 fn a_referenced_audience_source_must_be_bound() {
     let dir = tempfile::tempdir().expect("a temp dir is creatable");
     let path = dir.path().join("appa.toml");
-    let unbound = POLICY.replace("[externals.audience.slack]\nurl = \"AUDIENCE_URL\"\n", "");
+    let unbound = POLICY.replace(SLACK_BINDING, "");
     std::fs::write(&path, unbound).expect("the fixture writes");
+    // The binding carries the provider's declaration, so without it the policy's own
+    // `slack:` references have no provider to resolve against.
     let config = Config::load(&path).expect("the file validates");
     assert!(matches!(
         Runtime::open(config, dir.path().join("appa.db"), None),
-        Err(appa_runtime::api::OpenError::UnboundExternal { .. })
+        Err(appa_runtime::api::OpenError::Policy(error))
+            if matches!(*error, appa_policy::ConfigError::UndeclaredProvider { .. })
     ));
 }
 

--- a/appa-runtime/tests/audience.rs
+++ b/appa-runtime/tests/audience.rs
@@ -724,3 +724,70 @@ async fn a_cap_written_with_a_group_is_read_per_act_from_the_source() {
     );
     assert_eq!(source.requests().len(), 4);
 }
+
+/// `POLICY` with a channel-keyed sink: posting to a channel requires that channel's members
+/// among the current readers, the channel read from the call.
+const CHANNEL_POLICY: &str = r#"
+[policy]
+version = 2
+
+[[policy.tool]]
+name = "read_hr"
+delta = { audience = ["alice@corp.example", "bob@corp.example"] }
+
+[[policy.tool]]
+name = "post"
+parameters = { type = "object", properties = { channel_id = { type = "string" }, text = { type = "string" } }, required = ["channel_id", "text"] }
+requires = { audience = { contains = ["@slack:channel/$channel_id"] } }
+effects = ["egress"]
+delta = {}
+
+[externals]
+timeout_ms = 1000
+max_body_bytes = 4096
+
+[externals.audience.slack]
+url = "AUDIENCE_URL"
+selectors = [{ template = "viewer", feeds = "self" }, { template = "channel/<id>" }]
+"#;
+
+fn post_to(channel_id: &str) -> ProposedCall {
+    ProposedCall {
+        tool: "post".to_string(),
+        arguments: raw(serde_json::json!({ "channel_id": channel_id, "text": "hi" })),
+    }
+}
+
+/// A selector placeholder is instantiated from each call: the source is asked for exactly the
+/// collection the call's argument spells, and its answer is checked as a static mention's is.
+#[tokio::test]
+async fn a_selector_placeholder_asks_the_source_for_the_collection_the_call_spells() {
+    let dir = tempfile::tempdir().expect("a temp dir is creatable");
+    let (url, source) = serve_source().await;
+    let runtime = narrowed_under(&dir, CHANNEL_POLICY, &url).await;
+
+    source.members(Some(vec!["alice@corp.example"]));
+    assert_eq!(
+        propose(&runtime, post_to("C1")).await,
+        HookDecision::AllowCall { spawn: None }
+    );
+    ran(&runtime, post_to("C1")).await;
+    let requests = source.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]["declaration"]["templates"],
+        serde_json::json!(["viewer", "channel/<id>"])
+    );
+    assert_eq!(requests[0]["artifact"], serde_json::json!({ "selector": "channel/C1" }));
+
+    // Another channel is another collection, asked for by its own selector.
+    source.members(Some(vec!["alice@corp.example", "slack:U-carol"]));
+    assert!(matches!(
+        propose(&runtime, post_to("C2")).await,
+        HookDecision::DenyCall { .. }
+    ));
+    let requests = source.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[1]["artifact"], serde_json::json!({ "selector": "channel/C2" }));
+    assert!(audit_len(&runtime) > 0, "the decided acts read back");
+}

--- a/appa-runtime/tests/marketplace.rs
+++ b/appa-runtime/tests/marketplace.rs
@@ -466,15 +466,9 @@ fn a_battery_that_validates_loads() {
 
     for (what, validates_expected, loads_expected, fragment) in fragments {
         let package = tempfile::tempdir().expect("a temp dir is creatable");
-        // The manifest declares the audience source a row binds: which sources a
-        // battery binds is a separate rule, tested in `appa-package`.
-        let audiences = match fragment.contains("[externals.audience.probe]") {
-            true => "audiences = [\"probe\"]\n",
-            false => "",
-        };
         std::fs::write(
             package.path().join("appa-package.toml"),
-            format!("schema = 1\nname = \"probe\"\ndescription = \"a fragment on a rule's edge\"\n\n[battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n{audiences}"),
+            "schema = 1\nname = \"probe\"\ndescription = \"a fragment on a rule's edge\"\n\n[battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n",
         )
         .expect("the manifest is writable");
         std::fs::write(package.path().join("appa.toml"), &fragment).expect("the policy is writable");

--- a/appa-runtime/tests/marketplace.rs
+++ b/appa-runtime/tests/marketplace.rs
@@ -231,6 +231,86 @@ fn every_battery_composes_into_each_host_it_declares() {
     }
 }
 
+/// Every audience source a battery binds refuses a consult whose declared
+/// templates are not the ones it serves, and does so before it reads a
+/// credential: with no `APPA_PROVIDER_*` variable set, the matching
+/// declaration reaches the token check (exit 1) and a foreign one stops at
+/// the declaration check (exit 2). A policy and a script of different
+/// versions never answer each other, whatever the policy declares.
+#[test]
+fn every_bound_audience_source_checks_its_declaration_before_its_credential() {
+    let root = marketplace_root();
+    let mut checked = 0;
+    for entry in &manifest().packages {
+        let directory = root.join(entry.path.as_str());
+        let Role::Battery(battery) = validate_package(&directory).expect("the package validates").role else {
+            continue;
+        };
+        let installed = tempfile::tempdir().expect("a temp dir is creatable");
+        copy_tree(&directory, installed.path());
+        let policy: toml::Value = toml::from_str(
+            &std::fs::read_to_string(installed.path().join(battery.policy.as_str())).expect("the battery policy reads"),
+        )
+        .expect("the battery policy is TOML");
+        for source in appa_policy::declared_sources(&policy).expect("the battery declares its sources") {
+            let provider = &source.provider;
+            let argv: Vec<&str> = policy["externals"]["audience"][provider]["command"]
+                .as_array()
+                .expect("a battery binds its source by a command")
+                .iter()
+                .map(|word| word.as_str().expect("an argv word"))
+                .collect();
+            let served: Vec<String> = source
+                .templates
+                .iter()
+                .map(|t| t.template.as_str().to_owned())
+                .collect();
+            let mut foreign = served.clone();
+            foreign.push("foreign/<x>".to_owned());
+            for (templates, expected) in [(served, 1), (foreign, 2)] {
+                let consult = serde_json::json!({
+                    "version": 1,
+                    "kind": "audience",
+                    "name": provider,
+                    "declaration": { "templates": templates },
+                    "artifact": { "selector": "viewer" },
+                });
+                let mut child = Command::new(argv[0])
+                    .args(&argv[1..])
+                    .current_dir(installed.path())
+                    .env_clear()
+                    .env("PATH", std::env::var("PATH").unwrap_or_default())
+                    .stdin(std::process::Stdio::piped())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped())
+                    .spawn()
+                    .expect("the helper spawns");
+                child
+                    .stdin
+                    .take()
+                    .expect("stdin is piped")
+                    .write_all(consult.to_string().as_bytes())
+                    .expect("the consult writes");
+                let output = child.wait_with_output().expect("the helper exits");
+                assert_eq!(
+                    output.status.code(),
+                    Some(expected),
+                    "{provider} of {}: {}",
+                    entry.path,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                assert!(
+                    output.stdout.is_empty(),
+                    "{provider} of {} answered without a credential",
+                    entry.path
+                );
+            }
+            checked += 1;
+        }
+    }
+    assert!(checked >= 3, "the shipped batteries bind audience sources");
+}
+
 /// One package directory, as a deployment would hold it.
 fn copy_tree(source: &Path, destination: &Path) {
     std::fs::create_dir_all(destination).expect("the destination is creatable");
@@ -353,13 +433,48 @@ fn a_battery_that_validates_loads() {
             format!("[deployment]\nname = \"x\"\n{}", body(tool, "")),
         ),
         ("no policy version", no, no, format!("[policy]\n\n{tool}")),
+        (
+            "a source declaring the selectors it serves",
+            yes,
+            yes,
+            body(
+                tool,
+                &format!(
+                    "{command}selectors = [{{ template = \"viewer\", feeds = \"self\" }}, {{ template = \"channel/<id>\" }}]\n"
+                ),
+            ),
+        ),
+        (
+            "a selector feeding an audience outside the chain",
+            no,
+            no,
+            body(
+                tool,
+                &format!("{command}selectors = [{{ template = \"viewer\", feeds = \"public\" }}]\n"),
+            ),
+        ),
+        (
+            "a selector declared twice",
+            no,
+            no,
+            body(
+                tool,
+                &format!("{command}selectors = [{{ template = \"viewer\" }}, {{ template = \"viewer\" }}]\n"),
+            ),
+        ),
     ];
 
     for (what, validates_expected, loads_expected, fragment) in fragments {
         let package = tempfile::tempdir().expect("a temp dir is creatable");
+        // The manifest declares the audience source a row binds: which sources a
+        // battery binds is a separate rule, tested in `appa-package`.
+        let audiences = match fragment.contains("[externals.audience.probe]") {
+            true => "audiences = [\"probe\"]\n",
+            false => "",
+        };
         std::fs::write(
             package.path().join("appa-package.toml"),
-            "schema = 1\nname = \"probe\"\ndescription = \"a fragment on a rule's edge\"\n\n[battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n",
+            format!("schema = 1\nname = \"probe\"\ndescription = \"a fragment on a rule's edge\"\n\n[battery]\npolicy = \"appa.toml\"\nhosts = [\"claude-code\"]\nhelpers = [\"audience-source.py\"]\n{audiences}"),
         )
         .expect("the manifest is writable");
         std::fs::write(package.path().join("appa.toml"), &fragment).expect("the policy is writable");

--- a/examples/claude-code-battery/appa.toml
+++ b/examples/claude-code-battery/appa.toml
@@ -18,10 +18,10 @@ hint = "Ask the person running the session."
 [policy.authority.permits]
 attention = ["hitl"]
 
-# Audience mappings are root-only. The Slack battery ships the source
-# script; mapping its collections here registers the `slack` provider,
-# so the binding below must sit beside the mapping. The script reads
-# its token from APPA_PROVIDER_SLACK_TOKEN.
+# Audience mappings are root-only. The Slack battery binds the `slack`
+# source and declares its selectors; the mapping here registers the
+# provider onto the chain. The battery's script reads its token from
+# APPA_PROVIDER_SLACK_TOKEN.
 [policy.audience]
 self = ["slack:viewer"]
 internal = ["slack:full-members"]
@@ -35,10 +35,6 @@ max_body_bytes = 1048576
 
 [externals.authorities.hitl]
 builtin = "hitl"
-
-[externals.audience.slack]
-command = ["python3", "../../marketplace/batteries/slack/audience-source.py"]
-token_env = "APPA_PROVIDER_SLACK_TOKEN"   # the one variable this command inherits
 
 # Root contracts run before every included battery. This local rule bypasses
 # the shipped Bash classifier for `cargo test` and adds a fresh approval step.

--- a/integrations/appa-guide/references/claude-code.md
+++ b/integrations/appa-guide/references/claude-code.md
@@ -141,9 +141,10 @@ matched battery covers.
   placeholder instead of `internal`: `delta = { audience = ["@slack:channel/$channel_id"] }`
   for a read, `requires = { audience = { contains = ["@slack:channel/$channel_id"] } }`
   for a write. The spelling must match a template the provider declares under
-  `selectors` on its `[externals.audience.<provider>]` binding, and every
-  `$argument` must be a required string in the contract's `parameters`. Use it
-  whenever the matched battery declares such a template.
+  `selectors` on its `[externals.audience.<provider>]` binding; each
+  `$argument` becomes a required string argument of the contract, so no
+  `parameters` schema is needed for it. Use it whenever the matched battery
+  declares such a template.
 - An annotator's answer writes an audience as a static contract does: `self`,
   `internal`, an `@` mention, or a literal reader, inside its mandate's
   `audiences`. Omitted, the mandate admits every audience the policy writes.

--- a/integrations/appa-guide/references/claude-code.md
+++ b/integrations/appa-guide/references/claude-code.md
@@ -136,6 +136,14 @@ matched battery covers.
 - Static contracts can reference `self` and `internal` without an audience
   source. Checking a literal recipient against either audience requires an
   explicit audience source.
+- A tool that reads or writes one resource whose readers a source can list
+  (a Slack channel, a GitHub repository, a Linear team) uses a selector
+  placeholder instead of `internal`: `delta = { audience = ["@slack:channel/$channel_id"] }`
+  for a read, `requires = { audience = { contains = ["@slack:channel/$channel_id"] } }`
+  for a write. The spelling must match a template the provider declares under
+  `selectors` on its `[externals.audience.<provider>]` binding, and every
+  `$argument` must be a required string in the contract's `parameters`. Use it
+  whenever the matched battery declares such a template.
 - An annotator's answer writes an audience as a static contract does: `self`,
   `internal`, an `@` mention, or a literal reader, inside its mandate's
   `audiences`. Omitted, the mandate admits every audience the policy writes.

--- a/marketplace/batteries/github/README.md
+++ b/marketplace/batteries/github/README.md
@@ -69,10 +69,8 @@ from = ["github:org/archestra-ai/team/finance"]
 ```
 
 Every consult carries the declared templates, and the script refuses
-one whose declaration differs from what it serves (exit status 2)
-before it reads a token: a policy and a script of different versions
-never answer each other. The runtime probes `viewer` and the mapped
-`org/<org>/members` at startup, so the skew surfaces before a decision.
+one whose declaration differs from what it serves (exit status 2), so a
+policy and a script of different versions never answer each other.
 
 The script reads its token from `APPA_PROVIDER_GITHUB_TOKEN`, which the
 binding's `token_env` forwards. The token needs the `read:org` and

--- a/marketplace/batteries/github/README.md
+++ b/marketplace/batteries/github/README.md
@@ -31,8 +31,8 @@ Gists, Notifications, Projects, security alerts) are not listed here.
 A tool the policy does not name is blocked; add rules for them in your
 root config if you enable those sets.
 
-**`audience-source.py`** — the `github` audience source. It answers the
-stock catalog's selectors over the GitHub REST API:
+**`audience-source.py`** — the `github` audience source. It answers
+these selectors over the GitHub REST API:
 
 - `github:viewer` — the token's own reader: its primary verified email
   from `/user/emails`, else `github:<login>`. Feeds `self`.
@@ -53,8 +53,10 @@ large organization needs `externals.timeout_ms` sized for it. The member lookup
 resolves a `github:<login>` member the same way and answers `null`
 for a login GitHub does not know.
 
-The source is not wired by this file: audience mappings are root-only,
-and the binding must sit beside them. In the root config:
+The battery binds the source itself, under `[externals.audience.github]`
+in `appa.toml`, and declares the three templates above as its
+`selectors`. Audience mappings are root-only, so the root config maps
+the chain onto them:
 
 ```toml
 [policy.audience]
@@ -64,14 +66,13 @@ internal = ["github:org/archestra-ai/members"]
 [policy.audience.group.finance]
 within = "internal"
 from = ["github:org/archestra-ai/team/finance"]
-
-[externals.audience.github]
-command = ["python3", "batteries/github/audience-source.py"]
-token_env = "APPA_PROVIDER_GITHUB_TOKEN"
 ```
 
-A command path is resolved against the directory of the config file
-that names it, so write the path as your root config sees the battery.
+Every consult carries the declared templates, and the script refuses
+one whose declaration differs from what it serves (exit status 2)
+before it reads a token: a policy and a script of different versions
+never answer each other. The runtime probes `viewer` and the mapped
+`org/<org>/members` at startup, so the skew surfaces before a decision.
 
 The script reads its token from `APPA_PROVIDER_GITHUB_TOKEN`, which the
 binding's `token_env` forwards. The token needs the `read:org` and

--- a/marketplace/batteries/github/appa-package.toml
+++ b/marketplace/batteries/github/appa-package.toml
@@ -7,4 +7,3 @@ policy = "appa.toml"
 hosts = ["claude-code", "kagent"]
 namespaces = ["github"]
 helpers = ["audience-source.py"]
-audiences = ["github"]

--- a/marketplace/batteries/github/appa-package.toml
+++ b/marketplace/batteries/github/appa-package.toml
@@ -7,3 +7,4 @@ policy = "appa.toml"
 hosts = ["claude-code", "kagent"]
 namespaces = ["github"]
 helpers = ["audience-source.py"]
+audiences = ["github"]

--- a/marketplace/batteries/github/appa.toml
+++ b/marketplace/batteries/github/appa.toml
@@ -25,12 +25,21 @@
 #   #
 # To cover a whole organisation instead, match `owner:my-org`.
 #
-# The battery also ships `audience-source.py`, the `github` audience
-# source. Audience mappings are root-only, so the binding sits beside
-# them in the root config, not here — the README shows the wiring.
+# The battery also binds `audience-source.py`, the `github` audience
+# source, and declares the selectors it serves. The root config maps
+# `self` and `internal` onto them — the README shows the wiring.
 
 [policy]
 version = 2
+
+[externals.audience.github]
+command = ["python3", "audience-source.py"]
+token_env = "APPA_PROVIDER_GITHUB_TOKEN"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "org/<org>/members", feeds = "internal" },
+  { template = "org/<org>/team/<team>" },
+]
 
 # --- who am I: no outside content, nothing sent ---
 

--- a/marketplace/batteries/github/audience-source.py
+++ b/marketplace/batteries/github/audience-source.py
@@ -1,6 +1,6 @@
 """The github audience source: one consult in, one answer out.
 
-Serves the stock `github` selector catalog over the GitHub REST API:
+Serves these selector templates over the GitHub REST API:
 
   viewer                  the token's own reader
   org/<org>/members       one explicitly selected organization's members
@@ -35,6 +35,8 @@ import urllib.request
 
 API_ROOT = "https://api.github.com"
 TOKEN_VAR = "APPA_PROVIDER_GITHUB_TOKEN"
+SOURCE_NAME = "github"
+SERVED_TEMPLATES = ["viewer", "org/<org>/members", "org/<org>/team/<team>"]
 TIMEOUT_SECONDS = 30
 PAGE_SIZE = 100
 
@@ -165,6 +167,23 @@ def answer(call, artifact):
             raise ValueError("the artifact must carry exactly a selector or a member")
 
 
+def check_declaration(request):
+    """The policy's declared templates against the ones this script serves.
+
+    The binding beside this script declares them to the policy, and the
+    runtime sends that declaration with every consult. A mismatch is a
+    version skew between policy and script, refused before any credential
+    is read; the exit status 2 tells it apart from a provider failure.
+    """
+    declared = request.get("declaration", {}).get("templates")
+    if declared != SERVED_TEMPLATES:
+        print(
+            f"{SOURCE_NAME} audience source: the policy declares {declared!r}, this script serves {SERVED_TEMPLATES!r}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
 def main():
     request = json.load(sys.stdin)
 
@@ -172,8 +191,9 @@ def main():
         raise ValueError("unsupported request version")
     if request.get("kind") != "audience":
         raise ValueError("unexpected consult kind")
-    if request.get("name") != "github":
+    if request.get("name") != SOURCE_NAME:
         raise ValueError("unexpected source name")
+    check_declaration(request)
 
     token = os.environ.get(TOKEN_VAR)
     if not token:

--- a/marketplace/batteries/github/test_audience_source.py
+++ b/marketplace/batteries/github/test_audience_source.py
@@ -198,6 +198,13 @@ class EnvelopeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1, result.stderr)
         self.assertIn("APPA_PROVIDER_GITHUB_TOKEN", result.stderr)
 
+    def test_a_foreign_declaration_is_refused_before_the_token_is_read(self):
+        declared = self.envelope()["declaration"]["templates"]
+        for templates in [declared + ["channel/<id>"], declared[1:], [], list(reversed(declared))]:
+            result = self.run_script(self.envelope(declaration={"templates": templates}), {"PATH": "/usr/bin:/bin"})
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertEqual(result.stdout, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/marketplace/batteries/google-workspace/README.md
+++ b/marketplace/batteries/google-workspace/README.md
@@ -6,8 +6,8 @@ Workspace directory.
 
 ## Files
 
-**`audience-source.py`** — answers the stock catalog's selectors over
-Google's OpenID userinfo and Admin SDK Directory APIs:
+**`audience-source.py`** — answers these selectors over Google's
+OpenID userinfo and Admin SDK Directory APIs:
 
 - `google-workspace:viewer` — the token's own reader: its email when
   the userinfo endpoint marks it verified, else
@@ -26,8 +26,10 @@ the account's primary email, so an alias resolves to the same reader
 as the account; it answers `null` for an address the directory does
 not know.
 
-The source is not wired by this file: audience mappings are root-only,
-and the binding must sit beside them. In the root config:
+The battery binds the source itself, under
+`[externals.audience.google-workspace]` in `appa.toml`, and declares
+the three templates above as its `selectors`. Audience mappings are
+root-only, so the root config maps the chain onto them:
 
 ```toml
 [policy.audience]
@@ -37,14 +39,13 @@ internal = ["google-workspace:full-members"]
 [policy.audience.group.finance]
 within = "internal"
 from = ["google-workspace:group/finance@corp.com"]
-
-[externals.audience.google-workspace]
-command = ["python3", "batteries/google-workspace/audience-source.py"]
-token_env = "APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN"
 ```
 
-A command path is resolved against the directory of the config file
-that names it, so write the path as your root config sees the battery.
+Every consult carries the declared templates, and the script refuses
+one whose declaration differs from what it serves (exit status 2)
+before it reads a token: a policy and a script of different versions
+never answer each other. The runtime probes `viewer` and
+`full-members` at startup, so the skew surfaces before a decision.
 
 The script reads its token from `APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN`,
 which the binding's `token_env` forwards: an OAuth2 access token with the

--- a/marketplace/batteries/google-workspace/README.md
+++ b/marketplace/batteries/google-workspace/README.md
@@ -42,10 +42,8 @@ from = ["google-workspace:group/finance@corp.com"]
 ```
 
 Every consult carries the declared templates, and the script refuses
-one whose declaration differs from what it serves (exit status 2)
-before it reads a token: a policy and a script of different versions
-never answer each other. The runtime probes `viewer` and
-`full-members` at startup, so the skew surfaces before a decision.
+one whose declaration differs from what it serves (exit status 2), so a
+policy and a script of different versions never answer each other.
 
 The script reads its token from `APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN`,
 which the binding's `token_env` forwards: an OAuth2 access token with the

--- a/marketplace/batteries/google-workspace/appa-package.toml
+++ b/marketplace/batteries/google-workspace/appa-package.toml
@@ -7,4 +7,3 @@ policy = "appa.toml"
 hosts = ["claude-code"]
 namespaces = ["google-workspace"]
 helpers = ["audience-source.py"]
-audiences = ["google-workspace"]

--- a/marketplace/batteries/google-workspace/appa-package.toml
+++ b/marketplace/batteries/google-workspace/appa-package.toml
@@ -7,3 +7,4 @@ policy = "appa.toml"
 hosts = ["claude-code"]
 namespaces = ["google-workspace"]
 helpers = ["audience-source.py"]
+audiences = ["google-workspace"]

--- a/marketplace/batteries/google-workspace/appa.toml
+++ b/marketplace/batteries/google-workspace/appa.toml
@@ -1,9 +1,18 @@
 # Google Workspace battery.
 #
-# This battery ships `audience-source.py`, the `google-workspace`
-# audience source; it carries no tool rules yet. Audience mappings are
-# root-only, so the binding sits beside them in the root config, not
-# here — the README shows the wiring.
+# This battery binds `audience-source.py`, the `google-workspace`
+# audience source, and declares the selectors it serves; it carries no
+# tool rules yet. The root config maps `self` and `internal` onto the
+# selectors — the README shows the wiring.
 
 [policy]
 version = 2
+
+[externals.audience.google-workspace]
+command = ["python3", "audience-source.py"]
+token_env = "APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "full-members", feeds = "internal" },
+  { template = "group/<group-address>" },
+]

--- a/marketplace/batteries/google-workspace/audience-source.py
+++ b/marketplace/batteries/google-workspace/audience-source.py
@@ -1,7 +1,7 @@
 """The google-workspace audience source: one consult in, one answer out.
 
-Serves the stock `google-workspace` selector catalog over Google's
-OpenID userinfo and Admin SDK Directory APIs:
+Serves these selector templates over Google's OpenID userinfo and
+Admin SDK Directory APIs:
 
   viewer                   the token's own reader
   full-members             every active Workspace user — no suspended,
@@ -40,6 +40,8 @@ import urllib.request
 USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
 DIRECTORY_ROOT = "https://admin.googleapis.com/admin/directory/v1"
 TOKEN_VAR = "APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN"
+SOURCE_NAME = "google-workspace"
+SERVED_TEMPLATES = ["viewer", "full-members", "group/<group-address>"]
 TIMEOUT_SECONDS = 30
 
 
@@ -149,6 +151,23 @@ def answer(call, artifact):
             raise ValueError("the artifact must carry exactly a selector or a member")
 
 
+def check_declaration(request):
+    """The policy's declared templates against the ones this script serves.
+
+    The binding beside this script declares them to the policy, and the
+    runtime sends that declaration with every consult. A mismatch is a
+    version skew between policy and script, refused before any credential
+    is read; the exit status 2 tells it apart from a provider failure.
+    """
+    declared = request.get("declaration", {}).get("templates")
+    if declared != SERVED_TEMPLATES:
+        print(
+            f"{SOURCE_NAME} audience source: the policy declares {declared!r}, this script serves {SERVED_TEMPLATES!r}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
 def main():
     request = json.load(sys.stdin)
 
@@ -156,8 +175,9 @@ def main():
         raise ValueError("unsupported request version")
     if request.get("kind") != "audience":
         raise ValueError("unexpected consult kind")
-    if request.get("name") != "google-workspace":
+    if request.get("name") != SOURCE_NAME:
         raise ValueError("unexpected source name")
+    check_declaration(request)
 
     token = os.environ.get(TOKEN_VAR)
     if not token:

--- a/marketplace/batteries/google-workspace/test_audience_source.py
+++ b/marketplace/batteries/google-workspace/test_audience_source.py
@@ -190,6 +190,13 @@ class EnvelopeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1, result.stderr)
         self.assertIn("APPA_PROVIDER_GOOGLE_WORKSPACE_TOKEN", result.stderr)
 
+    def test_a_foreign_declaration_is_refused_before_the_token_is_read(self):
+        declared = self.envelope()["declaration"]["templates"]
+        for templates in [declared + ["channel/<id>"], declared[1:], [], list(reversed(declared))]:
+            result = self.run_script(self.envelope(declaration={"templates": templates}), {"PATH": "/usr/bin:/bin"})
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertEqual(result.stdout, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/marketplace/batteries/slack/README.md
+++ b/marketplace/batteries/slack/README.md
@@ -58,10 +58,8 @@ from = ["slack:user-group/finance"]
 ```
 
 Every consult carries the declared templates, and the script refuses
-one whose declaration differs from what it serves (exit status 2)
-before it reads a token: a policy and a script of different versions
-never answer each other. The runtime probes `viewer` and
-`full-members` at startup, so the skew surfaces before a decision.
+one whose declaration differs from what it serves (exit status 2), so a
+policy and a script of different versions never answer each other.
 
 The script reads its token from `APPA_PROVIDER_SLACK_TOKEN`, which the
 binding's `token_env` forwards. The token needs the `users:read`,

--- a/marketplace/batteries/slack/README.md
+++ b/marketplace/batteries/slack/README.md
@@ -21,8 +21,8 @@ or updating a canvas, creating a channel. Trusted data that reaches
 autonomously without human interruption, while requester secrets
 (`self`) are strictly prevented from entering channels.
 
-**`audience-source.py`** — the `slack` audience source. It answers the
-stock catalog's selectors over the Slack Web API:
+**`audience-source.py`** — the `slack` audience source. It answers
+these selectors over the Slack Web API:
 
 - `slack:viewer` — the token's own reader. Feeds `self`, so use a
   user token when the session acts for a person; a bot token makes the
@@ -42,8 +42,10 @@ confirmed, else `slack:<id>`, which merges with no other provider's
 reader. The member lookup resolves a `slack:U...` member the same way
 and answers `null` for an id Slack does not know.
 
-The source is not wired by this file: audience mappings are root-only,
-and the binding must sit beside them. In the root config:
+The battery binds the source itself, under `[externals.audience.slack]`
+in `appa.toml`, and declares the three templates above as its
+`selectors`. Audience mappings are root-only, so the root config maps
+the chain onto them:
 
 ```toml
 [policy.audience]
@@ -53,14 +55,13 @@ internal = ["slack:full-members"]
 [policy.audience.group.finance]
 within = "internal"
 from = ["slack:user-group/finance"]
-
-[externals.audience.slack]
-command = ["python3", "batteries/slack/audience-source.py"]
-token_env = "APPA_PROVIDER_SLACK_TOKEN"
 ```
 
-A command path is resolved against the directory of the config file
-that names it, so write the path as your root config sees the battery.
+Every consult carries the declared templates, and the script refuses
+one whose declaration differs from what it serves (exit status 2)
+before it reads a token: a policy and a script of different versions
+never answer each other. The runtime probes `viewer` and
+`full-members` at startup, so the skew surfaces before a decision.
 
 The script reads its token from `APPA_PROVIDER_SLACK_TOKEN`, which the
 binding's `token_env` forwards. The token needs the `users:read`,

--- a/marketplace/batteries/slack/appa-package.toml
+++ b/marketplace/batteries/slack/appa-package.toml
@@ -7,4 +7,3 @@ policy = "appa.toml"
 hosts = ["claude-code"]
 namespaces = ["claude_ai_Slack"]
 helpers = ["audience-source.py"]
-audiences = ["slack"]

--- a/marketplace/batteries/slack/appa-package.toml
+++ b/marketplace/batteries/slack/appa-package.toml
@@ -7,3 +7,4 @@ policy = "appa.toml"
 hosts = ["claude-code"]
 namespaces = ["claude_ai_Slack"]
 helpers = ["audience-source.py"]
+audiences = ["slack"]

--- a/marketplace/batteries/slack/appa.toml
+++ b/marketplace/batteries/slack/appa.toml
@@ -21,12 +21,21 @@
 #   requires = { trust = "trusted" }
 #   delta = {}
 #
-# The battery also ships `audience-source.py`, the `slack` audience
-# source. Audience mappings are root-only, so the binding sits beside
-# them in the root config, not here — the README shows the wiring.
+# The battery also binds `audience-source.py`, the `slack` audience
+# source, and declares the selectors it serves. The root config maps
+# `self` and `internal` onto them — the README shows the wiring.
 
 [policy]
 version = 2
+
+[externals.audience.slack]
+command = ["python3", "audience-source.py"]
+token_env = "APPA_PROVIDER_SLACK_TOKEN"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "full-members", feeds = "internal" },
+  { template = "user-group/<handle>" },
+]
 
 # --- reads: internal ---
 

--- a/marketplace/batteries/slack/audience-source.py
+++ b/marketplace/batteries/slack/audience-source.py
@@ -1,6 +1,6 @@
 """The slack audience source: one consult in, one answer out.
 
-Serves the stock `slack` selector catalog over the Slack Web API:
+Serves these selector templates over the Slack Web API:
 
   viewer               the token's own reader
   full-members         every full workspace member — no guests, no
@@ -31,6 +31,8 @@ import urllib.request
 
 API_ROOT = "https://slack.com/api/"
 TOKEN_VAR = "APPA_PROVIDER_SLACK_TOKEN"
+SOURCE_NAME = "slack"
+SERVED_TEMPLATES = ["viewer", "full-members", "user-group/<handle>"]
 TIMEOUT_SECONDS = 30
 
 
@@ -171,6 +173,23 @@ def answer(call, artifact):
             raise ValueError("the artifact must carry exactly a selector or a member")
 
 
+def check_declaration(request):
+    """The policy's declared templates against the ones this script serves.
+
+    The binding beside this script declares them to the policy, and the
+    runtime sends that declaration with every consult. A mismatch is a
+    version skew between policy and script, refused before any credential
+    is read; the exit status 2 tells it apart from a provider failure.
+    """
+    declared = request.get("declaration", {}).get("templates")
+    if declared != SERVED_TEMPLATES:
+        print(
+            f"{SOURCE_NAME} audience source: the policy declares {declared!r}, this script serves {SERVED_TEMPLATES!r}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
 def main():
     request = json.load(sys.stdin)
 
@@ -178,8 +197,9 @@ def main():
         raise ValueError("unsupported request version")
     if request.get("kind") != "audience":
         raise ValueError("unexpected consult kind")
-    if request.get("name") != "slack":
+    if request.get("name") != SOURCE_NAME:
         raise ValueError("unexpected source name")
+    check_declaration(request)
 
     token = os.environ.get(TOKEN_VAR)
     if not token:

--- a/marketplace/batteries/slack/test_audience_source.py
+++ b/marketplace/batteries/slack/test_audience_source.py
@@ -228,6 +228,13 @@ class EnvelopeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1, result.stderr)
         self.assertIn("APPA_PROVIDER_SLACK_TOKEN", result.stderr)
 
+    def test_a_foreign_declaration_is_refused_before_the_token_is_read(self):
+        declared = self.envelope()["declaration"]["templates"]
+        for templates in [declared + ["channel/<id>"], declared[1:], [], list(reversed(declared))]:
+            result = self.run_script(self.envelope(declaration={"templates": templates}), {"PATH": "/usr/bin:/bin"})
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertEqual(result.stdout, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/marketplace/marketplace.toml
+++ b/marketplace/marketplace.toml
@@ -8,11 +8,11 @@ digest = "sha256:6856d2b668f484385ed3078f27e3fbbf89092941147b2708a9e9c32c871e41a
 
 [packages.battery.github]
 path = "batteries/github"
-digest = "sha256:43aac415f91a5cfe1be336ee71e9390e8ecaf72a5d6fbc9fa44d501335f55c48"
+digest = "sha256:e8001ba0c26d1a39fffbed8af1011026bea4b6319801aee3ff6b9344d2089d94"
 
 [packages.battery.google-workspace]
 path = "batteries/google-workspace"
-digest = "sha256:a3063be34cffc07930547f964969f857886798e0e2e2e0b00705b0d20bd96508"
+digest = "sha256:767b11b54a25e2d0d225cce59655d30224419279202703515a2b2f1fe37f2acb"
 
 [packages.battery.grain]
 path = "batteries/grain"
@@ -24,11 +24,11 @@ digest = "sha256:ae234d868a848766fb0bfeb14cbf5ed229aeef8e0448c25dac923d1479308b4
 
 [packages.battery.slack]
 path = "batteries/slack"
-digest = "sha256:8b4598df4d0f83ba29a2ded48be4382dcbc6908390df7906378671cb80fd1299"
+digest = "sha256:c22d304c6299ce34436a57401be1333b9201909df04700a7e262ee629a27ff00"
 
 [packages.plugin.claude-code]
 path = "plugins/claude-code"
-digest = "sha256:e49eaeb09d3ed01be8dfa2aa221f34024ad5c35a9769e0ef9a53f043d3bbbf35"
+digest = "sha256:5cbb451f0d4433d1ffa082beba5ce3cd3ddd8d9156bb8d168748ce0c99223e1c"
 
 [packages.plugin.kagent]
 path = "plugins/kagent"

--- a/marketplace/marketplace.toml
+++ b/marketplace/marketplace.toml
@@ -8,11 +8,11 @@ digest = "sha256:6856d2b668f484385ed3078f27e3fbbf89092941147b2708a9e9c32c871e41a
 
 [packages.battery.github]
 path = "batteries/github"
-digest = "sha256:9c712fe55bf86f40003ff2ad939784fa1d106ddc382beeafa2f08ff3ab0555a9"
+digest = "sha256:43aac415f91a5cfe1be336ee71e9390e8ecaf72a5d6fbc9fa44d501335f55c48"
 
 [packages.battery.google-workspace]
 path = "batteries/google-workspace"
-digest = "sha256:4098dca12850701f474bfd0284a5f2d282b9f3de30da6561b36f9a5f9a72d55e"
+digest = "sha256:a3063be34cffc07930547f964969f857886798e0e2e2e0b00705b0d20bd96508"
 
 [packages.battery.grain]
 path = "batteries/grain"
@@ -24,11 +24,11 @@ digest = "sha256:ae234d868a848766fb0bfeb14cbf5ed229aeef8e0448c25dac923d1479308b4
 
 [packages.battery.slack]
 path = "batteries/slack"
-digest = "sha256:d57d698314e80c03b2ea40be798fa71ad78c5d12dd724de3cdd8ea774df80fb7"
+digest = "sha256:8b4598df4d0f83ba29a2ded48be4382dcbc6908390df7906378671cb80fd1299"
 
 [packages.plugin.claude-code]
 path = "plugins/claude-code"
-digest = "sha256:d7ac4ba2e16b26ab8642c863e2c90cf824bd8a940b2def140075f9f2f51d28eb"
+digest = "sha256:e49eaeb09d3ed01be8dfa2aa221f34024ad5c35a9769e0ef9a53f043d3bbbf35"
 
 [packages.plugin.kagent]
 path = "plugins/kagent"

--- a/marketplace/marketplace.toml
+++ b/marketplace/marketplace.toml
@@ -28,7 +28,7 @@ digest = "sha256:c22d304c6299ce34436a57401be1333b9201909df04700a7e262ee629a27ff0
 
 [packages.plugin.claude-code]
 path = "plugins/claude-code"
-digest = "sha256:5cbb451f0d4433d1ffa082beba5ce3cd3ddd8d9156bb8d168748ce0c99223e1c"
+digest = "sha256:0d4dc165cd70582d189dea4712140255caa4c94a57412eccbed472d4196a848b"
 
 [packages.plugin.kagent]
 path = "plugins/kagent"

--- a/marketplace/plugins/claude-code/default.appa.toml
+++ b/marketplace/plugins/claude-code/default.appa.toml
@@ -315,17 +315,6 @@ builtin = "hitl"
 #   [policy.audience]
 #   self = ["github:viewer"]
 #   internal = ["github:org/<your-org>/members"]
-#
-# Members without a published GitHub email are readers such as `github:<login>`.
-# To map them to addresses, route the battery's lookups to a `readers` table:
-# a root entry for the provider carrying only `lookup` attaches to the
-# battery's binding.
-#
-#   [externals.audience.github]
-#   lookup = "people"
-#
-#   [externals.audience.people]
-#   readers = { "github:<login>" = "<login>@<your-domain>" }
 
 # Whether the agent may report on its own through the `yell` tool. Off leaves it
 # unadvertised and unroutable; a person can always report with `appa yell`.

--- a/marketplace/plugins/claude-code/default.appa.toml
+++ b/marketplace/plugins/claude-code/default.appa.toml
@@ -308,20 +308,21 @@ builtin = "hitl"
 # actual membership: a rule naming an individual recipient
 # (`requires = { audience = { contains = ["$to"] } }`) checked against a
 # narrowed session. Without a source the chain still decides symbolically and
-# such a call is refused as unanswerable. To add one, copy the GitHub battery
-# beside this file, put the mapping under `[policy]`, and bind the source here:
+# such a call is refused as unanswerable. To add one, install the GitHub
+# battery — it binds the `github` source and declares its selectors — and put
+# the mapping under `[policy]` here:
 #
 #   [policy.audience]
 #   self = ["github:viewer"]
 #   internal = ["github:org/<your-org>/members"]
 #
-#   [externals.audience.github]
-#   command = ["python3", "batteries/github/audience-source.py"]
-#   token_env = "APPA_PROVIDER_GITHUB_TOKEN"
-#
 # Members without a published GitHub email are readers such as `github:<login>`.
-# To map them to addresses, add `lookup = "people"` to the entry above and a
-# `readers` table:
+# To map them to addresses, route the battery's lookups to a `readers` table:
+# a root entry for the provider carrying only `lookup` attaches to the
+# battery's binding.
+#
+#   [externals.audience.github]
+#   lookup = "people"
 #
 #   [externals.audience.people]
 #   readers = { "github:<login>" = "<login>@<your-domain>" }

--- a/website-chat-playground/src/lint.rs
+++ b/website-chat-playground/src/lint.rs
@@ -83,6 +83,7 @@ mod tests {
     use super::*;
 
     use appa_engine::authority::DeclaredTransition;
+    use appa_engine::contract::DeltaAudience;
     use appa_engine::label::DeclaredAudience;
     use appa_engine::label::ReaderId;
     use appa_engine::value::ToolName;
@@ -111,10 +112,10 @@ mod tests {
         };
         assert_eq!(
             invoices.delta.audience.as_ref(),
-            Some(&DeclaredAudience::restricted([
+            Some(&DeltaAudience::Static(DeclaredAudience::restricted([
                 ReaderId::new("cfo@corp.example"),
                 ReaderId::new("ap-lead@corp.example"),
-            ]))
+            ])))
         );
         let email = checked
             .config

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -18,7 +18,8 @@ batteries/
 |-- claude-code/
 |   `-- appa.toml
 `-- slack/
-    `-- appa.toml
+    |-- appa.toml
+    `-- audience-source.py
 ```
 
 To include batteries in your config, list them in `appa.toml`:
@@ -42,6 +43,7 @@ OpenAPPA combines these files into one config.
 | Version | Every file uses the same version. |
 | Annotators | Each annotator name must be unique. |
 | Script path | A script path is relative to the config file that names it. |
+| Audience sources | A battery binds the membership service it ships and declares its selector templates. A root entry for the same provider may carry only `lookup`. |
 
 OpenAPPA checks the combined config before using it. If a reload fails, the current config keeps running.
 
@@ -147,6 +149,44 @@ delta = {}
 [externals.authorities.approve-small-payment]
 command = ["python3", "./approve-small-payment.py"]
 ```
+
+## Audience sources
+
+A battery that covers a provider with its own directory ships a membership service beside its config and binds it. The binding declares the selector templates the service understands under `selectors`; the battery's own contracts may then name those collections, including per-resource ones such as one channel's members:
+
+```toml
+# batteries/slack/appa.toml
+[[policy.tool]]
+name = "mcp/claude_ai_Slack/slack_read_channel"
+parameters = { type = "object", properties = { channel_id = { type = "string" } }, required = ["channel_id"] }
+delta = { audience = ["@slack:channel/$channel_id"] }
+
+[externals.audience.slack]
+command = ["python3", "audience-source.py"]
+token_env = "APPA_PROVIDER_SLACK_TOKEN"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "full-members", feeds = "internal" },
+  { template = "user-group/<handle>" },
+  { template = "channel/<id>" },
+]
+```
+
+The root config decides what the built-in audiences mean and supplies the credential. It maps `self` and `internal` under `[policy.audience]`, which only the root can carry, and exports the token variable the battery names. To route the provider's member lookups elsewhere, the root adds an entry for the same provider whose only key is `lookup`; any other key beside the battery's binding is a duplicate and fails to load.
+
+```toml
+# root config
+include = ["./batteries/slack/appa.toml"]
+
+[policy]
+version = 2
+
+[policy.audience]
+self = ["slack:viewer"]
+internal = ["slack:full-members"]
+```
+
+Every consult OpenAPPA sends the service carries the declared templates as `declaration.templates`. The shipped services compare that list with the templates they serve and refuse a mismatch before reading their token, and the start-up probe of `viewer` and `full-members` triggers that check before any agent call. See [Configure audience membership](/contracts#configure-audience-membership) for the declaration and the request protocol.
 
 ## Customise a battery
 

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -43,7 +43,7 @@ OpenAPPA combines these files into one config.
 | Version | Every file uses the same version. |
 | Annotators | Each annotator name must be unique. |
 | Script path | A script path is relative to the config file that names it. |
-| Audience sources | A battery binds the membership service it ships and declares its selector templates. A root entry for the same provider may carry only `lookup`. |
+| Audience sources | A battery binds the membership service it ships and declares its selector templates. A root entry for the same provider is a duplicate. |
 
 OpenAPPA checks the combined config before using it. If a reload fails, the current config keeps running.
 
@@ -172,7 +172,7 @@ selectors = [
 ]
 ```
 
-The root config decides what the built-in audiences mean and supplies the credential. It maps `self` and `internal` under `[policy.audience]`, which only the root can carry, and exports the token variable the battery names. To route the provider's member lookups elsewhere, the root adds an entry for the same provider whose only key is `lookup`; any other key beside the battery's binding is a duplicate and fails to load.
+The root config decides what the built-in audiences mean and supplies the credential. It maps `self` and `internal` under `[policy.audience]`, which only the root can carry, and exports the token variable the battery names. A root entry for the same provider is a duplicate binding and fails to load.
 
 ```toml
 # root config

--- a/website/content/docs/batteries.md
+++ b/website/content/docs/batteries.md
@@ -158,7 +158,6 @@ A battery that covers a provider with its own directory ships a membership servi
 # batteries/slack/appa.toml
 [[policy.tool]]
 name = "mcp/claude_ai_Slack/slack_read_channel"
-parameters = { type = "object", properties = { channel_id = { type = "string" } }, required = ["channel_id"] }
 delta = { audience = ["@slack:channel/$channel_id"] }
 
 [externals.audience.slack]

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -315,6 +315,11 @@ delta = { audience = ["@slack:channel/$channel_id"] }
 name = "mcp/claude_ai_Slack/slack_send_message"
 parameters = { type = "object", properties = { channel_id = { type = "string" }, message = { type = "string" } }, required = ["channel_id", "message"] }
 requires = { trust = "trusted", audience = { contains = ["@slack:channel/$channel_id"] } }
+
+# The service that reads Slack membership declares the channel template.
+[externals.audience.slack]
+url = "https://audience.corp/slack"
+selectors = [{ template = "viewer", feeds = "self" }, { template = "channel/<id>" }]
 ```
 
 A selector placeholder MAY be the only entry of `delta.audience` or of `requires.audience.contains`. It MAY also be an entry of an annotator's `audiences` mandate; see [Permits and hint](#permits-and-hint). It MUST NOT appear under `within`, beside other entries in one list, or in an annotator's answer.
@@ -369,7 +374,7 @@ Configuring a provider does not connect OpenAPPA directly to Google Workspace, S
 | `template` | One selector format: literal segments and `<variable>` segments separated by `/`, such as `viewer`, `full-members`, `group/<group-address>`, or `channel/<id>`. A `<variable>` segment matches one non-empty segment. |
 | `feeds` | `self` or `internal`: the built-in audience this template may supply. Omit it for a template that supplies only named groups and `@provider:selector` mentions. |
 
-A provider exists in a policy when a `[policy.audience]` selector references it. Every selector the policy writes MUST match one declared template of its provider, with the role its position needs:
+A provider exists in a policy when the policy names it: by a `[policy.audience]` selector, by a `@provider:selector` mention in a tool contract or an annotator mandate, or by a selector placeholder. Every selector the policy writes MUST match one declared template of its provider, with the role its position needs:
 
 | Audience key | Templates you can use |
 |---|---|
@@ -405,7 +410,7 @@ selectors = [
 ]
 ```
 
-OpenAPPA rejects policy references to undeclared named audiences, providers that no `[policy.audience]` selector references, or selectors that match no declared template.
+OpenAPPA rejects policy references to undeclared named audiences, providers that no `[externals.audience.<provider>]` entry declares, or selectors that match no declared template.
 
 ##### Reader IDs
 

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -306,13 +306,11 @@ A selector placeholder names a source collection whose selector takes one or mor
 # Reading a channel restricts the result to that channel's members.
 [[policy.tool]]
 name = "mcp/claude_ai_Slack/slack_read_channel"
-parameters = { type = "object", properties = { channel_id = { type = "string" } }, required = ["channel_id"] }
 delta = { audience = ["@slack:channel/$channel_id"] }
 
 # Posting to a channel requires that its members can already read the data.
 [[policy.tool]]
 name = "mcp/claude_ai_Slack/slack_send_message"
-parameters = { type = "object", properties = { channel_id = { type = "string" }, message = { type = "string" } }, required = ["channel_id", "message"] }
 requires = { trust = "trusted", audience = { contains = ["@slack:channel/$channel_id"] } }
 
 # The service that reads Slack membership declares the channel template.

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -295,9 +295,35 @@ parameters = { type = "object", properties = { recipient = { type = "string" } }
 requires = { audience = { contains = ["$recipient"] } }
 ```
 
-OpenAPPA reads the proposed call's `recipient` argument and checks that the current audience includes its readers. The tool's `parameters` schema must declare the argument as a required top-level string. Argument placeholders are allowed only under `contains`.
+OpenAPPA reads the proposed call's `recipient` argument and checks that the current audience includes its readers. The tool's `parameters` schema must declare the argument as a required top-level string. A whole-entry argument placeholder is allowed only under `contains`.
 
 The argument can contain a literal reader, `public`, `self`, `internal`, or an `@` mention. An unresolved dynamic mention stops the call with an operational error.
+
+#### Read a source collection from a tool argument
+
+A selector placeholder names a source collection whose selector takes one or more segments from the call. Write `@<provider>:<selector>` and put `$<argument_name>` in place of a segment:
+
+```toml
+# Reading a channel restricts the result to that channel's members.
+[[policy.tool]]
+name = "mcp/claude_ai_Slack/slack_read_channel"
+parameters = { type = "object", properties = { channel_id = { type = "string" } }, required = ["channel_id"] }
+delta = { audience = ["@slack:channel/$channel_id"] }
+
+# Posting to a channel requires that its members can already read the data.
+[[policy.tool]]
+name = "mcp/claude_ai_Slack/slack_send_message"
+parameters = { type = "object", properties = { channel_id = { type = "string" }, message = { type = "string" } }, required = ["channel_id", "message"] }
+requires = { trust = "trusted", audience = { contains = ["@slack:channel/$channel_id"] } }
+```
+
+A selector placeholder MAY be the only entry of `delta.audience` or of `requires.audience.contains`. It MAY also be an entry of an annotator's `audiences` mandate; see [Permits and hint](#permits-and-hint). It MUST NOT appear under `within`, beside other entries in one list, or in an annotator's answer.
+
+Each `$<argument_name>` MUST name a required top-level string argument of the tool's `parameters`. The spelling, with each `$<argument_name>` read as a variable segment, MUST match one template the provider declares under `selectors`; see [Declare selector templates](#declare-selector-templates). A `$<argument_name>` segment matches only a `<variable>` segment of the template.
+
+At check time OpenAPPA replaces each `$<argument_name>` with the call's argument value. The result is an ordinary `@provider:selector` mention: OpenAPPA reads its members from the provider's service, records the answer with the decision, and checks the call exactly as for a static mention. In the example above, reading channel `C0123` restricts the result to the members of `C0123`, and posting to `C0123` requires that every member of `C0123` is already a reader.
+
+A static mention cannot contain a segment that starts with `$`. There is no escape: a collection whose selector begins with `$` cannot be written in a policy.
 
 #### Configure audience membership
 
@@ -305,7 +331,7 @@ Membership answers: who belongs to this audience? OpenAPPA asks an external memb
 
 Under `[policy.audience]`, `self` and `internal` list the selectors that supply their members. `[policy.audience.group.<name>]` declares a named group with `within` and `from`.
 
-Each selector entry has the form `provider:selector`. The provider identifies the service configured under `[externals.audience.<provider>]`. The selector tells that service which reader or group to read.
+Each selector entry has the form `provider:selector`. The provider identifies the service configured under `[externals.audience.<provider>]`. The selector tells that service which reader or group to read. The service's `selectors` declaration lists the selector templates it understands.
 
 The example below uses a Google Workspace membership service to define `self`, `internal`, and `@finance`:
 
@@ -320,32 +346,38 @@ internal = ["google-workspace:full-members"]
 within = "internal"
 from = ["google-workspace:group/finance@corp.com"]
 
-# Set the service that supplies Google Workspace membership.
+# Set the service that supplies Google Workspace membership and declare what it serves.
 [externals.audience.google-workspace]
 url = "https://audience.corp/google-workspace"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "full-members", feeds = "internal" },
+  { template = "group/<group-address>" },
+]
 ```
 
 For `google-workspace:group/finance@corp.com`, OpenAPPA sends `group/finance@corp.com` as the selector to the membership service configured under `[externals.audience.google-workspace]`. The service reads the group's members and returns them to OpenAPPA.
 
-OpenAPPA defines the selector formats below. The external service must understand these formats and perform the membership lookup. Configuring a provider does not connect OpenAPPA directly to Google Workspace, Slack, or GitHub; you must supply the service that makes that connection.
+Configuring a provider does not connect OpenAPPA directly to Google Workspace, Slack, or GitHub; you must supply the service that makes that connection. Each shipped battery supplies the service for the provider it covers and declares that service's templates; see [What is a battery](/batteries#audience-sources).
 
-The current implementation has a fixed set of providers and selector formats. You cannot add a new provider name or selector format through the policy file. Replace values in angle brackets with the group address, handle, organization, or team to read.
+##### Declare selector templates
 
-| Provider | Selector formats understood by its service |
+`selectors` on `[externals.audience.<provider>]` declares the selector templates the service understands. Each entry has a `template` and an optional `feeds`:
+
+| Field | Meaning |
 |---|---|
-| `google-workspace` | `viewer`, `full-members`, `group/<group-address>` |
-| `slack` | `viewer`, `full-members`, `user-group/<handle>` |
-| `github` | `viewer`, `org/<org>/members`, `org/<org>/team/<team>` |
+| `template` | One selector format: literal segments and `<variable>` segments separated by `/`, such as `viewer`, `full-members`, `group/<group-address>`, or `channel/<id>`. A `<variable>` segment matches one non-empty segment. |
+| `feeds` | `self` or `internal`: the built-in audience this template may supply. Omit it for a template that supplies only named groups and `@provider:selector` mentions. |
 
-Choose a selector based on the audience you configure:
+A provider exists in a policy when a `[policy.audience]` selector references it. Every selector the policy writes MUST match one declared template of its provider, with the role its position needs:
 
-| Audience key | Selectors you can use |
+| Audience key | Templates you can use |
 |---|---|
-| `self` | `viewer`: the identity OpenAPPA acts for. |
-| `internal` | `full-members` for Google Workspace or Slack; `org/<org>/members` for GitHub. For example, `github:org/acme/members` makes members of `acme` internal. Members of other GitHub organizations are not included by this source. |
-| `group.<name>.from` | A specific group or an organization's members, using any of the formats above except `viewer`. |
+| `self` | A template with `feeds = "self"`, usually `viewer`: the identity OpenAPPA acts for. |
+| `internal` | A template with `feeds = "internal"`, such as `full-members` or `org/<org>/members`. For example, `github:org/acme/members` makes members of `acme` internal. Members of other GitHub organizations are not included by this source. |
+| `group.<name>.from`, `@provider:selector` mentions, and selector placeholders | Any declared template except one with `feeds = "self"`. |
 
-OpenAPPA rejects the configuration if you use a selector in the wrong key. For example, `slack:viewer` cannot define `internal`. The load error for a selector that matches no format lists the formats the provider understands.
+OpenAPPA rejects the configuration if you use a selector in the wrong key. For example, `slack:viewer` cannot define `internal`. The load error for a selector that matches no template lists the templates the provider declares. The declared templates enter the policy identity; the URL, command, and credentials do not.
 
 If a key lists several sources, the audience includes members from any of them. For example, `internal = ["google-workspace:full-members", "slack:full-members"]` includes members returned by either service.
 
@@ -363,12 +395,17 @@ internal = ["slack:full-members"]
 name = "get_incident"
 delta = { audience = ["@slack:user-group/oncall"] }
 
-# Set the service that supplies Slack membership.
+# Set the service that supplies Slack membership and declare what it serves.
 [externals.audience.slack]
 url = "https://audience.corp/slack"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "full-members", feeds = "internal" },
+  { template = "user-group/<handle>" },
+]
 ```
 
-OpenAPPA rejects policy references to undeclared named audiences, providers not used in any selector, or unsupported selector formats.
+OpenAPPA rejects policy references to undeclared named audiences, providers that no `[policy.audience]` selector references, or selectors that match no declared template.
 
 ##### Reader IDs
 
@@ -387,6 +424,8 @@ A service that reports one account under two different addresses within one oper
 Audience providers support HTTP endpoints and local commands.
 
 OpenAPPA can ask the membership service for a group's members or for the reader ID behind one member. The examples below show the request data and response data. For the complete JSON request and response format, see [The consult request](#the-consult-request).
+
+Every request carries `declaration.templates`: the templates the policy declares for the provider. The service MUST compare that list with the templates it serves and MUST refuse the request when the lists differ, before it reads its credential or calls the provider. OpenAPPA treats the refusal as an operational failure of the service that names the provider; it records no decision.
 
 To read the members of the Slack `oncall` group, OpenAPPA sends:
 
@@ -432,6 +471,11 @@ internal = ["github:org/acme/members"]
 [externals.audience.github]
 command = ["python3", "batteries/github/audience-source.py"]
 token_env = "APPA_PROVIDER_GITHUB_TOKEN"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "org/<org>/members", feeds = "internal" },
+  { template = "org/<org>/team/<team>" },
+]
 lookup = "people"
 
 [externals.audience.people]
@@ -440,9 +484,11 @@ readers = { "github:alice" = "alice@corp.com" }
 
 For a provider with `lookup`, OpenAPPA also looks up every group member that is not an email address. With the configuration above, the member `github:alice` reported for `org/acme/members` becomes the reader `alice@corp.com`. A `null` answer, or a member absent from a `readers` table, leaves the member as written. OpenAPPA records lookup answers with the decision like other membership responses.
 
+A battery binds the membership service it ships in its own `appa.toml`, with the service's `selectors`. The root config keeps the `[policy.audience]` mappings. To route such a provider's member lookups, the root MAY add `[externals.audience.<provider>]` with `lookup` as its only key; OpenAPPA attaches that routing to the battery's binding. A root entry with any other key beside a battery's binding is a duplicate binding, and OpenAPPA rejects the configuration.
+
 ##### Source probe at start and reload
 
-Before it serves a configuration, and before it switches to a reloaded one, OpenAPPA reads every selector the policy references once, asks each configured `lookup` entry for one member those answers owe, and applies the reader ID rule to each answer. A service that fails or returns a malformed reader ID stops the start or the reload with the provider, the selector or member, and the reason. A failed reload leaves the previous configuration serving. Replay does not probe.
+Before it serves a configuration, and before it switches to a reloaded one, OpenAPPA reads every selector the policy references once, asks each configured `lookup` entry for one member those answers owe, and applies the reader ID rule to each answer. A service that fails or returns a malformed reader ID stops the start or the reload with the provider, the selector or member, and the reason. A service that refuses its declared templates fails this probe, so a policy whose `selectors` disagree with the service never serves. A failed reload leaves the previous configuration serving. Replay does not probe.
 
 ### Trust
 
@@ -613,11 +659,13 @@ An annotator's permits limit the values it can use in its answers. The following
 | Field | Allowed values in an answer | If omitted |
 |---|---|---|
 | `ranks` | Ranks used in `delta.trust` or `requires.trust`. | Every rank in the trust chain. |
-| `audiences` | Built-in audiences, `@` references, or literal reader IDs that the answer may use. | `self`, `internal`, named groups, and reader IDs declared in the policy. |
+| `audiences` | Built-in audiences, `@` references, selector placeholders, or literal reader IDs that the answer may use. | `self`, `internal`, named groups, and reader IDs declared in the policy. |
 | `marks` | Required attention marks. | Every mark declared in an authority's `permits.attention`. |
 | `effects` | Effects that the call may record or require. | Every effect name declared by the policy. |
 
 `public` is always allowed in an answer, so it is not listed in `audiences`. Setting `audiences = []` allows only public answers.
+
+A selector placeholder in `audiences`, such as `@github:repo/$owner/$repo/collaborators`, is instantiated for each call. Every `$<argument_name>` in it MUST name a required top-level string argument of every tool that uses the annotator, so the wildcard `*` tool cannot use such an annotator. The consult request and the answer schema list the concrete spelling for that call, such as `@github:repo/acme/api/collaborators`, and the answer MAY use only that spelling. The annotator can answer about the resource the call names and about no other. See [Read a source collection from a tool argument](#read-a-source-collection-from-a-tool-argument) for the placeholder rules.
 
 An empty list and an omitted field have different meanings. For example, `marks = []` prevents the annotator from requiring attention. Omitting `marks` allows it to use any mark declared in an authority's `permits.attention`.
 
@@ -1045,6 +1093,11 @@ builtin = "hitl"
 
 [externals.audience.google-workspace]
 url = "https://audience.corp/google-workspace"
+selectors = [
+  { template = "viewer", feeds = "self" },
+  { template = "full-members", feeds = "internal" },
+  { template = "group/<group-address>" },
+]
 ```
 
 After the agent reads the original ticket, it can email readers identified as company members by the membership service. External email and public issue creation require approval. Approval permits one call and leaves the trajectory internal.
@@ -1127,7 +1180,7 @@ The available settings depend on the component's role:
 | `authorities` | Exactly one of `url`, `command`, or `builtin`. | Optional. Without a binding, the authority returns no answer. |
 | `sanitizers` | Exactly one of `url`, `command`, or `builtin`. | Required, except for `attest-schema`. |
 | `annotators` | Exactly one of `url` or `command`. | Required unless the declaration specifies a builtin. |
-| `audience` | Exactly one of `url`, `command`, or `readers`; optional `lookup`. | Required for each referenced provider and each `lookup` target. `readers` is allowed only on a `lookup` target. |
+| `audience` | Exactly one of `url`, `command`, or `readers`; `selectors` on a `url` or `command` entry; optional `lookup`. | Required for each referenced provider and each `lookup` target. `readers` is allowed only on a `lookup` target. A root entry whose only key is `lookup` routes a provider that an included file binds. |
 
 OpenAPPA rejects an external component name that the policy does not declare, or a component that is missing its required implementation. For annotators, `builtin` belongs on `[[policy.annotator]]`, not under `[externals]`.
 
@@ -1187,7 +1240,7 @@ Each component uses these fields differently:
 | `annotation` | `hint`, `inputs`, `trust_ranks`, `audiences`, `attention_marks`, `effects` | `args` | `delta`, `requires`, `emits` |
 | `audience` | `templates` | `selector` or `member` | `members` or `principal` |
 
-For an audience request, `declaration.templates` lists the selector formats that OpenAPPA registers for the provider, such as `viewer` and `user-group/<handle>`. The service reads the requested selector or member ID from `artifact` and returns its result under `answer`.
+For an audience request, `declaration.templates` lists the selector templates the policy declares for the provider under `selectors`, such as `viewer` and `user-group/<handle>`. The service MUST refuse a request whose templates differ from the ones it serves. It reads the requested selector or member ID from `artifact` and returns its result under `answer`.
 
 OpenAPPA records membership responses with the decision that requested them. If that decision requires an approval or remedy, OpenAPPA reuses those responses when it continues the decision. A new decision can request updated membership. Replaying a recorded decision uses its saved responses without calling the membership service. Responses from unrelated decisions cannot be substituted.
 

--- a/website/content/docs/contracts.md
+++ b/website/content/docs/contracts.md
@@ -291,11 +291,10 @@ Under `contains`, use `$<argument_name>` to read an audience from a tool argumen
 ```toml
 [[policy.tool]]
 name = "send_email"
-parameters = { type = "object", properties = { recipient = { type = "string" } }, required = ["recipient"] }
 requires = { audience = { contains = ["$recipient"] } }
 ```
 
-OpenAPPA reads the proposed call's `recipient` argument and checks that the current audience includes its readers. The tool's `parameters` schema must declare the argument as a required top-level string. A whole-entry argument placeholder is allowed only under `contains`.
+OpenAPPA reads the proposed call's `recipient` argument and checks that the current audience includes its readers. The binding makes `recipient` a required top-level string of the tool's `parameters`: OpenAPPA adds the property when the schema omits it, makes a declared string property required, and rejects a schema that declares it with another type. A whole-entry argument placeholder is allowed only under `contains`.
 
 The argument can contain a literal reader, `public`, `self`, `internal`, or an `@` mention. An unresolved dynamic mention stops the call with an operational error.
 
@@ -324,7 +323,7 @@ selectors = [{ template = "viewer", feeds = "self" }, { template = "channel/<id>
 
 A selector placeholder MAY be the only entry of `delta.audience` or of `requires.audience.contains`. It MAY also be an entry of an annotator's `audiences` mandate; see [Permits and hint](#permits-and-hint). It MUST NOT appear under `within`, beside other entries in one list, or in an annotator's answer.
 
-Each `$<argument_name>` MUST name a required top-level string argument of the tool's `parameters`. The spelling, with each `$<argument_name>` read as a variable segment, MUST match one template the provider declares under `selectors`; see [Declare selector templates](#declare-selector-templates). A `$<argument_name>` segment matches only a `<variable>` segment of the template.
+Each `$<argument_name>` becomes a required top-level string argument of the tool, as under `contains`; see [Read an audience from a tool argument](#read-an-audience-from-a-tool-argument). The spelling, with each `$<argument_name>` read as a variable segment, MUST match one template the provider declares under `selectors`; see [Declare selector templates](#declare-selector-templates). A `$<argument_name>` segment matches only a `<variable>` segment of the template.
 
 At check time OpenAPPA replaces each `$<argument_name>` with the call's argument value. The result is an ordinary `@provider:selector` mention: OpenAPPA reads its members from the provider's service, records the answer with the decision, and checks the call exactly as for a static mention. In the example above, reading channel `C0123` restricts the result to the members of `C0123`, and posting to `C0123` requires that every member of `C0123` is already a reader.
 
@@ -489,7 +488,7 @@ readers = { "github:alice" = "alice@corp.com" }
 
 For a provider with `lookup`, OpenAPPA also looks up every group member that is not an email address. With the configuration above, the member `github:alice` reported for `org/acme/members` becomes the reader `alice@corp.com`. A `null` answer, or a member absent from a `readers` table, leaves the member as written. OpenAPPA records lookup answers with the decision like other membership responses.
 
-A battery binds the membership service it ships in its own `appa.toml`, with the service's `selectors`. The root config keeps the `[policy.audience]` mappings. To route such a provider's member lookups, the root MAY add `[externals.audience.<provider>]` with `lookup` as its only key; OpenAPPA attaches that routing to the battery's binding. A root entry with any other key beside a battery's binding is a duplicate binding, and OpenAPPA rejects the configuration.
+A battery binds the membership service it ships in its own `appa.toml`, with the service's `selectors`. The root config keeps the `[policy.audience]` mappings. A root entry for a provider that a battery binds is a duplicate binding, and OpenAPPA rejects the configuration.
 
 ##### Source probe at start and reload
 
@@ -670,7 +669,7 @@ An annotator's permits limit the values it can use in its answers. The following
 
 `public` is always allowed in an answer, so it is not listed in `audiences`. Setting `audiences = []` allows only public answers.
 
-A selector placeholder in `audiences`, such as `@github:repo/$owner/$repo/collaborators`, is instantiated for each call. Every `$<argument_name>` in it MUST name a required top-level string argument of every tool that uses the annotator, so the wildcard `*` tool cannot use such an annotator. The consult request and the answer schema list the concrete spelling for that call, such as `@github:repo/acme/api/collaborators`, and the answer MAY use only that spelling. The annotator can answer about the resource the call names and about no other. See [Read a source collection from a tool argument](#read-a-source-collection-from-a-tool-argument) for the placeholder rules.
+A selector placeholder in `audiences`, such as `@github:repo/$owner/$repo/collaborators`, is instantiated for each call. Every `$<argument_name>` in it becomes a required top-level string argument of every tool that uses the annotator, so the wildcard `*` tool, whose arguments the policy does not describe, cannot use such an annotator. The consult request and the answer schema list the concrete spelling for that call, such as `@github:repo/acme/api/collaborators`, and the answer MAY use only that spelling. The annotator can answer about the resource the call names and about no other. See [Read a source collection from a tool argument](#read-a-source-collection-from-a-tool-argument) for the placeholder rules.
 
 An empty list and an omitted field have different meanings. For example, `marks = []` prevents the annotator from requiring attention. Omitting `marks` allows it to use any mark declared in an authority's `permits.attention`.
 
@@ -1185,7 +1184,7 @@ The available settings depend on the component's role:
 | `authorities` | Exactly one of `url`, `command`, or `builtin`. | Optional. Without a binding, the authority returns no answer. |
 | `sanitizers` | Exactly one of `url`, `command`, or `builtin`. | Required, except for `attest-schema`. |
 | `annotators` | Exactly one of `url` or `command`. | Required unless the declaration specifies a builtin. |
-| `audience` | Exactly one of `url`, `command`, or `readers`; `selectors` on a `url` or `command` entry; optional `lookup`. | Required for each referenced provider and each `lookup` target. `readers` is allowed only on a `lookup` target. A root entry whose only key is `lookup` routes a provider that an included file binds. |
+| `audience` | Exactly one of `url`, `command`, or `readers`; `selectors` on a `url` or `command` entry; optional `lookup`. | Required for each referenced provider and each `lookup` target. `readers` is allowed only on a `lookup` target. |
 
 OpenAPPA rejects an external component name that the policy does not declare, or a component that is missing its required implementation. For annotators, `builtin` belongs on `[[policy.annotator]]`, not under `[externals]`.
 

--- a/website/content/docs/how-it-works.md
+++ b/website/content/docs/how-it-works.md
@@ -27,7 +27,7 @@ OpenAPPA operates with three concepts:
 
    Audience and Trust make up the security label. OpenAPPA also tracks Effects and checks Attention requirements:
 
-   1. **Audience:** Who is authorized to access data in this agent session. Reading data for a smaller audience restricts where the agent can send data later. For example, after reading an internal customer record, the agent cannot send session data to a public destination.
+   1. **Audience:** Who is authorized to access data in this agent session. Reading data for a smaller audience restricts where the agent can send data later. For example, after reading an internal customer record, the agent cannot send session data to a public destination. An audience can be as specific as the members of one Slack channel: the contract spells the channel from the call's own argument, so reading channel `C0123` is for its members, and posting to it requires that they can already read the data.
    2. **Trust:** How much the data in the session can be trusted. Reading an untrusted web page can lower the session's trust, and tools that require trusted input will no longer be allowed to run.
    3. **Effect:** What the agent has already done, such as sending an email or changing a system. Effects accumulate in the session history. A policy can require an effect to have happened, or prevent an action after an effect has happened.
    4. **Attention:** Approval or review required for a specific action. Unlike effects, attention does not accumulate. An approval clears the attention requirement for that action only, and later calls must request attention again.

--- a/website/content/docs/write-a-battery.md
+++ b/website/content/docs/write-a-battery.md
@@ -60,11 +60,11 @@ scripts its bindings name. Run `bash scripts/appa-marketplace.sh` to generate
 the catalog entry and content digest, then commit `marketplace/marketplace.toml`
 with the package. CI checks that the generated catalog is current.
 
-`appa.toml` contains the tool contracts. An annotator determines contracts that static rules cannot express. An audience source supplies provider users or groups for the deployment's audience configuration.
+`appa.toml` contains the tool contracts. An annotator determines contracts that static rules cannot express. An audience source supplies the members of the provider's collections: the viewer, the full membership, groups, and per-resource readers such as one channel's members. The battery binds it under `[externals.audience.<provider>]` with `command`, `token_env`, and the `selectors` it serves, and names the provider under `audiences` in `appa-package.toml`. Contracts in the battery may then name those collections with selector placeholders, such as `@slack:channel/$channel_id`.
 
 The battery `README.md` must name the server version and list the covered tools. It must also explain each contract, script, test, and known limit.
 
-Add the battery config to `include` in `examples/claude-code-battery/appa.toml`. Add the Authority and audience source settings it needs.
+Add the battery config to `include` in `examples/claude-code-battery/appa.toml`. Add the Authority settings and the `[policy.audience]` mappings it needs; the battery binds its own audience source.
 
 The test suite loads this example to make sure all included batteries work together.
 
@@ -72,9 +72,7 @@ The test suite loads this example to make sure all included batteries work toget
 
 ### Unit tests
 
-Write tests for every annotator and audience source. Use saved API responses instead of calling the real service.
-
-Test expected input, invalid input, provider errors, and missing data.
+Write tests for every annotator and audience source that need no credential: the consult envelope, the template check against `declaration.templates`, argument and selector handling, and every refusal path. An audience source must refuse a declaration that lists templates it does not serve, before it reads its token; test that refusal. Check the service against the real provider with a replay trace and a real token, as described below.
 
 For example, to test a Python battery:
 

--- a/website/content/docs/write-a-battery.md
+++ b/website/content/docs/write-a-battery.md
@@ -60,7 +60,7 @@ scripts its bindings name. Run `bash scripts/appa-marketplace.sh` to generate
 the catalog entry and content digest, then commit `marketplace/marketplace.toml`
 with the package. CI checks that the generated catalog is current.
 
-`appa.toml` contains the tool contracts. An annotator determines contracts that static rules cannot express. An audience source supplies the members of the provider's collections: the viewer, the full membership, groups, and per-resource readers such as one channel's members. The battery binds it under `[externals.audience.<provider>]` with `command`, `token_env`, and the `selectors` it serves, and names the provider under `audiences` in `appa-package.toml`. Contracts in the battery may then name those collections with selector placeholders, such as `@slack:channel/$channel_id`.
+`appa.toml` contains the tool contracts. An annotator determines contracts that static rules cannot express. An audience source supplies the members of the provider's collections: the viewer, the full membership, groups, and per-resource readers such as one channel's members. The battery binds it under `[externals.audience.<provider>]` with `command`, `token_env`, and the `selectors` it serves. Contracts in the battery may then name those collections with selector placeholders, such as `@slack:channel/$channel_id`.
 
 The battery `README.md` must name the server version and list the covered tools. It must also explain each contract, script, test, and known limit.
 
@@ -140,13 +140,6 @@ delta = {}
 name = "mcp/mail/send"
 requires = { trust = "suspicious", audience = { contains = ["$to"] } }
 delta = {}
-
-[policy.tool.parameters]
-type = "object"
-required = ["to"]
-
-[policy.tool.parameters.properties.to]
-type = "string"
 
 [externals]
 timeout_ms = 30000

--- a/website/lib/terms.ts
+++ b/website/lib/terms.ts
@@ -73,7 +73,7 @@ const TERMS = {
   "@finance":
     "A mention of a configured named audience. It stays symbolic in labels and the log; its membership is read from the audience sources per act and pinned.",
   "[policy.audience]":
-    "Maps the built-in audiences to membership sources. self lists selectors of templates declared with feeds = self, the identity OpenAPPA acts for; internal lists selectors of templates declared with feeds = internal, and for GitHub only explicitly selected organizations. A provider exists in the policy when a selector here references it. Multiple sources are unioned.",
+    "Maps the built-in audiences to membership sources. self lists selectors of templates declared with feeds = self, the identity OpenAPPA acts for; internal lists selectors of templates declared with feeds = internal, and for GitHub only explicitly selected organizations. A provider exists in the policy when a selector here, a mention in a contract or mandate, or a selector placeholder names it. Multiple sources are unioned.",
   "[policy.audience.group.<name>]":
     "One configured named audience, mentioned as @name: an optional within assertion into a built-in audience, and the from selectors that supply its members. Multiple sources are unioned.",
   self: "The identity OpenAPPA acts for. This can be a person or a service. The configured viewer sources supply its reader IDs, which are combined into the self audience.",

--- a/website/lib/terms.ts
+++ b/website/lib/terms.ts
@@ -55,7 +55,7 @@ const TERMS = {
   "Tool(argument:pattern)":
     "An ordered tool contract selector. Every argument:pattern clause must match its top-level string argument. OpenAPPA uses the first matching contract in authored order, including overlapping native and canonical names. An asterisk matches any argument text; a bare name is the fallback. A sanitizer rewrite selecting another contract is judged under that contract.",
   delta:
-    "The label contribution of an admitted call result. A delta never expands permissions: it intersects reader sets, lowers the trust rank, or leaves the trajectory label unchanged.",
+    "The label contribution of an admitted call result. A delta never expands permissions: it intersects reader sets, lowers the trust rank, or leaves the trajectory label unchanged. Its audience may be one selector placeholder such as @slack:channel/$channel_id, resolved from the call's arguments at check time.",
   requires:
     "The prerequisites for executing a tool call: rules on allowed readers, trust levels, and required history.",
   audience:
@@ -69,16 +69,18 @@ const TERMS = {
   public:
     "The reserved unrestricted audience state, not a reader ID: no audience restriction applies. An agent with public reach can send data to any outbound destination. As a placeholder argument it names the Public audience, which only a Public trajectory includes. Never a group member.",
   "@name":
-    "A mention of a symbolic audience: @finance names a configured [policy.audience.group.<name>], and @provider:selector reads a source collection directly. The mention stays symbolic in labels and the log; membership is read from the configured sources per act and pinned.",
+    "A mention of a symbolic audience: @finance names a configured [policy.audience.group.<name>], and @provider:selector reads a source collection directly. A selector segment written as $argument is a selector placeholder, filled from the call's argument at check time. The mention stays symbolic in labels and the log; membership is read from the configured sources per act and pinned.",
   "@finance":
     "A mention of a configured named audience. It stays symbolic in labels and the log; its membership is read from the audience sources per act and pinned.",
   "[policy.audience]":
-    "Maps the built-in audiences to membership sources. self lists viewer selectors for the identity OpenAPPA acts for; internal lists full-membership collections, and for GitHub only explicitly selected organizations. Multiple sources are unioned.",
+    "Maps the built-in audiences to membership sources. self lists selectors of templates declared with feeds = self, the identity OpenAPPA acts for; internal lists selectors of templates declared with feeds = internal, and for GitHub only explicitly selected organizations. A provider exists in the policy when a selector here references it. Multiple sources are unioned.",
   "[policy.audience.group.<name>]":
     "One configured named audience, mentioned as @name: an optional within assertion into a built-in audience, and the from selectors that supply its members. Multiple sources are unioned.",
   self: "The identity OpenAPPA acts for. This can be a person or a service. The configured viewer sources supply its reader IDs, which are combined into the self audience.",
   lookup:
-    "On [externals.audience.<provider>]: the name of another [externals.audience.<name>] entry that answers this provider's member lookups. OpenAPPA then also looks up every group member of that provider that is not an email address.",
+    "On [externals.audience.<provider>]: the name of another [externals.audience.<name>] entry that answers this provider's member lookups. OpenAPPA then also looks up every group member of that provider that is not an email address. A root entry whose only key is lookup routes a provider that an included battery binds.",
+  selectors:
+    "On [externals.audience.<provider>]: the selector templates the service understands, each with an optional feeds role, self or internal. Every selector or mention the policy writes must match one; a selector placeholder must match one with $argument only on <variable> segments. The declaration enters the policy identity, and every consult carries it as declaration.templates for the service to check.",
   readers:
     "On an [externals.audience.<name>] entry that a lookup names: an inline table from <provider>:<id> to reader ID. OpenAPPA answers member lookups from it without calling a service. A member absent from the table keeps its ID.",
   inputs:
@@ -86,7 +88,7 @@ const TERMS = {
   ranks:
     "Trust ranks an annotator may use in delta.trust and requires.trust. If omitted, it may use every rank in trust_chain.",
   audiences:
-    "Audiences an annotator may use in its answer. public is always allowed and must not be listed here. An empty list allows only public; omitting the field allows audiences declared in the policy.",
+    "Audiences an annotator may use in its answer. public is always allowed and must not be listed here. An empty list allows only public; omitting the field allows audiences declared in the policy. A selector placeholder entry is instantiated per call, so the answer may name only the resource the call's arguments spell.",
   marks:
     "Attention marks an annotator may require. An empty list allows none. If omitted, it may use every mark declared in an authority's permits.attention.",
   "$tool_call":
@@ -112,7 +114,7 @@ const TERMS = {
   emits:
     "The effects listed in an annotator's JSON answer. OpenAPPA records them when the tool succeeds. Policy TOML uses the field name effects.",
   contains:
-    "Under requires.audience: the current audience must include these readers; a $arg placeholder is allowed only here. Under requires.effects: the trajectory already recorded this effect.",
+    "Under requires.audience: the current audience must include these readers; a whole-entry $arg placeholder is allowed only here, and a selector placeholder such as @slack:channel/$channel_id is allowed here and in delta. Under requires.effects: the trajectory already recorded this effect.",
   within:
     "Under requires.audience: the current audience must sit within this audience; a tool_input rewrite cannot clear it. On a [policy.audience.group.<name>]: the trusted policy assertion that the group sits within a built-in audience (self or internal).",
   excludes:

--- a/website/lib/terms.ts
+++ b/website/lib/terms.ts
@@ -78,7 +78,7 @@ const TERMS = {
     "One configured named audience, mentioned as @name: an optional within assertion into a built-in audience, and the from selectors that supply its members. Multiple sources are unioned.",
   self: "The identity OpenAPPA acts for. This can be a person or a service. The configured viewer sources supply its reader IDs, which are combined into the self audience.",
   lookup:
-    "On [externals.audience.<provider>]: the name of another [externals.audience.<name>] entry that answers this provider's member lookups. OpenAPPA then also looks up every group member of that provider that is not an email address. A root entry whose only key is lookup routes a provider that an included battery binds.",
+    "On [externals.audience.<provider>]: the name of another [externals.audience.<name>] entry that answers this provider's member lookups. OpenAPPA then also looks up every group member of that provider that is not an email address.",
   selectors:
     "On [externals.audience.<provider>]: the selector templates the service understands, each with an optional feeds role, self or internal. Every selector or mention the policy writes must match one; a selector placeholder must match one with $argument only on <variable> segments. The declaration enters the policy identity, and every consult carries it as declaration.templates for the service to check.",
   readers:


### PR DESCRIPTION
Per-resource audiences, engine half. Batteries that use it follow in a stacked PR.

## Declared selector templates

- `[externals.audience.<provider>]` declares `selectors = [{ template, feeds? }]`; the Rust catalog of stock selectors is gone. `feeds` is `self` or `internal`; a template without it feeds named groups and mentions only.
- A `[policy.audience]` selector, a mention, or a placeholder must match a declared template of a registered provider, with what its position may read.
- Batteries bind their own audience source; a root entry for the same provider is a duplicate binding. `validate_package` reads the providers a battery binds from its policy, and the marketplace refuses two batteries binding one provider.
- Resolver scripts compare `declaration.templates` with what they serve before reading a token and exit 2 on a mismatch; a credential-free marketplace test drives every bound resolver through that check.

## Selector placeholders

- `@provider:seg/$arg` is the sole entry of a `delta.audience` or a `requires.audience.contains`, or an entry of an annotator's `audiences` mandate.
- Each `$arg` becomes a required string of the tool's `parameters` at load (added, or promoted from optional; another type is refused), and the spelling routes to a declared template. A wildcard cannot route through a placeholder mandate; a provider-run tool cannot carry a placeholder delta.
- Minting refuses a call whose argument fills no writable segment. The delta placeholder is bound to its call at `Registry::annotation_of` and at replay; a `contains` placeholder resolves where recipients are read; a mandate is instantiated per call before the consult and at annotation validation. A recorded call that fills no placeholder is refused.
- A provider enters the policy when a `[policy.audience]` selector, a contract mention or placeholder, or a mandate names it.

## Docs

`contracts.md`, `how-it-works.md`, `terms.ts`, `batteries.md`, `write-a-battery.md`, and the claude-code guide reference cover declarations, placeholders, and the resolver check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Svx2Q2g2QmjqtyJuYyKyM
