### PR TITLE
feat: Add PostgreSQL storage and embedded remedy execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "clap",
  "flate2",
  "futures-util",
- "hmac",
+ "hmac 0.12.1",
  "jsonschema",
  "libc",
  "libloading",
@@ -133,7 +133,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "thiserror",
@@ -200,7 +200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "tracing",
 ]
@@ -212,6 +212,9 @@ dependencies = [
  "appa-engine",
  "appa-policy",
  "appa-runtime-api",
+ "native-tls",
+ "postgres",
+ "postgres-native-tls",
  "rusqlite",
  "serde",
  "serde_json",
@@ -256,7 +259,7 @@ dependencies = [
  "appa-runtime-api",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "toml",
@@ -435,6 +438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +463,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -538,6 +556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +576,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -655,6 +685,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,9 +793,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -811,6 +871,12 @@ dependencies = [
  "nom",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -889,6 +955,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1025,7 +1106,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1114,7 +1195,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1161,6 +1251,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1521,6 +1620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,8 +1742,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1726,6 +1861,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,10 +1891,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1794,6 +1984,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +2039,63 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "postgres"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5",
+ "memchr",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2180,7 +2446,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "tokio",
  "tracing",
@@ -2290,7 +2556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "libsqlite3-sys",
  "smallvec",
@@ -2611,7 +2877,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2662,6 +2939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +2984,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2868,6 +3162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +3201,42 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -3124,6 +3469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3485,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "untrusted"
@@ -3245,12 +3611,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3362,6 +3746,19 @@ dependencies = [
  "tokio-util",
  "toml",
  "tower",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/appa-eventlog/Cargo.toml
+++ b/appa-eventlog/Cargo.toml
@@ -11,8 +11,12 @@ rusqlite = { version = "0.40", default-features = false, features = ["bundled"] 
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+postgres = { version = "0.19", optional = true, features = ["with-serde_json-1"] }
+postgres-native-tls = { version = "0.5", optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [features]
+postgres = ["dep:postgres", "dep:postgres-native-tls", "dep:native-tls"]
 # The fail points the runtime's own tests drive: a commit that rolls back in
 # place of committing, and a foreign writer that wins the compare-and-swap.
 # A dev-dependency enables it, so it is absent from every non-test build.

--- a/appa-eventlog/src/lib.rs
+++ b/appa-eventlog/src/lib.rs
@@ -8,8 +8,8 @@
 //! This crate is where the log is written and read. The record encoding, the database, and the
 //! conditional append are private to it: a caller hands it [`Fact`]s and gets [`Log`]s back, and
 //! never names SQL, a row, or a byte. Where the log is kept is the closed [`Backend`] enum,
-//! dispatched by `match` — no trait, because two SQLite connection modes are not two
-//! implementations.
+//! dispatched by `match`: SQLite for standalone use and optional PostgreSQL for
+//! embedded hosts that install the schema through their own migrations.
 //!
 //! Two tables, and no derived state:
 //!
@@ -46,6 +46,9 @@ use appa_engine::profile::PolicyFileKey;
 use appa_engine::value::TrajectoryId;
 use appa_runtime_api::{AdapterName, inventory::ToolInventory};
 
+#[cfg(feature = "postgres")]
+pub mod postgres;
+
 const SCHEMA_VERSION: i64 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,10 +59,17 @@ pub enum Backend {
     /// Private to one [`LogStore`] and gone when it drops. An in-memory adapter sits
     /// beside the durable one deliberately: the decision core cannot tell them apart.
     Memory,
+    /// Schema is installed by the embedding application's migrations.
+    #[cfg(feature = "postgres")]
+    Postgres {
+        url: String,
+    },
 }
 
 pub struct LogStore {
-    connection: Mutex<Connection>,
+    connection: Option<Mutex<Connection>>,
+    #[cfg(feature = "postgres")]
+    postgres: Option<postgres::PostgresStore>,
     #[cfg(feature = "fault-injection")]
     commits_until_failure: std::sync::atomic::AtomicU64,
     #[cfg(feature = "fault-injection")]
@@ -160,6 +170,8 @@ impl From<&CreateError> for StoreErrorClass {
             CreateError::Malformed { .. } => StoreErrorClass::Malformed,
             CreateError::PolicyFileMismatch => StoreErrorClass::PolicyMismatch,
             CreateError::Storage(_) => StoreErrorClass::Storage,
+            #[cfg(feature = "postgres")]
+            CreateError::Postgres(_) => StoreErrorClass::Storage,
             #[cfg(feature = "fault-injection")]
             CreateError::Injected => StoreErrorClass::Storage,
         }
@@ -173,6 +185,8 @@ impl From<&ReadError> for StoreErrorClass {
             ReadError::PolicyFileMissing { .. } => StoreErrorClass::PolicyUnavailable,
             ReadError::Undecodable(_) => StoreErrorClass::Undecodable,
             ReadError::Storage(_) => StoreErrorClass::Storage,
+            #[cfg(feature = "postgres")]
+            ReadError::Postgres(_) => StoreErrorClass::Storage,
         }
     }
 }
@@ -182,6 +196,8 @@ impl From<&AppendError> for StoreErrorClass {
         match error {
             AppendError::Conflict { .. } => StoreErrorClass::Conflict,
             AppendError::Storage(_) => StoreErrorClass::Storage,
+            #[cfg(feature = "postgres")]
+            AppendError::Postgres(_) => StoreErrorClass::Storage,
             #[cfg(feature = "fault-injection")]
             AppendError::Injected => StoreErrorClass::Storage,
         }
@@ -196,6 +212,9 @@ pub enum OpenError {
     ForeignSchema { path: String, found: i64, expected: i64 },
     #[error("storage failure: {0}")]
     Storage(#[from] rusqlite::Error),
+    #[cfg(feature = "postgres")]
+    #[error("PostgreSQL storage failure: {0}")]
+    Postgres(#[from] postgres::PostgresError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -211,6 +230,9 @@ pub enum CreateError {
     PolicyFileMismatch,
     #[error("storage failure: {0}")]
     Storage(#[from] rusqlite::Error),
+    #[cfg(feature = "postgres")]
+    #[error("PostgreSQL storage failure: {0}")]
+    Postgres(#[from] postgres::PostgresError),
     #[cfg(feature = "fault-injection")]
     #[error("injected failure before commit")]
     Injected,
@@ -226,6 +248,9 @@ pub enum ReadError {
     Undecodable(String),
     #[error("storage failure: {0}")]
     Storage(#[from] rusqlite::Error),
+    #[cfg(feature = "postgres")]
+    #[error("PostgreSQL storage failure: {0}")]
+    Postgres(#[from] postgres::PostgresError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -234,18 +259,41 @@ pub enum AppendError {
     Conflict { current: u64 },
     #[error("storage failure: {0}")]
     Storage(#[from] rusqlite::Error),
+    #[cfg(feature = "postgres")]
+    #[error("PostgreSQL storage failure: {0}")]
+    Postgres(#[from] postgres::PostgresError),
     #[cfg(feature = "fault-injection")]
     #[error("injected failure before commit")]
     Injected,
 }
 
 impl LogStore {
+    /// Coordinate host-owned receipts with the connection that writes event batches.
+    /// The embedding host must serialize operations during an outer transaction.
+    #[cfg(feature = "postgres")]
+    pub fn postgres(&self) -> Option<&postgres::PostgresStore> {
+        self.postgres.as_ref()
+    }
+
     /// Open the log. A fresh database gets the schema and its version stamp; an existing one is
     /// checked for damage and for a version this build understands, and refused otherwise.
     pub fn open(backend: Backend) -> Result<LogStore, OpenError> {
+        #[cfg(feature = "postgres")]
+        if let Backend::Postgres { url } = &backend {
+            return Ok(LogStore {
+                connection: None,
+                postgres: Some(postgres::PostgresStore::open(url.clone())?),
+                #[cfg(feature = "fault-injection")]
+                commits_until_failure: std::sync::atomic::AtomicU64::new(0),
+                #[cfg(feature = "fault-injection")]
+                contended_appends: std::sync::atomic::AtomicU64::new(0),
+            });
+        }
         let (mut connection, path) = match &backend {
             Backend::Sqlite { path } => (Connection::open(path)?, path.display().to_string()),
             Backend::Memory => (Connection::open_in_memory()?, ":memory:".to_string()),
+            #[cfg(feature = "postgres")]
+            Backend::Postgres { .. } => unreachable!("handled above"),
         };
         if matches!(backend, Backend::Sqlite { .. }) {
             let probe = || -> Result<String, rusqlite::Error> {
@@ -299,7 +347,9 @@ impl LogStore {
             transaction.commit()?;
         }
         Ok(LogStore {
-            connection: Mutex::new(connection),
+            connection: Some(Mutex::new(connection)),
+            #[cfg(feature = "postgres")]
+            postgres: None,
             #[cfg(feature = "fault-injection")]
             commits_until_failure: std::sync::atomic::AtomicU64::new(0),
             #[cfg(feature = "fault-injection")]
@@ -316,6 +366,10 @@ impl LogStore {
             return Err(CreateError::PolicyFileMismatch);
         }
         let bytes = encode(&opening);
+        #[cfg(feature = "postgres")]
+        if let Some(pg) = &self.postgres {
+            return pg.create(&root, &key, policy_file, bytes);
+        }
         let mut connection = self.lock();
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         transaction.execute(
@@ -348,6 +402,10 @@ impl LogStore {
     /// to open one — reading the whole log to learn only this would cost the caller a second
     /// read on the path that then goes on to read it properly.
     pub fn has_root(&self, root: &TrajectoryId) -> Result<bool, ReadError> {
+        #[cfg(feature = "postgres")]
+        if let Some(pg) = &self.postgres {
+            return pg.has_root(root).map_err(Into::into);
+        }
         let connection = self.lock();
         let found: Option<i64> = connection
             .query_row(
@@ -362,6 +420,10 @@ impl LogStore {
     /// Read one root's whole log, with the position it stands at and the policy file it opened
     /// under.
     pub fn log(&self, root: &TrajectoryId) -> Result<Log, ReadError> {
+        #[cfg(feature = "postgres")]
+        if let Some(pg) = &self.postgres {
+            return pg.log(root);
+        }
         let (batches, policy_file) = {
             let connection = self.lock();
             stored(&connection, root)?
@@ -383,6 +445,10 @@ impl LogStore {
     }
 
     fn append_bytes(&self, based_on: &Log, bytes: Vec<u8>) -> Result<(), AppendError> {
+        #[cfg(feature = "postgres")]
+        if let Some(pg) = &self.postgres {
+            return pg.append(based_on, bytes);
+        }
         let mut connection = self.lock();
         #[cfg(feature = "fault-injection")]
         if self.contention_fires() {
@@ -478,6 +544,8 @@ impl LogStore {
 
     fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.connection
+            .as_ref()
+            .expect("SQLite-only operation")
             .lock()
             .expect("the log store mutex is never poisoned: no panics under the lock")
     }
@@ -947,5 +1015,92 @@ mod tests {
         let first = opened();
         assert!(first.log(&root()).is_ok());
         assert!(matches!(memory().log(&root()), Err(ReadError::UnknownRoot { .. })));
+    }
+
+    /// Run against an Archestra-migrated, disposable PostgreSQL database:
+    /// OPENAPPA_TEST_DATABASE_URL=... cargo test -p appa-eventlog --features postgres -- --ignored
+    #[cfg(feature = "postgres")]
+    #[test]
+    #[ignore = "requires OPENAPPA_TEST_DATABASE_URL and host migrations"]
+    fn postgres_preserves_encoding_cas_and_outer_transaction_atomicity() {
+        let url = std::env::var("OPENAPPA_TEST_DATABASE_URL").expect("test database URL");
+        let first = LogStore::open(Backend::Postgres { url: url.clone() }).unwrap();
+        let second = LogStore::open(Backend::Postgres { url }).unwrap();
+        let unique = tempfile::tempdir().unwrap();
+        let id = TrajectoryId::new(format!("pg-test:{}", unique.path().display()));
+        let facts = vec![Fact::Boundary {
+            trajectory: id.clone(),
+            kind: appa_engine::fact::BoundaryKind::VoidReturn,
+        }];
+        let sqlite = memory();
+        first.create_root(opening(&id), POLICY.as_bytes()).unwrap();
+        sqlite.create_root(opening(&id), POLICY.as_bytes()).unwrap();
+        assert_eq!(first.log(&id).unwrap(), sqlite.log(&id).unwrap());
+        assert!(matches!(
+            second.create_root(opening(&id), POLICY.as_bytes()),
+            Err(CreateError::AlreadyExists { .. })
+        ));
+
+        let before = first.log(&id).unwrap();
+        let tx = first.postgres().unwrap().begin().unwrap();
+        first.append(&before, &facts).unwrap();
+        first.append(&first.log(&id).unwrap(), &facts).unwrap();
+        assert_eq!(first.log(&id).unwrap().basis(), 3);
+        assert_eq!(
+            second.log(&id).unwrap(),
+            before,
+            "uncommitted hook writes are invisible"
+        );
+        drop(tx);
+        assert_eq!(first.log(&id).unwrap(), before, "all hook writes roll back together");
+
+        let tx = first.postgres().unwrap().begin().unwrap();
+        first.append(&before, &facts).unwrap();
+        tx.commit().unwrap();
+        assert!(matches!(
+            second.append(&before, &facts),
+            Err(AppendError::Conflict { current: 2 })
+        ));
+        sqlite.append(&sqlite.log(&id).unwrap(), &facts).unwrap();
+        assert_eq!(second.log(&id).unwrap(), sqlite.log(&id).unwrap());
+
+        let observation = observed(id.as_str(), "demo");
+        first.append_inventory(&first.log(&id).unwrap(), &observation).unwrap();
+        sqlite
+            .append_inventory(&sqlite.log(&id).unwrap(), &observation)
+            .unwrap();
+        assert_eq!(second.log(&id).unwrap(), sqlite.log(&id).unwrap());
+
+        let stale = first.log(&id).unwrap();
+        let barrier = std::sync::Barrier::new(2);
+        let outcomes = std::thread::scope(|scope| {
+            let a = scope.spawn(|| {
+                barrier.wait();
+                first.append(&stale, &facts)
+            });
+            let b = scope.spawn(|| {
+                barrier.wait();
+                second.append(&stale, &facts)
+            });
+            [a.join().unwrap(), b.join().unwrap()]
+        });
+        assert_eq!(outcomes.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|result| matches!(result, Err(AppendError::Conflict { current: 4 })))
+                .count(),
+            1
+        );
+        assert_eq!(second.log(&id).unwrap().basis(), 4);
+
+        first
+            .postgres()
+            .unwrap()
+            .with_client(move |client| {
+                client.execute("DELETE FROM openappa_events WHERE root=$1", &[&id.as_str()])?;
+                Ok(())
+            })
+            .unwrap();
     }
 }

--- a/appa-eventlog/src/postgres.rs
+++ b/appa-eventlog/src/postgres.rs
@@ -1,0 +1,274 @@
+//! PostgreSQL storage for embedded hosts. The host installs the schema; Rust
+//! retains the SQLite event encoding and policy-file validation. A dedicated
+//! connection thread keeps the synchronous log API usable from async hooks.
+
+use std::sync::mpsc;
+
+use ::postgres::Client;
+use postgres_native_tls::MakeTlsConnector;
+
+use super::*;
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct PostgresError(pub String);
+
+impl From<::postgres::Error> for PostgresError {
+    fn from(error: ::postgres::Error) -> Self {
+        Self(error.to_string())
+    }
+}
+
+struct ConnectionState {
+    client: Client,
+    transaction: bool,
+}
+
+type Job = Box<dyn FnOnce(&mut ConnectionState) + Send>;
+
+#[derive(Clone)]
+pub struct PostgresStore {
+    sender: mpsc::Sender<Job>,
+}
+
+impl PostgresStore {
+    pub(super) fn open(url: String) -> Result<Self, PostgresError> {
+        let (sender, receiver) = mpsc::channel::<Job>();
+        let (ready, initialized) = mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("appa-postgres".into())
+            .spawn(move || {
+                let connect = || -> Result<Client, PostgresError> {
+                    let tls = native_tls::TlsConnector::new().map_err(|e| PostgresError(e.to_string()))?;
+                    let mut client = Client::connect(&url, MakeTlsConnector::new(tls))?;
+                    // Deliberately no DDL: an incompatible/missing host migration refuses startup.
+                    client.batch_execute(
+                        "SELECT root, seq, payload FROM openappa_events LIMIT 0;
+                    SELECT hash, bytes FROM openappa_policy_files LIMIT 0;
+                    SET lock_timeout = '30s'; SET statement_timeout = '60s'",
+                    )?;
+                    Ok(client)
+                };
+                match connect() {
+                    Ok(client) => {
+                        let _ = ready.send(Ok(()));
+                        let mut state = ConnectionState {
+                            client,
+                            transaction: false,
+                        };
+                        for job in receiver {
+                            job(&mut state);
+                        }
+                    }
+                    Err(error) => {
+                        let _ = ready.send(Err(error));
+                    }
+                }
+            })
+            .map_err(|e| PostgresError(e.to_string()))?;
+        initialized
+            .recv()
+            .map_err(|_| PostgresError("connection worker stopped".into()))??;
+        Ok(Self { sender })
+    }
+
+    fn run<T: Send + 'static>(
+        &self,
+        operation: impl FnOnce(&mut ConnectionState) -> Result<T, PostgresError> + Send + 'static,
+    ) -> Result<T, PostgresError> {
+        let (send, recv) = mpsc::sync_channel(1);
+        self.sender
+            .send(Box::new(move |state| {
+                let _ = send.send(operation(state));
+            }))
+            .map_err(|_| PostgresError("connection worker stopped".into()))?;
+        recv.recv()
+            .map_err(|_| PostgresError("connection worker stopped".into()))?
+    }
+
+    /// Host integration SQL (receipts, advisory locks) runs on the exact same
+    /// connection as the event log. Never expose this capability to clients.
+    pub fn with_client<T: Send + 'static>(
+        &self,
+        operation: impl FnOnce(&mut Client) -> Result<T, PostgresError> + Send + 'static,
+    ) -> Result<T, PostgresError> {
+        self.run(move |state| operation(&mut state.client))
+    }
+
+    /// Hold an outer transaction across asynchronous hook dispatch. The host
+    /// must serialize access to this store until commit or rollback.
+    pub fn begin(&self) -> Result<PostgresTransaction, PostgresError> {
+        self.run(|state| {
+            if state.transaction {
+                return Err(PostgresError("transaction already active".into()));
+            }
+            state.client.batch_execute("BEGIN")?;
+            state.transaction = true;
+            Ok(())
+        })?;
+        Ok(PostgresTransaction {
+            store: self.clone(),
+            finished: false,
+        })
+    }
+
+    fn mutate<T: Send + 'static>(
+        &self,
+        root: String,
+        operation: impl FnOnce(&mut Client) -> Result<T, PostgresError> + Send + 'static,
+    ) -> Result<T, PostgresError> {
+        self.run(move |state| {
+            let outer = state.transaction;
+            if !outer {
+                state.client.batch_execute("BEGIN")?;
+            }
+            let result = (|| {
+                state
+                    .client
+                    .query_one("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", &[&root])?;
+                operation(&mut state.client)
+            })();
+            if !outer {
+                state
+                    .client
+                    .batch_execute(if result.is_ok() { "COMMIT" } else { "ROLLBACK" })?;
+            }
+            result
+        })
+    }
+
+    pub(super) fn has_root(&self, root: &TrajectoryId) -> Result<bool, PostgresError> {
+        let root = root.as_str().to_owned();
+        self.with_client(move |client| {
+            Ok(client
+                .query_opt("SELECT 1 FROM openappa_events WHERE root = $1 LIMIT 1", &[&root])?
+                .is_some())
+        })
+    }
+
+    pub(super) fn create(
+        &self,
+        root: &TrajectoryId,
+        key: &PolicyFileKey,
+        policy: &[u8],
+        bytes: Vec<u8>,
+    ) -> Result<TrajectoryId, CreateError> {
+        let id = root.as_str().to_owned();
+        let hash = key.as_str().to_owned();
+        let policy = policy.to_vec();
+        let created = self.mutate(id.clone(), move |client| {
+            if client
+                .query_opt("SELECT 1 FROM openappa_events WHERE root = $1 LIMIT 1", &[&id])?
+                .is_some()
+            {
+                return Ok(false);
+            }
+            client.execute(
+                "INSERT INTO openappa_policy_files (hash, bytes) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                &[&hash, &policy],
+            )?;
+            client.execute(
+                "INSERT INTO openappa_events (root, seq, payload) VALUES ($1, 0, $2)",
+                &[&id, &bytes],
+            )?;
+            Ok(true)
+        })?;
+        if !created {
+            return Err(CreateError::AlreadyExists {
+                root: root.as_str().to_owned(),
+            });
+        }
+        Ok(root.clone())
+    }
+
+    pub(super) fn log(&self, root: &TrajectoryId) -> Result<Log, ReadError> {
+        let id = root.as_str().to_owned();
+        let batches = self.with_client(move |client| {
+            let rows = client.query(
+                "SELECT seq, payload FROM openappa_events WHERE root = $1 ORDER BY seq",
+                &[&id],
+            )?;
+            let mut batches = Vec::with_capacity(rows.len());
+            for (index, row) in rows.into_iter().enumerate() {
+                if row.get::<_, i64>(0) != index as i64 {
+                    return Err(PostgresError("event sequence contains a gap".into()));
+                }
+                batches.push(row.get::<_, Vec<u8>>(1));
+            }
+            Ok(batches)
+        })?;
+        let Some(first) = batches.first() else {
+            return Err(ReadError::UnknownRoot {
+                root: root.as_str().to_owned(),
+            });
+        };
+        let opening = match decode(first)? {
+            Batch::Facts(facts) => facts,
+            Batch::Inventory(_) => Vec::new(),
+        };
+        let Some(Fact::TrajectoryOpened { policy_file_key, .. }) = opening.first() else {
+            return Err(ReadError::Undecodable("log does not begin with an opening".into()));
+        };
+        let hash = policy_file_key.as_str().to_owned();
+        let lookup = hash.clone();
+        let policy = self
+            .with_client(move |client| {
+                Ok(client
+                    .query_opt("SELECT bytes FROM openappa_policy_files WHERE hash = $1", &[&lookup])?
+                    .map(|row| row.get::<_, Vec<u8>>(0)))
+            })?
+            .ok_or(ReadError::PolicyFileMissing { key: hash })?;
+        decoded(root, batches, policy)
+    }
+
+    pub(super) fn append(&self, based_on: &Log, bytes: Vec<u8>) -> Result<(), AppendError> {
+        let root = based_on.root.as_str().to_owned();
+        let basis = based_on.basis;
+        let conflict = self.mutate(root.clone(), move |client| {
+            let current = client
+                .query_one("SELECT count(*) FROM openappa_events WHERE root = $1", &[&root])?
+                .get::<_, i64>(0) as u64;
+            if current != basis {
+                return Ok(Some(current));
+            }
+            client.execute(
+                "INSERT INTO openappa_events (root, seq, payload) VALUES ($1, $2, $3)",
+                &[&root, &(current as i64), &bytes],
+            )?;
+            Ok(None)
+        })?;
+        if let Some(current) = conflict {
+            return Err(AppendError::Conflict { current });
+        }
+        Ok(())
+    }
+}
+
+pub struct PostgresTransaction {
+    store: PostgresStore,
+    finished: bool,
+}
+
+impl PostgresTransaction {
+    pub fn commit(mut self) -> Result<(), PostgresError> {
+        self.store.run(|state| {
+            state.client.batch_execute("COMMIT")?;
+            state.transaction = false;
+            Ok(())
+        })?;
+        self.finished = true;
+        Ok(())
+    }
+}
+
+impl Drop for PostgresTransaction {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.store.run(|state| {
+                let result = state.client.batch_execute("ROLLBACK");
+                state.transaction = false;
+                result.map_err(Into::into)
+            });
+        }
+    }
+}

--- a/appa-runtime/src/api/mod.rs
+++ b/appa-runtime/src/api/mod.rs
@@ -713,7 +713,11 @@ impl Prepared {
             error @ appa_eventlog::OpenError::ForeignSchema { .. } => OpenError::Damaged(error.to_string()),
             error => OpenError::Storage(error.to_string()),
         })?;
-        Ok(Runtime {
+        Ok(self.with_store(Arc::new(store)))
+    }
+
+    fn with_store(self, store: Arc<LogStore>) -> Runtime {
+        Runtime {
             inner: Arc::new(Inner {
                 deployment: std::sync::RwLock::new(Arc::new(self.deployment)),
                 retired: std::sync::Mutex::new(std::collections::BTreeMap::new()),
@@ -726,14 +730,14 @@ impl Prepared {
                 gates: self.gates,
                 naming: self.naming,
             }),
-        })
+        }
     }
 }
 
 struct Inner {
     deployment: std::sync::RwLock<Arc<Deployment>>,
     retired: std::sync::Mutex<std::collections::BTreeMap<String, Arc<RuntimeEngine>>>,
-    store: LogStore,
+    store: Arc<LogStore>,
     modules: crate::builtins::ModuleRegistry,
     executing: std::sync::Mutex<std::collections::BTreeSet<String>>,
     permits: std::sync::Mutex<std::collections::BTreeMap<PermitKey, Vec<Vouch>>>,
@@ -829,6 +833,16 @@ fn inventory_at(
 }
 
 impl Runtime {
+    /// Embed the existing runtime over host-managed storage without changing
+    /// policy naming, hook semantics, or starting an HTTP server.
+    pub fn open_with_store(
+        config: Config,
+        store: Arc<LogStore>,
+        modules: Option<PathBuf>,
+    ) -> Result<Runtime, OpenError> {
+        Ok(Prepared::new(config, modules, ToolNaming::AsAuthored)?.with_store(store))
+    }
+
     /// Run the serving load checks without opening a store, making network requests,
     /// or activating a deployment. Unknown inventory is reported, not rejected.
     pub(crate) fn validate_served(

--- a/appa-runtime/src/api/session.rs
+++ b/appa-runtime/src/api/session.rs
@@ -839,7 +839,8 @@ impl Session {
                         // Batch-terminal: every sibling settles first; any no-answer
                         // then aborts the invocation, discarding the siblings' answers,
                         // before another engine round or any append.
-                        let consults = requests.into_iter().map(|request| self.consult(request, None, None));
+                        // Embedded hosts supply the ruling outside an MCP elicitation context.
+                        let consults = requests.into_iter().map(|request| self.consult(request, None, ruling));
                         for answered in crate::external::settle_batch(consults).await {
                             evidence.push(answered?);
                         }

--- a/appa-runtime/src/mcp.rs
+++ b/appa-runtime/src/mcp.rs
@@ -190,7 +190,8 @@ impl From<ExecuteRemedyPlanArgs> for RemedyArguments {
 async fn execute_remedy(
     runtime: &Runtime,
     args: ExecuteRemedyPlanArgs,
-    request: RequestContext<RoleServer>,
+    request: Option<RequestContext<RoleServer>>,
+    expected_actor: Option<&appa_runtime_api::Actor>,
 ) -> CallToolResult {
     let quoted = OfferId(args.offer_id.clone());
     let arguments = RemedyArguments::from(args);
@@ -203,10 +204,18 @@ async fn execute_remedy(
             },
         );
     };
-    let elicitation = Elicitation::new(request, runtime.review_timeout());
+    if expected_actor.is_some_and(|expected| expected != &acting) {
+        return render(
+            runtime,
+            RemedyOutcome::Refused {
+                detail: "offer belongs to a different session".into(),
+            },
+        );
+    }
+    let elicitation = request.map(|request| Elicitation::new(request, runtime.review_timeout()));
     let started = std::time::Instant::now();
     let outcome = runtime
-        .remedy(&acting, quoted.clone(), arguments, Some(&elicitation), ruling)
+        .remedy(&acting, quoted.clone(), arguments, elicitation.as_ref(), ruling)
         .await;
     // Recorded from the typed outcome, before `render` turns it into the text the model
     // reads: a remedy that takes a minute and then declines is the shape of "APPA is in
@@ -224,6 +233,18 @@ async fn execute_remedy(
         },
     );
     render(runtime, outcome)
+}
+
+/// The existing MCP remedy implementation for an in-process gateway. The host
+/// first dispatches ToolCall and supplies its authenticated actor. Authorities
+/// bound in the policy still work; an interactive MCP elicitation without a
+/// request context returns NoAnswer through the existing consult mechanism.
+pub async fn execute_embedded_remedy(
+    runtime: &Runtime,
+    actor: &appa_runtime_api::Actor,
+    args: ExecuteRemedyPlanArgs,
+) -> CallToolResult {
+    execute_remedy(runtime, args, None, Some(actor)).await
 }
 
 #[tool_router]
@@ -254,7 +275,7 @@ impl RuntimeTools {
         Parameters(args): Parameters<ExecuteRemedyPlanArgs>,
         request: RequestContext<RoleServer>,
     ) -> CallToolResult {
-        execute_remedy(&self.runtime, args, request).await
+        execute_remedy(&self.runtime, args, Some(request), None).await
     }
 
     #[tool(description = "Report to the OpenAPPA developers when APPA is malfunctioning, \
@@ -337,7 +358,7 @@ impl RuntimeToolService {
         Parameters(args): Parameters<ExecuteRemedyPlanArgs>,
         request: RequestContext<RoleServer>,
     ) -> CallToolResult {
-        execute_remedy(&self.runtime, args, request).await
+        execute_remedy(&self.runtime, args, Some(request), None).await
     }
 
     #[tool(

--- a/appa-runtime/tests/hitl_elicitation.rs
+++ b/appa-runtime/tests/hitl_elicitation.rs
@@ -527,6 +527,34 @@ async fn a_harness_ruling_approves_with_no_elicitation_channel() {
 }
 
 #[tokio::test]
+async fn an_embedded_host_ruling_survives_without_any_mcp_request_context() {
+    let deployment = deployment().await;
+    let actor = Actor {
+        root: deployment.root.clone(),
+        child: None,
+    };
+    let args = serde_json::json!({ "offer_id": deployment.offer });
+    let gate = hooks::handle(
+        &deployment.runtime,
+        HookEvent::ToolCall {
+            actor: actor.clone(),
+            call: ProposedCall {
+                tool: appa_runtime_api::CONTROL_TOOL.into(),
+                arguments: raw(args.clone()),
+            },
+            spawn: false,
+            ruling: Some(Ruling::Approve),
+        },
+    )
+    .await;
+    assert!(matches!(gate, HookDecision::PassControl));
+    let result =
+        appa_runtime::mcp::execute_embedded_remedy(&deployment.runtime, &actor, serde_json::from_value(args).unwrap())
+            .await;
+    assert!(format!("{:?}", result.content).contains("Authorized"), "{result:?}");
+}
+
+#[tokio::test]
 async fn a_harness_ruling_denies_and_retires_the_offer() {
     let deployment = deployment().await;
     let answer = execute_with(&deployment, Absent, Some(Ruling::Deny)).await;

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,292 @@
+# OpenAPPA integration with Archestra
+
+This document records the agreed target architecture. Add clarifications only after the user approves them.
+
+1. **Runtime:** call OpenAPPA through TypeScript–Rust bindings inside Archestra, without a separate HTTP service.
+2. **Integration points:** call existing OpenAPPA hooks from Archestra’s existing LLM proxy. Add hooks only if necessary.
+3. **Session identity:** use session and parent IDs supplied by the client adapters.
+4. **Duplicate results:** Archestra tracks which tool results OpenAPPA has already processed.
+5. **Result replacements:** Archestra saves approved replacements and reapplies them whenever clients resend the original results.
+6. **Policy state:** OpenAPPA evaluates rules and maintains restrictions across requests and compaction.
+7. **Remedies:** reuse OpenAPPA’s existing remedy plans and MCP execution mechanism.
+8. **Persistence:** use Archestra’s PostgreSQL and migration system, with dedicated OpenAPPA tables where needed. OpenAPPA owns its storage format.
+
+## 1. Runtime — accepted clarification
+
+Use the same native binding approach as Archestra’s Dagger integration: `@archestra/sandbox-rs` uses napi-rs to expose Rust functions to TypeScript.
+
+- Add an equivalent package, such as `@archestra/openappa-rs`, linking the existing OpenAPPA Rust runtime. The package name is illustrative.
+- Load the native module inside Archestra’s backend and keep the runtime initialized across requests.
+- Expose an asynchronous binding to the existing OpenAPPA hook dispatcher. The LLM proxy passes events such as `SessionStart`, `ToolCall`, and `ToolResult`, and awaits their decisions.
+- Compile and package the native binary using the same build and loading pattern as `sandbox-rs`.
+- The call path is: **existing LLM proxy → native binding → existing OpenAPPA hook → decision returned to TypeScript**.
+- No separate OpenAPPA HTTP server is needed. The binding is new integration code; the existing hooks and policy engine are reused.
+- PostgreSQL support is a separate change. The binding alone does not replace OpenAPPA’s current SQLite storage integration.
+
+## 2. Integration points — accepted clarification
+
+Archestra’s existing LLM proxy calls OpenAPPA’s existing hook dispatcher through native bindings:
+
+- **`SessionStart`:** open or restore the conversation’s OpenAPPA state before checking its calls or results.
+- **`ToolCall`:** check a model-proposed tool call before releasing it to the client. Apply the allow/block decision and provide any remedy offers to the model. The client executes allowed calls. Remedy calls also pass through this check before MCP execution.
+- **`ToolResult`:** check each new tool result before sending it to the model. Apply any output replacement. Previously checked results reuse saved replacements instead of triggering the hook again.
+- **`Prompt`:** report a new user turn when the client adapter can reliably identify it. This marks a turn boundary; it does not check the prompt text against policy.
+- **`TurnEnd`:** report a completed agent turn when its completion is known, so OpenAPPA can clean up unfinished calls and temporary permissions.
+- **`ChildStart`, `ChildEnd`, and `SpawnResult`:** report child creation, check the child’s return, and report the parent’s spawning-tool result when the adapter can identify these events and their relationship.
+
+Archestra already buffers streamed tool calls until they are complete, evaluates guardrails, and releases only allowed calls. Reuse this mechanism, replacing the existing guardrail evaluation with OpenAPPA’s `ToolCall` hook. Streaming is an existing capability to preserve, not a gap.
+
+### Potential gaps
+
+- **Turn boundaries:** an inference request is not an entire agent turn. For example, the model requests a tool, the client runs it, and the client sends another model request—all within the same agent turn. If the user stops the client while a tool is running, the proxy may receive neither the result nor a “stopped” event. Completing an HTTP request therefore does not justify calling `TurnEnd`; Archestra needs a reliable signal that the client finished or stopped the turn. Likewise, call `Prompt` only for an identified new user turn, not every model request.
+- **Tool outcomes:** reuse Archestra’s existing execution-status and error handling to supply success, failure, or uncertain outcomes to OpenAPPA’s `ToolResult` hook. Do not introduce a separate classifier. During implementation, check which existing paths cover external clients; leave any unavailable status unknown.
+- **Children:** use session/parent IDs and the observed spawning call to associate each child with its approved spawn, reusing OpenAPPA’s existing association logic where possible. This selects the correct inherited restrictions and return requirements. A single pending spawn can be associated without another client-supplied ID, as in the Claude adapter. Multiple pending spawns need an unambiguous association. The client adapter must also identify which output is the child’s return to its parent so OpenAPPA can check it before it reaches the parent.
+- **Compaction:** summarization must use approved results. After compaction, retain restrictions by session ID and replace only tool results still present.
+
+The existing hooks cover the tool-call/result sequence. The unresolved work is obtaining reliable lifecycle information from each client and defining behavior when that information is missing.
+
+## 3. Session identity — accepted clarification
+
+Use the header contract supplied by the client adapters:
+
+- **`X-Appa-Session-ID`:** the current session ID, stable across model requests, user messages, and compaction. A child has its own session ID.
+- **`X-Appa-Parent-ID`:** the parent session ID for a child session; omitted for a top-level session.
+
+For the initial implementation, have Archestra Chat send these headers to the existing LLM proxy. The proxy uses these identities when calling OpenAPPA. Assume other client adapters will supply the same header contract; implementing their identity detection is outside this initial work.
+
+## 4. Duplicate results — accepted clarification
+
+Archestra tracks processed tool results in its existing PostgreSQL database, keyed by organization, authenticated caller, session ID, and tool-call ID. Reuse existing tables where practical; otherwise add a dedicated record containing that key, processing status, and approved output.
+
+- **New result:** call OpenAPPA’s `ToolResult` hook and save the processed status and approved output.
+- **Already processed result:** skip the hook and always substitute the saved approved output. Do not repeat policy updates or annotator/sanitizer calls just because the client resends history.
+- **No content hash initially:** deduplication uses the record key. Even if the client resends different content under that key, only the saved approved output reaches the model. A content hash would be an optional consistency check, not a requirement for this behavior.
+
+For example, if two consecutive requests both include the result for `call_123`, only the first processes it through OpenAPPA; the second reuses its approved output.
+
+Concurrent requests must not process the same result twice. Saving OpenAPPA state and the processed-result record must be coordinated so they remain consistent after a restart. The transaction and interrupted-processing behavior will be defined under Persistence.
+
+## 5. Result replacements — accepted clarification
+
+As agreed in point 4, Archestra saves each tool result’s approved output and uses it in model requests, both when first checked and whenever the result is resent. Duplicate detection skips repeated OpenAPPA processing; replacement determines what the model receives. These are two parts of the same result-handling flow.
+
+## 6. Policy state — accepted clarification
+
+OpenAPPA owns policy evaluation and the conversation’s restriction state. Archestra supplies session identities and hook events. Connect OpenAPPA’s persistence to Archestra’s PostgreSQL, preserving OpenAPPA’s existing state semantics rather than implementing a second policy-state system in TypeScript.
+
+Restrictions remain attached to the session across requests, compaction, and restarts. Removing a tool result from model history does not remove the restrictions that resulted from processing it. Stored approved tool outputs are separate from this conversation-level policy state.
+
+The PostgreSQL storage implementation and transaction details will be defined under Persistence.
+
+## 7. Remedies — accepted clarification
+
+Reuse OpenAPPA’s existing remedy plans and `execute_remedy_plan` MCP tool. Expose the tool through Archestra’s MCP gateway. The model chooses an offered plan, and the client executes the tool through the gateway; OpenAPPA validates and executes the plan.
+
+For simplicity, consider a dedicated gateway exposing only the remedy-plan tool. This is an option, not a finalized requirement. Gateway routing must reach the same OpenAPPA runtime and session state used by the LLM proxy.
+
+## 8. Persistence — accepted clarification
+
+Archestra owns the PostgreSQL database and runs table migrations. OpenAPPA owns its event format, serialization, and rebuilding policy state from stored events. Archestra does not need to interpret those events.
+
+- Add PostgreSQL support to OpenAPPA’s storage layer.
+- Create the required tables through Archestra’s migration system. OpenAPPA currently persists ordered event batches and the original policy files they reference. Dedicated tables could be named `openappa_events` and `openappa_policy_files`; these names are illustrative.
+- Store each event batch with its trajectory ID and sequence number, and each policy file with its hash and original bytes. Keep event encoding and decoding in OpenAPPA’s Rust code. PostgreSQL can store the serialized bytes without TypeScript interpreting them.
+- Preserve OpenAPPA’s ordering and concurrent-write checks when implementing PostgreSQL storage.
+- If a storage update needs different columns, include the corresponding Archestra migration. A change inside a serialized event does not necessarily require changing table columns, but OpenAPPA must preserve compatibility with saved history or provide a conversion.
+- Keep OpenAPPA’s policy history separate from Archestra’s chat and request logs. Archestra’s processed-result records and approved outputs remain its integration responsibility, as described in points 4 and 5.
+
+All eight points now have accepted clarifications. Detailed lifecycle mapping and the transaction behavior for interrupted or concurrent processing remain implementation design work.
+
+---
+
+## Implementation record — 2026-09-10
+
+Added under the subsequent instruction to implement, verify in Chrome, and
+record the built architecture and gaps. The accepted target above is preserved.
+
+### Isolation and implementation sequence
+
+The original checkouts and previous prototype worktrees were preserved. Work
+started from clean, paired worktrees:
+
+| Repository | Branch | Base | Worktree |
+| --- | --- | --- | --- |
+| OpenAPPA | `feat/archestra-native-postgres` | `91d432e1` | `/private/tmp/archestra-openappa-native/openappa` |
+| Archestra | `feat/openappa-native` | `fd32e2580` | `/private/tmp/archestra-openappa-native/archestra` |
+
+The inspection led to this sequence: add optional PostgreSQL storage and the
+host transaction seam; add the native package and Archestra migration; connect
+the existing proxy and Chat execution/lifecycle paths; expose the existing
+remedy mechanism; verify native persistence, proxy streaming, and live Chat.
+The decisions that inspection left open were interruption recovery, trustworthy
+caller identity, uncertain outcomes, child-return mapping, and packaging the
+coordinated repositories. Their implemented choices and limits follow.
+
+### Architecture that was built
+
+- `@archestra/openappa-rs` is a persistent async napi-rs addon using the existing
+  `@archestra/napi-loader` pattern. It calls `hooks::handle` on the real OpenAPPA
+  runtime. No OpenAPPA HTTP service is started. `Runtime::open_with_store`
+  accepts shared host-managed storage without replacing the policy engine.
+- The existing LLM proxy calls `SessionStart`, checks submitted results, and
+  calls `ToolCall` in both its streaming and non-streaming guardrail positions.
+  Its existing complete-call buffering and release/refusal behavior remain.
+  Existing normalization handles decorated names and `run_tool` targets.
+- Chat sends `X-Appa-Session-ID` from its conversation ID. The model constructor
+  supports `X-Appa-Parent-ID`; top-level Chat omits it. Organization and caller
+  are authenticated and included in the native actor identity. Chat signs the
+  proxy-agent/user/session/parent tuple with Archestra's existing auth secret
+  for the internal HTTP hop. A loopback connection or user attribution header
+  alone cannot authenticate a policy session. The internal signature header is
+  redacted and is not sent to the LLM provider.
+- Chat supplies `Prompt` for an identified new user message and `TurnEnd` on
+  non-aborted UI stream completion. These are not emitted per inference.
+  Unknown cancellation is left to the existing next-prompt cleanup. Detached
+  MCP tasks are disabled while this initial Chat adapter is enabled.
+- Chat checks the durable call receipt again immediately before execution,
+  including resumed approval calls. It captures the existing MCP execution
+  outcome before formatting, checks output before returning it to the AI SDK,
+  and saves only approved text into conversation history. The proxy substitutes
+  the saved approved output on every history resend.
+- The built-in `archestra__execute_remedy_plan` gateway tool uses OpenAPPA's
+  existing MCP execution logic through `execute_embedded_remedy`. It is implicit
+  protocol support while enabled, following Archestra's existing run-control
+  pattern. Each execution still checks the control call and validates the
+  offer against the authenticated native actor. Remote authority/sanitizer
+  bindings use the actual runtime implementation.
+- Archestra migration `0463_openappa_native.sql` creates `openappa_events`,
+  `openappa_policy_files`, `openappa_sessions`, `openappa_operations`, and
+  `openappa_processed_results`. Rust owns event bytes, original policy bytes,
+  decoding, replay, ordering, and compare-and-swap checks. TypeScript does not
+  interpret policy events. Existing SQLite storage remains supported.
+
+### Persistence decisions
+
+A dedicated PostgreSQL connection thread supports OpenAPPA's existing sync
+store API under async hooks. Host receipt SQL and native event writes use the
+same connection. The initial binding serializes hooks within a process and
+uses a PostgreSQL advisory lock per trajectory family across processes.
+
+Before an operation that might consult an external authority, the binding
+commits a `pending` receipt. All hook event writes and the completed receipt
+then share one transaction. Success commits both. Failure rolls back both and
+rebuilds transient runtime state. A surviving pending receipt blocks the family
+after interruption, including after process restart. An operator must inspect
+the event/receipt and external authority history before recovery; there is no
+automatic reset or blind consult retry.
+
+Completed result keys are organization + authenticated caller + session +
+tool-call ID. A changed resend still gets the saved approved output, with no
+additional hook or sanitizer invocation. Call operation IDs reject changed
+inputs. Result correlation uses the stored original checked call, so it does
+not depend on that call still appearing in compacted model history.
+
+This coordinates database state and avoids repeating uncertain external work.
+It does **not** claim exactly-once side effects at arbitrary remote services:
+their result may be lost before the database transaction commits.
+
+### Verified behavior
+
+| Check | Observed result |
+| --- | --- |
+| OpenAPPA runtime unit suite | 499 passed |
+| Existing event-store suite | 18 passed |
+| PostgreSQL parity/concurrency/transaction test | Passed against migrated PostgreSQL 17 |
+| Native Node/PostgreSQL suite | 6 passed, including cross-process replay and an actual HTTP sanitizer |
+| Backend regression suites | 261 passed across 8 files, including 9 new proxy/identity tests |
+| Backend TypeScript and changed-file Biome checks | Passed |
+| Archestra migration chain and migration checks | Applied successfully; 0 errors, 208 linter warnings, including index warnings on the new empty tables |
+| Native build and async loader smoke | Built and loaded on macOS arm64 |
+| Container source selection | Matching isolated source selection passed Cargo metadata and `cargo check --locked` |
+
+The native tests cover concurrent duplicate results, changed resends, caller/
+tenant isolation, remedy acceptance, retained restrictions after a fresh
+process receives no prior model history, one-time sanitization with saved
+replacement replay, unknown outcomes, and a failed receipt update that rolls
+back event writes and leaves a durable pending record.
+
+Chrome MCP was used against the isolated Archestra UI at
+`http://127.0.0.1:13000`. **GPT-5.6 Terra was selected in the Chat dropdown**;
+the database recorded `gpt-5.6-terra` for the live requests. The supplied API key
+was entered through Archestra's provider form and was not put in source or this
+document. Initial checks used
+`/chat/3a5cdee1-0502-427e-9dc5-b815885f3dbe`; the final normal-discovery test used
+`/chat/50b7487c-e365-4b91-b134-119f3340cbc5`.
+
+Live Chat returned the requested text, blocked `archestra__whoami` with a native
+remedy offer, executed the offered remedy through the MCP gateway, and returned
+the actual agent identity after retry. The test agent's read-only tools were
+configured through Archestra's existing assignment API. Its Auto-mode
+exclusions initially kept those tools unavailable; switching this disposable
+test assistant to Custom access resolved that configuration issue. Failed
+executions did not incorrectly apply a successful-read restriction.
+
+The final test admitted the existing read-only `archestra__search_tools` step,
+blocked `whoami`, executed the offered acceptance remedy, and returned the real
+agent identity. After restarting the backend (listener PID changed from 11539
+to 14657), `archestra__list_agents` was blocked with **"trust is suspicious,
+below the required floor trusted"**. PostgreSQL recorded that exact native
+deny decision, eight `gpt-5.6-terra` interactions for the conversation, and three
+completed result receipts with no pending result. The separate native test
+covers the stronger case of restarting with no prior model history supplied.
+
+An earlier browser probe stopped at the model's tool-discovery requirement,
+before attempting a tool. It was not evidence of native policy enforcement.
+Adding the discovery tool to the test fixture and starting a fresh conversation
+resolved it. An optional change to advertise all assigned schemas was rejected
+by automatic approval review and was not applied; the final test used the
+existing discovery path.
+
+### Gaps and corrections to assumptions
+
+1. **Unknown is not success.** Several proxy adapters default `isError` to false.
+   That is not proof of execution success. Chat supplies the real MCP outcome;
+   other clients remain unknown when no trustworthy status is available.
+   Existing OpenAPPA `Indeterminate` returns Keep/Ack, so the binding explicitly
+   withholds an unknown body's text instead of forwarding unevaluated content.
+2. **A proxy refusal ends the model step.** The existing refusal mechanism shows
+   and saves the remedy offer. It reaches the model on the next user turn;
+   automatic same-turn remedy continuation is not implemented. This is a limit
+   of the preserved proxy behavior, not missing streaming support.
+3. **Registering a remedy tool was insufficient.** Ordinary agent assignment
+   initially hid it. The implementation now advertises and permits the enabled
+   control tool implicitly, with native session/offer authorization intact.
+4. **Child hooks are not a finished Chat child adapter.** Native child-start,
+   child-end, and spawn-result plumbing reuses existing hooks, but Chat does
+   not yet deliver the full child return contract. Agent/skill delegation is
+   refused while enabled. Native feedback can still suggest child delegation
+   as an alternative; that suggestion is not usable in this initial Chat flow.
+5. **Interactive elicitation needs a bridge.** Existing bound remote remedies
+   work; interactive MCP human review has no embedded request-context bridge
+   yet and uses the runtime's existing no-answer behavior.
+6. **Locked chats and rich results are limited.** Locked Chat is refused because
+   native tables do not yet use its browser-held encryption keys. Approved text
+   is supported; raw MCP UI content, images, and structured output are omitted
+   so they cannot bypass output replacement during history or compaction.
+7. **Start new conversations when enabling.** Old results without native call
+   receipts are refused. Prototype/SQLite histories are not silently migrated.
+   Other client lifecycle detection and provider-hosted tool execution are not
+   implemented by this initial Chat adapter.
+8. **Deployment work remains explicit.** Local builds require matching sibling
+   checkouts. Docker uses a named `openappa` source context and the normal native
+   build/deploy path. The full Linux/musl platform image was not built in this
+   verification; the copied source selection was checked on the host. CI must
+   supply/pin the matching OpenAPPA checkout when these branches are adopted.
+9. **Operational follow-ups remain.** Dispatch is initially serialized per
+   process; connection recovery currently requires backend restart. Retention,
+   user/organization purge integration, and an interrupted-operation recovery
+   UI are not provided. PostgreSQL uses system TLS trust and URL SSL settings;
+   deployment-specific client certificate options need validation.
+10. **Existing checks still exist.** OpenAPPA replaces legacy proxy evaluation.
+    Chat/gateway access controls and their own execution checks remain active.
+    Enabling OpenAPPA does not grant access to otherwise unavailable tools.
+
+A pre-existing circular import between Archestra's built-in-agent constants
+and system-prompt templates prevented the fresh UI from loading. Extracting the
+dependency-free IDs fixed that startup prerequisite. Dev UI React warnings
+unrelated to OpenAPPA were observed. An early claim during test debugging that
+provider validation stripped identity headers was incorrect: the fixture user
+lacked organization membership. No header-schema workaround was retained.
+
+The detailed build/setup/transaction notes and reproducible commands are in
+`archestra/platform/archestra-rs/openappa-rs/README.md` in the paired worktree.

--- a/summary.md
+++ b/summary.md
@@ -290,3 +290,10 @@ lacked organization membership. No header-schema workaround was retained.
 
 The detailed build/setup/transaction notes and reproducible commands are in
 `archestra/platform/archestra-rs/openappa-rs/README.md` in the paired worktree.
+
+
+## Prototype follow-up: embedded human review
+
+Ported the host-ruling propagation fix from demo-11-09-25 into feat/archestra-native-postgres. Embedded remedy execution now carries the supplied human ruling through authority consultation even when no MCP request context exists. Added a direct regression test for this path.
+
+The companion Archestra feat/openappa-native branch carries denial-as-tool-result handling, original call preservation, durable exact-input resumption, authoritative denial replay, model-visible narrowing remedies, and the native Archestra approval UI bridge. Demo policy/UI/tools and the separate Claude protocol-negotiation workaround are excluded.


### PR DESCRIPTION
Let Archestra run the existing APPA runtime inside its backend, store APPA events in PostgreSQL, and execute remedies through direct Rust calls.

Companion integration: [Archestra #7838](https://github.com/archestra-ai/archestra/pull/7838). This PR adds section 1. Sections 2 and 3 explain how the companion Archestra PR calls it and stores the results.

## 1. What is added to APPA

- Optional PostgreSQL storage for APPA’s existing event log and saved policy files. The policy engine and event format are reused.
- `Runtime::open_with_store(...)` lets Archestra start APPA with that storage inside its backend process.
- `execute_embedded_remedy(...)` calls APPA’s existing remedy implementation without an MCP network request. It checks that the offer belongs to the supplied session.
- A fix passes the human decision from Archestra’s approval form into APPA’s existing approval handling, including when there is no MCP request context.
- The PostgreSQL store lets the Archestra Rust binding use the same connection and transaction for its additional records.

No new APPA hook event types are added. The integration calls existing `hooks::handle(...)` events such as `SessionStart`, `Prompt`, `ToolCall`, `ToolResult` and `TurnEnd`. Policy decisions and remedy rules remain APPA’s responsibility.

