### PR TITLE
feat(cli): appa runtime stop, and a purge of the deployment

### DIFF
--- a/appa-runtime/src/bin/appa.rs
+++ b/appa-runtime/src/bin/appa.rs
@@ -22,8 +22,6 @@ enum Command {
     ActivateClaude {
         #[arg(long)]
         config: PathBuf,
-        #[arg(long)]
-        previous_binary: Option<PathBuf>,
     },
     /// Internal journalled removal using the selected release executable.
     #[command(hide = true)]
@@ -187,10 +185,7 @@ fn main() -> ExitCode {
     };
     match parsed.command {
         Command::BuildInfo => appa_runtime::installation::native::build_info(),
-        Command::ActivateClaude {
-            config,
-            previous_binary,
-        } => match appa_runtime::init::activate_claude_code(&config, previous_binary.as_deref()) {
+        Command::ActivateClaude { config } => match appa_runtime::init::activate_claude_code(&config) {
             Ok(_) => ExitCode::SUCCESS,
             Err(error) => {
                 eprintln!("appa: {error}");

--- a/appa-runtime/src/init/endpoint.rs
+++ b/appa-runtime/src/init/endpoint.rs
@@ -231,20 +231,16 @@ fn terminate_owned_appa_runtime(pid: i32, endpoint: &Endpoint) -> Result<(), Ini
     terminate_appa_pid(pid)
 }
 
-/// Stop a runtime this init started, and wait for its process to go.
+/// Stop the appa runtime answering the endpoint as `pid`, this deployment's
+/// or an earlier one's, and wait until the endpoint no longer answers from it.
 pub(super) fn stop_owned_appa_runtime(pid: i32, endpoint: &Endpoint) -> Result<(), InitError> {
-    terminate_owned_appa_runtime(pid, endpoint)?;
-    let deadline = std::time::Instant::now() + STOP_DEADLINE;
-    while std::time::Instant::now() < deadline {
-        if !process_exists(pid) {
-            return Ok(());
+    let loopback = crate::loopback_http::Endpoint::parse(endpoint.url()).map_err(|reason| {
+        crate::runtime_start::StopError::Endpoint {
+            url: endpoint.url().to_owned(),
+            reason,
         }
-        std::thread::sleep(STOP_POLL);
-    }
-    Err(InitError::RuntimeSurvived {
-        pid,
-        endpoint: endpoint.url().to_owned(),
-    })
+    })?;
+    Ok(crate::runtime_start::stop_pid(&loopback, endpoint.url(), pid)?)
 }
 
 #[cfg(unix)]

--- a/appa-runtime/src/init/endpoint.rs
+++ b/appa-runtime/src/init/endpoint.rs
@@ -104,11 +104,11 @@ enum Divergence {
 /// Who is answering the endpoint, as far as one probe can establish.
 ///
 /// A healthy runtime left by an install under a different `APPA_INSTALL_DIR` or
-/// `APPA_DATA_DIR` is foreign: it is named and refused, never stopped. Stale
-/// runtimes are cleared before this classification through their separate
-/// health protocol.
+/// `APPA_DATA_DIR` is foreign: the activation stops it when it is this user's
+/// own appa process, and refuses it by pid otherwise. Stale runtimes are
+/// cleared before this classification through their separate health protocol.
 #[derive(Debug, PartialEq, Eq)]
-enum EndpointOwner {
+pub(super) enum EndpointOwner {
     /// Nothing answered, or what answered serves no fingerprint. Before the
     /// start this is the ordinary case; after it, it is a failure.
     Unidentified,
@@ -358,7 +358,7 @@ pub(crate) fn terminate_appa_pid(pid: i32) -> Result<(), InitError> {
 /// A deployment is a build *and* the configuration it serves. Comparing builds alone makes
 /// every install of one build look like the same deployment, which is how an install ends
 /// up reloading, and reporting on, a runtime that is not its own.
-fn endpoint_owner(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {
+pub(super) fn endpoint_owner(binary: &Path, config: &Path, endpoint: &Endpoint) -> Result<EndpointOwner, InitError> {
     let expected = crate::runtime_cli::binary_digest(binary).map_err(|source| InitError::InstallRuntime {
         path: binary.to_path_buf(),
         source,
@@ -501,14 +501,19 @@ fn reload_policy(endpoint: &Endpoint, config: &Path) -> Result<(), InitError> {
 pub(super) fn verify_runtime_deployment(runtime: &Path, config: &Path, endpoint: &Endpoint) -> Result<i32, InitError> {
     match endpoint_owner(runtime, config, endpoint)? {
         EndpointOwner::Deployment { pid } => Ok(pid),
-        EndpointOwner::Unidentified => Err(InitError::RuntimeIdentity {
-            endpoint: endpoint.url().to_owned(),
-            message: "it does not identify itself as an appa runtime. Stop it, then rerun the install.".to_owned(),
-        }),
+        EndpointOwner::Unidentified => Err(unidentified(endpoint)),
         EndpointOwner::Foreign { pid } => Err(InitError::RuntimeIdentity {
             endpoint: endpoint.url().to_owned(),
             message: format!("another appa deployment (pid {pid}) is answering. Stop it, then rerun the install."),
         }),
+    }
+}
+
+/// A listener that serves no appa identity is nobody's to stop from here.
+pub(super) fn unidentified(endpoint: &Endpoint) -> InitError {
+    InitError::RuntimeIdentity {
+        endpoint: endpoint.url().to_owned(),
+        message: "it does not identify itself as an appa runtime. Stop it, then rerun the install.".to_owned(),
     }
 }
 

--- a/appa-runtime/src/init/mcp.rs
+++ b/appa-runtime/src/init/mcp.rs
@@ -16,6 +16,9 @@ pub(super) const SERVER: &str = "appa";
 
 const TEMPLATE_PREFIX: &str = "${APPA_RUNTIME_URL:-";
 const TEMPLATE_SUFFIX: &str = "}/mcp";
+/// The template as `claude mcp get` reports it: without its default. What
+/// Claude stores keeps the default and expands it; only the report drops it.
+const REPORTED_TEMPLATE: &str = "${APPA_RUNTIME_URL}/mcp";
 
 /// What Claude Code reports under APPA's server name.
 pub(super) enum Registered {
@@ -29,7 +32,11 @@ pub(super) enum Registered {
 /// The registration Claude Code reports, whichever scope it comes from: a
 /// project-scoped server of the same name shadows the user scope one, so it is
 /// as much a conflict as a foreign user-scoped one.
-pub(super) fn current() -> Result<Registered, InitError> {
+///
+/// The report drops a template's default, and the production endpoint is the
+/// only default an install writes, so a template reported without one is read
+/// as the template of `endpoint`, this deployment's.
+pub(super) fn current(endpoint: &str) -> Result<Registered, InitError> {
     let output = Command::new("claude")
         .args(["mcp", "get", SERVER])
         .output()
@@ -49,6 +56,11 @@ pub(super) fn current() -> Result<Registered, InitError> {
         command: format!("mcp get {SERVER}"),
         message: "the answer names no URL".to_owned(),
     })?;
+    if url == REPORTED_TEMPLATE {
+        return Ok(Registered::Ours {
+            url: template(endpoint),
+        });
+    }
     if !is_ours(url) {
         return Err(InitError::McpConflict { url: url.to_owned() });
     }

--- a/appa-runtime/src/init/mod.rs
+++ b/appa-runtime/src/init/mod.rs
@@ -24,18 +24,23 @@ pub(crate) mod settings;
 mod skill;
 
 pub use self::paths::installed_config_path;
-pub use self::removal::claude_code_remove;
+pub use self::removal::{Purge, PurgedRuntime, claude_code_purge, claude_code_remove};
 
 use self::config::{ComposedPolicy, discard_file, verify_config};
 use self::endpoint::{
-    Endpoint, RuntimeOutcome, clear_stale_endpoint, endpoint_health, reconcile_policy, stop_owned_appa_runtime,
-    verify_runtime_deployment,
+    Endpoint, EndpointOwner, RuntimeOutcome, clear_stale_endpoint, endpoint_health, endpoint_owner, reconcile_policy,
+    stop_owned_appa_runtime, unidentified, verify_runtime_deployment,
 };
 #[cfg(windows)]
 use self::paths::windows_identity;
 use self::paths::{DeploymentPaths, appa_filename, deployment_paths, same_file};
 use self::receipt::{Receipt, Style};
 use self::settings::HookTarget;
+
+/// The way out of a deployment state an install cannot repair, named where
+/// that state is refused.
+pub const START_OVER: &str =
+    "to start over: appa plugin remove claude-code --purge, then appa plugin install claude-code";
 
 #[derive(Debug, Error)]
 pub enum InitError {
@@ -55,7 +60,7 @@ pub enum InitError {
     InstallRuntime { path: PathBuf, source: std::io::Error },
     #[error("cannot initialize {path}: {source}")]
     WriteFile { path: PathBuf, source: std::io::Error },
-    #[error("the deployment config {path} does not load: {source}")]
+    #[error("the deployment config {path} does not load: {source}; {}", START_OVER)]
     UnloadableConfig { path: PathBuf, source: Box<ConfigError> },
     #[error("cannot change APPA integration state at {path}: {message}")]
     NativeState { path: PathBuf, message: String },
@@ -84,6 +89,8 @@ pub enum InitError {
         path: PathBuf,
         message: String,
     },
+    #[error(transparent)]
+    Stop(#[from] crate::runtime_start::StopError),
     #[error("{operation}; restoring the previous installation also failed: {recovery}")]
     Recovery {
         operation: Box<InitError>,
@@ -101,7 +108,7 @@ pub enum InitError {
 /// before the profile is switched over. Directories and the deployed binary's
 /// parent are written before that settling; both are additive and neither is
 /// what Claude reads.
-pub fn activate_claude_code(config: &Path, previous_binary: Option<&Path>) -> Result<String, InitError> {
+pub fn activate_claude_code(config: &Path) -> Result<String, InitError> {
     // The endpoint is settled before anything is read: a release build ignores
     // the environment here, and the release check proves it on this refusal.
     let endpoint = Endpoint::resolve()?;
@@ -113,7 +120,7 @@ pub fn activate_claude_code(config: &Path, previous_binary: Option<&Path>) -> Re
         path: config.clone(),
         source: Box::new(source),
     })?;
-    install_claude(&build_label(), endpoint, config, previous_binary)
+    install_claude(&build_label(), endpoint, config)
 }
 
 /// The origin as a receipt names it: this binary's release tag, or the commit
@@ -130,12 +137,7 @@ fn build_label() -> String {
     }
 }
 
-fn install_claude(
-    origin: &str,
-    endpoint: Endpoint,
-    config: PathBuf,
-    previous_binary: Option<&Path>,
-) -> Result<String, InitError> {
+fn install_claude(origin: &str, endpoint: Endpoint, config: PathBuf) -> Result<String, InitError> {
     let appa = env::current_exe().map_err(InitError::CurrentExecutable)?;
     let paths = deployment_paths()?;
     let _profile_lock = lock_claude_profile(&paths.claude_dir)?;
@@ -171,15 +173,19 @@ fn install_claude(
     //    endpoint, and its health answer names the stale pid.
     clear_stale_endpoint(&endpoint)?;
     if endpoint_health(&endpoint)?.is_some() {
-        // Nobody is asked on behalf of a different deployment. An update stops
-        // the runtime of the binary it replaces, once that runtime proves to be
-        // serving this config; any other owner is refused with its pid named.
-        if let Err(current_error) = verify_runtime_deployment(&appa, &config, &endpoint) {
-            let Some(previous) = previous_binary else {
-                return Err(current_error);
-            };
-            let pid = verify_runtime_deployment(previous, &config, &endpoint)?;
-            stop_owned_appa_runtime(pid, &endpoint)?;
+        // An install claims the endpoint. The runtime an earlier deployment of
+        // this user's left there is stopped, whichever build or config it
+        // serves; a process that is not this user's appa runtime is refused
+        // with its pid named, and a listener with no appa identity is refused.
+        match endpoint_owner(&appa, &config, &endpoint)? {
+            EndpointOwner::Deployment { .. } => {}
+            EndpointOwner::Foreign { pid } => {
+                progress(&format!(
+                    "stopping the appa runtime (pid {pid}) of an earlier deployment"
+                ));
+                stop_owned_appa_runtime(pid, &endpoint)?;
+            }
+            EndpointOwner::Unidentified => return Err(unidentified(&endpoint)),
         }
     }
 

--- a/appa-runtime/src/init/mod.rs
+++ b/appa-runtime/src/init/mod.rs
@@ -161,7 +161,7 @@ fn install_claude(origin: &str, endpoint: Endpoint, config: PathBuf) -> Result<S
     // 2. What the profile holds under APPA's names. A server or a skill that
     //    no install wrote is refused here, with the profile untouched.
     progress("reading the Claude Code profile");
-    let registered = mcp::current()?;
+    let registered = mcp::current(endpoint.url())?;
     skill::verify(&paths.claude_dir)?;
     settings::verify(&paths)?;
 

--- a/appa-runtime/src/init/removal.rs
+++ b/appa-runtime/src/init/removal.rs
@@ -1,9 +1,14 @@
-//! Remove only what an activation wrote to this Claude profile.
+//! Remove only what an activation wrote to this Claude profile; or, purged,
+//! everything an install put on this machine.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use super::endpoint::Endpoint;
+use super::paths::DeploymentPaths;
 use super::{CLAPPA, InitError, appa_filename, deployment_paths, file_before, mcp, settings, skill, write_state};
+use crate::runtime_start::{StopError, Stopped};
+use crate::runtime_url::RuntimeTarget;
 
 #[cfg(unix)]
 pub(super) const REMOVING: &str = "#!/bin/sh\nprintf 'APPA plugin removal is incomplete; rerun appa plugin remove claude-code with the same config.\\n' >&2\nexit 1\n";
@@ -18,6 +23,70 @@ pub(super) const REMOVING: &str = "@echo off\r\necho APPA plugin removal is inco
 pub fn claude_code_remove() -> Result<(), InitError> {
     let paths = deployment_paths()?;
     let _profile_lock = super::lock_claude_profile(&paths.claude_dir)?;
+    remove_profile(&paths)
+}
+
+/// What a purge did about the runtime at the deployment's endpoint.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PurgedRuntime {
+    Nothing,
+    Stopped {
+        pid: i32,
+    },
+    /// A process there that is not this user's appa runtime, left as it is.
+    Left {
+        reason: String,
+    },
+}
+
+#[derive(Debug)]
+pub struct Purge {
+    pub runtime: PurgedRuntime,
+    pub removed: Vec<PathBuf>,
+}
+
+/// Everything an install put on this machine, gone: the profile entries, the
+/// runtime, the data directory with the deployed binary, database, logs and
+/// retained versions, and the config directory with the policy and the install
+/// state. `appa` itself stays on PATH for the install that follows. A process
+/// at the endpoint that is not this user's appa runtime is left and named,
+/// never a reason to keep the rest.
+pub fn claude_code_purge() -> Result<Purge, InitError> {
+    let paths = deployment_paths()?;
+    let _profile_lock = super::lock_claude_profile(&paths.claude_dir)?;
+    remove_profile(&paths)?;
+    let endpoint = Endpoint::resolve()?;
+    let target = RuntimeTarget {
+        url: endpoint.url().to_owned(),
+        user_owned: false,
+    };
+    let runtime = match crate::runtime_start::stop(&target) {
+        Ok(Stopped::Nothing) => PurgedRuntime::Nothing,
+        Ok(Stopped::Runtime { pid }) => PurgedRuntime::Stopped { pid },
+        Err(left @ (StopError::Unidentified { .. } | StopError::NotOwned { .. })) => PurgedRuntime::Left {
+            reason: left.to_string(),
+        },
+        Err(error) => return Err(error.into()),
+    };
+    let mut removed = Vec::new();
+    // The data directory first: the deployed binary and the database go before
+    // the policy. On macOS both are one directory, and the second is then absent.
+    for directory in [&paths.data_dir, &paths.config_dir] {
+        match fs::remove_dir_all(directory) {
+            Ok(()) => removed.push(directory.clone()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(InitError::WriteFile {
+                    path: directory.clone(),
+                    source,
+                });
+            }
+        }
+    }
+    Ok(Purge { runtime, removed })
+}
+
+fn remove_profile(paths: &DeploymentPaths) -> Result<(), InitError> {
     let deployed = paths.data_dir.join("bin").join(appa_filename());
     let launcher = paths.install_dir.join(CLAPPA.0);
     let launcher_before = file_before(&launcher)?;
@@ -25,19 +94,19 @@ pub fn claude_code_remove() -> Result<(), InitError> {
     // Everything foreign is refused before anything is removed.
     let registered = mcp::current()?;
     skill::verify(&paths.claude_dir)?;
-    settings::verify(&paths)?;
+    settings::verify(paths)?;
 
     // Disable the protected entrypoint before unregistering its hooks. A crash
     // must not leave a working-looking clappa that starts unprotected Claude.
     if launcher_before.is_some() {
         write_state(&launcher, REMOVING.as_bytes())?;
     }
-    settings::remove_hooks(&paths, &deployed)?;
+    settings::remove_hooks(paths, &deployed)?;
     if let mcp::Registered::Ours { .. } = registered {
         mcp::remove()?;
     }
     skill::remove(&paths.claude_dir)?;
-    settings::remove_statusline(&paths, &deployed)?;
+    settings::remove_statusline(paths, &deployed)?;
     if launcher_before.is_some() {
         if file_before(&launcher)?.as_deref() != Some(REMOVING.as_bytes()) {
             return Err(conflict(

--- a/appa-runtime/src/init/removal.rs
+++ b/appa-runtime/src/init/removal.rs
@@ -21,9 +21,10 @@ pub(super) const REMOVING: &str = "@echo off\r\necho APPA plugin removal is inco
 /// stay put. The `--config` flag of the bridge stays because the installed
 /// binary invokes it; the profile carries everything removal needs.
 pub fn claude_code_remove() -> Result<(), InitError> {
+    let endpoint = Endpoint::resolve()?;
     let paths = deployment_paths()?;
     let _profile_lock = super::lock_claude_profile(&paths.claude_dir)?;
-    remove_profile(&paths)
+    remove_profile(&paths, &endpoint)
 }
 
 /// What a purge did about the runtime at the deployment's endpoint.
@@ -52,10 +53,10 @@ pub struct Purge {
 /// at the endpoint that is not this user's appa runtime is left and named,
 /// never a reason to keep the rest.
 pub fn claude_code_purge() -> Result<Purge, InitError> {
+    let endpoint = Endpoint::resolve()?;
     let paths = deployment_paths()?;
     let _profile_lock = super::lock_claude_profile(&paths.claude_dir)?;
-    remove_profile(&paths)?;
-    let endpoint = Endpoint::resolve()?;
+    remove_profile(&paths, &endpoint)?;
     let target = RuntimeTarget {
         url: endpoint.url().to_owned(),
         user_owned: false,
@@ -86,13 +87,13 @@ pub fn claude_code_purge() -> Result<Purge, InitError> {
     Ok(Purge { runtime, removed })
 }
 
-fn remove_profile(paths: &DeploymentPaths) -> Result<(), InitError> {
+fn remove_profile(paths: &DeploymentPaths, endpoint: &Endpoint) -> Result<(), InitError> {
     let deployed = paths.data_dir.join("bin").join(appa_filename());
     let launcher = paths.install_dir.join(CLAPPA.0);
     let launcher_before = file_before(&launcher)?;
     verify_launcher(launcher_before.as_deref(), &launcher)?;
     // Everything foreign is refused before anything is removed.
-    let registered = mcp::current()?;
+    let registered = mcp::current(endpoint.url())?;
     skill::verify(&paths.claude_dir)?;
     settings::verify(paths)?;
 

--- a/appa-runtime/src/init/removal.rs
+++ b/appa-runtime/src/init/removal.rs
@@ -34,7 +34,8 @@ pub enum PurgedRuntime {
     Stopped {
         pid: i32,
     },
-    /// A process there that is not this user's appa runtime, left as it is.
+    /// A process there that is not this user's appa runtime, or does not
+    /// answer as one, left as it is.
     Left {
         reason: String,
     },
@@ -64,9 +65,11 @@ pub fn claude_code_purge() -> Result<Purge, InitError> {
     let runtime = match crate::runtime_start::stop(&target) {
         Ok(Stopped::Nothing) => PurgedRuntime::Nothing,
         Ok(Stopped::Runtime { pid }) => PurgedRuntime::Stopped { pid },
-        Err(left @ (StopError::Unidentified { .. } | StopError::NotOwned { .. })) => PurgedRuntime::Left {
-            reason: left.to_string(),
-        },
+        Err(left @ (StopError::Unidentified { .. } | StopError::NotOwned { .. } | StopError::Unexpected { .. })) => {
+            PurgedRuntime::Left {
+                reason: left.to_string(),
+            }
+        }
         Err(error) => return Err(error.into()),
     };
     let mut removed = Vec::new();

--- a/appa-runtime/src/installation.rs
+++ b/appa-runtime/src/installation.rs
@@ -39,6 +39,10 @@ pub enum InstallError {
     Changed(PathBuf),
     #[error("the install did not finish: {reason} Its record is {}; rerunning the install completes it.", path.display())]
     Recovery { path: PathBuf, reason: String },
+    /// The retained selection is not one this build reads: an earlier build's
+    /// shape, or a hand edit. Nothing here repairs it, so the way out is named.
+    #[error("the installation state {} is not one this build reads: {reason}; {}", path.display(), crate::init::START_OVER)]
+    State { path: PathBuf, reason: String },
 }
 
 fn io(operation: &'static str, path: &Path, source: std::io::Error) -> InstallError {
@@ -1001,9 +1005,12 @@ fn read_selection(path: &Path) -> Result<Option<Selection>, InstallError> {
     let Some(bytes) = optional_bytes(path)? else {
         return Ok(None);
     };
-    let selection: Selection =
-        serde_json::from_slice(&bytes).map_err(|error| InstallError::Invalid(error.to_string()))?;
-    selection.validate()?;
+    let state = |reason: String| InstallError::State {
+        path: path.to_owned(),
+        reason,
+    };
+    let selection: Selection = serde_json::from_slice(&bytes).map_err(|error| state(error.to_string()))?;
+    selection.validate().map_err(|error| state(error.to_string()))?;
     Ok(Some(selection))
 }
 
@@ -1266,6 +1273,21 @@ fn owned_include_path(filename: &str, commit: &Commit, entry: &PackageEntry, bat
 
 #[cfg(test)]
 mod tests {
+    /// A selection an earlier build wrote in a shape this one does not read is
+    /// refused as state, not as input: the record is a file, and the caller
+    /// needs to know that no argument of theirs fixes it.
+    #[test]
+    fn a_selection_of_another_shape_is_refused_as_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("active.json");
+        std::fs::write(&path, br#"{"schema":1,"claude_plugin":"gone"}"#).unwrap();
+        let error = super::read_selection(&path).unwrap_err();
+        assert!(
+            matches!(&error, super::InstallError::State { path: refused, .. } if *refused == path),
+            "{error}"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/appa-runtime/src/installation.rs
+++ b/appa-runtime/src/installation.rs
@@ -938,25 +938,24 @@ impl Installation {
             })?;
             if transaction.activation != Activation::None {
                 let activate = || {
-                    let previous = transaction
-                        .previous
-                        .as_ref()
-                        .filter(|selection| selection.plugins.contains("claude-code"))
-                        .map(|selection| {
-                            native::ClaudeArtifacts::prepare(self, selection.generation(), selection.platform)
-                        })
-                        .transpose()?;
                     match transaction.activation {
                         Activation::Claude => native::ClaudeArtifacts::prepare(
                             self,
                             transaction.selection.generation(),
                             transaction.selection.platform,
                         )?
-                        .activate(&self.config, previous.as_ref())?,
-                        Activation::RemoveClaude => previous
-                            .as_ref()
-                            .ok_or_else(|| InstallError::Invalid("removal requires its prior native artifact".into()))?
-                            .remove(&self.config)?,
+                        .activate(&self.config)?,
+                        Activation::RemoveClaude => {
+                            let previous = transaction
+                                .previous
+                                .as_ref()
+                                .filter(|selection| selection.plugins.contains("claude-code"))
+                                .ok_or_else(|| {
+                                    InstallError::Invalid("removal requires its prior native artifact".into())
+                                })?;
+                            native::ClaudeArtifacts::prepare(self, previous.generation(), previous.platform)?
+                                .remove(&self.config)?
+                        }
                         Activation::None => unreachable!("native activation branch excludes None"),
                     }
                     Ok::<_, InstallError>(())

--- a/appa-runtime/src/installation/cli.rs
+++ b/appa-runtime/src/installation/cli.rs
@@ -101,17 +101,23 @@ pub struct BatteryRemove {
 
 #[derive(Debug, Args)]
 #[command(
-    after_help = "Examples:\n  appa plugin remove claude-code\n  appa plugin remove claude-code --config ./deployment/appa.toml --json\n\nUnregisters only matching APPA-owned Claude support. Preserves policy, batteries,\nretained artifacts, trajectory data, and the running runtime. Never prompts."
+    after_help = "Examples:\n  appa plugin remove claude-code\n  appa plugin remove claude-code --config ./deployment/appa.toml --json\n  appa plugin remove claude-code --purge\n\nUnregisters only matching APPA-owned Claude support. Preserves policy, batteries,\nretained artifacts, trajectory data, and the running runtime. Never prompts.\n--purge goes on to stop the runtime and delete the data and config directories\nof the default deployment: the deployed binary, database, logs, retained\nversions, policy, and install state. appa itself stays on PATH."
 )]
 pub struct PluginRemove {
     /// Host plugin whose installer-owned registration is removed.
     #[arg(value_parser = ["claude-code", "kagent"])]
     name: String,
+    /// Also stop the runtime and delete the default deployment's data and config directories.
+    #[arg(long)]
+    purge: bool,
     #[command(flatten)]
     target: Target,
 }
 
 pub fn remove_plugin(args: PluginRemove) -> ExitCode {
+    if args.purge {
+        return purge_plugin(args);
+    }
     let result = (|| {
         let path = plugin_path(&args.target, &args.name)?;
         match Installation::inspect(&path) {
@@ -153,6 +159,33 @@ pub fn remove_plugin(args: PluginRemove) -> ExitCode {
         ))
     })();
     finish(&args.target, "plugin.remove".into(), result)
+}
+
+/// `--purge` reads none of the installation state: a state the installer cannot
+/// open is the state a purge exists for.
+fn purge_plugin(args: PluginRemove) -> ExitCode {
+    let result = (|| {
+        if args.name != "claude-code" {
+            return Err(InstallError::Invalid("--purge applies to claude-code".into()));
+        }
+        if args.target.config.is_some() {
+            return Err(InstallError::Invalid(
+                "--purge removes the default deployment only; drop --config and unset APPA_CONFIG".into(),
+            ));
+        }
+        eprintln!("appa: removing claude-code support, stopping the runtime, and deleting the deployment...");
+        let purge = crate::init::claude_code_purge().map_err(|error| InstallError::Invalid(error.to_string()))?;
+        let runtime = match purge.runtime {
+            crate::init::PurgedRuntime::Nothing => serde_json::json!({"state": "absent"}),
+            crate::init::PurgedRuntime::Stopped { pid } => serde_json::json!({"state": "stopped", "pid": pid}),
+            crate::init::PurgedRuntime::Left { reason } => serde_json::json!({"state": "left", "reason": reason}),
+        };
+        Ok((
+            None,
+            serde_json::json!({"plugin": "claude-code", "state": "purged", "runtime": runtime, "removed": purge.removed}),
+        ))
+    })();
+    finish(&args.target, "plugin.purge".into(), result)
 }
 
 fn package_name(value: &str) -> Result<PackageName, String> {
@@ -877,7 +910,14 @@ fn finish(
             .map_err(io::Error::other)
             .and_then(|()| writeln!(output))
     } else if let Some(error) = &receipt.error {
-        writeln!(io::stderr().lock(), "appa: {}", error.message)
+        let mut stderr = io::stderr().lock();
+        writeln!(stderr, "appa: {}", error.message).and_then(|()| {
+            if error.recovery_required {
+                writeln!(stderr, "appa: {}", crate::init::START_OVER)
+            } else {
+                Ok(())
+            }
+        })
     } else if let Some(kind) = receipt.operation.strip_suffix(".list") {
         let result = receipt
             .result
@@ -890,7 +930,28 @@ fn finish(
         .and_then(|result| result.get("plugin"))
         .and_then(serde_json::Value::as_str)
     {
-        if receipt.operation == "plugin.remove" {
+        if receipt.operation == "plugin.purge" {
+            let result = receipt.result.as_ref().expect("plugin result is present");
+            (|| {
+                let runtime = &result["runtime"];
+                match runtime["state"].as_str().unwrap_or_default() {
+                    "stopped" => writeln!(output, "Stopped the runtime (pid {}).", runtime["pid"])?,
+                    "left" => writeln!(
+                        output,
+                        "Left the process at the runtime endpoint: {}.",
+                        runtime["reason"].as_str().unwrap_or_default()
+                    )?,
+                    _ => writeln!(output, "No runtime was running.")?,
+                }
+                for path in result["removed"].as_array().into_iter().flatten() {
+                    writeln!(output, "Removed {}.", path.as_str().unwrap_or_default())?;
+                }
+                writeln!(
+                    output,
+                    "Plugin {plugin}: purged; appa stays on PATH. To install again: appa plugin install claude-code."
+                )
+            })()
+        } else if receipt.operation == "plugin.remove" {
             let result = receipt.result.as_ref().expect("plugin result is present");
             writeln!(
                 output,

--- a/appa-runtime/src/installation/cli.rs
+++ b/appa-runtime/src/installation/cli.rs
@@ -884,6 +884,7 @@ fn finish(
                 InstallError::Changed(_) => ("concurrent_edit", false),
                 InstallError::Invalid(_) => ("invalid_input", false),
                 InstallError::Io { .. } => ("io", false),
+                InstallError::State { .. } => ("unreadable_state", false),
             };
             (
                 Receipt {

--- a/appa-runtime/src/installation/native.rs
+++ b/appa-runtime/src/installation/native.rs
@@ -156,12 +156,12 @@ impl ClaudeArtifacts {
     }
 
     /// Caller holds the installation lock and durable activation journal.
-    pub fn activate(&self, config: &Path, previous: Option<&Self>) -> Result<(), InstallError> {
-        let mut arguments = vec!["activate-claude".as_ref(), "--config".as_ref(), config.as_os_str()];
-        if let Some(previous) = previous {
-            arguments.extend(["--previous-binary".as_ref(), previous.binary.as_os_str()]);
-        }
-        invoke(&self.binary, &arguments, Duration::from_secs(120))?;
+    pub fn activate(&self, config: &Path) -> Result<(), InstallError> {
+        invoke(
+            &self.binary,
+            &["activate-claude".as_ref(), "--config".as_ref(), config.as_os_str()],
+            Duration::from_secs(120),
+        )?;
         Ok(())
     }
 

--- a/appa-runtime/src/main.rs
+++ b/appa-runtime/src/main.rs
@@ -106,6 +106,11 @@ enum RuntimeCommand {
         #[arg(long)]
         data_dir: Option<PathBuf>,
     },
+    /// Stop the deployed runtime, when the process answering its endpoint is this user's own appa.
+    Stop {
+        #[command(flatten)]
+        target: crate::runtime_url::RuntimeUrl,
+    },
 }
 
 /// `appa runtime ensure`: the start every protected SessionStart performs, run
@@ -121,6 +126,25 @@ fn ensure(target: &crate::runtime_url::RuntimeUrl, config: Option<PathBuf>, data
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("appa runtime ensure: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// `appa runtime stop`: the deployed runtime goes, whichever install started it.
+fn stop(target: &crate::runtime_url::RuntimeUrl) -> ExitCode {
+    let target = target.resolve();
+    match crate::runtime_start::stop(&target) {
+        Ok(crate::runtime_start::Stopped::Nothing) => {
+            println!("nothing answers {}", target.url);
+            ExitCode::SUCCESS
+        }
+        Ok(crate::runtime_start::Stopped::Runtime { pid }) => {
+            println!("stopped the runtime (pid {pid}) at {}", target.url);
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("appa runtime stop: {error}");
             ExitCode::FAILURE
         }
     }
@@ -393,8 +417,10 @@ where
     T: Into<OsString> + Clone,
 {
     let args = Args::parse_from(args);
-    if let Some(RuntimeCommand::Ensure { target, data_dir }) = args.command {
-        return ensure(&target, args.config, data_dir);
+    match args.command {
+        Some(RuntimeCommand::Ensure { target, data_dir }) => return ensure(&target, args.config, data_dir),
+        Some(RuntimeCommand::Stop { target }) => return stop(&target),
+        None => {}
     }
     let runtime = match tokio::runtime::Builder::new_multi_thread().enable_all().build() {
         Ok(runtime) => runtime,

--- a/appa-runtime/src/runtime_start.rs
+++ b/appa-runtime/src/runtime_start.rs
@@ -1,6 +1,7 @@
-//! Bring up the deployed runtime when nothing healthy answers its endpoint.
+//! Bring up the deployed runtime when nothing healthy answers its endpoint,
+//! and stop the one that does.
 //!
-//! Two callers share this: `appa plugin install claude-code`, as its last
+//! Two callers share the start: `appa plugin install claude-code`, as its last
 //! step, and every protected SessionStart, before the hook posts its first
 //! event. A protected session therefore needs no login service, and an install
 //! that ends here leaves the runtime up, so the first protected session pays
@@ -43,12 +44,8 @@ pub enum StartError {
     Paths(String),
     #[error("nothing answers {url}, and a runtime at a URL the session named is the user's own to start")]
     UserOwnedUnreachable { url: String },
-    #[error("pid {pid} is not this user's appa runtime; not stopping it")]
-    NotOwned { pid: i32 },
-    #[error("cannot tell whether pid {pid} is this user's appa runtime: {detail}")]
-    Ownership { pid: i32, detail: String },
-    #[error("the stale runtime at {url} (pid {pid}) did not stop")]
-    DidNotStop { url: String, pid: i32 },
+    #[error(transparent)]
+    Stop(#[from] StopError),
     #[error("{url} answers neither ok nor the stale runtime being stopped: {answer:?}")]
     Unexpected { url: String, answer: String },
     #[error("cannot create {path}: {source}")]
@@ -65,6 +62,34 @@ pub enum StartError {
     },
     #[error("the runtime did not become healthy at {url}. Its own error is the last line of {log}")]
     NotHealthy { url: String, log: PathBuf },
+}
+
+/// Why the runtime answering an endpoint was not stopped.
+#[derive(Debug, Error)]
+pub enum StopError {
+    #[error("{url} is not a runtime endpoint: {reason}")]
+    Endpoint { url: String, reason: String },
+    #[error("the runtime at {url} is the user's own to stop: the session named that URL itself")]
+    UserOwned { url: String },
+    #[error("{url} answers healthy but does not identify its pid; stop that process yourself")]
+    Unidentified { url: String },
+    #[error("pid {pid} is not this user's appa runtime; not stopping it")]
+    NotOwned { pid: i32 },
+    #[error("cannot tell whether pid {pid} is this user's appa runtime: {detail}")]
+    Ownership { pid: i32, detail: String },
+    #[error("the runtime at {url} (pid {pid}) did not stop")]
+    DidNotStop { url: String, pid: i32 },
+    #[error("{url} answers neither ok nor stale: {answer:?}")]
+    Unexpected { url: String, answer: String },
+}
+
+/// What a stop found at the endpoint, and did.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Stopped {
+    /// Nothing answered.
+    Nothing,
+    /// This user's appa runtime answered from the process named, and is gone.
+    Runtime { pid: i32 },
 }
 
 /// What one health probe found at the endpoint.
@@ -155,27 +180,103 @@ pub fn ensure(target: &RuntimeTarget, deployment: &Deployment, executable: &Path
     start(&endpoint, &target.url, deployment, executable)
 }
 
+/// Stop the runtime answering `target`, whichever deployment started it, when
+/// it is this user's own appa process.
+///
+/// An install claims the deployment's endpoint, so a runtime an earlier
+/// deployment left there is stopped rather than reported. A process that is
+/// not appa, or not this user's, is refused with its pid named: the pid
+/// arrives in an HTTP body from whoever holds the port. A runtime at a URL the
+/// session named is the user's own, and is left as it is.
+pub fn stop(target: &RuntimeTarget) -> Result<Stopped, StopError> {
+    let endpoint = Endpoint::parse(&target.url).map_err(|reason| StopError::Endpoint {
+        url: target.url.clone(),
+        reason,
+    })?;
+    if target.user_owned {
+        return Err(StopError::UserOwned {
+            url: target.url.clone(),
+        });
+    }
+    let pid = match probe(&endpoint) {
+        Health::Unreachable => return Ok(Stopped::Nothing),
+        Health::Stale(pid) => pid,
+        Health::Ok => serving_pid(&endpoint).ok_or_else(|| StopError::Unidentified {
+            url: target.url.clone(),
+        })?,
+        Health::Other(answer) => {
+            return Err(StopError::Unexpected {
+                url: target.url.clone(),
+                answer,
+            });
+        }
+    };
+    terminate_owned(pid)?;
+    let deadline = Instant::now() + STOP_BUDGET;
+    // Gone means the endpoint no longer answers from that process: one its
+    // parent has not reaped yet still exists, and holds nothing.
+    while process_exists(pid) && answering_pid(&endpoint) == Some(pid) {
+        if Instant::now() >= deadline {
+            return Err(StopError::DidNotStop {
+                url: target.url.clone(),
+                pid,
+            });
+        }
+        std::thread::sleep(POLL);
+    }
+    Ok(Stopped::Runtime { pid })
+}
+
+/// The pid the endpoint answers from, healthy or stale.
+fn answering_pid(endpoint: &Endpoint) -> Option<i32> {
+    match probe(endpoint) {
+        Health::Ok => serving_pid(endpoint),
+        Health::Stale(pid) => Some(pid),
+        Health::Other(_) | Health::Unreachable => None,
+    }
+}
+
+/// The pid a healthy runtime names at `/binary-fingerprint`: the second field
+/// of its first line.
+fn serving_pid(endpoint: &Endpoint) -> Option<i32> {
+    let answer = get(endpoint, "/binary-fingerprint", &Deadline::spanning(PROBE_BUDGET)).ok()?;
+    if !answer.is_success() {
+        return None;
+    }
+    String::from_utf8_lossy(&answer.body)
+        .lines()
+        .next()?
+        .split_whitespace()
+        .nth(1)
+        .and_then(crate::init::endpoint::positive_pid)
+}
+
+/// Signal `pid` once it proves to be this user's appa runtime. No process at
+/// that pid is not a failure: a concurrent stop got there first.
+fn terminate_owned(pid: i32) -> Result<(), StopError> {
+    if !process_exists(pid) {
+        return Ok(());
+    }
+    match is_owned_appa_runtime(pid) {
+        Ok(true) => {}
+        Ok(false) => return Err(StopError::NotOwned { pid }),
+        Err(error) => {
+            return Err(StopError::Ownership {
+                pid,
+                detail: error.to_string(),
+            });
+        }
+    }
+    terminate_appa_pid(pid).map_err(|error| StopError::Ownership {
+        pid,
+        detail: error.to_string(),
+    })
+}
+
 /// Stop the stale runtime and wait for the port to refuse. `Ok(true)` means a
 /// concurrent starter has already put a healthy runtime there.
 fn stop_stale(endpoint: &Endpoint, url: &str, pid: i32) -> Result<bool, StartError> {
-    // No process at that pid: a concurrent starter already stopped it, and the
-    // wait below sees the port refuse or that starter's replacement.
-    if process_exists(pid) {
-        match is_owned_appa_runtime(pid) {
-            Ok(true) => {}
-            Ok(false) => return Err(StartError::NotOwned { pid }),
-            Err(error) => {
-                return Err(StartError::Ownership {
-                    pid,
-                    detail: error.to_string(),
-                });
-            }
-        }
-        terminate_appa_pid(pid).map_err(|error| StartError::Ownership {
-            pid,
-            detail: error.to_string(),
-        })?;
-    }
+    terminate_owned(pid)?;
     let deadline = Instant::now() + STOP_BUDGET;
     loop {
         match probe(endpoint) {
@@ -196,10 +297,11 @@ fn stop_stale(endpoint: &Endpoint, url: &str, pid: i32) -> Result<bool, StartErr
             }
         }
         if Instant::now() >= deadline {
-            return Err(StartError::DidNotStop {
+            return Err(StopError::DidNotStop {
                 url: url.to_owned(),
                 pid,
-            });
+            }
+            .into());
         }
         std::thread::sleep(POLL);
     }

--- a/appa-runtime/src/runtime_start.rs
+++ b/appa-runtime/src/runtime_start.rs
@@ -46,8 +46,6 @@ pub enum StartError {
     UserOwnedUnreachable { url: String },
     #[error(transparent)]
     Stop(#[from] StopError),
-    #[error("{url} answers neither ok nor the stale runtime being stopped: {answer:?}")]
-    Unexpected { url: String, answer: String },
     #[error("cannot create {path}: {source}")]
     Directory {
         path: PathBuf,
@@ -165,10 +163,11 @@ pub fn ensure(target: &RuntimeTarget, deployment: &Deployment, executable: &Path
             }
         }
         Health::Other(answer) => {
-            return Err(StartError::Unexpected {
+            return Err(StopError::Unexpected {
                 url: target.url.clone(),
                 answer,
-            });
+            }
+            .into());
         }
         Health::Unreachable if target.user_owned => {
             return Err(StartError::UserOwnedUnreachable {
@@ -211,20 +210,27 @@ pub fn stop(target: &RuntimeTarget) -> Result<Stopped, StopError> {
             });
         }
     };
+    stop_pid(&endpoint, &target.url, pid)?;
+    Ok(Stopped::Runtime { pid })
+}
+
+/// Stop the process answering `endpoint` as `pid`, once it proves to be this
+/// user's appa runtime, and wait until the endpoint no longer answers from
+/// it. Gone means that: a process its parent has not reaped yet still
+/// exists, and holds nothing.
+pub(crate) fn stop_pid(endpoint: &Endpoint, url: &str, pid: i32) -> Result<(), StopError> {
     terminate_owned(pid)?;
     let deadline = Instant::now() + STOP_BUDGET;
-    // Gone means the endpoint no longer answers from that process: one its
-    // parent has not reaped yet still exists, and holds nothing.
-    while process_exists(pid) && answering_pid(&endpoint) == Some(pid) {
+    while process_exists(pid) && answering_pid(endpoint) == Some(pid) {
         if Instant::now() >= deadline {
             return Err(StopError::DidNotStop {
-                url: target.url.clone(),
+                url: url.to_owned(),
                 pid,
             });
         }
         std::thread::sleep(POLL);
     }
-    Ok(Stopped::Runtime { pid })
+    Ok(())
 }
 
 /// The pid the endpoint answers from, healthy or stale.
@@ -284,16 +290,18 @@ fn stop_stale(endpoint: &Endpoint, url: &str, pid: i32) -> Result<bool, StartErr
             Health::Ok => return Ok(true),
             Health::Stale(still) if still == pid => {}
             Health::Stale(other) => {
-                return Err(StartError::Unexpected {
+                return Err(StopError::Unexpected {
                     url: url.to_owned(),
                     answer: format!("stale {other}"),
-                });
+                }
+                .into());
             }
             Health::Other(answer) => {
-                return Err(StartError::Unexpected {
+                return Err(StopError::Unexpected {
                     url: url.to_owned(),
                     answer,
-                });
+                }
+                .into());
             }
         }
         if Instant::now() >= deadline {

--- a/appa-runtime/tests/common/init_fixture.rs
+++ b/appa-runtime/tests/common/init_fixture.rs
@@ -102,6 +102,18 @@ impl Fixture {
         self.bridge("remove-claude")
     }
 
+    /// `appa plugin remove claude-code --purge` against this fixture, with the
+    /// endpoint the purge stops named by the caller.
+    pub fn purge(&self, endpoint: &str) -> Command {
+        let mut command = Command::new(&self.appa);
+        command
+            .current_dir(&self.root)
+            .args(["plugin", "remove", "claude-code", "--purge"]);
+        self.environment(&mut command);
+        command.env("APPA_ENDPOINT", endpoint).env_remove("APPA_CONFIG");
+        command
+    }
+
     fn bridge(&self, subcommand: &str) -> Command {
         let mut command = Command::new(&self.appa);
         command

--- a/appa-runtime/tests/common/mod.rs
+++ b/appa-runtime/tests/common/mod.rs
@@ -60,6 +60,13 @@ pub struct ServedRuntime {
     pub url: String,
 }
 
+impl ServedRuntime {
+    /// Whether the runtime process has exited, reaping it when it has.
+    pub fn has_exited(&mut self) -> bool {
+        self.child.try_wait().expect("the child polls").is_some()
+    }
+}
+
 impl Drop for ServedRuntime {
     fn drop(&mut self) {
         let _ = self.child.kill();

--- a/appa-runtime/tests/fixtures/fake-claude.sh
+++ b/appa-runtime/tests/fixtures/fake-claude.sh
@@ -3,6 +3,9 @@
 # registration under APPA's name, kept in $FAKE_CLAUDE_HOME/mcp-appa as the
 # JSON `add-json` was given. Every invocation is logged, one line each.
 #
+# FAKE_CLAUDE_RENDERS_TEMPLATE reports a template URL the way Claude does:
+# without its default.
+#
 # FAKE_CLAUDE_FAIL_ONCE=mcp-add fails the first `add-json` of this fixture;
 # `mcp-add-always` fails every one, which is what a rollback that cannot put
 # the earlier registration back looks like.
@@ -34,6 +37,11 @@ case "$*" in
       exit 1
     fi
     url=$(sed 's/.*"url":"\([^"]*\)".*/\1/' "$store")
+    if [ -n "${FAKE_CLAUDE_RENDERS_TEMPLATE:-}" ]; then
+      case "$url" in
+        '${APPA_RUNTIME_URL:-'*'}/mcp') url='${APPA_RUNTIME_URL}/mcp' ;;
+      esac
+    fi
     printf 'appa:\n  Scope: User config (available in all your projects)\n  Status: ✔ Connected\n  Type: http\n  URL: %s\n\nTo remove this server, run: claude mcp remove appa -s user\n' "$url"
     ;;
   "mcp remove appa --scope user")

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -304,6 +304,33 @@ fn a_rerun_keeps_the_config_and_rewrites_nothing_it_already_wrote() {
     assert_eq!(calls.matches("mcp remove").count(), 0);
 }
 
+/// `claude mcp get` reports a template without its default. The registration
+/// an install wrote comes back that way and is still the install's own: a
+/// rerun rewrites nothing, and a removal takes it back.
+#[test]
+fn a_registration_reported_without_its_default_is_the_installs_own() {
+    let fixture = Fixture::new();
+    fixture.successful_activation();
+    let written = Installed::of(&fixture);
+
+    let rerun = fixture
+        .activate()
+        .env("FAKE_CLAUDE_RENDERS_TEMPLATE", "1")
+        .output()
+        .expect("appa activates");
+    assert!(rerun.status.success(), "{}", String::from_utf8_lossy(&rerun.stderr));
+    assert_eq!(Installed::of(&fixture), written);
+    assert_eq!(fixture.claude_calls().matches("mcp add-json").count(), 1);
+
+    let removed = fixture
+        .remove()
+        .env("FAKE_CLAUDE_RENDERS_TEMPLATE", "1")
+        .output()
+        .expect("appa removes");
+    assert!(removed.status.success(), "{}", String::from_utf8_lossy(&removed.stderr));
+    assert_eq!(fixture.mcp_registration(), None);
+}
+
 /// A foreign runtime owning the endpoint from a process that is not this
 /// user's appa is refused before the profile is touched at all, so the
 /// installation it would have replaced is still the one that is registered

--- a/appa-runtime/tests/init_cli.rs
+++ b/appa-runtime/tests/init_cli.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 mod common;
 #[path = "common/init_fixture.rs"]
 mod init_fixture;
-use common::repo_root;
+use common::{free_port, http, repo_root, serve_runtime};
 use init_fixture::{Fixture, Installed, default_policy_key, runtime_fingerprint, shipped_default_config};
 
 /// The release workflow proves a released binary ignores `APPA_ENDPOINT` by
@@ -304,11 +304,12 @@ fn a_rerun_keeps_the_config_and_rewrites_nothing_it_already_wrote() {
     assert_eq!(calls.matches("mcp remove").count(), 0);
 }
 
-/// A foreign runtime already owning the endpoint is refused before the profile
-/// is touched at all, so the installation it would have replaced is still the
-/// one that is registered and running. Another build is one way to be foreign;
-/// this build serving another deployment's configuration is the other, and it
-/// is the one a digest alone cannot see.
+/// A foreign runtime owning the endpoint from a process that is not this
+/// user's appa is refused before the profile is touched at all, so the
+/// installation it would have replaced is still the one that is registered
+/// and running. Another build is one way to be foreign; this build serving
+/// another deployment's configuration is the other, and it is the one a
+/// digest alone cannot see. The fake's pid is its own exited shell.
 #[test]
 fn a_foreign_runtime_is_refused_before_the_profile_is_touched() {
     let fixture = Fixture::new();
@@ -350,6 +351,101 @@ fn a_foreign_runtime_is_refused_before_the_profile_is_touched() {
             "a refused endpoint must leave the working launcher armed"
         );
     }
+}
+
+/// A runtime an earlier deployment of this user's left at the endpoint is
+/// stopped by the activation, which then goes on to its own start. The
+/// stand-in is a process named `appa` of this user's, answering as another
+/// build until it is gone.
+#[test]
+fn an_earlier_deployments_runtime_of_the_users_own_is_stopped_by_the_activation() {
+    let fixture = Fixture::new();
+    let stand_in = fixture.root.join("stand-in");
+    let started = Command::new(fixture.root.join("fake-starter.sh"))
+        .env("FAKE_RUNTIME_STAND_IN", &stand_in)
+        .status()
+        .expect("the stand-in starts");
+    assert!(started.success());
+    let pid: i32 = fs::read_to_string(stand_in.join("pid"))
+        .expect("the stand-in recorded its pid")
+        .trim()
+        .parse()
+        .expect("the recorded pid parses");
+    assert_eq!(unsafe { libc::kill(pid, 0) }, 0, "the stand-in runs");
+
+    let output = fixture
+        .activate()
+        .env("FAKE_RUNTIME_STAND_IN", &stand_in)
+        .env("FAKE_CURL_CALLS", fixture.root.join("curl-calls"))
+        .env("FAKE_RUNTIME_FINGERPRINT", "an-earlier-build")
+        .env("FAKE_RUNTIME_FINGERPRINT_LATER", runtime_fingerprint(&fixture.appa))
+        .output()
+        .expect("appa activates");
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert_ne!(
+        unsafe { libc::kill(pid, 0) },
+        0,
+        "the earlier deployment's runtime is gone"
+    );
+    assert!(fixture.launcher_is_armed());
+}
+
+/// A purge takes the profile back, stops the runtime at the deployment's
+/// endpoint, and deletes the data and config directories; `appa` on PATH
+/// stays. It reads none of the installation state, and it applies to the
+/// default deployment only.
+#[test]
+fn a_purge_takes_back_the_profile_stops_the_runtime_and_deletes_the_deployment() {
+    let fixture = Fixture::new();
+    fixture.successful_activation();
+    let mut served = serve_runtime(&fixture.config.join("appa.toml"), &fixture.root.join("served.db"));
+    let installed = Installed::of(&fixture);
+
+    let refused = fixture
+        .purge(&served.url)
+        .args(["--config", fixture.config.join("appa.toml").to_str().unwrap()])
+        .output()
+        .expect("appa runs");
+    assert!(!refused.status.success(), "a purge names no config");
+    assert_eq!(Installed::of(&fixture), installed);
+    assert_eq!(
+        http(&format!("{}/health", served.url), "GET", None).as_deref(),
+        Some("ok")
+    );
+
+    let output = fixture.purge(&served.url).output().expect("appa purges");
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert_profile_taken_back(&fixture);
+    assert_eq!(http(&format!("{}/health", served.url), "GET", None), None);
+    assert!(served.has_exited(), "the runtime is stopped");
+    assert!(!fixture.data.exists(), "the data directory is gone");
+    assert!(!fixture.config.exists(), "the config directory is gone");
+    assert!(fixture.bin.join("appa").is_file(), "appa on PATH stays");
+}
+
+/// The profile holds nothing of the install: no hook entry, no status line, no
+/// MCP registration, no skill, no launcher.
+fn assert_profile_taken_back(fixture: &Fixture) {
+    assert_eq!(fixture.settings_value(), serde_json::json!({}));
+    assert_eq!(fixture.mcp_registration(), None);
+    assert!(!fixture.skill().parent().unwrap().exists());
+    assert!(!fixture.launcher().exists());
+}
+
+/// A purge of a deployment whose runtime is down still deletes everything.
+#[test]
+fn a_purge_with_no_runtime_running_deletes_the_deployment() {
+    let fixture = Fixture::new();
+    fixture.successful_activation();
+    let dead = format!("http://127.0.0.1:{}", free_port());
+
+    let output = fixture.purge(&dead).output().expect("appa purges");
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert_profile_taken_back(&fixture);
+    assert!(!fixture.data.exists() && !fixture.config.exists());
 }
 
 #[test]

--- a/appa-runtime/tests/marketplace_cli.rs
+++ b/appa-runtime/tests/marketplace_cli.rs
@@ -187,7 +187,7 @@ fn corrupt_selection_returns_one_error_envelope_and_preserves_bytes() {
     assert_eq!(output.status.code(), Some(1));
     let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(document["status"], "error");
-    assert_eq!(document["error"]["code"], "invalid_input");
+    assert_eq!(document["error"]["code"], "unreadable_state");
     assert!(document.get("result").is_none());
     assert_eq!(std::fs::read(active).unwrap(), b"broken");
     assert!(!state.join("install.lock").exists());

--- a/appa-runtime/tests/runtime_stop.rs
+++ b/appa-runtime/tests/runtime_stop.rs
@@ -1,0 +1,127 @@
+#![cfg(unix)]
+//! `appa runtime stop`: the runtime at the deployment's endpoint goes when it
+//! is this user's own appa process, and nothing else is touched.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+mod common;
+#[path = "common/init_fixture.rs"]
+mod init_fixture;
+use common::{free_port, http, serve_runtime};
+use init_fixture::shipped_default_config;
+
+fn stop(arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_appa"))
+        .arg("runtime")
+        .arg("stop")
+        .args(arguments)
+        .env_remove("APPA_RUNTIME_URL")
+        .output()
+        .expect("appa runtime stop runs")
+}
+
+/// The pid a healthy runtime names at `/binary-fingerprint`.
+fn serving_pid(url: &str) -> i32 {
+    http(&format!("{url}/binary-fingerprint"), "GET", None)
+        .expect("the runtime identifies itself")
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .expect("the identity names a pid")
+        .parse()
+        .expect("the pid parses")
+}
+
+fn process_exists(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+fn fixture_config() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let config = directory.path().join("appa.toml");
+    std::fs::write(&config, shipped_default_config()).expect("the config is written");
+    let db = directory.path().join("appa.db");
+    (directory, config, db)
+}
+
+#[test]
+fn the_runtime_at_the_deployment_endpoint_is_stopped() {
+    let (_directory, config, db) = fixture_config();
+    let mut served = serve_runtime(&config, &db);
+
+    let output = stop(&["--deployment-url", &served.url]);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline && !served.has_exited() {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(served.has_exited(), "the runtime process is gone");
+    assert_eq!(http(&format!("{}/health", served.url), "GET", None), None);
+}
+
+#[test]
+fn nothing_answering_is_not_a_failure() {
+    let url = format!("http://127.0.0.1:{}", free_port());
+    let output = stop(&["--deployment-url", &url]);
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+}
+
+/// A runtime the session named itself is the user's own: neither the hooks
+/// nor this command restart or stop it.
+#[test]
+fn a_runtime_at_a_url_of_the_users_own_is_left_running() {
+    let (_directory, config, db) = fixture_config();
+    let served = serve_runtime(&config, &db);
+    let pid = serving_pid(&served.url);
+
+    let output = stop(&["--url", &served.url]);
+
+    assert!(!output.status.success());
+    assert!(process_exists(pid));
+    assert_eq!(
+        http(&format!("{}/health", served.url), "GET", None).as_deref(),
+        Some("ok")
+    );
+}
+
+/// A listener answering as a runtime whose pid is not this user's appa process:
+/// the pid arrived in an HTTP body, so it is checked before it is signalled.
+#[test]
+fn a_process_that_is_not_this_users_appa_runtime_is_refused() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("a loopback port");
+    let url = format!("http://{}", listener.local_addr().expect("the bound address"));
+    // This test process: alive, this user's, and not named appa.
+    let identity = format!("not-a-build {}\n/nowhere/appa.toml", std::process::id());
+    std::thread::spawn(move || {
+        for connection in listener.incoming() {
+            let Ok(mut connection) = connection else {
+                return;
+            };
+            let mut reader = BufReader::new(connection.try_clone().expect("the stream clones"));
+            let mut request = String::new();
+            if reader.read_line(&mut request).is_err() {
+                continue;
+            }
+            let body = if request.starts_with("GET /health") {
+                "ok"
+            } else {
+                identity.as_str()
+            };
+            let answer = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = connection.write_all(answer.as_bytes());
+            let _ = connection.flush();
+        }
+    });
+
+    let output = stop(&["--deployment-url", &url]);
+
+    assert!(!output.status.success());
+    assert_eq!(http(&format!("{url}/health"), "GET", None).as_deref(), Some("ok"));
+}

--- a/marketplace/marketplace.toml
+++ b/marketplace/marketplace.toml
@@ -28,7 +28,7 @@ digest = "sha256:d57d698314e80c03b2ea40be798fa71ad78c5d12dd724de3cdd8ea774df80fb
 
 [packages.plugin.claude-code]
 path = "plugins/claude-code"
-digest = "sha256:05ab075d14a0045807be21d4270b30116dd482707c39cdca4946d0a63e3824ae"
+digest = "sha256:d7ac4ba2e16b26ab8642c863e2c90cf824bd8a940b2def140075f9f2f51d28eb"
 
 [packages.plugin.kagent]
 path = "plugins/kagent"

--- a/marketplace/plugins/claude-code/README.md
+++ b/marketplace/plugins/claude-code/README.md
@@ -72,9 +72,9 @@ cargo install --path appa-runtime --force
 appa plugin install claude-code
 ```
 
-The install reports each slow phase on stderr and never prompts. If another
-APPA deployment owns the runtime endpoint, it refuses and names the process to
-stop; an unidentified listener or another user's process is never stopped.
+The install reports each slow phase on stderr and never prompts. A runtime an
+earlier APPA deployment of yours left at the runtime endpoint is stopped; an
+unidentified listener or another user's process is named and never stopped.
 
 The install puts `clappa` beside `appa` so the short command works in later
 examples.
@@ -251,21 +251,21 @@ session's hooks at session start, and the hook wire between the hooks and the
 runtime carries no version, so a session running across an upgrade keeps
 talking to the runtime it started with.
 
-Init stops a runtime that is still executing the path a previous init deployed
-to, and aborts before touching Claude if it cannot, rather than registering
-new hooks against an old runtime. That covers the paths your current
-environment resolves to. A runtime left by an init run under a different
-`APPA_INSTALL_DIR` or `APPA_DATA_DIR` executes a path this init never computes:
-it is reported so you can stop it yourself, never killed. An `appa` left at the
-old install path is named in the receipt and never deleted; remove it when you
-are ready.
+The install claims the runtime endpoint. A runtime an earlier deployment of
+yours left there is stopped, whichever build or config it serves and whatever
+`APPA_INSTALL_DIR` or `APPA_DATA_DIR` it ran under, and the install aborts
+before touching Claude when that runtime will not stop. A process at the
+endpoint that is not your own `appa` is named and never stopped. An `appa`
+left at the old install path is never deleted; remove it when you are ready.
+
+`appa runtime stop` stops the runtime on its own, under the same rule. A
+runtime at `APPA_RUNTIME_URL` is yours and is left alone.
 
 ## Uninstall
 
 ```sh
-appa plugin remove claude-code
-pkill -f 'appa runtime'
-rm -rf ~/.local/share/appa/bin ~/.local/share/appa/cache
+appa plugin remove claude-code           # the Claude Code profile only
+appa plugin remove claude-code --purge   # also stop the runtime and delete the deployment
 rm -f ~/.local/bin/appa
 cargo uninstall appa   # checkout builds only
 ```
@@ -273,10 +273,14 @@ cargo uninstall appa   # checkout builds only
 `appa plugin remove claude-code` takes back only what an install wrote: its
 hook entries, its `statusLine`, the `appa` MCP server, the skill, and
 `clappa`. A statusline, hook entry or skill of your own survives untouched.
+The policy, database, and runtime stay at the locations in the table above.
 
-The policy and database stay at the locations in the table above; delete
-them only if you want the history gone. Remove a `clappa` shell alias
-separately if you added one instead of the command.
+`--purge` goes on to stop the runtime and delete both directories in the
+table: the deployed binary, database, logs, retained versions, policy, and
+install state. It reads none of the install state, so it is the way out of
+a deployment an install refuses. `appa` on PATH stays, so the next
+`appa plugin install claude-code` starts from nothing. Remove a `clappa`
+shell alias separately if you added one instead of the command.
 
 ## Statusline
 

--- a/website/content/docs/claude-code.md
+++ b/website/content/docs/claude-code.md
@@ -28,9 +28,9 @@ one.
 The install prints progress while it selects the version, updates Claude Code,
 and starts the runtime, and it never prompts. A release binary installs the
 version published for its tag; a checkout build installs its own version,
-exported from the commit it was built from. If a different APPA
-deployment already owns the runtime endpoint, the install refuses and names the
-process to stop. An unidentified listener is never stopped automatically.
+exported from the commit it was built from. A runtime an earlier APPA
+deployment of yours left at the runtime endpoint is stopped; a process there
+that is not your own `appa` is named and never stopped.
 
 Initialization installs `clappa` beside `appa` so the short command works below.
 
@@ -176,17 +176,14 @@ max_concurrent = 4
 
 ## Uninstall
 
-To uninstall OpenAPPA from Claude Code, take its entries out of your Claude Code profile, stop the local runtime, and remove its binaries:
+`appa plugin remove claude-code` takes OpenAPPA's entries out of your Claude Code profile and leaves the runtime, policy, and database in place. `--purge` also stops the runtime and deletes the policy, database, logs, and retained versions, so the next install starts from nothing:
 
 ```sh
-appa plugin remove claude-code
-pkill -f 'appa runtime'
-rm -rf ~/.local/share/appa/bin ~/.local/share/appa/cache
+appa plugin remove claude-code           # the Claude Code profile only
+appa plugin remove claude-code --purge   # also stop the runtime and delete the deployment
 rm -f ~/.local/bin/appa
 cargo uninstall appa   # checkout builds only
-
-# optional — also remove the policy, database, and alias:
-rm -rf ~/.config/appa ~/.local/share/appa      # Linux
-rm -rf ~/Library/"Application Support/appa"    # macOS
 sed -i.bak '/clappa/d' ~/.zshrc                # alias fallback only
 ```
+
+`appa runtime stop` stops the runtime on its own. Both stop only a runtime that is your own `appa` process; a runtime at `APPA_RUNTIME_URL` is yours and is left alone.


### PR DESCRIPTION
A deployment can be stopped and wiped, and an install over an earlier deployment's runtime stops that runtime itself.

Depends on #298 (the branch carries its commit; rebase once it merges).

## What changes

- `appa runtime stop` stops the runtime answering the deployment endpoint when the process is this user's `appa`, and waits until the endpoint no longer answers from it. A URL the session named (`--url`, `APPA_RUNTIME_URL`) is the user's own and is refused; nothing answering is not a failure.
- `appa plugin remove claude-code --purge` takes back the Claude profile entries, stops the runtime the same way, and deletes the data and config directories: binary, database, logs, retained versions, policy, install state. `appa` itself stays on PATH. A process at the endpoint that is not this user's `appa`, or does not answer as one, is left and named in the result. `--purge` refuses `--config` and `APPA_CONFIG`: it removes the default deployment only.
- `appa plugin install claude-code` stops a runtime of the user's own that an earlier deployment left at the endpoint, instead of failing on it. A process there that does not identify itself as an `appa` runtime still refuses the install.
- An installation state this build does not read (an earlier build's selection, a hand edit) is refused with the way out named: purge, then install. The same hint follows an unloadable config and a failed recovery.
- `claude mcp get` reports a template URL without its default, so a rerun or a removal read the install's own registration as a conflict. A template reported that way is the install's own.

## Validation

`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace --no-fail-fast`, `bash scripts/appa-marketplace.sh --check`. Live on macOS: `appa runtime stop`, purge with a running runtime and without one, install over a running runtime of another deployment, rerun and remove after the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLi2evLA3suGN8ko4frXwu
