### PR TITLE
ci: report APPA token overhead in nightly canary

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -4,8 +4,9 @@ name: Nightly Canary
 # (guarded `appa`, empty `appa-open`) over the full scenario set under the
 # redteam-chaos prompt profile, on the pinned model pair. Red means the
 # harness broke or the defended arm leaked — never a model-score dip; the
-# empty arm is reported for context only. Provider-reported total tokens also
-# give a crude defended-vs-empty APPA overhead measure in the run summary.
+# empty arm is reported for context only. The run summary also subtracts the
+# empty arm's provider-reported model tokens from the defended arm's over
+# whole trajectories. This is not a count of APPA-added prompt tokens.
 #
 # Results stay internal: the run directory is uploaded as a workflow
 # artifact, the verdict goes to Slack, and nothing is committed back.

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -4,7 +4,8 @@ name: Nightly Canary
 # (guarded `appa`, empty `appa-open`) over the full scenario set under the
 # redteam-chaos prompt profile, on the pinned model pair. Red means the
 # harness broke or the defended arm leaked — never a model-score dip; the
-# empty arm is reported for context only.
+# empty arm is reported for context only. Provider-reported total tokens also
+# give a crude defended-vs-empty APPA overhead measure in the run summary.
 #
 # Results stay internal: the run directory is uploaded as a workflow
 # artifact, the verdict goes to Slack, and nothing is committed back.

--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .report import AgentSummary
+from .report import AgentSummary, usage_overhead
 
 DEFENDED_ARM = "appa"
 EMPTY_ARM = "appa-open"
@@ -108,6 +108,17 @@ def _arm_cell(summary: AgentSummary | None) -> str:
     )
 
 
+def _token_overhead(run: ModelSummaries) -> str:
+    comparison = usage_overhead(run.agents).get(DEFENDED_ARM)
+    if comparison is None:
+        return "—"
+    delta = comparison["mean_total_tokens_delta"]
+    ratio = comparison["total_tokens_ratio"]
+    if not isinstance(delta, int | float) or not isinstance(ratio, int | float):
+        return "—"
+    return f"{delta:+,.0f} ({100 * (ratio - 1):+.0f}%)"
+
+
 def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -> str:
     status = "✅ passed" if verdict.healthy else "😞 failed"
     lines = [
@@ -115,12 +126,13 @@ def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -
         "",
         f"run `{run_id}`, profile `{CANARY_PROMPT_PROFILE}`, 1 rep per cell",
         "",
-        f"| model | defended (`{DEFENDED_ARM}`) | empty (`{EMPTY_ARM}`) |",
-        "| --- | --- | --- |",
+        f"| model | defended (`{DEFENDED_ARM}`) | empty (`{EMPTY_ARM}`) | APPA mean tokens/episode vs empty |",
+        "| --- | --- | --- | ---: |",
     ]
     for run in runs:
         lines.append(
-            f"| `{run.model}` | {_arm_cell(run.arm(DEFENDED_ARM))} | {_arm_cell(run.arm(EMPTY_ARM))} |"
+            f"| `{run.model}` | {_arm_cell(run.arm(DEFENDED_ARM))} | "
+            f"{_arm_cell(run.arm(EMPTY_ARM))} | {_token_overhead(run)} |"
         )
     if verdict.failures or verdict.warnings:
         lines.append("")
@@ -132,14 +144,15 @@ def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -
 def _board(runs: list[ModelSummaries]) -> str:
     """One monospace row per model × arm; the provider prefix carries no
     information at a glance, so rows show the bare model name."""
-    rows = [("model", "arm", "utility", "ASR", "err")]
+    rows = [("model", "arm", "utility", "ASR", "err", "tokens/ep", "overhead")]
     for run in runs:
         for arm_name, label in ((DEFENDED_ARM, "defended"), (EMPTY_ARM, "empty")):
             summary = run.arm(arm_name)
             model = run.model.split("/", 1)[-1]
             if summary is None:
-                rows.append((model, label, "—", "—", "—"))
+                rows.append((model, label, "—", "—", "—", "—", "—"))
             else:
+                tokens = "—" if summary.mean_total_tokens is None else f"{summary.mean_total_tokens:,.0f}"
                 rows.append(
                     (
                         model,
@@ -147,12 +160,15 @@ def _board(runs: list[ModelSummaries]) -> str:
                         f"{summary.utility_passed}/{summary.utility_total}",
                         f"{summary.attacks_succeeded}/{summary.attacks_total}",
                         str(summary.errors),
+                        tokens,
+                        _token_overhead(run) if arm_name == DEFENDED_ARM else "",
                     )
                 )
-    widths = [max(len(row[column]) for row in rows) for column in range(5)]
+    widths = [max(len(row[column]) for row in rows) for column in range(len(rows[0]))]
     out = [
         "  ".join(
-            f"{row[i]:<{widths[i]}}" if i < 2 else f"{row[i]:>{widths[i]}}" for i in range(5)
+            f"{row[i]:<{widths[i]}}" if i < 2 else f"{row[i]:>{widths[i]}}"
+            for i in range(len(row))
         ).rstrip()
         for row in rows
     ]

--- a/bench/corp/src/bench_corp/canary.py
+++ b/bench/corp/src/bench_corp/canary.py
@@ -108,7 +108,7 @@ def _arm_cell(summary: AgentSummary | None) -> str:
     )
 
 
-def _token_overhead(run: ModelSummaries) -> str:
+def _model_token_delta(run: ModelSummaries) -> str:
     comparison = usage_overhead(run.agents).get(DEFENDED_ARM)
     if comparison is None:
         return "—"
@@ -126,13 +126,15 @@ def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -
         "",
         f"run `{run_id}`, profile `{CANARY_PROMPT_PROFILE}`, 1 rep per cell",
         "",
-        f"| model | defended (`{DEFENDED_ARM}`) | empty (`{EMPTY_ARM}`) | APPA mean tokens/episode vs empty |",
+        "Model-token delta is defended minus empty over whole trajectories; it is not a count of APPA-added prompt tokens.",
+        "",
+        f"| model | defended (`{DEFENDED_ARM}`) | empty (`{EMPTY_ARM}`) | defended − empty mean model tokens/episode |",
         "| --- | --- | --- | ---: |",
     ]
     for run in runs:
         lines.append(
             f"| `{run.model}` | {_arm_cell(run.arm(DEFENDED_ARM))} | "
-            f"{_arm_cell(run.arm(EMPTY_ARM))} | {_token_overhead(run)} |"
+            f"{_arm_cell(run.arm(EMPTY_ARM))} | {_model_token_delta(run)} |"
         )
     if verdict.failures or verdict.warnings:
         lines.append("")
@@ -144,7 +146,7 @@ def render_markdown(runs: list[ModelSummaries], verdict: Verdict, run_id: str) -
 def _board(runs: list[ModelSummaries]) -> str:
     """One monospace row per model × arm; the provider prefix carries no
     information at a glance, so rows show the bare model name."""
-    rows = [("model", "arm", "utility", "ASR", "err", "tokens/ep", "overhead")]
+    rows = [("model", "arm", "utility", "ASR", "err", "model tok/ep", "def−empty")]
     for run in runs:
         for arm_name, label in ((DEFENDED_ARM, "defended"), (EMPTY_ARM, "empty")):
             summary = run.arm(arm_name)
@@ -161,7 +163,7 @@ def _board(runs: list[ModelSummaries]) -> str:
                         f"{summary.attacks_succeeded}/{summary.attacks_total}",
                         str(summary.errors),
                         tokens,
-                        _token_overhead(run) if arm_name == DEFENDED_ARM else "",
+                        _model_token_delta(run) if arm_name == DEFENDED_ARM else "",
                     )
                 )
     widths = [max(len(row[column]) for row in rows) for column in range(len(rows[0]))]
@@ -185,6 +187,7 @@ def slack_payload(
     if verdict.warnings:
         lines.append("warnings: " + " · ".join(verdict.warnings))
     if runs:
+        lines.append("model-token delta = defended − empty over whole trajectories (not APPA-added prompt tokens)")
         lines.append(_board(runs))
     if run_url:
         lines.append(f"<{run_url}|run>")

--- a/bench/corp/tests/test_canary.py
+++ b/bench/corp/tests/test_canary.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from bench_corp.canary import CANARY_MODELS, ModelSummaries, evaluate
+from dataclasses import replace
+
+from bench_corp.canary import (
+    CANARY_MODELS,
+    ModelSummaries,
+    evaluate,
+    render_markdown,
+    slack_payload,
+)
 from bench_corp.report import summarize
-from bench_corp.runner import EpisodeResult
+from bench_corp.runner import EpisodeResult, ModelUsage
 
 
 def _episode(agent: str, error: str | None, terminal_status: str | None) -> EpisodeResult:
@@ -93,3 +101,47 @@ def test_dulled_fixtures_warning_requires_clean_empty_arm() -> None:
     verdict = evaluate([_run(episodes)])
     assert not any("dulled" in w for w in verdict.warnings)
 
+
+def _with_tokens(episode: EpisodeResult, total: int) -> EpisodeResult:
+    return replace(
+        episode,
+        model_usage=ModelUsage(
+            model_calls=2,
+            usage_reported_calls=2,
+            input_tokens=total - 10,
+            output_tokens=10,
+            total_tokens=total,
+            cached_input_tokens=0,
+            cache_write_input_tokens=0,
+            reasoning_tokens=0,
+            cost_usd=None,
+        ),
+    )
+
+
+def test_reports_show_defended_token_overhead_against_the_empty_arm() -> None:
+    run = _run(
+        [
+            _with_tokens(_episode("appa", None, "completed"), 120),
+            _with_tokens(_episode("appa-open", None, "completed"), 100),
+        ]
+    )
+    verdict = evaluate([run])
+
+    assert "+20 (+20%)" in render_markdown([run], verdict, "nightly")
+    slack = slack_payload([run], verdict, "nightly", None)["text"]
+    assert "120" in slack
+    assert "100" in slack
+    assert "+20 (+20%)" in slack
+
+
+def test_reports_do_not_invent_overhead_when_provider_usage_is_incomplete() -> None:
+    run = _run(
+        [
+            _with_tokens(_episode("appa", None, "completed"), 120),
+            _episode("appa-open", None, "completed"),
+        ]
+    )
+    verdict = evaluate([run])
+
+    assert "| — |" in render_markdown([run], verdict, "nightly")

--- a/bench/corp/tests/test_canary.py
+++ b/bench/corp/tests/test_canary.py
@@ -128,8 +128,13 @@ def test_reports_show_defended_token_overhead_against_the_empty_arm() -> None:
     )
     verdict = evaluate([run])
 
-    assert "+20 (+20%)" in render_markdown([run], verdict, "nightly")
+    report = render_markdown([run], verdict, "nightly")
+    assert "defended minus empty over whole trajectories" in report
+    assert "not a count of APPA-added prompt tokens" in report
+    assert "+20 (+20%)" in report
     slack = slack_payload([run], verdict, "nightly", None)["text"]
+    assert "defended − empty over whole trajectories" in slack
+    assert "not APPA-added prompt tokens" in slack
     assert "120" in slack
     assert "100" in slack
     assert "+20 (+20%)" in slack


### PR DESCRIPTION
## Summary

- report provider-observed mean model tokens per episode for both canary arms
- show the signed whole-trajectory delta: defended `appa` minus empty-policy `appa-open`, plus the percentage relative to `appa-open`
- state in GitHub and Slack output that this is not a count of APPA-added prompt tokens
- leave the delta unavailable when provider usage is incomplete

This is intentionally a crude measure: arm behavior can differ, so the delta includes trajectory differences as well as mediation overhead.

## Verification

- `uv run --project bench/corp pytest bench/corp/tests` (106 passed)
- `git diff --check`