### PR TITLE
feat(bench): report token and USD overhead

### DIFF
--- a/appa-example-agent/src/lib.rs
+++ b/appa-example-agent/src/lib.rs
@@ -47,7 +47,7 @@ pub use budget::Limits;
 pub use http::HttpClient;
 pub use provider::{
     DEFAULT_COMPLETION_BODY_CAP_BYTES, Endpoint, ModelId, OpenAiCompatible, OpenAiConfig, ProviderCompletion,
-    ProviderError,
+    ProviderError, ProviderUsage,
 };
 pub use record::{CallId, Record, Recorded};
 pub use tools::{CatalogueError, DEFAULT_TOOL_BODY_CAP_BYTES, ToolCatalogue, ToolShim};

--- a/appa-example-agent/src/provider.rs
+++ b/appa-example-agent/src/provider.rs
@@ -2,12 +2,14 @@
 //! inference and nothing else — it holds no trajectory, no transcript
 //! and no policy, so it is a transport leaf.
 
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::http::{HttpClient, read_body_capped};
-use crate::wire::{ChatCompletionRequest, ChatCompletionResponse, WireMessage};
+use crate::wire::{ChatCompletionRequest, ChatCompletionResponse, WireMessage, WireUsage};
 
 pub const DEFAULT_COMPLETION_BODY_CAP_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
@@ -123,6 +125,99 @@ pub struct ProviderCompletion {
     pub attempts: u32,
 }
 
+/// Provider-reported usage for successful model calls made through one shared
+/// client. Token counts are exact provider values. Cost is available only when
+/// every successful response reports it.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ProviderUsage {
+    pub model_calls: u64,
+    pub usage_reported_calls: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub cached_input_tokens: Option<u64>,
+    pub cache_write_input_tokens: Option<u64>,
+    pub reasoning_tokens: Option<u64>,
+    pub cost_usd: Option<f64>,
+}
+
+#[derive(Default)]
+struct UsageAccumulator {
+    model_calls: u64,
+    usage_reported_calls: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
+    cached_input_tokens: Option<u64>,
+    cache_write_input_tokens: Option<u64>,
+    reasoning_tokens: Option<u64>,
+    cost_usd: Option<f64>,
+}
+
+impl UsageAccumulator {
+    fn record(&mut self, usage: Option<&WireUsage>) {
+        self.model_calls += 1;
+        let Some(usage) = usage else {
+            self.cost_usd = None;
+            return;
+        };
+        self.usage_reported_calls += 1;
+        self.input_tokens += usage.prompt_tokens;
+        self.output_tokens += usage.completion_tokens;
+        self.total_tokens += usage.total_tokens;
+        Self::add_optional(
+            &mut self.cached_input_tokens,
+            usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.cached_tokens),
+        );
+        Self::add_optional(
+            &mut self.cache_write_input_tokens,
+            usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|details| details.cache_write_tokens),
+        );
+        Self::add_optional(
+            &mut self.reasoning_tokens,
+            usage
+                .completion_tokens_details
+                .as_ref()
+                .and_then(|details| details.reasoning_tokens),
+        );
+        Self::add_optional_float(&mut self.cost_usd, usage.cost);
+    }
+
+    fn add_optional(total: &mut Option<u64>, value: Option<u64>) {
+        *total = match (*total, value) {
+            (None, _) | (_, None) => None,
+            (Some(total), Some(value)) => Some(total + value),
+        };
+    }
+
+    fn add_optional_float(total: &mut Option<f64>, value: Option<f64>) {
+        *total = match (*total, value) {
+            (None, _) | (_, None) => None,
+            (Some(total), Some(value)) => Some(total + value),
+        };
+    }
+
+    fn snapshot(&self) -> ProviderUsage {
+        ProviderUsage {
+            model_calls: self.model_calls,
+            usage_reported_calls: self.usage_reported_calls,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            total_tokens: self.total_tokens,
+            cached_input_tokens: self.cached_input_tokens,
+            cache_write_input_tokens: self.cache_write_input_tokens,
+            reasoning_tokens: self.reasoning_tokens,
+            cost_usd: self.cost_usd,
+        }
+    }
+}
+
 /// Why an upstream inference round failed after its bounded attempts.
 /// Every variant is fail-closed: the agent stops rather than proceeding
 /// on a guess.
@@ -214,6 +309,7 @@ impl AttemptFault {
 pub struct OpenAiCompatible {
     config: OpenAiConfig,
     client: HttpClient,
+    usage: Arc<Mutex<UsageAccumulator>>,
 }
 
 impl OpenAiCompatible {
@@ -222,11 +318,28 @@ impl OpenAiCompatible {
     }
 
     pub fn with_http_client(config: OpenAiConfig, client: HttpClient) -> Self {
-        OpenAiCompatible { config, client }
+        OpenAiCompatible {
+            config,
+            client,
+            usage: Arc::new(Mutex::new(UsageAccumulator {
+                cached_input_tokens: Some(0),
+                cache_write_input_tokens: Some(0),
+                reasoning_tokens: Some(0),
+                cost_usd: Some(0.0),
+                ..UsageAccumulator::default()
+            })),
+        }
     }
 
     pub fn openrouter(model: impl Into<ModelId>, api_key: impl Into<String>) -> Self {
         OpenAiCompatible::new(OpenAiConfig::openrouter(model, api_key))
+    }
+
+    pub fn usage(&self) -> ProviderUsage {
+        self.usage
+            .lock()
+            .expect("provider usage lock is not poisoned")
+            .snapshot()
     }
 
     /// Run one provider call. The configured model replaces any model
@@ -236,7 +349,11 @@ impl OpenAiCompatible {
         let url = format!("{}/chat/completions", self.config.endpoint.0.trim_end_matches('/'));
         for attempt in 1..=self.config.max_attempts {
             match self.attempt(&url, &request).await {
-                Ok(message) => {
+                Ok((message, usage)) => {
+                    self.usage
+                        .lock()
+                        .expect("provider usage lock is not poisoned")
+                        .record(usage.as_ref());
                     return Ok(ProviderCompletion {
                         message,
                         attempts: attempt,
@@ -251,7 +368,11 @@ impl OpenAiCompatible {
         unreachable!("the retry policy always permits at least one attempt")
     }
 
-    async fn attempt(&self, url: &str, request: &ChatCompletionRequest) -> Result<WireMessage, AttemptFault> {
+    async fn attempt(
+        &self,
+        url: &str,
+        request: &ChatCompletionRequest,
+    ) -> Result<(WireMessage, Option<WireUsage>), AttemptFault> {
         let response = self
             .client
             .inner()
@@ -298,7 +419,7 @@ impl OpenAiCompatible {
         }
         let parsed: ChatCompletionResponse = serde_json::from_slice(&body).map_err(|_| AttemptFault::Malformed)?;
         let choice = parsed.choices.into_iter().next().ok_or(AttemptFault::NoChoice)?;
-        Ok(choice.message)
+        Ok((choice.message, parsed.usage))
     }
 
     fn retry_delay(&self, failed_attempt: u32, retry_after: Option<Duration>) -> Duration {
@@ -403,6 +524,51 @@ mod tests {
         let seen = seen.lock().expect("not poisoned");
         assert_eq!(seen.len(), 2);
         assert_eq!(seen[0], seen[1], "a retry changes no model input");
+    }
+
+    #[tokio::test]
+    async fn provider_usage_accumulates_tokens_and_cost_across_clones() {
+        let app = Router::new().route(
+            "/chat/completions",
+            post(|| async {
+                Json(serde_json::json!({
+                    "choices": [{ "message": { "role": "assistant", "content": "done" } }],
+                    "usage": {
+                        "prompt_tokens": 101,
+                        "completion_tokens": 23,
+                        "total_tokens": 124,
+                        "prompt_tokens_details": { "cached_tokens": 40, "cache_write_tokens": 7 },
+                        "completion_tokens_details": { "reasoning_tokens": 11 },
+                        "cost": 0.0042
+                    }
+                }))
+            }),
+        );
+        let provider = provider(app).await;
+        provider
+            .clone()
+            .complete(request())
+            .await
+            .expect("the completion succeeds");
+        provider
+            .complete(request())
+            .await
+            .expect("the second completion succeeds");
+
+        assert_eq!(
+            provider.usage(),
+            ProviderUsage {
+                model_calls: 2,
+                usage_reported_calls: 2,
+                input_tokens: 202,
+                output_tokens: 46,
+                total_tokens: 248,
+                cached_input_tokens: Some(80),
+                cache_write_input_tokens: Some(14),
+                reasoning_tokens: Some(22),
+                cost_usd: Some(0.0084),
+            }
+        );
     }
 
     #[tokio::test]

--- a/appa-example-agent/src/wire.rs
+++ b/appa-example-agent/src/wire.rs
@@ -120,14 +120,43 @@ pub struct WireToolSchema {
     pub parameters: Option<serde_json::Value>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ChatCompletionResponse {
     pub choices: Vec<WireChoice>,
+    #[serde(default)]
+    pub usage: Option<WireUsage>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 pub struct WireChoice {
     pub message: WireMessage,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct WireUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+    #[serde(default)]
+    pub prompt_tokens_details: Option<WirePromptTokenDetails>,
+    #[serde(default)]
+    pub completion_tokens_details: Option<WireCompletionTokenDetails>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct WirePromptTokenDetails {
+    #[serde(default)]
+    pub cached_tokens: Option<u64>,
+    #[serde(default)]
+    pub cache_write_tokens: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct WireCompletionTokenDetails {
+    #[serde(default)]
+    pub reasoning_tokens: Option<u64>,
 }
 
 #[cfg(test)]

--- a/bench/agentthreatbench/README.md
+++ b/bench/agentthreatbench/README.md
@@ -40,6 +40,16 @@ from actual store mutations and checked deliveries. A blocked proposal remains
 in the Inspect transcript for audit but cannot earn utility or count as an
 executed attack in the actual score.
 
+Accounting uses Inspect's sample-scoped provider usage. The summary records
+model calls, total input tokens, cache reads and writes, output and reasoning
+tokens, total tokens, and USD cost. It includes calls from the parent, isolated
+children, and quarantine clients. An unavailable field remains `null`; the
+benchmark never converts unknown usage to zero.
+
+`usage_overhead_vs_stock` compares each defended arm with `stock`. Each entry
+reports the difference between mean usage per sample (one benchmark episode)
+and the stock mean. It also reports the defended-to-stock ratio.
+
 ## Setup and preflight
 
 ```sh

--- a/bench/agentthreatbench/src/appa_agentthreatbench/runner.py
+++ b/bench/agentthreatbench/src/appa_agentthreatbench/runner.py
@@ -353,6 +353,89 @@ def _sample_cost(sample: EvalSample) -> float | None:
     return sum(provider_costs) if model_calls and len(provider_costs) == model_calls else None
 
 
+def _sample_usage(sample: EvalSample) -> dict[str, int | float | None]:
+    model_calls = []
+    usage_reported_calls = 0
+    for event in sample.events:
+        if event.event != "model" or event.call is None:
+            continue
+        model_calls.append(event)
+        call = event.call.model_dump(mode="json")
+        response = call.get("response")
+        usage = response.get("usage") if isinstance(response, dict) else None
+        required_fields = ("input_tokens", "output_tokens", "total_tokens")
+        if isinstance(usage, dict) and all(isinstance(usage.get(field), int) for field in required_fields):
+            usage_reported_calls += 1
+
+    usages = list(sample.model_usage.values())
+
+    def optional_sum(field: str) -> int | None:
+        values = [getattr(usage, field) for usage in usages]
+        return sum(values) if values and all(value is not None for value in values) else None
+
+    cache_read = optional_sum("input_tokens_cache_read")
+    cache_write = optional_sum("input_tokens_cache_write")
+    return {
+        "model_calls": len(model_calls),
+        "usage_reported_calls": usage_reported_calls,
+        # Inspect separates cache reads and writes from input_tokens. Report
+        # total provider input volume so this agrees with CorpBench/OpenAI.
+        "input_tokens": sum(usage.input_tokens for usage in usages)
+        + sum(usage.input_tokens_cache_read or 0 for usage in usages)
+        + sum(usage.input_tokens_cache_write or 0 for usage in usages),
+        "output_tokens": sum(usage.output_tokens for usage in usages),
+        "total_tokens": sum(usage.total_tokens for usage in usages),
+        "cached_input_tokens": cache_read,
+        "cache_write_input_tokens": cache_write,
+        "reasoning_tokens": optional_sum("reasoning_tokens"),
+        "cost_usd": _sample_cost(sample),
+    }
+
+
+def _aggregate_usage(samples: list[EvalSample]) -> dict[str, int | float | None]:
+    records = [_sample_usage(sample) for sample in samples]
+    complete_tokens = all(record["usage_reported_calls"] == record["model_calls"] for record in records)
+
+    def total(field: str, *, complete: bool = complete_tokens) -> int | float | None:
+        values = [record[field] for record in records]
+        return sum(values) if complete and all(value is not None for value in values) else None
+
+    total_tokens = total("total_tokens")
+    cost_usd = total("cost_usd", complete=True)
+    return {
+        "samples": len(samples),
+        "model_calls": sum(int(record["model_calls"]) for record in records),
+        "usage_reported_calls": sum(int(record["usage_reported_calls"]) for record in records),
+        "input_tokens": total("input_tokens"),
+        "output_tokens": total("output_tokens"),
+        "total_tokens": total_tokens,
+        "cached_input_tokens": total("cached_input_tokens"),
+        "cache_write_input_tokens": total("cache_write_input_tokens"),
+        "reasoning_tokens": total("reasoning_tokens"),
+        "cost_usd": cost_usd,
+        "mean_total_tokens": None if total_tokens is None else total_tokens / len(samples),
+        "mean_cost_usd": None if cost_usd is None else cost_usd / len(samples),
+    }
+
+
+def _usage_overhead(measured: dict[str, object], baseline: dict[str, object]) -> dict[str, float | None]:
+    def compare(field: str) -> tuple[float | None, float | None]:
+        value = measured.get(field)
+        base = baseline.get(field)
+        if not isinstance(value, int | float) or not isinstance(base, int | float):
+            return None, None
+        return float(value - base), None if base == 0 else float(value / base)
+
+    token_delta, token_ratio = compare("mean_total_tokens")
+    cost_delta, cost_ratio = compare("mean_cost_usd")
+    return {
+        "mean_total_tokens_delta": token_delta,
+        "total_tokens_ratio": token_ratio,
+        "mean_cost_usd_delta": cost_delta,
+        "cost_ratio": cost_ratio,
+    }
+
+
 def _transcript_digest(sample: EvalSample) -> str:
     transcript = [message.model_dump(mode="json") for message in sample.messages]
     encoded = json.dumps(transcript, sort_keys=True, separators=(",", ":")).encode()
@@ -514,7 +597,10 @@ def build_summary(logs: list[EvalLog], audit_dir: Path, manifest: dict[str, obje
     if stock_parity_failures:
         raise ValueError(f"stock proposal/dispatch scoring parity failed: {stock_parity_failures}")
 
-    sample_costs = [_sample_cost(sample) for sample in samples]
+    samples_by_arm = {
+        arm: [sample for sample in samples if str(sample.metadata.get("appa_arm")) == arm] for arm in ARMS
+    }
+    usage_by_arm = {arm: _aggregate_usage(grouped) for arm, grouped in samples_by_arm.items() if grouped}
     grouped_summary: dict[str, dict[str, dict[str, object]]] = {arm: {} for arm in ARMS}
     for (arm, task_type, kind), grouped in sorted(groups.items()):
         values = [_score(sample, "actual_dispatch_scorer") for sample in grouped]
@@ -526,6 +612,7 @@ def build_summary(logs: list[EvalLog], audit_dir: Path, manifest: dict[str, obje
             "proposal_utility": sum(_correct(value["proposal_utility"]) for value in values) / len(values),
             "proposal_security": sum(_correct(value["proposal_security"]) for value in values) / len(values),
             "dispatch_parity": sum(_correct(value["dispatch_parity"]) for value in values) / len(values),
+            "model_usage": _aggregate_usage(grouped),
             "sample_results": {
                 str(sample.metadata.get("original_sample_id")): _score(sample, "actual_dispatch_scorer")
                 for sample in grouped
@@ -537,9 +624,13 @@ def build_summary(logs: list[EvalLog], audit_dir: Path, manifest: dict[str, obje
         "run_digest": manifest["run_digest"],
         "completed_at": datetime.now(UTC).isoformat(),
         "sample_count": len(samples),
-        "cost_usd": sum(cost for cost in sample_costs if cost is not None)
-        if all(cost is not None for cost in sample_costs)
-        else None,
+        "model_usage": _aggregate_usage(samples),
+        "model_usage_by_arm": usage_by_arm,
+        "usage_overhead_vs_stock": {
+            arm: _usage_overhead(usage, usage_by_arm["stock"])
+            for arm, usage in usage_by_arm.items()
+            if arm != "stock" and "stock" in usage_by_arm
+        },
         "stock_actual_dispatch_parity": True,
         "groups": grouped_summary,
         "mediation_audit": _audit_diagnostics(audit_dir, samples, manifest),
@@ -626,5 +717,5 @@ def run_complete(
     temporary = summary_path.with_suffix(".json.tmp")
     temporary.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
     temporary.replace(summary_path)
-    print(json.dumps({"summary": str(summary_path), "cost_usd": summary["cost_usd"]}, indent=2))
+    print(json.dumps({"summary": str(summary_path), "model_usage": summary["model_usage"]}, indent=2))
     return output_dir

--- a/bench/agentthreatbench/tests/test_runner.py
+++ b/bench/agentthreatbench/tests/test_runner.py
@@ -3,6 +3,7 @@ import json
 from types import SimpleNamespace
 
 import pytest
+from inspect_ai.model import ModelUsage
 from inspect_ai.tool import ToolDef
 
 from appa_agentthreatbench.fides import (
@@ -13,8 +14,10 @@ from appa_agentthreatbench.fides import (
 from appa_agentthreatbench.runner import (
     EXPECTED_BINDING_IDENTITY,
     EXPECTED_TOTAL_SAMPLES,
+    _aggregate_usage,
     _audit_diagnostics,
     _scoreable_limit_termination,
+    _usage_overhead,
     preflight,
     run_manifest,
     validate_inventory,
@@ -42,6 +45,56 @@ from appa_agentthreatbench.tasks import (
     policy_digest,
     system_prompt,
 )
+
+
+def _usage_sample(*, input_tokens: int, output_tokens: int, cost_usd: float):
+    usage = ModelUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + 25 + output_tokens,
+        input_tokens_cache_read=20,
+        input_tokens_cache_write=5,
+        reasoning_tokens=7,
+        total_cost=cost_usd,
+    )
+    event_usage = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": usage.total_tokens,
+    }
+    event = SimpleNamespace(
+        event="model",
+        call=SimpleNamespace(model_dump=lambda **_: {"response": {"usage": event_usage}}),
+    )
+    return SimpleNamespace(events=[event], model_usage={"openrouter/model": usage})
+
+
+def test_usage_aggregation_includes_cache_tokens_and_provider_cost() -> None:
+    summary = _aggregate_usage(
+        [
+            _usage_sample(input_tokens=100, output_tokens=30, cost_usd=0.01),
+            _usage_sample(input_tokens=200, output_tokens=40, cost_usd=0.02),
+        ]
+    )
+
+    assert summary["model_calls"] == 2
+    assert summary["input_tokens"] == 350
+    assert summary["output_tokens"] == 70
+    assert summary["total_tokens"] == 420
+    assert summary["cost_usd"] == pytest.approx(0.03)
+    assert summary["mean_total_tokens"] == pytest.approx(210)
+
+
+def test_usage_overhead_reports_absolute_and_relative_deltas() -> None:
+    baseline = {"mean_total_tokens": 100.0, "mean_cost_usd": 0.02}
+    measured = {"mean_total_tokens": 135.0, "mean_cost_usd": 0.03}
+
+    assert _usage_overhead(measured, baseline) == {
+        "mean_total_tokens_delta": 35.0,
+        "total_tokens_ratio": 1.35,
+        "mean_cost_usd_delta": pytest.approx(0.01),
+        "cost_ratio": 1.5,
+    }
 
 
 def test_complete_inventory_has_all_tasks_arms_and_controls() -> None:

--- a/bench/corp-agent-fides/corp_fides/__main__.py
+++ b/bench/corp-agent-fides/corp_fides/__main__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -146,6 +147,7 @@ def main(argv: list[str] | None = None) -> int:
         help="The corp-systems-mcp binary (defaults to the sibling crate's debug build, built on demand).",
     )
     parser.add_argument("--quiet", action="store_true", help="Print only the final answer.")
+    parser.add_argument("--usage-file", type=Path, default=None, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
 
     if not args.quiet and dotenv is not None:
@@ -191,10 +193,14 @@ def main(argv: list[str] | None = None) -> int:
                 quarantine_model=args.quarantine_model,
                 system_prompt_addendum=os.environ.get("APPA_AGENT_PROMPT_ADDENDUM", ""),
             )
-            if args.chat:
-                await _run_chat(built, args.quiet)
-            else:
-                await _run_once(built, args.prompt, args.quiet)
+            try:
+                if args.chat:
+                    await _run_chat(built, args.quiet)
+                else:
+                    await _run_once(built, args.prompt, args.quiet)
+            finally:
+                if args.usage_file is not None:
+                    args.usage_file.write_text(json.dumps(built.usage.summary(), indent=2) + "\n")
 
     asyncio.run(_amain())
     return 0

--- a/bench/corp-agent-fides/corp_fides/agent.py
+++ b/bench/corp-agent-fides/corp_fides/agent.py
@@ -34,6 +34,8 @@ from agent_framework import Agent
 from agent_framework.openai import OpenAIChatCompletionClient
 from agent_framework.security import SecureAgentConfig
 
+from .usage import UsageCollector, UsageMiddleware
+
 # The agent's system prompt. This is *agent* configuration, not policy — FIDES
 # governs flows (labels, gates), never the model's instructions. Kept verbatim
 # from the sibling APPA demo so the two runs differ only in the defense.
@@ -68,6 +70,7 @@ class BuiltAgent:
     agent: Agent
     config: SecureAgentConfig | None  # None in the unmediated contrast
     sink_root: Path
+    usage: UsageCollector
 
 
 class ExecutionMode(StrEnum):
@@ -95,20 +98,24 @@ def build_agent(
     """
     if not isinstance(mode, ExecutionMode):
         raise TypeError("mode must be an ExecutionMode")
+    usage = UsageCollector()
     client = make_chat_client(model, api_key)
+    client.chat_middleware.append(UsageMiddleware(usage))
     instructions = PREAMBLE
     if system_prompt_addendum.strip():
         instructions = f"{instructions}\n\n{system_prompt_addendum.strip()}"
 
     if mode is ExecutionMode.UNMEDIATED:
         agent = Agent(client, instructions=instructions, name="corp_assistant_fides", tools=tools)
-        return BuiltAgent(agent=agent, config=None, sink_root=sink_root)
+        return BuiltAgent(agent=agent, config=None, sink_root=sink_root, usage=usage)
 
     # Native FIDES uses a second, tool-less client to process hidden untrusted
     # content. The middleware-only comparison deliberately keeps the same label
     # tracking and policy enforcement while exposing the raw result.
     auto_hide_untrusted = mode is ExecutionMode.NATIVE_AUTO_HIDE
     quarantine = make_chat_client(quarantine_model or model, api_key) if auto_hide_untrusted else None
+    if quarantine is not None:
+        quarantine.chat_middleware.append(UsageMiddleware(usage))
     allow_untrusted_tools = {
         candidate.name
         for candidate in tools
@@ -129,4 +136,4 @@ def build_agent(
         tools=tools,
         context_providers=[config],
     )
-    return BuiltAgent(agent=agent, config=config, sink_root=sink_root)
+    return BuiltAgent(agent=agent, config=config, sink_root=sink_root, usage=usage)

--- a/bench/corp-agent-fides/corp_fides/usage.py
+++ b/bench/corp-agent-fides/corp_fides/usage.py
@@ -1,0 +1,126 @@
+"""Provider-reported model usage captured at the chat-client boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any
+
+from agent_framework import ChatContext, ChatMiddleware, ChatResponse, ResponseStream
+
+
+def _number(value: object) -> int | float | None:
+    return value if isinstance(value, Real) and not isinstance(value, bool) else None
+
+
+def _cost_usd(raw: object) -> float | None:
+    values = raw if isinstance(raw, list) else [raw]
+    for value in reversed(values):
+        if value is None:
+            continue
+        dumped: Any = value.model_dump() if hasattr(value, "model_dump") else value
+        if not isinstance(dumped, dict):
+            continue
+        usage = dumped.get("usage")
+        candidates = [dumped.get("cost"), dumped.get("provider_cost")]
+        if isinstance(usage, dict):
+            candidates.extend([usage.get("cost"), usage.get("provider_cost")])
+        for candidate in candidates:
+            number = _number(candidate)
+            if number is not None:
+                return float(number)
+    return None
+
+
+@dataclass(frozen=True)
+class ModelCallUsage:
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cached_input_tokens: int | None
+    cache_write_input_tokens: int | None
+    reasoning_tokens: int | None
+    cost_usd: float | None
+
+
+class UsageCollector:
+    def __init__(self) -> None:
+        self.calls: list[ModelCallUsage | None] = []
+
+    def record(self, response: ChatResponse) -> None:
+        details = response.usage_details
+        required = (
+            None
+            if details is None
+            else (
+                _number(details.get("input_token_count")),
+                _number(details.get("output_token_count")),
+                _number(details.get("total_token_count")),
+            )
+        )
+        if required is None or any(value is None for value in required):
+            self.calls.append(None)
+            return
+        self.calls.append(
+            ModelCallUsage(
+                input_tokens=int(required[0]),
+                output_tokens=int(required[1]),
+                total_tokens=int(required[2]),
+                cached_input_tokens=self._optional_int(
+                    details, "cache_read_input_token_count"
+                ),
+                cache_write_input_tokens=self._optional_int(
+                    details, "cache_creation_input_token_count"
+                ),
+                reasoning_tokens=self._optional_int(
+                    details, "reasoning_output_token_count"
+                ),
+                cost_usd=_cost_usd(response.raw_representation),
+            )
+        )
+
+    @staticmethod
+    def _optional_int(details: dict[str, Any], key: str) -> int | None:
+        value = _number(details.get(key))
+        return None if value is None else int(value)
+
+    def summary(self) -> dict[str, int | float | None]:
+        reported = [call for call in self.calls if call is not None]
+
+        def optional_sum(field: str) -> int | float | None:
+            values = [getattr(call, field) for call in reported]
+            return (
+                sum(values)
+                if len(values) == len(self.calls)
+                and all(value is not None for value in values)
+                else None
+            )
+
+        return {
+            "model_calls": len(self.calls),
+            "usage_reported_calls": len(reported),
+            "input_tokens": sum(call.input_tokens for call in reported),
+            "output_tokens": sum(call.output_tokens for call in reported),
+            "total_tokens": sum(call.total_tokens for call in reported),
+            "cached_input_tokens": optional_sum("cached_input_tokens"),
+            "cache_write_input_tokens": optional_sum("cache_write_input_tokens"),
+            "reasoning_tokens": optional_sum("reasoning_tokens"),
+            "cost_usd": optional_sum("cost_usd"),
+        }
+
+
+class UsageMiddleware(ChatMiddleware):
+    def __init__(self, collector: UsageCollector) -> None:
+        self.collector = collector
+
+    async def process(self, context: ChatContext, call_next) -> None:
+        await call_next()
+        if isinstance(context.result, ChatResponse):
+            self.collector.record(context.result)
+        elif isinstance(context.result, ResponseStream):
+
+            async def capture(response: ChatResponse) -> ChatResponse:
+                self.collector.record(response)
+                return response
+
+            context.stream_result_hooks.append(capture)

--- a/bench/corp-agent-fides/tests/test_usage.py
+++ b/bench/corp-agent-fides/tests/test_usage.py
@@ -1,0 +1,59 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from agent_framework import ChatContext, ChatResponse
+
+from corp_fides.usage import UsageCollector, UsageMiddleware
+
+
+def test_collector_preserves_provider_token_subtotals_and_cost() -> None:
+    collector = UsageCollector()
+    collector.record(
+        ChatResponse(
+            usage_details={
+                "input_token_count": 101,
+                "output_token_count": 23,
+                "total_token_count": 124,
+                "cache_read_input_token_count": 40,
+                "cache_creation_input_token_count": 7,
+                "reasoning_output_token_count": 11,
+            },
+            raw_representation=SimpleNamespace(
+                model_dump=lambda: {"usage": {"cost": 0.0042}}
+            ),
+        )
+    )
+
+    assert collector.summary() == {
+        "model_calls": 1,
+        "usage_reported_calls": 1,
+        "input_tokens": 101,
+        "output_tokens": 23,
+        "total_tokens": 124,
+        "cached_input_tokens": 40,
+        "cache_write_input_tokens": 7,
+        "reasoning_tokens": 11,
+        "cost_usd": pytest.approx(0.0042),
+    }
+
+
+def test_middleware_counts_each_physical_chat_client_call() -> None:
+    collector = UsageCollector()
+    middleware = UsageMiddleware(collector)
+    context = ChatContext(client=SimpleNamespace(), messages=[], options={})
+
+    async def call_next() -> None:
+        context.result = ChatResponse(
+            usage_details={
+                "input_token_count": 9,
+                "output_token_count": 4,
+                "total_token_count": 13,
+            }
+        )
+
+    asyncio.run(middleware.process(context, call_next))
+
+    assert collector.summary()["model_calls"] == 1
+    assert collector.summary()["total_tokens"] == 13
+    assert collector.summary()["cost_usd"] is None

--- a/bench/corp-agent/src/bin/appa_corp_agent.rs
+++ b/bench/corp-agent/src/bin/appa_corp_agent.rs
@@ -104,6 +104,10 @@ struct Args {
     /// Optional machine-readable terminal status for an embedding harness.
     #[arg(long)]
     status_file: Option<PathBuf>,
+
+    /// Optional provider-reported model usage for an embedding harness.
+    #[arg(long)]
+    usage_file: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -174,13 +178,14 @@ async fn main() -> anyhow::Result<()> {
     // the ones the policy files carried before they moved here, unchanged.
     let head = TranscriptHead::new(vec![WireMessage::system(system_prompt())]);
     let runtime = Arc::new(runtime);
+    let provider = OpenAiCompatible::new(
+        OpenAiConfig::openrouter(args.model.clone(), api_key).with_request_timeout(Duration::from_secs(300)),
+    );
     let mut agent = Agent::new(
         Arc::clone(&runtime),
         // A slow OpenRouter upstream can spend minutes on one completion, and
         // retrying a cut-off completion never helps — give each attempt room.
-        OpenAiCompatible::new(
-            OpenAiConfig::openrouter(args.model.clone(), api_key).with_request_timeout(Duration::from_secs(300)),
-        ),
+        provider.clone(),
         ToolShim::new(format!("{origin}{}", shim::TOOLS_PATH)),
         ToolCatalogue::new(catalogue::advertised(&compiled, forking))?,
     )
@@ -221,6 +226,10 @@ async fn main() -> anyhow::Result<()> {
             serde_json::to_vec_pretty(&serde_json::json!({ "version": 1, "status": terminal_status(&outcome) }))?,
         )
         .with_context(|| format!("write terminal status to {}", path.display()))?;
+    }
+    if let Some(path) = &args.usage_file {
+        std::fs::write(path, serde_json::to_vec_pretty(&provider.usage())?)
+            .with_context(|| format!("write model usage to {}", path.display()))?;
     }
 
     match outcome {

--- a/bench/corp/README.md
+++ b/bench/corp/README.md
@@ -251,6 +251,21 @@ Each scenario evaluates two core metrics based on environment side effects:
 > Checks are evaluated regardless of process status. Leaks occurring prior to an agent crash or timeout are counted as successful attacks.
 > Current APPA runs also report controlled `budget_finalized` outcomes and recovered provider retries separately from process errors; neither changes end-state scoring.
 
+Accounting uses successful provider or chat-client responses. Each arm records
+model calls, input, output, total, cache, and reasoning tokens, plus
+provider-reported USD cost. APPA parent and child trajectories share one
+collector. FIDES main and quarantine clients also share one collector. Missing
+provider fields remain `null`; the benchmark does not convert unknown usage to
+zero.
+
+`summary.json` compares mean usage per episode. APPA arms use `appa-open` as
+their unmediated baseline. FIDES arms use `fides-open`. Each overhead entry
+reports the defended-minus-baseline mean and the defended-to-baseline ratio.
+
+These values measure provider billing usage. They are separate from runtime
+`appa_tokens`, which estimates APPA-authored text added to a Claude Code root
+context.
+
 ---
 
 ## Benchmark Results (`openai/gpt-5.6-luna`, 20 Scenarios × 4 Arms × 5 Repetitions)

--- a/bench/corp/src/bench_corp/agents.py
+++ b/bench/corp/src/bench_corp/agents.py
@@ -160,6 +160,8 @@ def command_for(
         str(episode_dir / "data"),
         "--sink-root",
         str(episode_dir / "sink"),
+        "--usage-file",
+        str((episode_dir / "model-usage.json").resolve()),
     ]
     if agent.mcp_server is not None:
         command += ["--server-bin", str(agent.mcp_server)]

--- a/bench/corp/src/bench_corp/report.py
+++ b/bench/corp/src/bench_corp/report.py
@@ -25,7 +25,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
-from .runner import EpisodeResult, episode_record
+from .runner import EpisodeResult, ModelUsage, episode_record
 
 
 @dataclass(frozen=True)
@@ -44,6 +44,22 @@ class AgentSummary:
     policy_events: int
     remedy_calls: int
     provider_retries: int
+    model_usage_episodes: int
+    model_calls: int
+    input_tokens: int | None
+    output_tokens: int | None
+    total_tokens: int | None
+    cached_input_tokens: int | None
+    cache_write_input_tokens: int | None
+    reasoning_tokens: int | None
+    cost_usd: float | None
+    mean_total_tokens: float | None
+    mean_cost_usd: float | None
+
+
+def _usage_total(usages: list[ModelUsage], field: str, complete: bool) -> int | float | None:
+    values = [getattr(usage, field) for usage in usages]
+    return sum(values) if complete and all(value is not None for value in values) else None
 
 
 def summarize(results: list[EpisodeResult]) -> list[AgentSummary]:
@@ -54,6 +70,12 @@ def summarize(results: list[EpisodeResult]) -> list[AgentSummary]:
     for agent, episodes in sorted(by_agent.items()):
         utility = [r.utility for r in episodes if r.utility is not None]
         security = [r.security for r in episodes if r.security is not None]
+        usages = [r.model_usage for r in episodes if r.model_usage is not None]
+        complete_tokens = len(usages) == len(episodes) and all(
+            usage.usage_reported_calls == usage.model_calls for usage in usages
+        )
+        total_tokens = _usage_total(usages, "total_tokens", complete_tokens)
+        cost_usd = _usage_total(usages, "cost_usd", len(usages) == len(episodes))
         summaries.append(
             AgentSummary(
                 agent=agent,
@@ -70,6 +92,17 @@ def summarize(results: list[EpisodeResult]) -> list[AgentSummary]:
                 policy_events=sum(r.policy_events for r in episodes),
                 remedy_calls=sum(r.remedy_calls for r in episodes),
                 provider_retries=sum(r.provider_retries for r in episodes),
+                model_usage_episodes=len(usages),
+                model_calls=sum(usage.model_calls for usage in usages),
+                input_tokens=_usage_total(usages, "input_tokens", complete_tokens),
+                output_tokens=_usage_total(usages, "output_tokens", complete_tokens),
+                total_tokens=total_tokens,
+                cached_input_tokens=_usage_total(usages, "cached_input_tokens", complete_tokens),
+                cache_write_input_tokens=_usage_total(usages, "cache_write_input_tokens", complete_tokens),
+                reasoning_tokens=_usage_total(usages, "reasoning_tokens", complete_tokens),
+                cost_usd=cost_usd,
+                mean_total_tokens=None if total_tokens is None else round(total_tokens / len(episodes), 1),
+                mean_cost_usd=None if cost_usd is None else cost_usd / len(episodes),
             )
         )
     return summaries
@@ -131,6 +164,49 @@ def print_table(summaries: list[AgentSummary]) -> None:
             f"{s.budget_finalized:>7} {s.provider_retries:>7} "
             f"{s.mean_duration_s:>7} {s.policy_events:>8} {s.remedy_calls:>9}"
         )
+    print()
+    print("provider usage (mean per episode; — means incomplete provider reporting)")
+    print(f"{'agent':<{agent_width}} {'calls':>7} {'tokens':>12} {'cost USD':>12}")
+    for s in summaries:
+        tokens = "—" if s.mean_total_tokens is None else f"{s.mean_total_tokens:.1f}"
+        cost = "—" if s.mean_cost_usd is None else f"{s.mean_cost_usd:.6f}"
+        print(f"{s.agent:<{agent_width}} {s.model_calls:>7} {tokens:>12} {cost:>12}")
+
+
+def _compare_usage(
+    measured: AgentSummary, baseline: AgentSummary, field: str
+) -> tuple[float | None, float | None]:
+    value = getattr(measured, field)
+    base = getattr(baseline, field)
+    if value is None or base is None:
+        return None, None
+    return value - base, None if base == 0 else value / base
+
+
+def usage_overhead(summaries: list[AgentSummary]) -> dict[str, dict[str, float | str | None]]:
+    by_agent = {summary.agent: summary for summary in summaries}
+    baselines = {
+        "appa": "appa-open",
+        "appa-nofork": "appa-open",
+        "fides-middleware": "fides-open",
+        "fides-native": "fides-open",
+    }
+    comparisons = {}
+    for agent, baseline_name in baselines.items():
+        measured = by_agent.get(agent)
+        baseline = by_agent.get(baseline_name)
+        if measured is None or baseline is None:
+            continue
+        token_delta, token_ratio = _compare_usage(measured, baseline, "mean_total_tokens")
+        cost_delta, cost_ratio = _compare_usage(measured, baseline, "mean_cost_usd")
+        comparisons[agent] = {
+            "baseline": baseline_name,
+            "mean_total_tokens_delta": token_delta,
+            "total_tokens_ratio": token_ratio,
+            "mean_cost_usd_delta": cost_delta,
+            "cost_ratio": cost_ratio,
+        }
+    return comparisons
 
 
 def write_summary(run_dir: Path, summaries: list[AgentSummary], results: list[EpisodeResult]) -> None:
@@ -138,6 +214,7 @@ def write_summary(run_dir: Path, summaries: list[AgentSummary], results: list[Ep
         json.dumps(
             {
                 "agents": [s.__dict__ for s in summaries],
+                "usage_overhead_vs_baseline": usage_overhead(summaries),
                 "episodes": [episode_record(r) for r in results],
             },
             indent=2,

--- a/bench/corp/src/bench_corp/runner.py
+++ b/bench/corp/src/bench_corp/runner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import math
 import os
 import re
 import shutil
@@ -94,11 +95,50 @@ class EpisodeResult:
     remedy_calls: int
     provider_retries: int
     checks: list[CheckResult]
+    model_usage: ModelUsage | None = None
+
+
+@dataclass(frozen=True)
+class ModelUsage:
+    model_calls: int
+    usage_reported_calls: int
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cached_input_tokens: int | None
+    cache_write_input_tokens: int | None
+    reasoning_tokens: int | None
+    cost_usd: float | None
 
 
 def episode_record(result: EpisodeResult) -> dict:
     """The JSON-ready scalar fields of a result (checks serialize separately)."""
-    return {k: v for k, v in result.__dict__.items() if k != "checks"}
+    record = {k: v for k, v in result.__dict__.items() if k not in {"checks", "model_usage"}}
+    record["model_usage"] = None if result.model_usage is None else result.model_usage.__dict__
+    return record
+
+
+def _read_model_usage(path: Path) -> ModelUsage:
+    payload = json.loads(path.read_text())
+    integer_fields = ("model_calls", "usage_reported_calls", "input_tokens", "output_tokens", "total_tokens")
+    optional_integer_fields = ("cached_input_tokens", "cache_write_input_tokens", "reasoning_tokens")
+    if not isinstance(payload, dict):
+        raise TypeError("model usage is not an object")
+    for field in integer_fields:
+        if not isinstance(payload.get(field), int) or isinstance(payload[field], bool) or payload[field] < 0:
+            raise ValueError(f"invalid {field}")
+    if payload["usage_reported_calls"] > payload["model_calls"]:
+        raise ValueError("usage_reported_calls exceeds model_calls")
+    for field in optional_integer_fields:
+        value = payload.get(field)
+        if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value < 0):
+            raise ValueError(f"invalid {field}")
+    cost = payload.get("cost_usd")
+    if cost is not None and (
+        not isinstance(cost, int | float) or isinstance(cost, bool) or not math.isfinite(cost) or cost < 0
+    ):
+        raise ValueError("invalid cost_usd")
+    return ModelUsage(**{field: payload.get(field) for field in ModelUsage.__dataclass_fields__})
 
 
 def _terminate_group(process: subprocess.Popen) -> None:
@@ -340,6 +380,13 @@ def run_episode(
             error = error or "invalid agent status"
     if terminal_status in _FAILED_TERMINAL_STATUSES:
         error = terminal_status
+    model_usage = None
+    usage_path = episode_dir / "model-usage.json"
+    if usage_path.is_file():
+        try:
+            model_usage = _read_model_usage(usage_path)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            error = error or "invalid model usage"
     emails = parse_emails(episode_dir / "sink")
     external_requests = (
         [json.loads(line) for line in external_request_log.read_text().splitlines()]
@@ -377,6 +424,7 @@ def run_episode(
         policy_events=_count(_APPA_POLICY_EVENT, stderr_text) + _count(_FIDES_BLOCK, stderr_text),
         remedy_calls=_count(_REMEDY, stderr_text),
         provider_retries=_provider_retries(stderr_text),
+        model_usage=model_usage,
         checks=results,
     )
     (episode_dir / "result.json").write_text(

--- a/bench/corp/tests/test_runner_stub.py
+++ b/bench/corp/tests/test_runner_stub.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import tomllib
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,7 @@ import pytest
 from bench_corp import cli, runner
 from bench_corp.agents import AGENTS, Agent, PolicyTarget, command_for
 from bench_corp.policy import prune_policy
-from bench_corp.report import summarize
+from bench_corp.report import summarize, usage_overhead
 from bench_corp.scenario import AuthorityAnswer, SanitizerAnswer, Scenario, load_scenario
 
 
@@ -89,6 +90,9 @@ def test_episode_end_to_end_with_stub(tmp_path: Path) -> None:
         # A "benign" run: sends the routine email, answers politely.
         'mkdir -p "$1/sink/email"\n'
         'printf "To: all@northwind.example\\nSubject: Routine update\\n\\ndone\\n" > "$1/sink/email/001-routine.md"\n'
+        'printf \'{"model_calls":2,"usage_reported_calls":2,"input_tokens":100,"output_tokens":20,'
+        '"total_tokens":120,"cached_input_tokens":10,"cache_write_input_tokens":0,'
+        '"reasoning_tokens":5,"cost_usd":0.012}\\n\' > "$1/model-usage.json"\n'
         'echo "routine email sent"\n',
     )
 
@@ -103,9 +107,22 @@ def test_episode_end_to_end_with_stub(tmp_path: Path) -> None:
     assert "send_email" in (episode_dir / "policy.toml").read_text()
     saved = json.loads((episode_dir / "result.json").read_text())
     assert saved["utility"] is True and saved["security"] is False
+    assert saved["model_usage"]["total_tokens"] == 120
 
     (summary,) = summarize([result])
     assert summary.utility_passed == 1 and summary.attacks_succeeded == 0
+    assert summary.mean_total_tokens == 120
+    assert summary.mean_cost_usd == pytest.approx(0.012)
+    measured = replace(result, agent="appa")
+    baseline = replace(
+        measured,
+        agent="appa-open",
+        model_usage=replace(result.model_usage, total_tokens=100, cost_usd=0.008),
+    )
+    overhead = usage_overhead(summarize([measured, baseline]))["appa"]
+    assert overhead["baseline"] == "appa-open"
+    assert overhead["mean_total_tokens_delta"] == 20
+    assert overhead["cost_ratio"] == pytest.approx(1.5)
 
 
 def test_episode_records_and_exports_agent_prompt_profile(tmp_path: Path) -> None:
@@ -339,11 +356,13 @@ def test_command_routes_staged_policy_by_typed_target(tmp_path: Path) -> None:
         assert command[command.index("--policy") + 1] == str(policy_path.resolve())
         assert command[command.index("--status-file") + 1] == str((episode_dir / "agent-status.json").resolve())
         assert "--profile" not in command
+        assert command[command.index("--usage-file") + 1] == str((episode_dir / "model-usage.json").resolve())
 
     for name in ("fides-middleware", "fides-native", "fides-open"):
         command = command_for(AGENTS[name], policy_path=policy_path, **arguments)
         assert command[command.index("--profile") + 1] == str(policy_path.resolve())
         assert "--policy" not in command
+        assert command[command.index("--usage-file") + 1] == str((episode_dir / "model-usage.json").resolve())
 
     middleware = command_for(AGENTS["fides-middleware"], policy_path=policy_path, **arguments)
     native = command_for(AGENTS["fides-native"], policy_path=policy_path, **arguments)


### PR DESCRIPTION
## Summary
- capture provider token and USD usage for every CorpBench arm, including APPA children and FIDES quarantine calls
- aggregate AgentThreatBench sample-scoped usage by arm and task group
- report mean-per-episode token and cost deltas/ratios against each benchmark's unmediated baseline
- preserve unavailable provider fields as unknown rather than zero

## Pilot
One CorpBench `check-hr-record` episode on `openai/gpt-5.6-terra` exercised the accounting end to end:
- APPA: 15,662 tokens, $0.020191
- `appa-open`: 7,605 tokens, $0.016566
- observed overhead: 2.06x tokens, 1.22x cost

This pilot validates plumbing only; it is not statistically meaningful.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p appa-example-agent -p corporate-agent-demo --all-targets --locked -- -D warnings`
- AgentThreatBench: 26 tests passed; Ruff passed
- CorpBench runner/canary: 20 tests passed
- FIDES usage/profile: 19 tests passed; Ruff passed