### PR TITLE
fix(ci): drop the removed --archive flag from the release verify probes

### DIFF
--- a/.github/workflows/build-appa-runtime-binaries.yml
+++ b/.github/workflows/build-appa-runtime-binaries.yml
@@ -185,7 +185,7 @@ jobs:
           # one: this probe used to pass on an empty answer, which is how it
           # stayed inert for four releases.
           hostile=$(APPA_ENDPOINT=http://127.0.0.1:0 "./${EXECUTABLE}" activate-claude \
-            --config ./no-such-dir/appa.toml --archive ./no-such-archive.tar.gz 2>&1 || true)
+            --config ./no-such-dir/appa.toml 2>&1 || true)
           case "$hostile" in
             *"is not a usable runtime endpoint"*)
               echo "::error::the released binary honoured APPA_ENDPOINT: ${hostile}"
@@ -305,7 +305,7 @@ jobs:
             # classified, the unrecognised one included: this probe used to pass
             # on an empty answer, which is how it stayed inert for four releases.
             $env:APPA_ENDPOINT = "http://127.0.0.1:0"
-            $hostile = (& $cli activate-claude --config .\no-such-dir\appa.toml --archive .\no-such-archive.tar.gz 2>&1 | Out-String)
+            $hostile = (& $cli activate-claude --config .\no-such-dir\appa.toml 2>&1 | Out-String)
             $env:APPA_ENDPOINT = $null
             if ($hostile -match "is not a usable runtime endpoint") {
               throw "the released binary honoured APPA_ENDPOINT: $hostile"


### PR DESCRIPTION
`activate-claude` no longer takes `--archive` (#298), so the "Verify Unix package" and "Verify Windows package" probes fail every release build with `unexpected argument '--archive' found`, leaving v0.18.0 a draft without assets.

- Drop `--archive` from both probes; the probe still classifies on `does not load` (checked against a local release build).
- After merge, republish with `release.yml` → `publish_existing_release=true`, `version=0.18.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nMLrDb3sJ5c8BkxFLLYbW